### PR TITLE
Grid plots from multiple figures.

### DIFF
--- a/docs/user-guide/live_data_reduction.ipynb
+++ b/docs/user-guide/live_data_reduction.ipynb
@@ -81,7 +81,7 @@
     "    prototype_factory,\n",
     "    {\n",
     "        BeamlimeLogger: sc.get_logger(),\n",
-    "        DataFeedingSpeed: DataFeedingSpeed(1/14),\n",
+    "        DataFeedingSpeed: DataFeedingSpeed(0.3),\n",
     "        NumFrames: NumFrames(5),\n",
     "        EventRate: EventRate(10_000),\n",
     "        FrameRate: FrameRate(14),\n",
@@ -114,9 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from plopp.widgets import Box, HBar\n",
-    "\n",
-    "Box(HBar(list(plot_saver.figures.values())))"
+    "plot_saver.show()"
    ]
   }
  ],

--- a/src/beamlime/stateless_workflow.py
+++ b/src/beamlime/stateless_workflow.py
@@ -45,10 +45,11 @@ class DummyWorkflow:
 
     def __call__(self, group: JSONGroup) -> WorkflowResult:
         return {
-            'random-counts': sc.DataArray(
+            f'random-counts-{i}': sc.DataArray(
                 data=sc.array(dims=['x'], values=self.rng.random(10), unit='counts'),
                 coords={'x': self.x},
             )
+            for i in range(4)
         }
 
 


### PR DESCRIPTION
Fixes #136 

`PlotSaver`/`PlotStreamer` now make a grid of plots, if there are multiple figures to render.
For easier testing, I made the dummy workflow to return multiple data-arrays.

# In terminal

https://github.com/scipp/beamlime/assets/17974113/a096d061-9d11-47b1-a326-a850f67345de

# In Jupyter notebook

https://github.com/scipp/beamlime/assets/17974113/2f5b2863-7557-4ad4-9de9-75bd9a565b13

