### PR TITLE
fix: plot update; default handler arguments to match old behavior

### DIFF
--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -66,8 +66,9 @@ class DataAssembler(HandlerInterface):
 
     def __init__(
         self,
-        merge_every_nth: MergeMessageCountInterval = float('inf'),
-        max_seconds_between_messages: MergeMessageTimeInterval = 5,
+        *,
+        merge_every_nth: MergeMessageCountInterval = 1,
+        max_seconds_between_messages: MergeMessageTimeInterval = float('inf'),
     ):
         self._store = {}
         self._should_send_message = maxcount_or_maxtime(
@@ -135,7 +136,7 @@ class PlotStreamer(HandlerInterface):
             self.artists[name] = next(iter(plot.artists))
             self.figures[name] = plot
         else:
-            figure.update(data, key=self.artists[name])
+            figure.update({self.artists[name]: data})
 
     def update_histogram(self, message: WorkflowResultUpdate) -> None:
         content = message.content

--- a/tests/applications/test_listeners.py
+++ b/tests/applications/test_listeners.py
@@ -68,7 +68,10 @@ async def test_data_assembler_returns_after_n_messages(fake_listener):
 
 
 async def test_data_assembler_returns_after_s_seconds(fake_listener):
-    handler = DataAssembler(max_seconds_between_messages=0.1)
+    handler = DataAssembler(
+        merge_every_nth=3,  # higher than number of messages we push below
+        max_seconds_between_messages=0.1,
+    )
     gen = fake_listener.run()
     handler.set_run_start(await anext(gen))
     response = handler.assemble_detector_data(await anext(gen))


### PR DESCRIPTION
Tried to run the example notebook and no figure was produced because the default config of the merge handler was to merge five messages, but the example only produces fewer messages so the workflow was never run.

Also encountered some error with the figure update function. Don't know what that was about, but now it seems fixed.