### PR TITLE
Copier update.

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 9c3feff
+_commit: 37fea4d
 _src_path: gh:scipp/copier_template
 description: Live data reduction visualisation framework for ESS.
 max_python: '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
 name: CI
 
 on:
@@ -24,7 +21,7 @@ jobs:
         run: |
           echo "min_python=$(cat .github/workflows/python-version-ci)" >> $GITHUB_OUTPUT
           echo "min_tox_env=py$(cat .github/workflows/python-version-ci | sed 's/\.//g')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
 name: Docs
 
 on:
@@ -51,7 +48,7 @@ jobs:
         with:
           ref: ${{ inputs.branch == '' && github.ref_name || inputs.branch }}
           fetch-depth: 0  # history required so cmake can determine version
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
       - run: python -m pip install --upgrade pip
@@ -62,7 +59,7 @@ jobs:
         if: ${{ inputs.version == '' }}
       - run: tox -e linkcheck
         if: ${{ inputs.linkcheck }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docs_html
           path: html/

--- a/.github/workflows/nightly_at_main.yml
+++ b/.github/workflows/nightly_at_main.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
 name: Nightly test at main branch
 
 on:

--- a/.github/workflows/nightly_at_release.yml
+++ b/.github/workflows/nightly_at_release.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
 name: Nightly tests at latest release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
 name: Release
 
 on:
@@ -31,7 +28,7 @@ jobs:
             boa
       - run: conda mambabuild --channel conda-forge --channel scipp --no-anaconda-upload --override-channels --output-folder conda/package conda
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: conda-package-noarch
           path: conda/package/noarch/*.tar.bz2
@@ -45,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0  # history required so setuptools_scm can determine version
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
 
@@ -56,7 +53,7 @@ jobs:
         run: python -m build
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -71,7 +68,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v3
-      - uses: pypa/gh-action-pypi-publish@v1.8.12
+      - uses: pypa/gh-action-pypi-publish@v1.8.14
 
   upload_conda:
     name: Deploy Conda

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
 name: Test
 
 on:
@@ -57,7 +54,7 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r ${{ inputs.pip-recipe }}
       - run: tox -e ${{ inputs.tox-env }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ inputs.coverage-report }}
         with:
           name: CoverageReport

--- a/.github/workflows/unpinned.yml
+++ b/.github/workflows/unpinned.yml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
 name: Unpinned tests at latest release
 
 on:

--- a/docs/_templates/doc_version.html
+++ b/docs/_templates/doc_version.html
@@ -1,2 +1,2 @@
 <!-- This will display the version of the docs -->
-Current {{ project }} version: {{ version }} (<a href="https://github.com/scipp/{{ project|lower }}/releases">older versions</a>).
+Current {{ project }} version: {{ version }} (<a href="https://github.com/{{orgname}}/{{ project|lower }}/releases">older versions</a>).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,12 +30,14 @@ extensions = [
     'nbsphinx',
     'myst_parser',
 ]
+
 try:
     import sciline.sphinxext.domain_types  # noqa: F401
 
     extensions.append('sciline.sphinxext.domain_types')
 except ModuleNotFoundError:
     pass
+
 
 myst_enable_extensions = [
     "amsmath",
@@ -81,6 +83,7 @@ napoleon_type_aliases = {
 typehints_defaults = 'comma'
 typehints_use_rtype = False
 
+
 sciline_domain_types_prefix = 'beamlime'
 sciline_domain_types_aliases = {
     'scipp._scipp.core.DataArray': 'scipp.DataArray',
@@ -90,6 +93,7 @@ sciline_domain_types_aliases = {
     'scipp._scipp.core.Variable': 'scipp.Variable',
     'scipp.core.data_group.DataGroup': 'scipp.DataGroup',
 }
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements/make_base.py
+++ b/requirements/make_base.py
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-
 import sys
 from argparse import ArgumentParser
 from pathlib import Path


### PR DESCRIPTION
- Update CI actions not to use deprecated node js version 
- Remove unnecessary copyright messages.


I didn't run the ``tox -e deps`` since there was no change in the requirements. 