### PR TITLE
Use real deserialized data types instead of mapping.

### DIFF
--- a/src/beamlime/applications/_random_data_providers.py
+++ b/src/beamlime/applications/_random_data_providers.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 from collections.abc import Generator
-from typing import Any, NewType, TypedDict
+from typing import Any, NewType
 
 import numpy as np
 from numpy.random import default_rng
+from streaming_data_types.eventdata_ev44 import EventData
+
+# ``EventData`` is the deserialized form of the event data type.
 
 # Configuration
 EventRate = NewType("EventRate", int)  # [events/s]
@@ -19,16 +22,7 @@ ReferenceTimeZero = NewType("ReferenceTimeZero", int)  # [ns]
 DetectorName = NewType("DetectorName", str)
 DetectorNumberCandidates = NewType("DetectorNumberCandidates", list[int])
 
-
-class EV44(TypedDict):
-    source_name: DetectorName
-    reference_time: list[float] | np.ndarray
-    reference_time_index: list[int] | np.ndarray
-    time_of_flight: list[float] | np.ndarray
-    pixel_id: list[int] | np.ndarray | None
-
-
-RandomEV44Generator = Generator[EV44, Any, Any]
+RandomEV44Generator = Generator[EventData, Any, Any]
 
 
 def random_ev44_generator(
@@ -37,7 +31,7 @@ def random_ev44_generator(
     detector_numbers: DetectorNumberCandidates | None = None,
     event_rate: EventRate,
     frame_rate: FrameRate,
-) -> Generator[EV44, Any, Any]:
+) -> Generator[EventData, Any, Any]:
     """Randomly select detector numbers (pixel ids) and generate events per frame."""
     rng = default_rng(123)
     ef_rate = int(event_rate / frame_rate)
