### PR TITLE
Add stripped geometry files in a Pooch

### DIFF
--- a/scripts/setup-kafka-topics.sh
+++ b/scripts/setup-kafka-topics.sh
@@ -42,17 +42,7 @@ kafka-topics --create --bootstrap-server kafka:29092 \
   --config retention.bytes=-1
 
 kafka-topics --create --bootstrap-server kafka:29092 \
-  --topic ${BEAMLIME_INSTRUMENT}_beam_monitor_cumulative \
-  --config cleanup.policy=delete \
-  --config delete.retention.ms=60000 \
-  --config max.message.bytes=327680 \
-  --config retention.bytes=1073741824 \
-  --config retention.ms=30000 \
-  --config segment.bytes=10485760 \
-  --config segment.ms=60000
-
-kafka-topics --create --bootstrap-server kafka:29092 \
-  --topic ${BEAMLIME_INSTRUMENT}_beam_monitor_sliding \
+  --topic ${BEAMLIME_INSTRUMENT}_beam_monitor_processed \
   --config cleanup.policy=delete \
   --config delete.retention.ms=60000 \
   --config max.message.bytes=327680 \

--- a/src/beamlime/config/raw_detectors/nmx.py
+++ b/src/beamlime/config/raw_detectors/nmx.py
@@ -1,23 +1,35 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
-
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import scipp as sc
 from ess.reduce.live import raw
 
