### PR TITLE
Handle multiple messages at a time

### DIFF
--- a/src/beamlime/core/handler.py
+++ b/src/beamlime/core/handler.py
@@ -192,8 +192,8 @@ class PeriodicAccumulatingHandler(Handler[T, U]):
             self._preprocess(message)
         # Note that preprocess.get or accumulator.add may be expensive. We may thus ask
         # whether this should only be done when _produce_update is called. This would
-        # however lead to extra latency nad likely even a waste of time in waiting idly
-        # for new messages. Instead, but processing more eagerly the overall mechanism
+        # however lead to extra latency and likely even a waste of time in waiting idly
+        # for new messages. Instead, by processing more eagerly, the overall mechanism
         # is more responsive and will "converge" to a stable state of messages per call.
         # That is, if processing is too expensive for a small number of messages, this
         # delay will lead to more messages to be consumed in the next iteration, driving

--- a/src/beamlime/core/handler.py
+++ b/src/beamlime/core/handler.py
@@ -180,6 +180,14 @@ class PeriodicAccumulatingHandler(Handler[T, U]):
         )
 
     def handle(self, messages: list[Message[T]]) -> list[Message[V]]:
+        # Note an issue here: We preprocess all messages, with a range of timestamps.
+        # If one of the accumulators is a sliding-window accumulator, the cutoff time
+        # will not be precise. I do not expect this to be a problem as long as the
+        # processing time is low since then few messages at a time will be processed.
+        # As event rates go up, however, we will be processing more and more messages
+        # at a time, leading to a larger discrepancy. At this point we may experience
+        # some time-dependent fluctuations in sliding-window results. The mechanism may
+        # need to be revisited if this becomes a problem.
         for message in messages:
             self._preprocess(message)
         # Note that preprocess.get or accumulator.add may be expensive. We may thus ask

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -136,7 +136,7 @@ class DetectorCounts(Accumulator[np.ndarray, sc.DataArray]):
 # detector view config.
 _registry = {
     'geometry-dream-2025-01-01.nxs': 'md5:91aceb884943c76c0c21400ee74ad9b6',
-    'geometry-loki-2025-01-01.nxs': 'md5:e2e48c30ad02dcfa940b7c26885216f2',
+    'geometry-loki-2025-01-01.nxs': 'md5:8d0e103276934a20ba26bb525e53924a',
 }
 
 

--- a/src/beamlime/kafka/sink.py
+++ b/src/beamlime/kafka/sink.py
@@ -17,8 +17,6 @@ T = TypeVar("T")
 class SerializationError(Exception):
     """Raised when serialization of a message fails."""
 
-    pass
-
 
 class Serializer(Protocol, Generic[T]):
     def __call__(self, value: Message[T]) -> bytes: ...

--- a/src/beamlime/services/fake_detectors.py
+++ b/src/beamlime/services/fake_detectors.py
@@ -26,7 +26,7 @@ from beamlime.kafka.sink import KafkaSink, SerializationError
 
 # Configure detectors to fake for each instrument
 # Values as of January 2025. These may change if the detector configuration changes.
-_detector_config = {
+detector_config = {
     'dummy': {
         'panel_0': (1, 128**2),
     },
@@ -67,14 +67,14 @@ class FakeDetectorSource(MessageSource[sc.Dataset]):
         self._tof = sc.linspace('tof', 0, 71_000_000, num=50, unit='ns')
         self._interval_ns = interval_ns
         self._last_message_time = {
-            detector: time.time_ns() for detector in _detector_config[instrument]
+            detector: time.time_ns() for detector in detector_config[instrument]
         }
 
     def _make_normal(self, mean: float, std: float, size: int) -> np.ndarray:
         return self._rng.normal(loc=mean, scale=std, size=size).astype(np.int64)
 
     def _make_ids(self, name: str, size: int) -> np.ndarray:
-        low, high = _detector_config[self._instrument][name]
+        low, high = detector_config[self._instrument][name]
         return self._rng.integers(low=low, high=high + 1, size=size)
 
     def get_messages(self) -> list[Message[sc.Dataset]]:

--- a/src/beamlime/services/fake_detectors.py
+++ b/src/beamlime/services/fake_detectors.py
@@ -122,9 +122,9 @@ T = TypeVar('T')
 
 
 class IdentityHandler(Handler[T, T]):
-    def handle(self, message: Message[T]) -> list[Message[T]]:
+    def handle(self, messages: list[Message[T]]) -> list[Message[T]]:
         # We know the message does not originate from Kafka, so we can keep the key
-        return [message]
+        return messages
 
 
 def serialize_detector_events_to_ev44(

--- a/src/beamlime/services/fake_monitors.py
+++ b/src/beamlime/services/fake_monitors.py
@@ -88,9 +88,9 @@ T = TypeVar('T')
 
 
 class IdentityHandler(Handler[T, T]):
-    def handle(self, message: Message[T]) -> list[Message[T]]:
+    def handle(self, messages: list[Message[T]]) -> list[Message[T]]:
         # We know the message does not originate from Kafka, so we can keep the key
-        return [message]
+        return messages
 
 
 def serialize_variable_to_monitor_ev44(msg: Message[sc.Variable]) -> bytes:

--- a/tests/handlers/detector_data_handler_test.py
+++ b/tests/handlers/detector_data_handler_test.py
@@ -27,7 +27,7 @@ def test_factory_can_fall_back_to_configured_detector_number_for_LogicalView() -
         key=MessageKey(topic='abcde', source_name='ignored'),
         value=events,
     )
-    results = handler.handle(message)
+    results = handler.handle([message])
     assert len(results) == 1
     counts = results[0].value.sum().data
     assert sc.identical(counts, sc.scalar(3, unit='counts', dtype='int32'))

--- a/tests/handlers/monitor_data_handler_test.py
+++ b/tests/handlers/monitor_data_handler_test.py
@@ -24,23 +24,24 @@ def test_handler() -> None:
             time_of_arrival=np.array([int(1e6), int(2e6), int(4e7)]), unit='ns'
         ),
     )