@@ -47,7 +41,8 @@ def random_ev44_generator(
         cur_event_number = int(
             ef_rate * (rng.integers(99, 101) / 100)
         )  # 1% of fluctuation
-        yield EV44(
+        yield EventData(
+            message_id=None,  # Not used in beamlime.
             source_name=source_name,
             reference_time=np.asarray([et_zero]),
             reference_time_index=np.asarray([0]),
@@ -70,12 +65,13 @@ def nxevent_data_ev44_generator(
     event_index: np.ndarray,
     event_time_offset: np.ndarray,
     event_time_zero: np.ndarray,
-) -> Generator[EV44, Any, Any]:
+) -> Generator[EventData, Any, Any]:
     """Generate EV44 from datasets of a NXevent_data group."""
     from itertools import pairwise
 
     for i, (start, end) in enumerate(pairwise(event_index)):
-        yield EV44(
+        yield EventData(
+            message_id=None,  # Not used in beamlime.
             source_name=source_name,
             reference_time=np.asarray(event_time_zero[i : i + 1]),
             reference_time_index=np.asarray([0]),

--- a/src/beamlime/applications/daemons.py
+++ b/src/beamlime/applications/daemons.py
@@ -11,10 +11,12 @@ from typing import NewType
 import h5py
 import numpy as np
 import scippnexus as snx
+from streaming_data_types.eventdata_ev44 import EventData
+from streaming_data_types.logdata_f144 import ExtractedLogData
+from streaming_data_types.timestamps_tdct import Timestamps
 
 from ..logging import BeamlimeLogger
 from ._nexus_helpers import (
-    DeserializedMessage,
     NexusTemplate,
     RunStartInfo,
     StreamModuleKey,
@@ -23,7 +25,6 @@ from ._nexus_helpers import (
     collect_streaming_modules_from_nexus_file,
 )
 from ._random_data_providers import (
-    EV44,
     DataFeedingSpeed,
     DetectorName,
     EventRate,
@@ -45,7 +46,7 @@ class RunStart:
 @dataclass
 class DataPiece:
     key: StreamModuleKey
-    deserialized: DeserializedMessage
+    deserialized: EventData | Timestamps | ExtractedLogData
 
 
 @dataclass
@@ -87,7 +88,7 @@ def fake_event_generators(
     event_rate: EventRate,
     frame_rate: FrameRate,
     event_data_source_path: NexusFilePath | None = None,
-) -> dict[StreamModuleKey, Generator[dict[str, np.ndarray] | EV44]]:
+) -> dict[StreamModuleKey, Generator[dict[str, np.ndarray] | EventData]]:
     with snx.File(static_file) as f:
         detectors = _retrieve_groups_by_nx_class(f, snx.NXdetector)
         detector_numbers = {
@@ -106,7 +107,7 @@ def fake_event_generators(
         if key.module_type == 'ev44'
     }
 
-    generators: dict[StreamModuleKey, Generator[dict[str, np.ndarray] | EV44]] = {}
+    generators: dict[StreamModuleKey, Generator[dict[str, np.ndarray] | EventData]] = {}
     for key, value in ev44_modules.items():
         if (detector_number := detector_numbers.get(value.path[:-1])) is not None:
             detector_number = detector_number.values

--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -7,7 +7,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from numbers import Number
-from typing import NewType
+from typing import NewType, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,6 +17,7 @@ import scippnexus as snx
 from ess.reduce.live import raw
 from ess.reduce.nexus.json_nexus import JSONGroup
 from matplotlib.gridspec import GridSpec
+from streaming_data_types.eventdata_ev44 import EventData
 
 from beamlime.logging import BeamlimeLogger
 
@@ -229,8 +230,9 @@ class RawCountHandler(HandlerInterface):
         self.info("Initialized with %s", list(self._views))
 
     def handle(self, message: DataPieceReceived) -> WorkflowResultUpdate | None:
-        detname = message.content.deserialized['source_name'].split('/')[-1]
-        event_id = message.content.deserialized['pixel_id']
+        data_piece = cast(EventData, message.content.deserialized)
+        detname = data_piece.source_name.split('/')[-1]
+        event_id = data_piece.pixel_id
         if (det := self._detectors.get(detname)) is not None:
             for name in det:
                 buffer = self._buffer[name]

--- a/src/beamlime/executables/show_detector.py
+++ b/src/beamlime/executables/show_detector.py
@@ -8,7 +8,7 @@ from typing import NewType
 
 from confluent_kafka import OFFSET_BEGINNING, Consumer, Message, TopicPartition
 from confluent_kafka.admin import AdminClient
-from streaming_data_types.eventdata_ev44 import deserialise_ev44
+from streaming_data_types.eventdata_ev44 import EventData, deserialise_ev44
 
 from .. import Factory, ProviderGroup
 from ..applications._nexus_helpers import (
@@ -24,7 +24,6 @@ from ..applications.base import (
 from ..applications.daemons import (
     DataPiece,
     DataPieceReceived,
-    DeserializedMessage,
     FakeListener,
 )
 from ..applications.handlers import PlotSaver, RawCountHandler, WorkflowResultUpdate
@@ -67,9 +66,7 @@ def _collect_all_topic_partitions(
     ]
 
 
-def _wrap_event_msg_to_data_piece(
-    topic: str, deserialized: DeserializedMessage
-) -> DataPiece:
+def _wrap_event_msg_to_data_piece(topic: str, deserialized: EventData) -> DataPiece:
     key = StreamModuleKey(
         module_type='ev44', topic=topic, source=deserialized['source_name']
     )

--- a/src/beamlime/executables/show_detector.py
+++ b/src/beamlime/executables/show_detector.py
@@ -121,7 +121,7 @@ class EventListener(DaemonInterface):
         while True:
             msg = self.consumer.poll(0.5)
             if _is_event_msg_valid(msg):
-                deserialized = deserialise_ev44(msg.value())._asdict()
+                deserialized = deserialise_ev44(msg.value())
                 self.debug("%s", deserialized)
                 yield DataPieceReceived(
                     content=_wrap_event_msg_to_data_piece(msg.topic(), deserialized)

--- a/src/beamlime/executables/show_detector.py
+++ b/src/beamlime/executables/show_detector.py
@@ -68,7 +68,7 @@ def _collect_all_topic_partitions(
 
 def _wrap_event_msg_to_data_piece(topic: str, deserialized: EventData) -> DataPiece:
     key = StreamModuleKey(
-        module_type='ev44', topic=topic, source=deserialized['source_name']
+        module_type='ev44', topic=topic, source=deserialized.source_name
     )
     return DataPiece(key=key, deserialized=deserialized)
 


### PR DESCRIPTION
`Mapping` was a wrong choice.
They are deserialized as a `NamedTuple`.

Instead of type-hinting them with a generic type like mapping, we can now use real types we are expecting as a result of deserializing the messages.


> Deserialization will be done by a kafka-listener and sent to the downstream handlers/daemons.