### PR TITLE
Support dynamic registration of handlers.

### DIFF
--- a/tests/applications/test_application_handlers.py
+++ b/tests/applications/test_application_handlers.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+# Tests builtin handlers of ``beamlime.applications.Application``.
+from typing import AsyncGenerator, Optional
+from unittest.mock import MagicMock
+
+from beamlime.applications.base import (
+    Application,
+    DaemonInterface,
+    MessageBase,
+    MessageProtocol,
+    MessageRouter,
+)
+
+
+class SimpleDaemon(DaemonInterface):
+    class SimpleMessage(MessageBase):
+        ...
+
+    def __init__(self) -> None:
+        self.test_flag = False
+
+    def test_handler(self) -> None:
+        self.test_flag = True
+
+    async def run(self) -> AsyncGenerator[Optional[MessageProtocol], None]:
+        yield Application.RegisterHandler(
+            kwargs={'event_tp': self.SimpleMessage, 'handler': self.test_handler}
+        )  # Register the handler
+        yield self.SimpleMessage()  # Try triggering the handler
+        yield Application.Stop(args=(self.__class__,))  # Stop the application
+
+
+def test_dynamic_handler_registration(mock_logger: MagicMock) -> None:
+    # Build the application
+    message_router = MessageRouter()
+    message_router.logger = mock_logger
+    daemon = SimpleDaemon()
+    app = Application(mock_logger, message_router)
+
+    # Check the clean state
+    assert not daemon.test_flag
+    app.register_daemon(daemon)
+    assert daemon.SimpleMessage not in app.message_router.handlers
+
+    # Run the daemon and check the state
+    app.run()
+    assert daemon.test_handler in app.message_router.handlers[daemon.SimpleMessage]
+    assert daemon.test_flag


### PR DESCRIPTION
This feature was needed for allowing daemons to separate some tasks from the ``run`` routine.

For example, ``KafkaListener`` might need to handle arbitrary types of messages according to the ``run_start_message``.
With this change, ``KafkaListener`` can now register handlers whenever it receives ``run_start_message`` and don't have to handle them in the ``run`` routine. 
It can simply wrap received messages as a certain types of ``MessageProtocol`` and yield them, 
instead of wrap them **and** handle them within the routine.