+# TODO Unclear if this is transposed or not. Wait for updated files.
+dim = 'detector_number'
+sizes = {'x': 1280, 'y': 1280}
 nmx_detectors_config = {
     'dashboard': {'nrow': 1, 'ncol': 3},
     'detectors': {
         'Panel 0': {
             'detector_name': 'detector_panel_0',
+            'detector_number': sc.arange(
+                dim, 0 * 1280**2 + 1, 1 * 1280**2 + 1, unit=None
+            ).fold(dim=dim, sizes=sizes),
             'gridspec': (0, 0),
             'projection': raw.LogicalView(),
         },
         'Panel 1': {
             'detector_name': 'detector_panel_1',
+            'detector_number': sc.arange(
+                dim, 1 * 1280**2 + 1, 2 * 1280**2 + 1, unit=None
+            ).fold(dim=dim, sizes=sizes),
             'gridspec': (0, 1),
             'projection': raw.LogicalView(),
         },
         'Panel 2': {
             'detector_name': 'detector_panel_2',
+            'detector_number': sc.arange(
+                dim, 2 * 1280**2 + 1, 3 * 1280**2 + 1, unit=None
+            ).fold(dim=dim, sizes=sizes),
             'gridspec': (0, 2),
             'projection': raw.LogicalView(),
         },

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -48,14 +48,13 @@ class DetectorHandlerFactory(HandlerFactory[DetectorEvents, sc.DataArray]):
         self,
         *,
         instrument: str,
-        nexus_file: str | None,
         logger: logging.Logger | None = None,
         config: Config,
     ) -> None:
         self._logger = logger or logging.getLogger(__name__)
         self._config = config
         self._detector_config = detector_registry[instrument]['detectors']
-        self._nexus_file = nexus_file
+        self._nexus_file = _try_get_nexus_geometry_filename(instrument)
         self._window_length = 10
 
     def _key_to_detector_name(self, key: MessageKey) -> str:
@@ -173,3 +172,12 @@ def get_nexus_geometry_filename(
     dt = (date if date is not None else sc.datetime('now')).to(unit='s')
     filename = _parse_filename_lut(instrument)['datetime', dt].value
     return pathlib.Path(_pooch.fetch(filename))
+
+
+def _try_get_nexus_geometry_filename(
+    instrument: str, date: sc.Variable | None = None
+) -> pathlib.Path | None:
+    try:
+        return get_nexus_geometry_filename(instrument, date)
+    except IndexError:
+        return None

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -134,6 +134,8 @@ class DetectorCounts(Accumulator[np.ndarray, sc.DataArray]):
 # Note: Currently no need for a geometry file for NMX since the view is purely logical.
 # DetectorHandlerFactory will fall back to use the detector_number configured in the
 # detector view config.
+# Note: There will be multiple files per instrument, valid for different date ranges.
+# Files should thus not be replaced by making use of the pooch versioning mechanism.
 _registry = {
     'geometry-dream-2025-01-01.nxs': 'md5:91aceb884943c76c0c21400ee74ad9b6',
     'geometry-loki-2025-01-01.nxs': 'md5:e2e48c30ad02dcfa940b7c26885216f2',

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -131,6 +131,9 @@ class DetectorCounts(Accumulator[np.ndarray, sc.DataArray]):
         self._det.clear_counts()
 
 
+# Note: Currently no need for a geometry file for NMX since the view is purely logical.
+# DetectorHandlerFactory will fall back to use the detector_number configured in the
+# detector view config.
 _registry = {
     'geometry-dream-2025-01-01.nxs': 'md5:91aceb884943c76c0c21400ee74ad9b6',
     'geometry-loki-2025-01-01.nxs': 'md5:e2e48c30ad02dcfa940b7c26885216f2',

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -41,7 +41,9 @@ class DetectorHandlerFactory(HandlerFactory[DetectorEvents, sc.DataArray]):
 
     Handlers are created based on the instrument name in the message key which should
     identify the detector name. Depending on the configured detector views a NeXus file
-    with geometry information may be required to setup the view.
+    with geometry information may be required to setup the view. Currently the NeXus
+    files are always obtained via Pooch. Note that this may need to be refactored to a
+    more dynamic approach in the future.
     """
 
     def __init__(

--- a/src/beamlime/services/detector_data.py
+++ b/src/beamlime/services/detector_data.py
@@ -52,11 +52,7 @@ def run_service(
     adapter = ChainedAdapter(
         first=KafkaToEv44Adapter(), second=Ev44ToDetectorEventsAdapter()
     )
-    handler_factory_cls = partial(
-        DetectorHandlerFactory,
-        nexus_file=config.get('nexus_file'),
-        instrument=instrument,
-    )
+    handler_factory_cls = partial(DetectorHandlerFactory, instrument=instrument)
 
     builder = DataServiceBuilder(
         instrument=instrument,

--- a/src/beamlime/services/fake_detectors.py
+++ b/src/beamlime/services/fake_detectors.py
@@ -25,6 +25,7 @@ from beamlime.kafka.helpers import detector_topic
 from beamlime.kafka.sink import KafkaSink, SerializationError
 
 # Configure detectors to fake for each instrument
+# Values as of January 2025. These may change if the detector configuration changes.
 _detector_config = {
     'dummy': {
         'panel_0': (0, 128**2),
@@ -34,8 +35,18 @@ _detector_config = {
         'endcap_backward_detector': (71618, 229377),
         'endcap_forward_detector': (1, 71681),
     },
+    'loki': {
+        'loki_detector_0': (1, 802817),
+        'loki_detector_1': (802817, 1032193),
+        'loki_detector_2': (1032193, 1204225),
+        'loki_detector_3': (1204225, 1433601),
+        'loki_detector_4': (1433601, 1605633),
+        'loki_detector_5': (1605633, 2007041),
+        'loki_detector_6': (2007041, 2465793),
+        'loki_detector_7': (2465793, 2752513),
+        'loki_detector_8': (2752513, 3211265),
+    },
     'nmx': {},
-    'loki': {},
 }
 
 

--- a/src/beamlime/services/fake_detectors.py
+++ b/src/beamlime/services/fake_detectors.py
@@ -28,25 +28,27 @@ from beamlime.kafka.sink import KafkaSink, SerializationError
 # Values as of January 2025. These may change if the detector configuration changes.
 _detector_config = {
     'dummy': {
-        'panel_0': (0, 128**2),
+        'panel_0': (1, 128**2),
     },
     'dream': {
-        'mantle_detector': (229377, 720897),
-        'endcap_backward_detector': (71618, 229377),
-        'endcap_forward_detector': (1, 71681),
+        'mantle_detector': (229377, 720896),
+        'endcap_backward_detector': (71618, 229376),
+        'endcap_forward_detector': (1, 71680),
     },
     'loki': {
-        'loki_detector_0': (1, 802817),
-        'loki_detector_1': (802817, 1032193),
-        'loki_detector_2': (1032193, 1204225),
-        'loki_detector_3': (1204225, 1433601),
-        'loki_detector_4': (1433601, 1605633),
-        'loki_detector_5': (1605633, 2007041),
-        'loki_detector_6': (2007041, 2465793),
-        'loki_detector_7': (2465793, 2752513),
-        'loki_detector_8': (2752513, 3211265),
+        'loki_detector_0': (1, 802816),
+        'loki_detector_1': (802817, 1032192),
+        'loki_detector_2': (1032193, 1204224),
+        'loki_detector_3': (1204225, 1433600),
+        'loki_detector_4': (1433601, 1605632),
+        'loki_detector_5': (1605633, 2007040),
+        'loki_detector_6': (2007041, 2465792),
+        'loki_detector_7': (2465793, 2752512),
+        'loki_detector_8': (2752513, 3211264),
     },
-    'nmx': {},
+    'nmx': {
+        f'detector_panel_{i}': (i * 1280**2 + 1, (i + 1) * 1280**2) for i in range(3)
+    },
 }
 
 
@@ -73,7 +75,7 @@ class FakeDetectorSource(MessageSource[sc.Dataset]):
 
     def _make_ids(self, name: str, size: int) -> np.ndarray:
         low, high = _detector_config[self._instrument][name]
-        return self._rng.integers(low=low, high=high, size=size)
+        return self._rng.integers(low=low, high=high + 1, size=size)
 
     def get_messages(self) -> list[Message[sc.Dataset]]:
         current_time = time.time_ns()

--- a/tests/handlers/detector_data_handler_test.py
+++ b/tests/handlers/detector_data_handler_test.py
@@ -13,7 +13,7 @@ from beamlime.handlers.detector_data_handler import (
 
 
 def test_factory_can_fall_back_to_configured_detector_number_for_LogicalView() -> None:
-    factory = DetectorHandlerFactory(instrument='dummy', nexus_file=None, config={})
+    factory = DetectorHandlerFactory(instrument='dummy', config={})
     handler = factory.make_handler(
         MessageKey(topic='detector_data', source_name='panel_0')
     )

--- a/tests/handlers/detector_data_handler_test.py
+++ b/tests/handlers/detector_data_handler_test.py
@@ -33,11 +33,12 @@ def test_factory_can_fall_back_to_configured_detector_number_for_LogicalView() -
     assert sc.identical(counts, sc.scalar(3, unit='counts', dtype='int32'))
 
 
-def test_get_nexus_filename_returns_file_for_given_date() -> None:
+@pytest.mark.parametrize('instrument', ['dream', 'loki'])
+def test_get_nexus_filename_returns_file_for_given_date(instrument: str) -> None:
     filename = get_nexus_geometry_filename(
-        'dream', date=sc.datetime('2025-01-02T00:00:00')
+        instrument, date=sc.datetime('2025-01-02T00:00:00')
     )
-    assert str(filename).endswith('geometry-dream-2025-01-01.nxs')
+    assert str(filename).endswith(f'geometry-{instrument}-2025-01-01.nxs')
 
 
 def test_get_nexus_filename_uses_current_date_by_default() -> None:
@@ -46,6 +47,11 @@ def test_get_nexus_filename_uses_current_date_by_default() -> None:
     assert auto == explicit
 
 
+def test_get_nexus_filename_raises_if_instrument_unknown() -> None:
+    with pytest.raises(ValueError, match='No geometry files found for instrument'):
+        get_nexus_geometry_filename('abcde', date=sc.datetime('2025-01-01T00:00:00'))
+
+
 def test_get_nexus_filename_raises_if_datetime_out_of_range() -> None:
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError, match='No geometry file found for given date'):
         get_nexus_geometry_filename('dream', date=sc.datetime('2020-01-01T00:00:00'))

--- a/tests/handlers/detector_data_handler_test.py
+++ b/tests/handlers/detector_data_handler_test.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import numpy as np
+import pytest
 import scipp as sc
 
 from beamlime.core.handler import Message, MessageKey
 from beamlime.handlers.accumulators import DetectorEvents
-from beamlime.handlers.detector_data_handler import DetectorHandlerFactory
+from beamlime.handlers.detector_data_handler import (
+    DetectorHandlerFactory,
+    get_nexus_geometry_filename,
+)
 
 
 def test_factory_can_fall_back_to_configured_detector_number_for_LogicalView() -> None:
@@ -27,3 +31,21 @@ def test_factory_can_fall_back_to_configured_detector_number_for_LogicalView() -
     assert len(results) == 1
     counts = results[0].value.sum().data
     assert sc.identical(counts, sc.scalar(3, unit='counts', dtype='int32'))
+
+
+def test_get_nexus_filename_returns_file_for_given_date() -> None:
+    filename = get_nexus_geometry_filename(
+        'dream', date=sc.datetime('2025-01-02T00:00:00')
+    )
+    assert str(filename).endswith('geometry-dream-2025-01-01.nxs')
+
+
+def test_get_nexus_filename_uses_current_date_by_default() -> None:
+    auto = get_nexus_geometry_filename('dream')
+    explicit = get_nexus_geometry_filename('dream', date=sc.datetime('now'))
+    assert auto == explicit
+
+
+def test_get_nexus_filename_raises_if_datetime_out_of_range() -> None:
+    with pytest.raises(IndexError):
+        get_nexus_geometry_filename('dream', date=sc.datetime('2020-01-01T00:00:00'))


### PR DESCRIPTION
This allows for running the `detector_data` service without having to provide a local file.

As explained in the updated docstring, a more dynamic mechanism will likely need to be implemented in the future. We could even imagine having a service that can provide the path via Kafka.