### PR TITLE
Add tests for detector_data and monitor_data service equivalents

### DIFF
--- a/src/beamlime/core/handler.py
+++ b/src/beamlime/core/handler.py
@@ -84,6 +84,9 @@ class HandlerRegistry(Generic[Tin, Tout]):
         self._factory = factory
         self._handlers: dict[MessageKey, Handler] = {}
 
+    def __len__(self) -> int:
+        return len(self._handlers)
+
     def get(self, key: MessageKey) -> Handler:
         if key not in self._handlers:
             self._handlers[key] = self._factory.make_handler(key)

--- a/src/beamlime/core/processor.py
+++ b/src/beamlime/core/processor.py
@@ -48,5 +48,8 @@ class StreamProcessor(Generic[Tin, Tout]):
         results = []
         for key, msgs in messages_by_key.items():
             handler = self._handler_registry.get(key)
-            results.extend(handler.handle(msgs))
+            try:
+                results.extend(handler.handle(msgs))
+            except Exception:
+                self._logger.exception('Error processing messages for key %s', key)
         self._sink.publish_messages(results)

--- a/src/beamlime/services/fake_detectors.py
+++ b/src/beamlime/services/fake_detectors.py
@@ -29,16 +29,15 @@ from beamlime.kafka.sink import KafkaSink, SerializationError
 # Configure detectors to fake for each instrument
 # Values as of January 2025. These may change if the detector configuration changes.
 def _bifrost_generator() -> Generator[tuple[str, tuple[int, int]]]:
-    # This does not match the actual detector configuration
     start = 123
-    detector_start = 1
-    for i in range(1, 10):
-        for j in range(1, 6):
+    ntube = 3
+    for sector in range(1, 10):
+        for analyzer in range(1, 6):
+            base = ntube * 900 * (analyzer - 1) + 100 * (sector - 1)
             yield (
-                f'{start}_channel_{i}_{j}_triplet',
-                (detector_start, detector_start + 299),
+                f'{start}_channel_{sector}_{analyzer}_triplet',
+                (base + 1, base + 100 + 1800),
             )
-            detector_start += 300
             start += 4
         start += 1
 

--- a/src/beamlime/services/monitor_data.py
+++ b/src/beamlime/services/monitor_data.py
@@ -44,6 +44,20 @@ def make_monitor_data_adapter() -> RoutingAdapter:
     )
 
 
+def make_monitor_service_builder(
+    *, instrument: str, log_level: int = logging.INFO
+) -> DataServiceBuilder:
+    return DataServiceBuilder(
+        instrument=instrument,
+        name='monitor_data',
+        log_level=log_level,
+        adapter=make_monitor_data_adapter(),
+        handler_factory_cls=CommonHandlerFactory.from_handler(
+            create_monitor_data_handler
+        ),
+    )
+
+
 def run_service(
     *,
     sink_type: Literal['kafka', 'png'],
@@ -60,15 +74,7 @@ def run_service(
     else:
         sink = PlotToPngSink()
 
-    builder = DataServiceBuilder(
-        instrument=instrument,
-        name='monitor_data',
-        log_level=log_level,
-        adapter=make_monitor_data_adapter(),
-        handler_factory_cls=CommonHandlerFactory.from_handler(
-            create_monitor_data_handler
-        ),
-    )
+    builder = make_monitor_service_builder(instrument=instrument, log_level=log_level)
 
     with ExitStack() as stack:
         control_consumer = stack.enter_context(

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -191,5 +191,9 @@ def test_detector_data_service(instrument: str) -> None:
                 assert 5000 < msg.sum().value < 8000
             else:
                 assert msg.sum().value == 10000
+        elif instrument == 'bifrost':
+            # non-contiguous detector_number, but the fake produces random numbers, we
+            # should get about 1/9 of the counts
+            assert 500 < msg.sum().value < 3000
         else:
             assert msg.sum().value == 10000

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -179,6 +179,7 @@ def test_detector_data_service(instrument: str) -> None:
         for msg in sink.messages
         if msg.key.source_name.endswith('/cumulative')
     }
+    assert len(cumulative) == len(detectors)
     for name, msg in cumulative.items():
         if instrument == 'dream':
             if 'mantle_front_layer' in name:
@@ -187,7 +188,7 @@ def test_detector_data_service(instrument: str) -> None:
             elif 'High-Res' in name:
                 # non-contiguous detector_number, but the fake produces random numbers
                 # in the gaps
-                assert 6000 < msg.sum().value < 8000
+                assert 5000 < msg.sum().value < 8000
             else:
                 assert msg.sum().value == 10000
         else:


### PR DESCRIPTION
While this is not actually running the service scripts, the setup logic is (I think) as close as possible without actually using Kafka.

~Passing tests will require a release of scipp/essreduce#190.~ ... or so I thought.