### PR TITLE
Time-based update and window size for raw-detector view

### DIFF
--- a/src/beamlime/applications/raw_count_handlers.py
+++ b/src/beamlime/applications/raw_count_handlers.py
@@ -110,6 +110,8 @@ class RawCountHandler(HandlerInterface):
             self.info("Updating views at %s", reference_time)
             while reference_time >= self._next_update:
                 # If there were no pulses for a while we need to skip several updates.
+                # Note that we do not simply set _next_update based on reference_time
+                # to avoid drifts.
                 self._next_update += self._update_every
             results = {}
             for name, det in self._views.items():


### PR DESCRIPTION
This switches to a time based solution, which avoids linking the number of detectors to the update rate, and provides a more natural way of configuration.

This also adds config options instead of hard-coding the updates frequencies.

This probably makes #250 superfluous.