### PR TITLE
Move config to beamlime.config.raw_detectors for creating raw views

### DIFF
--- a/src/beamlime/applications/handlers.py
+++ b/src/beamlime/applications/handlers.py
@@ -19,7 +19,11 @@ from ess.reduce.nexus.json_nexus import JSONGroup
 from matplotlib.gridspec import GridSpec
 from streaming_data_types.eventdata_ev44 import EventData
 
-from beamlime.config.raw_detectors import _dream, _loki, _nmx
+from beamlime.config.raw_detectors import (
+    dream_detectors_config,
+    loki_detectors_config,
+    nmx_detectors_config,
+)
 from beamlime.logging import BeamlimeLogger
 
 from ..workflow_protocols import LiveWorkflow, WorkflowResult
@@ -34,9 +38,9 @@ from .base import HandlerInterface
 from .daemons import DataPieceReceived, NexusFilePath, RunStart
 
 detector_registry = {
-    'DREAM': _dream,
-    'LoKI': _loki,
-    'NMX': _nmx,
+    'DREAM': dream_detectors_config,
+    'LoKI': loki_detectors_config,
+    'NMX': nmx_detectors_config,
 }
 
 ResultRegistry = NewType("ResultRegistry", dict[str, sc.DataArray])

--- a/src/beamlime/config/raw_detectors/__init__.py
+++ b/src/beamlime/config/raw_detectors/__init__.py
@@ -1,11 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+
 """
-This config is used during Live Data Reduction detector view.
+This config is used to setup live raw detector views.
 Currently the instrument specific config is stored in python files, but
 they can be moved to a separate file format in the future.
 """
 
-from .dream import _dream
-from .loki import _loki
-from .nmx import _nmx
+from .dream import dream_detectors_config
+from .loki import loki_detectors_config
+from .nmx import nmx_detectors_config
 
-__all__ = ["_dream", "_loki", "_nmx"]
+__all__ = [dream_detectors_config, loki_detectors_config, nmx_detectors_config]

--- a/src/beamlime/config/raw_detectors/__init__.py
+++ b/src/beamlime/config/raw_detectors/__init__.py
@@ -1,0 +1,11 @@
+"""
+This config is used during Live Data Reduction detector view.
+Currently the instrument specific config is stored in python files, but
+they can be moved to a separate file format in the future.
+"""
+
+from .dream import _dream
+from .loki import _loki
+from .nmx import _nmx
+
+__all__ = ["_dream", "_loki", "_nmx"]

--- a/src/beamlime/config/raw_detectors/dream.py
+++ b/src/beamlime/config/raw_detectors/dream.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+
 # Order in 'resolution' matters so plots have X as horizontal axis and Y as vertical.
 # The other DREAM detectors have non-consecutive detector numbers. This is not
 # supported currently
@@ -6,7 +9,7 @@ from ess.reduce.live import raw
 
 _res_scale = 8
 
