### PR TITLE
Do not depend on json template for mocking streaming.

### DIFF
--- a/docs/user-guide/getting-started.ipynb
+++ b/docs/user-guide/getting-started.ipynb
@@ -16,14 +16,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden",
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "sys.path.append(\"../../tests/helpers\")\n",
+    "\n",
+    "from tests.applications.data import get_path\n",
+    "\n",
+    "os.environ[\"TEST_NEXUS_FILE_PATH\"] = get_path(\"ymir_detectors.nxs\").as_posix()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "!beamlime \\\n",
     "    --workflow dummy \\\n",
     "    --nexus-template-path ../../tests/applications/ymir_detectors.json \\\n",
-    "    --nexus-file-path 'ymir_detectors.nxs' \\\n",
-    "    --image-path-prefix reduction-result"
+    "    --nexus-file-path $TEST_NEXUS_FILE_PATH \\\n",
+    "    --image-path-prefix reduction-result \\\n",
+    "    --fill-dummy-data"
    ]
   },
   {
@@ -103,7 +125,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/live_data_reduction.ipynb
+++ b/docs/user-guide/live_data_reduction.ipynb
@@ -34,6 +34,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden",
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../../tests/helpers\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,6 +58,17 @@
     "\n",
     "sc.get_logger().addHandler(sc.logging.make_widget_handler())\n",
     "sc.display_logs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tests.applications.data import get_path\n",
+    "\n",
+    "file_path = get_path('ymir_detectors.nxs').as_posix()  # Path to the example file"
    ]
   },
   {
@@ -101,7 +128,7 @@
     "        NexusTemplatePath: NexusTemplatePath(\n",
     "            '../../tests/applications/ymir_detectors.json'\n",
     "        ),\n",
-    "        NexusFilePath: NexusFilePath(\"ymir_detectors.nxs\"),\n",
+    "        NexusFilePath: NexusFilePath(file_path),\n",
     "        # TODO: Make a matching file for the template\n",
     "        ResultRegistry: result_registry,\n",
     "    },\n",
@@ -162,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/src/beamlime/applications/_nexus_helpers.py
+++ b/src/beamlime/applications/_nexus_helpers.py
@@ -390,6 +390,7 @@ def _initialize_ev44(module_spec: StreamModuleValue) -> NexusGroup:
             initial_values=np.asarray([], dtype="int32"),
         ),
     ]
