### PR TITLE
Final proposal of ``MessageProtocol``

### DIFF
--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -2,21 +2,21 @@
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 import pathlib
 from dataclasses import dataclass
-from typing import Any, NewType
+from typing import Any, Mapping, NewType
 
 import scipp as sc
 
 from beamlime.logging import BeamlimeLogger
 
 from ..stateless_workflow import StatelessWorkflow, WorkflowResult
-from .base import HandlerInterface, MessageProtocol
+from .base import HandlerInterface, MessageBase, MessageProtocol
 
 Events = NewType("Events", list[sc.DataArray])
 
 
 @dataclass
-class WorkflowResultUpdate:
-    content: WorkflowResult
+class WorkflowResultUpdate(MessageBase):
+    kwargs: Mapping[str, WorkflowResult]
 
 
 class DataReductionHandler(HandlerInterface):
@@ -30,10 +30,9 @@ class DataReductionHandler(HandlerInterface):
         # TODO remove ties to specific type of data
         return f"{len(data)} pieces of {Events.__name__}"
 
-    def process_message(self, message: MessageProtocol) -> MessageProtocol:
-        content = message.content
-        self.info("Received, %s", self.format_received(content))
-        return WorkflowResultUpdate(content=self.workflow(content))
+    def process_message(self, chunk: Mapping) -> MessageProtocol:
+        self.info("Received, %s", self.format_received(chunk))
+        return WorkflowResultUpdate(kwargs=self.workflow(chunk))
 
 
 ImagePath = NewType("ImagePath", pathlib.Path)
@@ -64,9 +63,8 @@ class PlotStreamer(HandlerInterface):
         else:
             figure.update(data, key=self.artists[name])
 
-    def update_histogram(self, message: MessageProtocol) -> None:
-        content = message.content
-        for name, data in content.items():
+    def update_histogram(self, **plottables) -> None:
+        for name, data in plottables.items():
             self.plot_item(name, data)
 
 
@@ -77,8 +75,8 @@ class PlotSaver(PlotStreamer):
         super().__init__(logger)
         self.image_path = image_path
 
-    def save_histogram(self, message: MessageProtocol) -> None:
-        super().update_histogram(message)
+    def save_histogram(self, **plottables) -> None:
+        super().update_histogram(**plottables)
         self.info("Received histogram, saving into %s...", self.image_path)
         for name, figure in self.figures.items():
             figure.save(f'{self.image_path}-{name}.png')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,3 +78,11 @@ def default_factory() -> Factory:
     from beamlime.logging.providers import log_providers
 
     return Factory(log_providers)
+
+
+@pytest.fixture
+def mock_logger():
+    import logging
+    from unittest.mock import MagicMock
+
+    return MagicMock(spec=logging.Logger)


### PR DESCRIPTION
I propose that this should be the final shape of the `MessageProtocol`.

It now carries ``args: tuple``  and ``kwargs: dict``, which are positional arguments and key-word arguments respectively.

https://github.com/scipp/beamlime/blob/45832a9b9a9e9094814af3bb59fc11cc4750f889/src/beamlime/applications/base.py#L30-L35

So that the ``MessageRouter`` can directly call the handlers by unpacking those arguments like this.
https://github.com/scipp/beamlime/blob/45832a9b9a9e9094814af3bb59fc11cc4750f889/src/beamlime/applications/base.py#L144

Here are some pros&cons. And I tried to argue with the ``cons`` myself : D

## Pros
- ``handling method`` don't have to know about the ``MessageProtocol``.
  ``handling method``s don't have to receive ``Message`` object itself, so you can write a regular method and use it as a handler.
  It means, you don't necessarily have to ``wrap`` an existing function/method to make handler.
  You might still have to wrap it if it needs to return a ``Message`` as a handler, but not as a regular method.
- More loose condition of registering ``handling method`` (related to the previous one)
- More explicit type annotations when you populate the message, if you want.

## Cons
- Type annotation might be more verbose or confusing and duplicating.
   Now that there are two fields in the message, which can replace each other (if you are expecting the handlers to accept arguments in both positional, key-word based)
  And if an expected handler requires many arguments, and you want to annotate all of them, it might be very verbose.
  In that case, we can maybe use a typed dict.
- Not strict shape of handling method.
  Since now the arguments are more flexible, it might require more work to make the messages compatible with the handlers and vice versa.
  But it's always the case, the proposed protocol just makes it fails earlier in the router, not in the handler.
- Can't accept subset of arguments and ignore the rest after receiving the message.
   For example, if you want to trigger the handler but you don't need any of the arguments, (Maybe they are meant for other handlers) the handlers still need to have at least ``*args``, ``**kwargs``.
   But it also means that it can simply pick up subset of the arguments by the method definition itself, without filtering them in the handler.