### PR TITLE
bump README file hash

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def _make_pooch():
             'ymir.json': 'md5:5e913075094d97c5e9e9aca76fc32554',
             'ymir_detectors.nxs': 'md5:2e143cd839a84301b7459d5ab6df8454',
             # readme of the dataset
-            'README.md': 'md5:7e101b5c38dddc7d530e0594a2058950',
+            'README.md': 'md5:d53ffcf9c1363af7043e5a1a2071d2bd',
         },
     )
 


### PR DESCRIPTION
Looks like the [README.md](https://public.esss.dk/groups/scipp/beamlime/nexus_templates/README.md) file was edited on 14th Feb and it updated the hash. The CI should be fixed with this.