### PR TITLE
Fix fake listener event generator

### DIFF
--- a/docs/user-guide/live_data_reduction.ipynb
+++ b/docs/user-guide/live_data_reduction.ipynb
@@ -99,6 +99,7 @@
     "from beamlime.applications.daemons import (\n",
     "    DataPieceReceived,\n",
     "    FakeListener,\n",
+    "    FillDummyData,\n",
     "    NexusTemplatePath,\n",
     "    NumFrames,\n",
     "    DataFeedingSpeed,\n",
@@ -131,6 +132,7 @@
     "        NexusFilePath: NexusFilePath(file_path),\n",
     "        # TODO: Make a matching file for the template\n",
     "        ResultRegistry: result_registry,\n",
+    "        FillDummyData: FillDummyData(True),\n",
     "    },\n",
     "):\n",
     "    prototype_factory[BeamlimeLogger].setLevel(\"INFO\")\n",
@@ -175,7 +177,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "lime-dev-310",
    "language": "python",
    "name": "python3"
   },

--- a/src/beamlime/applications/daemons.py
+++ b/src/beamlime/applications/daemons.py
@@ -89,6 +89,23 @@ def fake_event_generators(
     frame_rate: FrameRate,
     event_data_source_path: NexusFilePath | None = None,
 ) -> dict[StreamModuleKey, Generator[dict[str, np.ndarray] | EventData]]:
+    """Create fake event generators based on the nexus structure or static file.
+
+    Parameters
+    ----------
+    nexus_structure : NexusTemplate | None
+        The nexus structure template.
+    static_file : NexusFilePath
+        The path to the nexus file with static information.
+    event_rate : EventRate
+        The event rate [Hz].
+    frame_rate : FrameRate
+        The frame rate [Hz].
+    event_data_source_path : NexusFilePath | None
+        The path to the nexus file with event data.
+        If None, random data will be generated.
+
+    """
     with snx.File(static_file) as f:
         detectors = _retrieve_groups_by_nx_class(f, snx.NXdetector)
         detector_numbers = {
@@ -115,12 +132,15 @@ def fake_event_generators(
             detector_number = None
         else:
             raise ValueError(f"Detector or monitor group not found for {value.path}")
-        # TODO This is bad! Silent fallback to random data generation!
-        if (
-            event_data := _try_load_nxevent_data(
+        if event_data_source_path is not None:
+            event_data = _try_load_nxevent_data(
                 file_path=event_data_source_path, group_path=value.path
             )
-        ) is not None:
+            if event_data is None:
+                raise ValueError(
+                    f"NXevent_data not found for {'/'.join(value.path)} "
+                    f"in {event_data_source_path}"
+                )
             generators[key] = nxevent_data_ev44_generator(
                 source_name=DetectorName(key.source), **event_data
             )
@@ -258,7 +278,10 @@ class FakeListener(DaemonInterface):
         group.add_argument(
             "--fill-dummy-data",
             default=False,
-            help="Fill the nexus file with dummy data.",
+            help="Fill the nexus file with dummy data. "
+            "If not set, random data will be generated."
+            "If set, the path to the nexus file with event data must be provided"
+            "using --nexus-file-path option.",
             action="store_true",
         )
 

--- a/src/beamlime/applications/daemons.py
+++ b/src/beamlime/applications/daemons.py
@@ -94,9 +94,11 @@ def fake_event_generators(
     Parameters
     ----------
     nexus_structure : NexusTemplate | None
-        The nexus structure template.
+        The nexus structure template. If given, the streaming modules will be collected
+        from it.
     static_file : NexusFilePath
         The path to the nexus file with static information.
+        If `nexus_structure` is None, the streaming modules will be collected from it.
     event_rate : EventRate
         The event rate [Hz].
     frame_rate : FrameRate

--- a/tests/applications/test_listeners.py
+++ b/tests/applications/test_listeners.py
@@ -36,6 +36,7 @@ def fake_listener(
     from beamlime.applications.daemons import (
         DataFeedingSpeed,
         EventRate,
+        FillDummyData,
         FrameRate,
         NumFrames,
     )
@@ -48,6 +49,7 @@ def fake_listener(
         num_frames=NumFrames(num_frames),
         event_rate=EventRate(100),
         frame_rate=FrameRate(14),
+        fill_dummy_data=FillDummyData(True),
     )
 
 


### PR DESCRIPTION
Fixes #258 

The option to fill dummy data already existed. 
Just improved how they are handled.
Now it'll raise if no events are found in the file when ``--fill-dummy-data`` is off.