-_dream = {
+dream_detectors_config = {
     'dashboard': {'nrow': 3, 'ncol': 2},
     'detectors': {
         'endcap_backward': {

--- a/src/beamlime/config/raw_detectors/dream.py
+++ b/src/beamlime/config/raw_detectors/dream.py
@@ -1,0 +1,49 @@
+# Order in 'resolution' matters so plots have X as horizontal axis and Y as vertical.
+# The other DREAM detectors have non-consecutive detector numbers. This is not
+# supported currently
+
+from ess.reduce.live import raw
+
+_res_scale = 8
+
+_dream = {
+    'dashboard': {'nrow': 3, 'ncol': 2},
+    'detectors': {
+        'endcap_backward': {
+            'detector_name': 'endcap_backward_detector',
+            'resolution': {'y': 30 * _res_scale, 'x': 20 * _res_scale},
+            'gridspec': (0, 0),
+        },
+        'endcap_forward': {
+            'detector_name': 'endcap_forward_detector',
+            'resolution': {'y': 20 * _res_scale, 'x': 20 * _res_scale},
+            'gridspec': (0, 1),
+        },
+        # We use the arc length instead of phi as it makes it easier to get a correct
+        # aspect ratio for the plot if both axes have the same unit.
+        'mantle_projection': {
+            'detector_name': 'mantle_detector',
+            'resolution': {'arclength': 10 * _res_scale, 'z': 40 * _res_scale},
+            'projection': 'cylinder_mantle_z',
+            'gridspec': (1, slice(None, 2)),
+        },
+        # Different view of the same detector, showing just the front layer instead of
+        # a projection.
+        'mantle_front_layer': {
+            'detector_name': 'mantle_detector',
+            'projection': raw.LogicalView(
+                fold={
+                    'wire': 32,
+                    'module': 5,
+                    'segment': 6,
+                    'strip': 256,
+                    'counter': 2,
+                },
+                transpose=('wire', 'module', 'segment', 'counter', 'strip'),
+                select={'wire': 0},
+                flatten={'z_id': ('module', 'segment', 'counter')},
+            ),
+            'gridspec': (2, slice(None, 2)),
+        },
+    },
+}

--- a/src/beamlime/config/raw_detectors/loki.py
+++ b/src/beamlime/config/raw_detectors/loki.py
@@ -1,0 +1,63 @@
+_res_scale = 8
+
+_loki = {
+    'dashboard': {'nrow': 3, 'ncol': 9, 'figsize_scale': 3},
+    'detectors': {
+        'Rear-detector': {
+            'detector_name': 'loki_detector_0',
+            'resolution': {'y': 12 * _res_scale, 'x': 12 * _res_scale},
+            'gridspec': (slice(0, 3), slice(0, 3)),
+            'pixel_noise': 'cylindrical',
+        },
+        # First window frame
+        'loki_detector_1': {
+            'detector_name': 'loki_detector_1',
+            'resolution': {'y': 3 * _res_scale, 'x': 9 * _res_scale},
+            'gridspec': (2, 4),
+            'pixel_noise': 'cylindrical',
+        },
+        'loki_detector_2': {
+            'detector_name': 'loki_detector_2',
+            'resolution': {'y': 9 * _res_scale, 'x': 3 * _res_scale},
+            'gridspec': (1, 3),
+            'pixel_noise': 'cylindrical',
+        },
+        'loki_detector_3': {
+            'detector_name': 'loki_detector_3',
+            'resolution': {'y': 3 * _res_scale, 'x': 9 * _res_scale},
+            'gridspec': (0, 4),
+            'pixel_noise': 'cylindrical',
+        },
+        'loki_detector_4': {
+            'detector_name': 'loki_detector_4',
+            'resolution': {'y': 9 * _res_scale, 'x': 3 * _res_scale},
+            'gridspec': (1, 5),
+            'pixel_noise': 'cylindrical',
+        },
+        # Second window frame
+        'loki_detector_5': {
+            'detector_name': 'loki_detector_5',
+            'resolution': {'y': 3 * _res_scale, 'x': 9 * _res_scale},
+            'gridspec': (2, 7),
+            'pixel_noise': 'cylindrical',
+        },
+        'loki_detector_6': {
+            'detector_name': 'loki_detector_6',
+            'resolution': {'y': 9 * _res_scale, 'x': 3 * _res_scale},
+            'gridspec': (1, 6),
+            'pixel_noise': 'cylindrical',
+        },
+        'loki_detector_7': {
+            'detector_name': 'loki_detector_7',
+            'resolution': {'y': 3 * _res_scale, 'x': 9 * _res_scale},
+            'gridspec': (0, 7),
+            'pixel_noise': 'cylindrical',
+        },
+        'loki_detector_8': {
+            'detector_name': 'loki_detector_8',
+            'resolution': {'y': 9 * _res_scale, 'x': 3 * _res_scale},
+            'gridspec': (1, 8),
+            'pixel_noise': 'cylindrical',
+        },
+    },
+}

--- a/src/beamlime/config/raw_detectors/loki.py
+++ b/src/beamlime/config/raw_detectors/loki.py
@@ -1,6 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+
 _res_scale = 8
 
-_loki = {
+loki_detectors_config = {
     'dashboard': {'nrow': 3, 'ncol': 9, 'figsize_scale': 3},
     'detectors': {
         'Rear-detector': {

--- a/src/beamlime/config/raw_detectors/nmx.py
+++ b/src/beamlime/config/raw_detectors/nmx.py
@@ -1,6 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+
 from ess.reduce.live import raw
 
-_nmx = {
+nmx_detectors_config = {
     'dashboard': {'nrow': 1, 'ncol': 3},
     'detectors': {
         'Panel 0': {
@@ -20,6 +23,3 @@ _nmx = {
         },
     },
 }
-# These banks currently have out-of-range event_id values, so we ignore them.
-del _nmx['detectors']['Panel 1']
-del _nmx['detectors']['Panel 2']

--- a/src/beamlime/config/raw_detectors/nmx.py
+++ b/src/beamlime/config/raw_detectors/nmx.py
@@ -1,0 +1,25 @@
+from ess.reduce.live import raw
+
+_nmx = {
+    'dashboard': {'nrow': 1, 'ncol': 3},
+    'detectors': {
+        'Panel 0': {
+            'detector_name': 'detector_panel_0',
+            'gridspec': (0, 0),
+            'projection': raw.LogicalView(),
+        },
+        'Panel 1': {
+            'detector_name': 'detector_panel_1',
+            'gridspec': (0, 1),
+            'projection': raw.LogicalView(),
+        },
+        'Panel 2': {
+            'detector_name': 'detector_panel_2',
+            'gridspec': (0, 2),
+            'projection': raw.LogicalView(),
+        },
+    },
+}
+# These banks currently have out-of-range event_id values, so we ignore them.
+del _nmx['detectors']['Panel 1']
+del _nmx['detectors']['Panel 2']


### PR DESCRIPTION
This PR moves the config of detectors to `beamlime.config.raw_detectors` and cleans up the `handlers.py` a bit. For now these are just python files but we can make them into TOML/YAML/.... in the future. We can also move them to instrument packages and register them via entry-points. I chose `beamlime.config.raw_detectors` to be explicit that this is the configuration used during raw detector view.