### PR TITLE
Cached provider

### DIFF
--- a/src/beamlime/constructors/inspectors.py
+++ b/src/beamlime/constructors/inspectors.py
@@ -41,12 +41,12 @@ _NewT = NewType("_NewT", int)
 
 
 class NewTypeMeta(type):
-    def __instancecheck__(cls, __instance: Any) -> bool:
+    def __instancecheck__(cls, instance: Any) -> bool:
         return (
-            callable(__instance)
-            and hasattr(__instance, "__supertype__")
-            and _NewT.__module__ == __instance.__module__
-            and _NewT.__qualname__ == __instance.__qualname__
+            callable(instance)
+            and hasattr(instance, "__supertype__")
+            and _NewT.__module__ == instance.__module__
+            and _NewT.__qualname__ == instance.__qualname__
         )
 
 

--- a/src/beamlime/constructors/inspectors.py
+++ b/src/beamlime/constructors/inspectors.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Literal, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, Literal, NewType, Type, TypeVar, Union
 
 
 class Empty:
@@ -23,7 +23,7 @@ class UnknownType:
     ...
 
 
-def validate_annotation(annotation) -> Literal[True]:
+def validate_annotation(annotation: Any) -> Literal[True]:
     """
     Check if the origin of the annotation is not Union.
 
@@ -37,11 +37,25 @@ def validate_annotation(annotation) -> Literal[True]:
 
 
 Product = TypeVar("Product")
-ProductType = Type[Product]
+_NewT = NewType("_NewT", int)
 
 
-def extract_underlying_product_type(product_type: ProductType) -> ProductType:
-    if hasattr(product_type, "__supertype__"):  # NewType
+class NewTypeMeta(type):
+    def __instancecheck__(cls, __instance: Any) -> bool:
+        return (
+            callable(__instance)
+            and hasattr(__instance, "__supertype__")
+            and _NewT.__module__ == __instance.__module__
+            and _NewT.__qualname__ == __instance.__qualname__
+        )
+
+
+class NewTypeProtocol(Generic[Product], metaclass=NewTypeMeta):
+    __supertype__: Type[Product]
+
+
+def extract_underlying_product_type(product_type: Type[Product]) -> Type[Product]:
+    if isinstance(product_type, NewTypeProtocol):
         return product_type.__supertype__
     else:
         return product_type
@@ -52,9 +66,9 @@ class ProductSpec:
     Specification of a product (returned value) of a provider.
     """
 
-    def __init__(self, product_type: Union[ProductType, ProductSpec]) -> None:
-        self.product_type: ProductType
-        self.returned_type: ProductType
+    def __init__(self, product_type: Union[Type[Product], ProductSpec]) -> None:
+        self.product_type: Type[Product]
+        self.returned_type: Type[Product]
 
         if isinstance(product_type, ProductSpec):
             self.product_type = product_type.product_type
@@ -73,19 +87,16 @@ class ProductSpec:
             return self.product_type == other.product_type
 
 
-def collect_arg_typehints(callable_obj: Callable) -> Dict[str, Any]:
+def collect_arg_typehints(callable_obj: Callable[..., Product]) -> Dict[str, Type[Any]]:
     from typing import get_type_hints
 
     if isinstance(callable_obj, type):
-        # TODO: When the callable_obj is a class,
-        # investigating ``__init__`` of the class should be okay
-        # but may replace this to the better solution and remove type check ignore tag.
-        return get_type_hints(callable_obj.__init__)  # type: ignore[misc]
+        return get_type_hints(callable_obj.__init__)
     else:
         return get_type_hints(callable_obj)
 
 