-    results = handler.handle(msg)
+    results = handler.handle([msg])
     assert len(results) == 2
     assert sc.identical(results[0].value, results[1].value)
 
-    results = handler.handle(msg)
+    results = handler.handle([msg])
     # No update since we are still in same update interval
     assert len(results) == 0
 
     msg = replace(msg, timestamp=msg.timestamp + int(1.2e9))
-    results = handler.handle(msg)
+    results = handler.handle([msg])
     assert len(results) == 2
     # Everything is still in same window
     assert sc.identical(results[0].value, results[1].value)
 
     msg = replace(msg, timestamp=msg.timestamp + int(9e9))
-    results = handler.handle(msg)
+    results = handler.handle([msg])
     assert len(results) == 2
+    # TODO outdated comment
     # Window contains 3 messages (should be 2, but due to initial update on first
     # message, we have 3), 4 messages since start.
     cumulative_value = -1
@@ -50,4 +51,4 @@ def test_handler() -> None:
             cumulative_value = msg.value
         else:
             sliding_window_value = msg.value
-    assert_identical(3 * cumulative_value, 4 * sliding_window_value)
+    assert_identical(2 * cumulative_value, 4 * sliding_window_value)

--- a/tests/handlers/monitor_data_handler_test.py
+++ b/tests/handlers/monitor_data_handler_test.py
@@ -41,9 +41,7 @@ def test_handler() -> None:
     msg = replace(msg, timestamp=msg.timestamp + int(9e9))
     results = handler.handle([msg])
     assert len(results) == 2
-    # TODO outdated comment
-    # Window contains 3 messages (should be 2, but due to initial update on first
-    # message, we have 3), 4 messages since start.
+    # Window contains 2 messages, 4 messages since start.
     cumulative_value = -1
     sliding_window_value = -1
     for msg in results:

--- a/tests/processor_test.py
+++ b/tests/processor_test.py
@@ -10,11 +10,11 @@ T = TypeVar('T')
 
 
 class ValueToStringHandler(Handler[T, str]):
-    def handle(self, message: Message[T]) -> list[Message[str]]:
-        msg = Message(
-            timestamp=message.timestamp, key='string', value=str(message.value)
-        )
-        return [msg]
+    def handle(self, messages: list[Message[T]]) -> list[Message[str]]:
+        return [
+            Message(timestamp=message.timestamp, key='string', value=str(message.value))
+            for message in messages
+        ]
 
 
 def test_consumes_and_produces_messages() -> None:

--- a/tests/services/data_service_test.py
+++ b/tests/services/data_service_test.py
@@ -28,8 +28,8 @@ class ForwardingAdapter(MessageAdapter[KafkaMessage, Message[int]]):
 
 
 class ForwardingHandler(Handler[int, int]):
