### PR TITLE
Benchmark session/runner helper.

### DIFF
--- a/tests/benchmarks/environments.py
+++ b/tests/benchmarks/environments.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import pathlib
+import platform
+import uuid
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import NewType
+
+from beamlime.constructors import ProviderGroup
+
+env_providers = ProviderGroup()
+
+OperatingSystem = NewType("OperatingSystem", str)
+OperatingSystemVersion = NewType("OperatingSystemVersion", str)
+PlatformDesc = NewType("PlatformDesc", str)
+MachineType = NewType("MachineType", str)
+TotalMemory = namedtuple('TotalMemory', ['value', 'unit'])
+
+
+env_providers[OperatingSystem] = platform.system
+env_providers[OperatingSystemVersion] = platform.version
+env_providers[PlatformDesc] = platform.platform
+env_providers[MachineType] = platform.machine
+
+
+@env_providers.provider
+def provide_totalmemory_gb() -> TotalMemory:
+    import psutil
+
+    return TotalMemory(int(psutil.virtual_memory().total / 10**9), 'GB')
+
+
+@env_providers.provider
+@dataclass
+class HardwareSpec:
+    """
+    Collection of the hardware profile.
+    OS, OS version, platform, machine type and memory.
+    """
+
+    operating_system: OperatingSystem
+    operating_system_version: OperatingSystemVersion
+    platform_desc: PlatformDesc
+    machine_type: MachineType
+    total_memory: TotalMemory
+
+
+GitRootDir = NewType("GitRoot", pathlib.Path)
+BenchmarkRootDir = NewType("BenchmarkRootPath", pathlib.Path)
+BenchmarkSessionID = NewType("BenchmarkSessionID", str)
+GitCommitID = NewType("GitCommitID", str)
+DateTimeSuffix = NewType("DateTimeSuffix", str)
+BenchmarkTargetName = NewType("BenchmarkTargetName", str)
+BenchmarkResultFilePath = NewType("BenchmarkResultFilePath", pathlib.Path)
+
+
+env_providers[BenchmarkSessionID] = lambda: uuid.uuid4().hex
+
+
+@env_providers.provider
+def provide_git_root() -> GitRootDir:
+    import subprocess
+
+    command = ['git', 'rev-parse', '--show-toplevel']
+    command_result = subprocess.run(command, stdout=subprocess.PIPE, text=True)
+    git_root_path = pathlib.Path(command_result.stdout.removesuffix('\n'))
+    return GitRootDir(git_root_path)
+
+
+@env_providers.provider
+def provide_git_commit_id() -> GitCommitID:
+    import subprocess
+
+    command = ['git', 'rev-parse', 'HEAD']
+    command_result = subprocess.run(command, stdout=subprocess.PIPE, text=True)
+    return GitCommitID(command_result.stdout.removesuffix('\n'))
+
+
+@env_providers.provider
+def provide_benchmark_root(git_root_path: GitRootDir) -> BenchmarkRootDir:
+    """
+    >>> provide_benchmark_root('./')
+    PosixPath('.benchmarks')
+    """
+    return BenchmarkRootDir(git_root_path / pathlib.Path('.benchmarks'))
+
+
+@env_providers.provider
+def provide_now() -> DateTimeSuffix:
+    from datetime import datetime
+
+    return DateTimeSuffix(datetime.utcnow().isoformat(timespec='seconds'))
+
+
+@env_providers.provider
+def provide_new_file_path(
+    prefix_timestamp: DateTimeSuffix, bm_root_dir: BenchmarkRootDir
+) -> BenchmarkResultFilePath:
+    return BenchmarkResultFilePath(
+        bm_root_dir / pathlib.Path(f'result-{prefix_timestamp}.json')
+    )
+
+
+@env_providers.provider
+@dataclass
+class BenchmarkEnvironment:
+    benchmark_run_id: BenchmarkSessionID  # Unique ID for each benchmark test.
+    git_commit_id: GitCommitID  # Git commit ID of the current implementation.
+    timestamp: DateTimeSuffix
+    hardware_spec: HardwareSpec