-def get_product_spec(callable_obj: Callable) -> ProductSpec:
+def get_product_spec(callable_obj: Callable[..., Product]) -> ProductSpec:
     """
     Retrieve the product of provider.
     If ``callable_obj`` is a function, it is a return type annotation,
@@ -98,7 +109,7 @@ def get_product_spec(callable_obj: Callable) -> ProductSpec:
         return ProductSpec(product)
 
 
-def extract_underlying_dep_type(tp: Any) -> ProductType:
+def extract_underlying_dep_type(tp: Any) -> Any:
     from typing import Union, get_args, get_origin
 
     if get_origin(tp) == Union:
@@ -122,12 +133,12 @@ class DependencySpec:
         self.dependency_type = extract_underlying_dep_type(dependency_type)
         self.default_product = default_value
 
-    def is_optional(self):
+    def is_optional(self) -> bool:
         return self.default_product is not Empty or self.dependency_type is UnknownType
 
 
 def collect_argument_specs(
-    callable_obj: Callable, *default_args, **default_keywords
+    callable_obj: Callable[..., Product], *default_args: Any, **default_keywords: Any
 ) -> Dict[str, DependencySpec]:
     """
     Collect Dependencies from the signature and type hints.
@@ -167,7 +178,9 @@ def collect_argument_specs(
     }
 
 
