### PR TITLE
Fix benchmark helper for MacOS.

### DIFF
--- a/tests/helpers/tests/benchmarks/environments.py
+++ b/tests/helpers/tests/benchmarks/environments.py
@@ -58,8 +58,14 @@ def provide_total_cpu_cores() -> LogicalCpuCores:
 @env_providers.provider
 def provide_process_cpu_affinity() -> ProcessCpuAffinity:
     """Process CPU affinity."""
-
-    return ProcessCpuAffinity(len(psutil.Process().cpu_affinity() or []), 'counts')
+    try:
+        return ProcessCpuAffinity(len(psutil.Process().cpu_affinity() or []), 'counts')
+    except AttributeError:
+        # In MacOS, the `cpu_affinity` attribute is not available.
+        # It is not easy to assign specific number of CPU cores to the process in MacOS.
+        # Therefore we can assume that the process can use all available physical cores
+        # when we analyze the benchmark results.
+        return ProcessCpuAffinity(None, 'counts')
 
 
 @env_providers.provider


### PR DESCRIPTION
``psutil`` doesn't support ``cpu_affinity`` in ``MacOS``.

It's not important/urgent but it was annoying when I run ``tox`` tests/docs build... 