### PR TITLE
Show detector patch

### DIFF
--- a/src/beamlime/applications/daemons.py
+++ b/src/beamlime/applications/daemons.py
@@ -219,7 +219,6 @@ class FakeListener(DaemonInterface):
             "--nexus-file-path",
             help="Path to the nexus file with static information and event data.",
             type=str,
-            required=True,
         )
         group.add_argument(
             "--data-feeding-speed",
@@ -256,6 +255,14 @@ class FakeListener(DaemonInterface):
     def from_args(
         cls, logger: BeamlimeLogger, args: argparse.Namespace
     ) -> "FakeListener":
+        if args.nexus_file_path is None:
+            # This option is not set as a required argument in the `add_argument_group`
+            # method, because it is only required if fake listener is used.
+            raise ValueError(
+                "The path to the nexus file is not provided. "
+                "Use --nexus-file-path option to set it."
+            )
+
         if args.nexus_template_path is not None:
             with open(args.nexus_template_path) as f:
                 nexus_template = json.load(f)

--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -155,7 +155,7 @@ class RawCountHandler(HandlerInterface):
         group.add_argument(
             "--static-file-path",
             help="Path to the nexus file that has static information.",
-            type=int,
+            type=str,
             required=True,
         )
         group.add_argument(

--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -141,10 +141,20 @@ class RawCountHandler(HandlerInterface):
             return WorkflowResultUpdate(results)
 
     @classmethod
+    def add_argument_group(cls, parser: argparse.ArgumentParser) -> None:
+        group = parser.add_argument_group("Raw Counter Configuration")
+        group.add_argument(
+            "--static-file-path",
+            help="Path to the nexus file that has static information.",
+            type=int,
+            required=True,
+        )
+
+    @classmethod
     def from_args(
         cls, logger: BeamlimeLogger, args: argparse.Namespace
     ) -> "RawCountHandler":
-        return cls(logger=logger, nexus_file=args.nexus_file_path)
+        return cls(logger=logger, nexus_file=args.static_file_path)
 
 
 class DataAssembler(HandlerInterface):

--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -7,6 +7,7 @@ import tempfile
 from dataclasses import dataclass
 from math import ceil
 from numbers import Number
+from time import time
 from typing import NewType
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
@SimonHeybrock I added some more arguments for easier command line testings.

As I tried it with a fake listener, I had this error.

I was using this file: /ess/data/coda/2024/268227/raw/268227_00029504.hdf

Do you have any idea why it happens and how to fix it?

```
 File "/Users/sunyoungyoo/ESS/beamlime/src/beamlime/applications/handlers.py", line 144, in handle
    det.add_counts(np.concatenate(buffer))
  File "/Users/sunyoungyoo/ESS/essreduce/src/ess/reduce/live/raw.py", line 161, in add_counts
    counts = self.bincount(data)
  File "/Users/sunyoungyoo/ESS/essreduce/src/ess/reduce/live/raw.py", line 90, in bincount
    out.values = np.bincount(offset, minlength=self._size).reshape(self.data.shape)
ValueError: 'list' argument must have no negative elements
```


However, with a workaround(I just filtered all negative offset in the bincount call) 
``show-detector`` command worked with a fake listener ...!

The command I used is:
```bash
show-detector --fake-listener \
  --static-file-path loki_valid.h5 \
  --nexus-file-path loki_valid.h5 \
  --image-path-prefix test \
  --num-frames 100

```