-def collect_attr_specs(callable_class: Callable) -> Dict[str, DependencySpec]:
+def collect_attr_specs(
+    callable_class: Callable[..., Product]
+) -> Dict[str, DependencySpec]:
     """
     Collect Dependencies from the type hints of the class.
     It ignores any attributes without type hints.

--- a/tests/constructors/factory_test.py
+++ b/tests/constructors/factory_test.py
@@ -187,3 +187,18 @@ def test_local_factory_overwritten():
     assert global_factory[Joke] == make_a_joke()
     with global_factory.local_factory(ProviderGroup(make_another_joke)) as factory:
         assert factory[Joke] == make_another_joke()
+
+
+def test_cached_provider_function():
+    provider_gr = ProviderGroup()
+    provider_gr.cached_provider(ProviderGroup, ProviderGroup)
+    factory = Factory(provider_gr)
+    assert factory[ProviderGroup] is factory[ProviderGroup]
+
+
+def test_cached_provider_function_copied():
+    provider_gr = ProviderGroup()
+    provider_gr.cached_provider(ProviderGroup, ProviderGroup)
+    factory = Factory(provider_gr)
+    another_factory = Factory(provider_gr)
+    assert factory[ProviderGroup] is not another_factory[ProviderGroup]

--- a/tests/constructors/provider_group_test.py
+++ b/tests/constructors/provider_group_test.py
@@ -127,3 +127,24 @@ def test_providers_merge_conflicting_keywords_raises():
     funnier.provider(Provider(make_a_joke, joke=orange_joke))
     with pytest.raises(ConflictProvidersError):
         funny.merge(funnier)
+
+
+def cached_function() -> ProviderGroup:
+    return ProviderGroup()
+
+
+def test_cached_provider_function():
+    provider_gr = ProviderGroup()
+    provider_gr.cached_provider(ProviderGroup, cached_function)
+    first_instance = provider_gr[ProviderGroup]()
+    second_instance = provider_gr[ProviderGroup]()
+    assert first_instance is second_instance
+
+
+def test_cached_provider_function_copied():
+    provider_gr = ProviderGroup()
+    provider_gr.cached_provider(ProviderGroup, cached_function)
+    new_gr = ProviderGroup()
+    new_gr.merge(provider_gr)
+
+    assert provider_gr[ProviderGroup]() is not new_gr[ProviderGroup]()

--- a/tests/constructors/provider_test.py
+++ b/tests/constructors/provider_test.py
@@ -149,3 +149,27 @@ def test_insufficient_annotation_raises():
 
     with pytest.raises(InsufficientAnnotationError):
         Provider(func_without_arg_type)
+
+
+def test_cached_provider():
+    from beamlime.constructors.providers import CachedProvider
+
+    class TestClass:
+        ...
+
+    cached_provider = CachedProvider(TestClass)
+    assert cached_provider() is cached_provider()
+
+
+def test_cached_provider_deep_copied():
+    from copy import deepcopy
+
+    from beamlime.constructors.providers import CachedProvider
+
+    class TestClass:
+        def __eq__(self, _obj: object) -> bool:
+            return isinstance(_obj, TestClass)
+
+    cached_provider = CachedProvider(TestClass)
+    assert cached_provider() is not deepcopy(cached_provider)()
+    assert cached_provider() == deepcopy(cached_provider)()

--- a/tests/constructors/provider_test.py
+++ b/tests/constructors/provider_test.py
@@ -161,6 +161,22 @@ def test_cached_provider():
     assert cached_provider() is cached_provider()
 
 
+def test_cached_provider_different_argument():
+    from beamlime.constructors.providers import (
+        CachedProvider,
+        CachedProviderCalledWithDifferentArgs,
+    )
+
+    class TestClass:
+        def __init__(self, arg: int) -> None:
+            self.arg = arg
+
+    cached_provider = CachedProvider(TestClass)
+    assert cached_provider(arg=0) is cached_provider(arg=0)
+    with pytest.raises(CachedProviderCalledWithDifferentArgs):
+        cached_provider(arg=1)
+
+
 def test_cached_provider_deep_copied():
     from copy import deepcopy
 

--- a/tests/constructors/provider_test.py
+++ b/tests/constructors/provider_test.py
@@ -194,8 +194,8 @@ def test_cached_provider_different_argument_handled():
     assert cached_provider(arg=0) is cached_provider(arg=0)
 
 
-def test_cached_provider_deep_copied():
-    from copy import deepcopy
+def test_cached_provider_copied():
+    from copy import copy
 
     from beamlime.constructors.providers import CachedProvider
 
@@ -204,5 +204,5 @@ def test_cached_provider_deep_copied():
             return isinstance(_obj, TestClass)
 
     cached_provider = CachedProvider(TestClass)
-    assert cached_provider() is not deepcopy(cached_provider)()
-    assert cached_provider() == deepcopy(cached_provider)()
+    assert cached_provider() is not copy(cached_provider)()
+    assert cached_provider() == copy(cached_provider)()

--- a/tests/constructors/provider_test.py
+++ b/tests/constructors/provider_test.py
@@ -161,7 +161,7 @@ def test_cached_provider():
     assert cached_provider() is cached_provider()
 
 
-def test_cached_provider_different_argument():
+def test_cached_provider_different_argument_raises():
     from beamlime.constructors.providers import (
         CachedProvider,
         CachedProviderCalledWithDifferentArgs,
@@ -175,6 +175,23 @@ def test_cached_provider_different_argument():
     assert cached_provider(arg=0) is cached_provider(arg=0)
     with pytest.raises(CachedProviderCalledWithDifferentArgs):
         cached_provider(arg=1)
+
+
+def test_cached_provider_different_argument_handled():
+    from beamlime.constructors.providers import (
+        CachedProvider,
+        CachedProviderCalledWithDifferentArgs,
+    )
+
+    class TestClass:
+        def __init__(self, arg: int) -> None:
+            self.arg = arg
+
+    cached_provider = CachedProvider(TestClass)
+    assert cached_provider(arg=0) is cached_provider(arg=0)
+    with pytest.raises(CachedProviderCalledWithDifferentArgs):
+        cached_provider(arg=1)
+    assert cached_provider(arg=0) is cached_provider(arg=0)
 
 
 def test_cached_provider_deep_copied():


### PR DESCRIPTION
The previous implementation, delayed registration no longer works since `ProviderGroup` is separated from `Factory`.
Therefore here is the new implementation.

The main purpose of the cached provider is to share a data-pipe instance between applications.

## ProviderGroup.cached_provider
`ProviderGroup` has `cached_provider` method to register a cached provider call.
It will wrap the `Callable` with `CachedProvider` instead of `Provider`, which is a subclass of `Provider`.

## CachedProvider
It is a subclass of `Provider`, which is a function wrapper similar to `partial`.
It wraps the `Callable` with `functools.lru_cache(maxsize=1)`.
The `__call__` will check if it was called with different arguments before and will not allow new ones.

## Provider.__deepcopy__
In order to keep the cache only available within the `Factory` or `ProviderGroup`,
`Provider` has `__deepcopy__` which will create a new instance of the `Provider` or a sub class if not overwritten.
`ProviderGroup` will make a deep copy of a provider dictionary when copied or merged.

## Type Hints
It also has more type hints but `mypy` with `--strict` option still doesn't pass for couple of cases.