--- a/tests/benchmarks/runner.py
+++ b/tests/benchmarks/runner.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from typing import Callable, Generic, NewType, Optional, TypeVar
+
+import scipp as sc
+
+from beamlime.constructors import Factory, ProviderGroup
+
+from .environments import (
+    BenchmarkEnvironment,
+    BenchmarkResultFilePath,
+    BenchmarkTargetName,
+    env_providers,
+)
+
+
+@dataclass
+class TimeMeasurement:
+    """Time measurement results."""
+
+    value: float
+    unit: str
+
+
+@dataclass
+class SpaceMeasurement:
+    """Memory measurement results."""
+
+    value: float
+    unit: str
+
+
+@dataclass
+class BenchmarkResult:  # Measurement results should always have value and unit.
+    time: TimeMeasurement
+    space: Optional[SpaceMeasurement] = None
+
+
+_Item = TypeVar("_Item")
+
+
+def _append_row(
+    obj: dict[str, list[Optional[_Item]]], row: dict[str, _Item]
+) -> dict[str, list[Optional[_Item]]]:
+    """
+    Helper function to extend Pandas Dataframe-like dictionary.
+    All columns(Corresponding to the highest level keys)
+    in the ``obj`` should always have the same length of rows.
+    """
+    # Reference count of rows.
+    _ref = min(len(v) for _, v in obj.items()) if obj else 0
+
+    for missing_k in (k for k in obj.keys() if k not in row):
+        # Append ``None`` if there is an existing key
+        # that does not exist in ``row``.
+        obj[missing_k].append(None)
+
+    for k, v in row.items():
+        # Fills with ``[None]*_ref`` if there is a new key
+        # that does not exist in the ``obj``.
+        obj.setdefault(k, [None] * _ref).append(v)
+
+    return obj
+
+
+R = TypeVar("R")
+
+
+@dataclass
+class SingleRunReport(Generic[R]):
+    callable_name: BenchmarkTargetName
+    benchmark_result: BenchmarkResult
+    arguments: dict
+    output: Optional[R] = None
+
+
+@dataclass  # Need dataclass decorator to use ``as_dict``.
+class BenchmarkReport:
+    """Benchmark report template."""
+
+    environment: BenchmarkEnvironment
+    target_names: list[BenchmarkTargetName]
+    measurements: dict[str, dict[str, list]]
+    arguments: dict[str, list]
+
+    def __init__(self) -> None:
+        self.target_names = list()
+        self.measurements = dict()
+        self.arguments = dict()
+
+    def append_measurement(self, result: BenchmarkResult) -> None:
+        measurement = asdict(result)
+        for meas_dim in measurement:
+            _append_row(
+                self.measurements.setdefault(meas_dim, dict(value=[], unit=[])),
+                measurement.get(meas_dim) or dict(value=None, unit=None),
+            )
+
+    def append(self, single_run_result: SingleRunReport) -> None:
+        self.target_names.append(single_run_result.callable_name)
+        self.append_measurement(single_run_result.benchmark_result)
+        _append_row(self.arguments, single_run_result.arguments)
+
+    def asdataset(self) -> sc.Dataset:
+        from .calculations import (
+            dict_to_scipp_scalar_column,
+            list_to_scipp_scalar_column,
+        )
+
+        return sc.Dataset(
+            data={
+                dim: sc.concat(dict_to_scipp_scalar_column(val_unit), dim='run')
+                for dim, val_unit in self.measurements.items()
+            },
+            coords={
+                arg_name: sc.concat(list_to_scipp_scalar_column(arg_values), dim='run')
+                for arg_name, arg_values in self.arguments.items()
+            },
+        )
+
+
+class BenchmarkRunner(ABC):
+    """Abstract benchmark runner class."""
+
+    @abstractmethod
+    def __call__(self, *args, **kwargs) -> SingleRunReport:
+        """Runner interface called by ``BenchmarkSession``.
+
+        BenchmarkRunner should always return a ``SingleRunReport``
+        which contains the returned value(object) of the call.
+        """
+        ...
+
+
+class SimpleRunner(BenchmarkRunner):
+    """Benchmark runner that simply measures duration of a function call."""
+
+    def __call__(self, func: Callable[..., R], *args, **kwargs) -> SingleRunReport[R]:
+        import inspect
+        import time
+
+        start = time.time()
+        call_result = func(*args, **kwargs)
+        stop = time.time()
+
+        function_name = func.__qualname__
+        function_arguments = inspect.signature(func).bind(*args, **kwargs).arguments
+
+        return SingleRunReport(
+            BenchmarkTargetName(function_name),
+            BenchmarkResult(time=TimeMeasurement(value=stop - start, unit='s')),
+            arguments=function_arguments,
+            output=call_result,
+        )
+
+
+class BenchmarkFileManager(ABC):
+    """Abstract file manager with ``save``/``load`` methods pair."""
+
+    def __init__(self, file_path: BenchmarkResultFilePath) -> None:
+        self.file_path = file_path
+
+    @abstractmethod
+    def save(
+        self, report: BenchmarkReport, path: Optional[BenchmarkResultFilePath] = None
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def load(self, path: Optional[BenchmarkResultFilePath] = None) -> BenchmarkReport:
+        ...
+
+
+class SimpleFileManager(BenchmarkFileManager):
+    def save(self, report: BenchmarkReport) -> None:
+        import json
+
+        self.file_path.write_text(json.dumps(asdict(report), indent=2) + '\n')
+
+    def load(self) -> BenchmarkReport:
+        import json
+
+        return BenchmarkReport(**json.loads(self.file_path.read_text()))
+
+
+BenchmarkIterations = NewType("BenchmarkIterations", int)
+
+
+@dataclass
+class BenchmarkSessionConfiguration:
+    iterations: BenchmarkIterations = BenchmarkIterations(1)
+
+
+@dataclass
+class BenchmarkSession:
+    """Benchmark session handling class.
+
+    ``run`` and ``save`` methods use
+    ``BenchmarkReport``, ``BenchmarkRunner`` and ``BenchmarkFileManager``
+    to run the benchmark test and save the result.
+
+    ``run`` calls ``BenchmarkRunner``(Callable)
+    to generate a single benchmark report (``SingleRunReport``)
+    and append the result to the ``BenchmarkReport``.
+
+    ``save`` calls  ``file_manager.save`` with its ``report``,
+    so that ``BenchmarkFileManager`` can dump the result into a file.
+
+    Configurable options should be handled by ``BenchmarkSessionConfiguration``
+    instead of having extra arguments in ``run`` methods.
+    So that all arguments of ``run`` can be directly passed to ``BenchmarkRunner``.
+
+    Context manager method ``configure`` allows to temporarily replace those options.
+    """
+
+    report: BenchmarkReport
+    runner: BenchmarkRunner
+    file_manager: BenchmarkFileManager
+    configurations: BenchmarkSessionConfiguration
+
+    def _update_configurations(self, **configs) -> None:
+        for config_name, config_value in configs.items():
+            setattr(self.configurations, config_name, config_value)
+
+    @contextmanager
+    def configure(self, **tmp_configurations):
+        """Temporarily replaces the session configurations.
+
+        See ``BenchmarkSessionConfiguration`` for available options.
+        """
+        original_configurations = {
+            config_name: getattr(self.configurations, config_name)
+            for config_name in tmp_configurations
+        }
+        self._update_configurations(**tmp_configurations)
+        yield None
+        self._update_configurations(**original_configurations)
+
+    def run(self, *runner_args, **parameters):
+        for i_iter in range(1, self.configurations.iterations + 1):
+            single_report = self.runner(*runner_args, **parameters)
+            self.report.append(single_report)
+            if i_iter == self.configurations.iterations:
+                return single_report.output
+
+    def save(self):
+        self.file_manager.save(self.report)
+
+
+def create_benchmark_runner_factory(
+    runner_type: type[BenchmarkRunner] = SimpleRunner,
+) -> Factory:
+    session_providers = ProviderGroup()
+    session_providers[BenchmarkSession] = BenchmarkSession
+    session_providers[BenchmarkReport] = BenchmarkReport
+    session_providers[BenchmarkRunner] = runner_type
+    session_providers[BenchmarkFileManager] = SimpleFileManager
+    session_providers[BenchmarkSessionConfiguration] = BenchmarkSessionConfiguration
+    return Factory(env_providers, session_providers)

--- a/tests/benchmarks/runner.py
+++ b/tests/benchmarks/runner.py
@@ -5,8 +5,6 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from typing import Callable, Generic, NewType, Optional, TypeVar
 
-import scipp as sc
-
 from beamlime.constructors import Factory, ProviderGroup
 
 from .environments import (
@@ -103,23 +101,6 @@ class BenchmarkReport:
         self.target_names.append(single_run_result.callable_name)
         self.append_measurement(single_run_result.benchmark_result)
         _append_row(self.arguments, single_run_result.arguments)
-
-    def asdataset(self) -> sc.Dataset:
-        from .calculations import (
-            dict_to_scipp_scalar_column,
-            list_to_scipp_scalar_column,
-        )
-
-        return sc.Dataset(
-            data={
-                dim: sc.concat(dict_to_scipp_scalar_column(val_unit), dim='run')
-                for dim, val_unit in self.measurements.items()
-            },
-            coords={
-                arg_name: sc.concat(list_to_scipp_scalar_column(arg_values), dim='run')
-                for arg_name, arg_values in self.arguments.items()
-            },
-        )
 
 
 class BenchmarkRunner(ABC):

--- a/tests/benchmarks/runner_test.py
+++ b/tests/benchmarks/runner_test.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import pathlib
+from typing import Callable
+
+import pytest
+
+from .environments import BenchmarkResultFilePath
+from .runner import BenchmarkRunner, BenchmarkSession, R, SingleRunReport
+
+
+class TestRunner(BenchmarkRunner):
+    """Test runner that always has 0 as a time measurement result."""
+
+    def __call__(self, func: Callable[..., R], **kwargs) -> SingleRunReport[R]:
+        from .runner import BenchmarkResult, BenchmarkTargetName, TimeMeasurement
+
+        return SingleRunReport(
+            BenchmarkTargetName(func.__qualname__),
+            BenchmarkResult(TimeMeasurement(0, 's')),
+            arguments=kwargs,
+            output=func(**kwargs),
+        )
+
+
+@pytest.fixture(scope='function')
+def benchmark_tmp_path(tmp_path: pathlib.Path) -> BenchmarkResultFilePath:
+    from .environments import BenchmarkRootDir
+    from .runner import create_benchmark_runner_factory
+
+    factory = create_benchmark_runner_factory()
+    with factory.constant_provider(BenchmarkRootDir, tmp_path):
+        return factory[BenchmarkResultFilePath]
+
+
+@pytest.fixture(scope='function')
+def benchmark(benchmark_tmp_path: BenchmarkResultFilePath):
+    from .runner import BenchmarkSession, create_benchmark_runner_factory
+
+    factory = create_benchmark_runner_factory(runner_type=TestRunner)
+    with factory.constant_provider(BenchmarkResultFilePath, benchmark_tmp_path):
+        session = factory[BenchmarkSession]
+        yield session
+        if not session.report.measurements:
+            raise RuntimeError("No results!")
+
+
+def _load_results(benchmark_tmp_path: BenchmarkResultFilePath) -> dict:
+    import json
+
+    return json.loads(benchmark_tmp_path.read_text())
+
+
+def test_benchmark_runner(
+    benchmark: BenchmarkSession, benchmark_tmp_path: BenchmarkResultFilePath
+):
+    def sample_func(a: int) -> int:
+        return a
+
+    assert benchmark.run(sample_func, a=1) == 1
+    benchmark.save()
+    saved = _load_results(benchmark_tmp_path)
+    assert saved['measurements']['time']['value'] == [0]
+    assert saved['arguments']['a'] == [1]
+
+
+def test_benchmark_runner_multi_arguments(
+    benchmark: BenchmarkSession, benchmark_tmp_path: BenchmarkResultFilePath
+):
+    def sample_func(a: int, **_) -> int:  # Allows arbitrary keyword arguments
+        return a
+
+    assert benchmark.run(sample_func, a=1) == 1
+    assert benchmark.run(sample_func, a=1, b=1) == 1
+    benchmark.save()
+    saved = _load_results(benchmark_tmp_path)
+    assert saved['measurements']['time']['value'] == [0, 0]
+    assert saved['arguments']['a'] == [1, 1]
+    assert saved['arguments']['b'] == [None, 1]
+
+
+def test_benchmark_runner_multi_iterations(
+    benchmark: BenchmarkSession, benchmark_tmp_path: BenchmarkResultFilePath
+):
+    def sample_func(a: int) -> int:
+        return a
+
+    with benchmark.configure(iterations=3):
+        assert benchmark.run(sample_func, a=1) == 1
+
+    benchmark.save()
+    saved = _load_results(benchmark_tmp_path)
+    assert len(saved['measurements']['time']['value']) == 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,12 @@ import pytest
 
 
 def pytest_addoption(parser: pytest.Parser):
+    parser.addoption("--benchmark-test", action="store_true", default=False)
     parser.addoption("--full-benchmark", action="store_true", default=False)
     parser.addoption("--kafka-test", action="store_true", default=False)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def kafka_test(request: pytest.FixtureRequest) -> bool:
     """
     Requires --kafka-test flag.
@@ -23,15 +24,31 @@ def kafka_test(request: pytest.FixtureRequest) -> bool:
     return True
 
 
-@pytest.fixture
-def full_benchmark(request: pytest.FixtureRequest) -> bool:
+@pytest.fixture(scope='session')
+def benchmark_test(request: pytest.FixtureRequest) -> bool:
     """
-    Requires --full-benchmark flag.
+    Requires --benchmark-test flag.
     """
-    if not request.config.getoption('--full-benchmark'):
+    if not (
+        request.config.getoption('--benchmark-test')
+        or request.config.getoption('--full-benchmark-test')
+    ):
+        pytest.skip(
+            "Skipping benchmark. " "Use ``--benchmark-test`` option to run this test."
+        )
+
+    return True
+
+
+@pytest.fixture(scope='session')
+def full_benchmark_test(request: pytest.FixtureRequest) -> bool:
+    """
+    Requires --full-benchmark-test flag.
+    """
+    if not request.config.getoption('--full-benchmark-test'):
         pytest.skip(
             "Skipping full benchmark. "
-            "Use ``--full-benchmark`` option to run this test."
+            "Use ``--full-benchmark-test`` option to run this test."
         )
 
     return True

--- a/tests/prototypes/parameters.py
+++ b/tests/prototypes/parameters.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from dataclasses import dataclass
-from typing import NewType
+from typing import NewType, TypeVar
 
 from beamlime.constructors import ProviderGroup
 
@@ -16,29 +16,54 @@ NumFrames = NewType("NumFrames", int)  # [dimensionless]
 ChunkSize = NewType("ChunkSize", int)
 HistogramBinSize = NewType("HistogramBinSize", int)
 
-
-default_param_providers = ProviderGroup()
-default_params = {
-    RandomSeed: 123,
-    FrameRate: 14,
-    NumFrames: 140,
-    ChunkSize: 28,
-    HistogramBinSize: 50,
-}
-
-default_param_providers[RandomSeed] = lambda: default_params[RandomSeed]
-default_param_providers[FrameRate] = lambda: default_params[FrameRate]
-default_param_providers[NumFrames] = lambda: default_params[NumFrames]
-default_param_providers[ChunkSize] = lambda: default_params[ChunkSize]
-default_param_providers[HistogramBinSize] = lambda: default_params[HistogramBinSize]
+P = TypeVar("P")
 
 
 @dataclass
-class BenchmarkParameters:
-    num_pixels: NumPixels
-    event_rate: EventRate
-    num_frames: NumFrames
-    frame_rate: FrameRate
+class TypedParameterContainerMixin:
+    @property
+    def name_type_map(self) -> dict[str, type]:
+        from typing import get_type_hints
+
+        annotations = get_type_hints(self.__class__)
+        return annotations
+
+    @property
+    def type_name_map(self) -> dict[type, str]:
+        return {
+            field_type: field_name
+            for field_name, field_type in self.name_type_map.items()
+        }
+
+    def as_type_dict(self) -> dict[type[P], P]:
+        from dataclasses import asdict
+
+        type_name_map = self.type_name_map
+        values = asdict(self)
+        return {
+            field_type: values[field_name]
+            for field_type, field_name in type_name_map.items()
+        }
 
 
-default_param_providers[BenchmarkParameters] = BenchmarkParameters
+@dataclass
+class PrototypeParameters(TypedParameterContainerMixin):
+    """All configurable parameters for prototypes."""
+
+    num_pixels: NumPixels = NumPixels(10_000)
+    event_rate: EventRate = EventRate(10_000)
+    histogram_bin_size: HistogramBinSize = HistogramBinSize(50)
+    chunk_size: ChunkSize = ChunkSize(28)
+    frame_rate: FrameRate = FrameRate(14)
+    num_frames: NumFrames = NumFrames(140)
+    random_seed: RandomSeed = RandomSeed(123)
+
+
+def collect_default_param_providers():
+    from functools import partial
+
+    default_param_providers = ProviderGroup()
+    for param_type, param_default_value in PrototypeParameters().as_type_dict().items():
+        default_param_providers[param_type] = partial(lambda x: x, param_default_value)
+
+    return default_param_providers

--- a/tests/prototypes/prototype_test.py
+++ b/tests/prototypes/prototype_test.py
@@ -1,18 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
 
 from beamlime.constructors import Factory
 
-from .prototype_mini import (
-    BaseApp,
-    StopWatch,
-    TargetCounts,
-    VisualizationDaemon,
-    run_prototype,
-)
+from ..benchmarks.runner import BenchmarkSession
+from .parameters import PrototypeParameters
 
 
 @pytest.fixture
@@ -24,40 +19,58 @@ def mini_factory() -> Generator[Factory, None, None]:
 
 @pytest.fixture
 def kafka_factory(kafka_test: bool) -> Generator[Factory, None, None]:
-    from .prototype_kafka import KafkaTopicDeleted, kafka_prototype_factory
+    from .prototype_kafka import kafka_prototype_factory
 
     assert kafka_test
-    kafka = kafka_prototype_factory()
-    yield kafka
-    assert kafka[KafkaTopicDeleted]
+    yield kafka_prototype_factory()
 
 
-def prototype_test_helper(prototype_factory: Factory, reference_app_tp: type[BaseApp]):
-    from .parameters import ChunkSize, EventRate, NumFrames, NumPixels
+def prototype_test_helper(prototype_factory: Factory):
+    from .prototype_mini import PrototypeBenchmarkRecipe, PrototypeRunner
 
-    # No laps recorded.
-    assert len(prototype_factory[StopWatch].lap_counts) == 0
+    prototype_runner = PrototypeRunner()
 
-    num_frames = 140
-    chunk_size = 28
-    run_prototype(
-        prototype_factory=prototype_factory,
-        parameters={
-            EventRate: 10**4,
-            NumPixels: 10**4,
-            NumFrames: num_frames,
-            ChunkSize: chunk_size,
-        },
-    )
-    stop_watch = prototype_factory[StopWatch]
-    reference_app_name = prototype_factory[reference_app_tp].app_name
-    assert prototype_factory[TargetCounts] == int(num_frames / chunk_size)
-    assert stop_watch.lap_counts[reference_app_name] == prototype_factory[TargetCounts]
+    recipe = PrototypeBenchmarkRecipe(params=PrototypeParameters())
+    prototype_runner(prototype_factory.providers, recipe)
 
 
 def test_mini_prototype(mini_factory: Factory):
-    prototype_test_helper(mini_factory, VisualizationDaemon)
+    prototype_test_helper(mini_factory)
 
 
 def test_kafka_prototype(kafka_factory: Factory):
-    prototype_test_helper(kafka_factory, VisualizationDaemon)
+    prototype_test_helper(kafka_factory)
+
+
+@pytest.fixture(scope='session')
+def prototype_benchmark(benchmark_test: bool) -> Generator[BenchmarkSession, Any, Any]:
+    from ..benchmarks.runner import BenchmarkRunner, create_benchmark_runner_factory
+    from .prototype_mini import PrototypeRunner
+
+    assert benchmark_test
+
+    benchmark_factory = create_benchmark_runner_factory()
+    with benchmark_factory.temporary_provider(BenchmarkRunner, PrototypeRunner):
+        benchmark_session = benchmark_factory[BenchmarkSession]
+        yield benchmark_session
+
+        benchmark_session.save()
+
+
+def test_mini_prototype_benchmark(prototype_benchmark: BenchmarkSession):
+    from .prototype_mini import (
+        BenchmarkTargetName,
+        PrototypeBenchmarkRecipe,
+        mini_prototype_factory,
+    )
+
+    recipe = PrototypeBenchmarkRecipe(
+        params=PrototypeParameters(), optional_parameters={'test-run': True}
+    )
+
+    with prototype_benchmark.configure(iterations=3):
+        prototype_benchmark.run(
+            mini_prototype_factory().providers,
+            recipe,
+            BenchmarkTargetName('mini_prototype'),
+        )


### PR DESCRIPTION
I put all the benchmark helper modules/functions under `tests/benchmarks`.

Loading benchmark results, visualizing and more pre-defined benchmark functions will be in the next PR.

## Context (The reason why not using existing ones.)

Existing benchmark helpers, extensions interfaces accept callable and arguments
so that they can run the callable object with arguments
and then save it to the session object or returns the benchmark results.

However, with `beamlime`, we build an application by dependency injection,
which means most of the arguments should be already defined when we build the callable object,
not when the callable object is called.

So, if we include the building stages in the benchmark, then it will include non-trivial time consuming computation which is not in our interest of benchmarking, and we would need to exclude the overhead.

Therefore we needed a benchmark helper that
- accepts different parameters/arguments and build the application from them 
- only measures the performance of the processes of our interest.
- works with async calls.

## Review points
- ``tests/benchmarks/runner.py``
The `BenchmarkSession` class is a bridge object that has a container of benchmark reports, and benchmark runner, file manager and configurations.
The benchmark reports(`BenchmarkReports`), file manager (`BenchmarkFileManager`) and configurations (`BenchmarkSessionConfiguration`) are not expected to be replaced with custom ones.

However, the benchmark runner (``BenchmarkRunner``) are meant to be replaced with custom runners so it is abstract class.

``SimpleRunner`` demonstrates what a runner should do,
and it is similar to existing benchmark helpers that measure consumed time of a callable object to be completed.

- `tests/prototypes/prototype_mini.py`
The runner for workflow prototype (`PrototypeRunner`) is in this file.

- `tests/prototypes/prototpye_test.py`
It has benchmark session object generator as a fixture and use ``PrototypeRunner`` to run a prototype.

## Benchmark result example
Here is the benchmark result saved under `.benchmarks` from the command `pytest --benchmark-test`.

```json
{
  "environment": {
    "benchmark_run_id": "1bf01bbc31d44c7998cc0b401ce8aba4",
    "git_commit_id": "7aa6d01eab0b8b1e44657e77e58fa47246d69b5b",
    "timestamp": "2023-11-06T09:25:47",
    "hardware_spec": {
      "operating_system": "Linux",
      "operating_system_version": "#34~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Sep  7 13:12:03 UTC 2",
      "platform_desc": "Linux-6.2.0-34-generic-x86_64-with-glibc2.35",
      "machine_type": "x86_64",
      "total_memory": [134, "GB"]
    }
  },
  "target_names": ["mini_prototype", "mini_prototype", "mini_prototype"],
  "measurements": {
    "time": {
      "value": [0.0913536548614502, 0.08919787406921387, 0.09025907516479492],
      "unit": ["s", "s", "s"]
    },
    "space": {
      "value": [null, null, null],
      "unit": [null, null, null]
    }
  },
  "arguments": {
    "num_pixels": [10000, 10000, 10000],
    "event_rate": [10000, 10000, 10000],
    "histogram_bin_size": [50, 50, 50],
    "chunk_size": [28, 28, 28],
    "frame_rate": [14, 14, 14],
    "num_frames": [140, 140, 140],
    "random_seed": [123, 123, 123],
    "test-run": [true, true, true]
  }
}

```