-    def handle(self, message: Message[int]) -> list[Message[int]]:
-        return [message]
+    def handle(self, messages: list[Message[int]]) -> list[Message[int]]:
+        return messages
 
 
 class EmptyConsumer(KafkaConsumer):

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+import time
+from functools import partial
+
+import numpy as np
+import pytest
+from streaming_data_types import eventdata_ev44
+
+from beamlime.fakes import FakeMessageSink
+from beamlime.handlers.detector_data_handler import DetectorHandlerFactory
+from beamlime.kafka.message_adapter import (
+    ChainedAdapter,
+    Ev44ToDetectorEventsAdapter,
+    FakeKafkaMessage,
+    KafkaMessage,
+    KafkaToEv44Adapter,
+)
+from beamlime.kafka.source import KafkaConsumer
+from beamlime.service_factory import DataServiceBuilder
+from beamlime.services.fake_detectors import detector_config
+
+
+class EmptyConsumer(KafkaConsumer):
+    def consume(self, num_messages: int, timeout: float) -> list[KafkaMessage]:
+        return []
+
+    def close(self) -> None:
+        pass
+
+
+class Ev44Consumer(KafkaConsumer):
+    def __init__(
+        self,
+        instrument: str = 'dummy',
+        events_per_message: int = 1_000,
+        max_events: int = 1_000_000,
+    ) -> None:
+        self._detector_config = detector_config[instrument]
+        self._events_per_message = events_per_message
+        self._max_events = max_events
+        self._pixel_id = np.ones(events_per_message, dtype=np.int32)
+        self._rng = np.random.default_rng()
+
+        self._reference_time = 0
+        self._running = False
+        self._count = 0
+        self._content = [
+            self.make_serialized_ev44(name) for name in self._detector_config
+        ]
+
+    def start(self) -> None:
+        self._running = True
+
+    def reset(self) -> None:
+        self._running = False
+        self._count = 0
+
+    @property
+    def at_end(self) -> bool:
+        return self._count * self._events_per_message >= self._max_events * len(
+            self._detector_config
+        )
+
+    def _make_timestamp(self) -> int:
+        self._reference_time += 1
+        self._count += 1
+        return self._reference_time * 71_000_000 // len(self._detector_config)
+
+    def make_serialized_ev44(self, name: str) -> bytes:
+        time_of_arrival = self._rng.uniform(
+            0, 70_000_000, self._events_per_message
+        ).astype(np.int32)
+        first, last = self._detector_config[name]
+        pixel_id = self._rng.integers(
+            first, last + 1, self._events_per_message, dtype=np.int32
+        )
+        # Note empty reference_time. KafkaToEv44Adapter uses message.timestamp(), which
+        # allows us to reuse the serialized content, to avoid seeing the cost in the
+        # benchmarks.
+        return eventdata_ev44.serialise_ev44(
+            source_name=name,
+            message_id=0,
+            reference_time=[],
+            reference_time_index=0,
+            time_of_flight=time_of_arrival,
+            pixel_id=pixel_id,
+        )
+
+    def consume(self, num_messages: int, timeout: float) -> list[KafkaMessage]:
+        if not self._running or self.at_end:
+            return []
+        messages = [
+            FakeKafkaMessage(
+                value=self._content[msg % len(self._content)],
+                topic="dummy",
+                timestamp=self._make_timestamp(),
+            )
+            for msg in range(num_messages)
+        ]
+        return messages
+
+    def close(self) -> None:
+        pass
+
+
+def start_and_wait_for_completion(consumer: Ev44Consumer) -> None:
+    consumer.start()
+    while not consumer.at_end:
+        time.sleep(0.01)
+    consumer.reset()
+
+
+@pytest.mark.parametrize('instrument', ['dummy', 'nmx', 'loki', 'dream'])
+@pytest.mark.parametrize('events_per_message', [10_000, 100_000, 1_000_000])
+def test_performance(benchmark, instrument: str, events_per_message: int) -> None:
+    # There is some caveat in this benchmark: Ev44Consumer has no concept of real time.
+    # It is thus always returning messages quickly, which shifts the balance in the
+    # services to a different place than in reality.
+    builder = DataServiceBuilder(
+        instrument=instrument,
+        name='detector_data',
+        adapter=ChainedAdapter(
+            first=KafkaToEv44Adapter(), second=Ev44ToDetectorEventsAdapter()
+        ),
+        handler_factory_cls=partial(DetectorHandlerFactory, instrument=instrument),
+    )
+    service = builder.build(
+        control_consumer=EmptyConsumer(),
+        consumer=EmptyConsumer(),
+        sink=FakeMessageSink(),
+    )
+
+    sink = FakeMessageSink()
+    consumer = Ev44Consumer(
+        instrument=instrument,
+        events_per_message=events_per_message,
+        max_events=50_000_000,
+    )
+    service = builder.build(
+        control_consumer=EmptyConsumer(), consumer=consumer, sink=sink
+    )
+    service.start(blocking=False)
+    benchmark(start_and_wait_for_completion, consumer=consumer)
+    service.stop()
+    assert len(sink.messages) > len(detector_config[instrument]) * 10


### PR DESCRIPTION
The reason for this change of mechanism is to allow for calling expensive preprocessing and accumulation more eagerly. We cannot afford to do this with every message. The previous approach of delaying until an update is produced had the downsides of introducing (1) additional latency and (2) spending more idle time waiting for messages and thus reducing the maximum achievable throughput.