### PR TITLE
Use static topic suffix, encode accumulator information in source name

### DIFF
--- a/src/beamlime/config/defaults/visualization.yaml
+++ b/src/beamlime/config/defaults/visualization.yaml
@@ -1,3 +1,2 @@
 topics:
-  - beam_monitor_cumulative
-  - beam_monitor_sliding
+  - beam_monitor_processed

--- a/src/beamlime/core/handler.py
+++ b/src/beamlime/core/handler.py
@@ -158,7 +158,11 @@ class PeriodicAccumulatingHandler(Handler[T, U]):
         return [
             Message(
                 timestamp=message.timestamp,
-                key=replace(key, topic=f'{key.topic}_{name}'),
+                key=replace(
+                    key,
+                    topic=f'{key.topic}_processed',
+                    source_name=f'{key.source_name}_{name}',
+                ),
                 value=accumulator.get(),
             )
             for name, accumulator in self._accumulators.items()

--- a/src/beamlime/services/dashboard.py
+++ b/src/beamlime/services/dashboard.py
@@ -214,7 +214,7 @@ class DashboardApp(ServiceBase):
             )
 
             for msg in monitor_messages:
-                key = f'{msg.key.topic}_{msg.key.source_name}'
+                key = msg.key.source_name
                 data = msg.value
                 if key not in self._monitor_plots:
                     self._monitor_plots[key] = self.create_monitor_plot(key, data)

--- a/tests/handlers/monitor_data_handler_test.py
+++ b/tests/handlers/monitor_data_handler_test.py
@@ -46,7 +46,7 @@ def test_handler() -> None:
     cumulative_value = -1
     sliding_window_value = -1
     for msg in results:
-        if 'cumulative' in msg.key.topic:
+        if 'cumulative' in msg.key.source_name:
             cumulative_value = msg.value
         else:
             sliding_window_value = msg.value


### PR DESCRIPTION
Fixes #290.

The main driver for this change is that with detector data we are more dynamic in terms of which views are configured. Constantly changing which topics one needs to subscribe to, e.g., in the dashboard, does not seem reasonable right now. Furthermore, if we publish to the ECDC Kafka then we cannot rely on auto-topic creation but need a more static solution.