### PR TITLE
Update runtime type-checker of the dependency injection module.

### DIFF
--- a/src/beamlime/constructors/inspectors.py
+++ b/src/beamlime/constructors/inspectors.py
@@ -38,13 +38,6 @@ def validate_annotation(annotation: Any) -> Literal[True]:
 
 Product = TypeVar("Product")
 
-
-def _is_type_newtype_py310(tp: Any) -> bool:
-    from typing import NewType
-
-    return isinstance(NewType, type) and isinstance(tp, NewType)
-
-
 _NewT = NewType("_NewT", int)
 
 
@@ -59,7 +52,12 @@ def _is_type_newtype_py39(tp: Any) -> bool:
 
 class NewTypeMeta(type):
     def __instancecheck__(cls, instance: Any) -> bool:
-        return _is_type_newtype_py310(instance) or _is_type_newtype_py39(instance)
+        import sys
+
+        if sys.version_info < (3, 10):  # py39
+            return _is_type_newtype_py39(instance)
+        else:
+            return isinstance(instance, NewType)
 
 
 class NewTypeProtocol(Generic[Product], metaclass=NewTypeMeta):

--- a/src/beamlime/constructors/inspectors.py
+++ b/src/beamlime/constructors/inspectors.py
@@ -37,26 +37,38 @@ def validate_annotation(annotation: Any) -> Literal[True]:
 
 
 Product = TypeVar("Product")
+
+
+def _is_type_newtype_py310(tp: Any) -> bool:
+    from typing import NewType
+
+    return isinstance(NewType, type) and isinstance(tp, NewType)
+
+
 _NewT = NewType("_NewT", int)
+
+
+def _is_type_newtype_py39(tp: Any) -> bool:
+    return (
+        callable(tp)
+        and hasattr(tp, "__supertype__")
+        and _NewT.__module__ == tp.__module__
+        and _NewT.__qualname__ == tp.__qualname__
+    )
 
 
 class NewTypeMeta(type):
     def __instancecheck__(cls, instance: Any) -> bool:
-        return (
-            callable(instance)
-            and hasattr(instance, "__supertype__")
-            and _NewT.__module__ == instance.__module__
-            and _NewT.__qualname__ == instance.__qualname__
-        )
+        return _is_type_newtype_py310(instance) or _is_type_newtype_py39(instance)
 
 
 class NewTypeProtocol(Generic[Product], metaclass=NewTypeMeta):
     __supertype__: Type[Product]
 
 
-def extract_underlying_product_type(product_type: Type[Product]) -> Type[Product]:
+def extract_underlying_type(product_type: Type[Product]) -> Type[Product]:
     if isinstance(product_type, NewTypeProtocol):
-        return product_type.__supertype__
+        return extract_underlying_type(product_type.__supertype__)
     else:
         return product_type
 
@@ -76,7 +88,7 @@ class ProductSpec:
         else:
             validate_annotation(product_type)
             self.product_type = product_type
-            self.returned_type = extract_underlying_product_type(product_type)
+            self.returned_type = extract_underlying_type(product_type)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ProductSpec):
@@ -109,32 +121,46 @@ def get_product_spec(callable_obj: Callable[..., Product]) -> ProductSpec:
         return ProductSpec(product)
 
 
-def extract_underlying_dep_type(tp: Any) -> Any:
-    from typing import Union, get_args, get_origin
-
-    if get_origin(tp) == Union:
-        if len((args := get_args(tp))) == 2 and type(None) in args:
-            # Optional
-            return args[0] if isinstance(None, args[1]) else args[1]
-        else:
-            raise NotImplementedError(
-                "Union annotation for dependencies is not supported."
-            )
-    else:
-        return tp
-
-
-class DependencySpec:
+class DependencySpec(Generic[Product]):
     """
     Specification of sub-dependencies (arguments/attributes) of a provider.
     """
 
     def __init__(self, dependency_type: Any, default_value: Product) -> None:
-        self.dependency_type = extract_underlying_dep_type(dependency_type)
+        self.dependency_type = self.extract_dependency_type(dependency_type)
+        self.runtime_type = extract_underlying_type(dependency_type)
         self.default_product = default_value
+
+    @staticmethod
+    def extract_dependency_type(dependency_type: Any) -> None:
+        from typing import Union, get_args, get_origin
+
+        if get_origin(dependency_type) == Union:
+            if len((args := get_args(dependency_type))) == 2 and type(None) in args:
+                # Optional
+                return args[0] if isinstance(None, args[1]) else args[1]
+            else:
+                raise NotImplementedError(
+                    "Union annotation for dependencies "
+                    "is not supported except for Optional."
+                )
+
+        return dependency_type
 
     def is_optional(self) -> bool:
         return self.default_product is not Empty or self.dependency_type is UnknownType
+
+    def __repr__(self) -> str:
+        def trim_repr(str_repr: str, max_len: int = 88) -> str:
+            return str_repr if len(str_repr) <= max_len else str_repr[:max_len] + "..."
+
+        default_repr = str(None) if (obj := self.default_product) is Empty else str(obj)
+        return (
+            f"{self.__class__.__name__}("
+            f"dependency_type: '{self.dependency_type.__name__}', "
+            f"runtime_type: '{self.runtime_type}', "
+            f"default_value: '{trim_repr(default_repr)}')"
+        )
 
 
 def collect_argument_specs(

--- a/tests/constructors/inspection_test.py
+++ b/tests/constructors/inspection_test.py
@@ -41,6 +41,16 @@ def test_new_type_underlying_type_retrieved():
     assert product_spec.returned_type is int
 
 
+def test_multi_inheritied_new_type_underlying_type_retrieved():
+    from typing import NewType
+
+    new_type = NewType("new_type", int)
+    new_new_type = NewType("new_new_type", new_type)
+    product_spec = ProductSpec(new_new_type)
+    assert product_spec.product_type is new_new_type
+    assert product_spec.returned_type is int
+
+
 def test_dependency_spec():
     dep_spec = DependencySpec(int, 0)
     assert dep_spec.dependency_type is int


### PR DESCRIPTION
There are 2 main things updated in the runtime type-checker of the dependency injection module.
- ``NewType`` instance check.
  It was using it's own `NewTypeProtocol` for `NewType` instance check,
  since it is a function object for python version 3.9 or below.
  However, from python version 3.10 or above, ``NewType`` actually returns a class object.
- ``extract_underlying_type``: Extracting runtime type of the ``NewType``.
  Now it retrieves ``__supertype__`` recursively of the ``NewType`` to extract runtime returned type.
  It is mainly for checking the compatibility between a type and the provider.

And another minor thing is that ``extract_dependency_type`` is now a static method of the ``DependencySpec`` so that it is not confused with ``extract_underlying_type``.