+    # TODO This check does not appear to work as expected.
     if not _is_monitor(group):
         # Monitor doesn't have pixel ids.
         group['children'].append(
@@ -452,6 +453,15 @@ def _merge_ev44(group: NexusGroup, data: DeserializedMessage) -> None:
         event_id_dataset["config"]["values"] = np.concatenate(
             (event_id_dataset["config"]["values"], data["pixel_id"])
         )
+    else:
+        # TODO See above, monitor check is not working, remove now that we know there is
+        # no pixel id.
+        try:
+            find_nexus_structure(group, ("event_id",))
+        except KeyError:
+            pass
+        else:
+            del group['children'][-1]
 
 
 def _initialize_f144(module_spec: StreamModuleValue) -> NexusGroup:

--- a/src/beamlime/applications/_nexus_helpers.py
+++ b/src/beamlime/applications/_nexus_helpers.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import pathlib
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -10,11 +11,13 @@ from typing import (
     TypeAlias,
     TypedDict,
     TypeGuard,
+    TypeVar,
     cast,
     get_args,
 )
 
 import numpy as np
+import scippnexus as snx
 
 
 class NexusDataset(TypedDict):
@@ -204,6 +207,85 @@ def _validate_ev44_module_spec(
         raise InvalidNexusStructureError(
             "Group containing ev44 module should have exactly one child"
         )
+
+
+FallBackNameType = TypeVar("FallBackNameType")
+
+
+def _get_instrument_name(
+    nxs_file: snx.File, fail_fall_back: FallBackNameType
+) -> FallBackNameType:
+    try:
+        return nxs_file["entry/instrument/name"][()]
+    except KeyError:
+        return fail_fall_back
+
+
+def _get_nx_class_attribute(group: snx.Group) -> dict[str, str]:
+    if group.nx_class == snx.NXdetector:
+        class_name = "NXdetector"
+    elif group.nx_class == snx.NXmonitor:
+        class_name = "NXmonitor"
+    elif group.nx_class == snx.NXevent_data:
+        class_name = "NXevent_data"
+    else:
+        raise NotImplementedError(f"NX class {group.nx_class} is not supported.")
+
+    return {
+        'name': 'NX_class',
+        'values': class_name,
+    }
+
+
+def _group_to_dict(group: snx.Group) -> NexusGroup:
+    return {
+        "children": [],
+        "name": group.name,
+        "attributes": [_get_nx_class_attribute(group)],
+    }
+
+
+def _retrieve_groups_by_nx_class(
+    nxs_file: snx.File, nx_class: type
+) -> dict[tuple[str, ...], snx.Group]:
+    instrument_path = "entry/instrument"
+    return {
+        tuple("/".join([instrument_path, grp_path]).split('/')): grp
+        for grp_path, grp in nxs_file[instrument_path][nx_class].items()
+    }
+
+
+def _collect_nx_event(
+    groups: dict[tuple[str, ...], snx.Group],
+) -> dict[tuple[str, ...], snx.Group]:
+    children = {}
+    for path, group in groups.items():
+        nx_events = group[snx.NXevent_data]
+        for name, nx_event in nx_events.items():
+            children[(*path, name)] = nx_event
+    return children
+
+
+def collect_streaming_modules_from_nexus_file(
+    nexus_file: str | pathlib.Path,
+) -> dict[StreamModuleKey, StreamModuleValue]:
+    """Collect all stream modules in a nexus file."""
+
+    with snx.File(nexus_file) as f:
+        detectors = _collect_nx_event(_retrieve_groups_by_nx_class(f, snx.NXdetector))
+        monitors = _collect_nx_event(_retrieve_groups_by_nx_class(f, snx.NXmonitor))
+        instrument_name = _get_instrument_name(f, fail_fall_back="unknown")
+        return {
+            StreamModuleKey(
+                module_type='ev44',
+                topic=f"{instrument_name}_detector",
+                source=det.parent.name,
+            ): StreamModuleValue(
+                path=det_path,
+                parent=_group_to_dict(det),
+            )
+            for det_path, det in {**detectors, **monitors}.items()
+        }
 
 
 def collect_streaming_modules(

--- a/src/beamlime/applications/daemons.py
+++ b/src/beamlime/applications/daemons.py
@@ -73,7 +73,6 @@ def _try_load_nxevent_data(
     if file_path is None:
         return
     with h5py.File(file_path, 'r') as f:
-        group_path = (*group_path, group_path[-1] + '_events')
         try:
             group = f['/'.join(group_path)]
         except KeyError:
@@ -115,6 +114,7 @@ def fake_event_generators(
             detector_number = None
         else:
             raise ValueError(f"Detector or monitor group not found for {value.path}")
+        # TODO This is bad! Silent fallback to random data generation!
         if (
             event_data := _try_load_nxevent_data(
                 file_path=event_data_source_path, group_path=value.path

--- a/src/beamlime/applications/daemons.py
+++ b/src/beamlime/applications/daemons.py
@@ -4,24 +4,23 @@ import argparse
 import asyncio
 import json
 import os
-from collections.abc import AsyncGenerator, Generator, Mapping
+from collections.abc import AsyncGenerator, Generator
 from dataclasses import dataclass
 from typing import NewType
 
 import h5py
 import numpy as np
+import scippnexus as snx
 
 from ..logging import BeamlimeLogger
 from ._nexus_helpers import (
     DeserializedMessage,
-    NexusPath,
     NexusTemplate,
     RunStartInfo,
     StreamModuleKey,
-    StreamModuleValue,
+    _retrieve_groups_by_nx_class,
     collect_streaming_modules,
-    find_nexus_structure,
-    iter_nexus_structure,
+    collect_streaming_modules_from_nexus_file,
 )
 from ._random_data_providers import (
     EV44,
@@ -57,8 +56,6 @@ class DataPieceReceived:
 NexusTemplatePath = NewType("NexusTemplatePath", str)
 NexusFilePath = NewType("NexusFilePath", str)
 
-EventDataSourcePath = NewType("EventDataSourcePath", str)
-
 
 def read_nexus_template_file(path: NexusTemplatePath) -> NexusTemplate:
     with open(path) as f:
@@ -86,14 +83,23 @@ def _try_load_nxevent_data(
 
 def fake_event_generators(
     *,
-    streaming_modules: dict[StreamModuleKey, StreamModuleValue],
-    nexus_structure: Mapping,
+    nexus_structure: NexusTemplate | None,
+    static_file: NexusFilePath,
     event_rate: EventRate,
     frame_rate: FrameRate,
-    event_data_source_path: EventDataSourcePath | None = None,
+    event_data_source_path: NexusFilePath | None = None,
 ) -> dict[StreamModuleKey, Generator[dict[str, np.ndarray] | EV44]]:
-    detectors = _find_groups_by_nx_class(nexus_structure, nx_class='NXdetector')
-    monitors = _find_groups_by_nx_class(nexus_structure, nx_class='NXmonitor')
+    with snx.File(static_file) as f:
+        detectors = _retrieve_groups_by_nx_class(f, snx.NXdetector)
+        detector_numbers = {
+            key: value['detector_number'][()] for key, value in detectors.items()
+        }
+        monitors = _retrieve_groups_by_nx_class(f, snx.NXmonitor)
+
+    if nexus_structure is not None:
+        streaming_modules = collect_streaming_modules(nexus_structure)
+    else:
+        streaming_modules = collect_streaming_modules_from_nexus_file(static_file)
 
     ev44_modules = {
         key: value
@@ -103,12 +109,10 @@ def fake_event_generators(
 
     generators: dict[StreamModuleKey, Generator[dict[str, np.ndarray] | EV44]] = {}
     for key, value in ev44_modules.items():
-        # TODO: Geometry should be parsed from a file instead of nexus_structure.
-        if (det_path := detectors.get(value.path[:-1])) is not None:
-            det_group = find_nexus_structure(det_path, ('detector_number',))
-            detector_numbers = det_group['config']['values']
+        if (detector_number := detector_numbers.get(value.path[:-1])) is not None:
+            detector_number = detector_number.values
         elif value.path[:-1] in monitors:
-            detector_numbers = None
+            detector_number = None
         else:
             raise ValueError(f"Detector or monitor group not found for {value.path}")
         if (
@@ -122,24 +126,14 @@ def fake_event_generators(
         else:
             generators[key] = random_ev44_generator(
                 source_name=DetectorName(key.source),
-                detector_numbers=detector_numbers,
+                detector_numbers=detector_number,
                 event_rate=event_rate,
                 frame_rate=frame_rate,
             )
     return generators
 
 
-def _find_groups_by_nx_class(
-    nexus_structure: Mapping, nx_class: str
-) -> dict[NexusPath, Mapping]:
-    return {
-        path: node
-        for path, node in iter_nexus_structure(nexus_structure)
-        if any(
-            attr.get('name') == 'NX_class' and attr.get('values') == nx_class
-            for attr in node.get('attributes', ())
-        )
-    }
+FillDummyData = NewType("FillDummyData", bool)
 
 
 class FakeListener(DaemonInterface):
@@ -150,12 +144,12 @@ class FakeListener(DaemonInterface):
         *,
         logger: BeamlimeLogger,
         speed: DataFeedingSpeed,
-        nexus_template: NexusTemplate,
+        nexus_template: NexusTemplate | None = None,
         nexus_file_path: NexusFilePath,
         num_frames: NumFrames,
         event_rate: EventRate,
         frame_rate: FrameRate,
-        event_data_source_path: EventDataSourcePath | None = None,
+        fill_dummy_data: FillDummyData = False,
     ):
         self.logger = logger
 
@@ -164,10 +158,10 @@ class FakeListener(DaemonInterface):
 
         self.random_event_generators = fake_event_generators(
             nexus_structure=self.nexus_structure,
-            event_data_source_path=event_data_source_path,
+            static_file=nexus_file_path,
             event_rate=event_rate,
             frame_rate=frame_rate,
-            streaming_modules=collect_streaming_modules(self.nexus_structure),
+            event_data_source_path=None if fill_dummy_data else nexus_file_path,
         )
         self.data_feeding_speed = speed
         self.num_frames = num_frames
@@ -175,7 +169,18 @@ class FakeListener(DaemonInterface):
     async def run(self) -> AsyncGenerator[MessageProtocol, None]:
         self.info("Fake data streaming started...")
         # Real listener will wait for the RunStart message to parse the structure
-        streaming_modules = collect_streaming_modules(self.nexus_structure)
+        if self.nexus_structure is None:
+            self.debug(
+                "Collecting streaming modules from the nexus file %s",
+                self.nexus_file_path,
+            )
+            streaming_modules = collect_streaming_modules_from_nexus_file(
+                self.nexus_file_path
+            )
+            self.debug("Streaming modules: %s", streaming_modules)
+        else:
+            streaming_modules = collect_streaming_modules(self.nexus_structure)
+
         self.debug(f"Streaming modules: {streaming_modules}")
 
         yield RunStart(
@@ -207,19 +212,14 @@ class FakeListener(DaemonInterface):
             "--nexus-template-path",
             help="Path to the nexus template file.",
             type=str,
-            required=True,
+            required=False,
+            default=None,
         )
         group.add_argument(
             "--nexus-file-path",
-            help="Path to the nexus file that contains static information.",
+            help="Path to the nexus file with static information and event data.",
             type=str,
             required=True,
-        )
-        group.add_argument(
-            "--event-data-source-path",
-            help="Path to the event data source file.",
-            type=str,
-            default=None,
         )
         group.add_argument(
             "--data-feeding-speed",
@@ -245,20 +245,29 @@ class FakeListener(DaemonInterface):
             help="Frame rate [Hz].",
             type=int,
         )
+        group.add_argument(
+            "--fill-dummy-data",
+            default=False,
+            help="Fill the nexus file with dummy data.",
+            action="store_true",
+        )
 
     @classmethod
     def from_args(
         cls, logger: BeamlimeLogger, args: argparse.Namespace
     ) -> "FakeListener":
-        with open(args.nexus_template_path) as f:
-            nexus_template = json.load(f)
+        if args.nexus_template_path is not None:
+            with open(args.nexus_template_path) as f:
+                nexus_template = json.load(f)
+        else:
+            nexus_template = None
         return cls(
             logger=logger,
             speed=DataFeedingSpeed(args.data_feeding_speed),
             nexus_template=nexus_template,
             nexus_file_path=NexusFilePath(args.nexus_file_path),
-            event_data_source_path=EventDataSourcePath(args.event_data_source_path),
             num_frames=NumFrames(args.num_frames),
             event_rate=EventRate(args.event_rate),
             frame_rate=FrameRate(args.frame_rate),
+            fill_dummy_data=args.fill_dummy_data,
         )

--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -105,12 +105,12 @@ class DataAssembler(HandlerInterface):
         self.debug("Data piece merged for %s", message.content.key)
         if self._should_send_message():
             nxevent_data = {
-                nexus_path_as_string(self.streaming_modules[key].path): JSONGroup(value)
+                nexus_path_as_string(self.streaming_modules[key].path): value
                 for key, value in self._nexus_store.items()
                 if key.module_type == "ev44"
             }
             nxlog = {
-                nexus_path_as_string(module_spec.path): JSONGroup(value)
+                nexus_path_as_string(module_spec.path): value
                 for key, value in self._nexus_store.items()
                 if key.module_type == "f144"
             }

--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -105,7 +105,7 @@ class DataAssembler(HandlerInterface):
         self.debug("Data piece merged for %s", message.content.key)
         if self._should_send_message():
             nxevent_data = {
-                nexus_path_as_string(module_spec.path): JSONGroup(value)
+                nexus_path_as_string(self.streaming_modules[key].path): JSONGroup(value)
                 for key, value in self._nexus_store.items()
                 if key.module_type == "ev44"
             }

--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -4,9 +4,11 @@ import argparse
 import pathlib
 import time
 from dataclasses import dataclass
+from math import ceil
 from numbers import Number
 from typing import NewType
 
+import matplotlib.pyplot as plt
 import plopp as pp
 import scipp as sc
 from ess.reduce.nexus.json_nexus import JSONGroup
@@ -250,16 +252,26 @@ class PlotSaver(PlotStreamer):
         self.image_path_prefix = image_path_prefix
 
     def save_histogram(self, message: WorkflowResultUpdate) -> None:
-        from plopp import tiled
-
-        super().update_histogram(message)
         image_file_name = f"{self.image_path_prefix}.png"
         self.info("Received histogram(s), saving into %s...", image_file_name)
-        plot_tile = tiled((len(self.figures) // self.max_column) + 1, self.max_column)
-        for i_fig, figure in enumerate(self.figures.values()):
-            plot_tile[i_fig // self.max_column, i_fig % self.max_column] = figure
 
-        plot_tile.save(image_file_name)
+        fig, axes = plt.subplots(
+            ceil(len(message.content) / self.max_column),
+            self.max_column,
+            figsize=(8, 8),
+        )
+        plt.subplots_adjust(wspace=0.3, hspace=0.3)
+        for (name, da), ax in zip(message.content.items(), axes.flat, strict=False):
+            # TODO We need a way of configuring plot options for each item. The below
+            # works for the SANS 60387-2022-02-28_2215.nxs AgBeh file and is useful for
+            # testing.
+            if da.unit == '':
+                extra = {'norm': 'log', 'vmin': 1e-1, 'vmax': 1e1, 'aspect': 'equal'}
+            else:
+                extra = {}
+            da.plot(ax=ax, title=name, **extra)
+        fig.savefig(image_file_name, dpi=100)
+        plt.close(fig)
 
     @classmethod
     def add_argument_group(cls, parser: argparse.ArgumentParser) -> None:

--- a/tests/applications/nexus_helpers_test.py
+++ b/tests/applications/nexus_helpers_test.py
@@ -24,7 +24,7 @@ from beamlime.applications._random_data_providers import (
     nxevent_data_ev44_generator,
     random_ev44_generator,
 )
-from beamlime.applications.daemons import fake_event_generators
+from beamlime.applications.daemons import NexusFilePath, fake_event_generators
 
 
 @pytest.fixture()
@@ -84,12 +84,12 @@ def ev44_generator() -> RandomEV44Generator:
 
 @pytest.fixture()
 def ymir_ev44_generator(
-    ymir_streaming_modules: dict[StreamModuleKey, StreamModuleValue],
     ymir: dict,
+    ymir_static_file: NexusFilePath,
 ) -> Generator[dict, None, None]:
     generators = fake_event_generators(
-        streaming_modules=ymir_streaming_modules,
         nexus_structure=ymir,
+        static_file=ymir_static_file,
         event_rate=EventRate(100),
         frame_rate=FrameRate(14),
     )

--- a/tests/applications/test_listeners.py
+++ b/tests/applications/test_listeners.py
@@ -8,6 +8,7 @@ from beamlime.applications.daemons import (
     Application,
     DataPieceReceived,
     FakeListener,
+    NexusFilePath,
     RunStart,
 )
 from beamlime.applications.handlers import DataAssembler
@@ -29,19 +30,20 @@ def num_frames(request) -> int:
 
 
 @pytest.fixture()
-def fake_listener(num_frames: int, ymir) -> FakeListener:
+def fake_listener(
+    num_frames: int, ymir, ymir_static_file: NexusFilePath
+) -> FakeListener:
     from beamlime.applications.daemons import (
         DataFeedingSpeed,
         EventRate,
         FrameRate,
-        NexusFilePath,
         NumFrames,
     )
 
     return FakeListener(
         logger=MockLogger(),
         nexus_template=ymir,
-        nexus_file_path=NexusFilePath(''),
+        nexus_file_path=ymir_static_file,
         speed=DataFeedingSpeed(1),
         num_frames=NumFrames(num_frames),
         event_rate=EventRate(100),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from typing import Literal
 import pytest
 
 from beamlime import Factory
+from beamlime.applications.daemons import NexusFilePath
 from tests.applications.data import get_path
 
 
@@ -103,6 +104,11 @@ def ymir() -> dict:
     with open(get_path('ymir_detectors.json')) as f:
         data = json.load(f)
     return data
+
+
+@pytest.fixture()
+def ymir_static_file() -> NexusFilePath:
+    return NexusFilePath(get_path("ymir_detectors.nxs").as_posix())
 
 
 @pytest.fixture()

--- a/tests/helpers/tests/applications/data.py
+++ b/tests/helpers/tests/applications/data.py
@@ -21,8 +21,9 @@ def _make_pooch():
             # read in a real run start message
             'ymir_detectors.json': 'md5:d9a25d4375ae3d414d91bfe504baa844',
             'ymir.json': 'md5:5e913075094d97c5e9e9aca76fc32554',
+            'ymir_detectors.nxs': 'md5:2e143cd839a84301b7459d5ab6df8454',
             # readme of the dataset
-            'README.md': 'md5:778a0f290894182db5db0170b4f102fa',
+            'README.md': 'md5:7e101b5c38dddc7d530e0594a2058950',
         },
     )
 


### PR DESCRIPTION
@SimonHeybrock  

This update should allow you to run beamlime only with a file without any json structure.

```bash
beamlime \ 
    --nexus-file-path 60392-2022-02-28_2215.nxs \
    --workflow ess-loki-monitor \
    --log-level DEBUG \
    --merge-every-nth 20 \
    --image-path-prefix loki-test \
    --num-frames 40 \
    #--fill-dummy-data  # uncomment this if you want to use actual data from the file.

```