### PR TITLE
Data reduction service

### DIFF
--- a/src/beamlime/config/config_names.py
+++ b/src/beamlime/config/config_names.py
@@ -5,6 +5,7 @@ This module contains constants for the configuration namespaces.
 """
 
 control_consumer = 'control_consumer'
+data_reduction = 'data_reduction'
 detector_data = 'detector_data'
 kafka_downstream = 'kafka_downstream'
 kafka_upstream = 'kafka_upstream'

--- a/src/beamlime/config/raw_detectors/__init__.py
+++ b/src/beamlime/config/raw_detectors/__init__.py
@@ -9,7 +9,7 @@ they can be moved to a separate file format in the future.
 
 import importlib
 import pkgutil
-from typing import Any
+from types import ModuleType
 
 
 def available_instruments() -> list[str]:
@@ -21,13 +21,12 @@ def available_instruments() -> list[str]:
     ]
 
 
-def get_detector_config(instrument: str) -> dict[str, Any]:
-    """Get detector config for given instrument."""
+def get_config(instrument: str) -> ModuleType:
+    """Get config module for given instrument."""
     try:
-        module = importlib.import_module(f'.{instrument}', __package__)
-        return module.detectors_config
+        return importlib.import_module(f'.{instrument}', __package__)
     except (ImportError, AttributeError) as e:
         raise ValueError(f'No detector config found for instrument {instrument}') from e
 
 
-__all__ = ['available_instruments', 'get_detector_config']
+__all__ = ['available_instruments', 'get_config']

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -8,6 +8,7 @@ import scipp as sc
 from ess.reduce.streaming import StreamProcessor
 from sciline.typing import Key
 
+from ..config.raw_detectors import get_config
 from ..core.handler import (
     Accumulator,
     Config,
@@ -29,15 +30,15 @@ class ReductionHandlerFactory(
     def __init__(
         self,
         *,
+        instrument: str,
         logger: logging.Logger | None = None,
         config: Config,
-        processors: dict[Key, StreamProcessor],
-        source_to_key: dict[str, Key],
     ) -> None:
         self._logger = logger or logging.getLogger(__name__)
         self._config = config
-        self._processors = processors
-        self._source_to_key = source_to_key
+        instrument_config = get_config(instrument)
+        self._processors = instrument_config.make_stream_processors()
+        self._source_to_key = instrument_config.source_to_key
 
     def make_handler(
         self, key: MessageKey

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -3,85 +3,27 @@
 from __future__ import annotations
 
 import logging
-from sciline.typing import Key
 
 import scipp as sc
 from ess.reduce.streaming import StreamProcessor
+from sciline.typing import Key
 
-from ..config import models
-from ..config.raw_detectors import get_detector_config
 from ..core.handler import (
     Accumulator,
     Config,
-    ConfigModelAccessor,
     Handler,
     HandlerFactory,
     PeriodicAccumulatingHandler,
 )
 from ..core.message import MessageKey
-from .accumulators import (
-    DetectorEvents,
-    ToNXevent_data,
-    GroupIntoPixels,
-    NullAccumulator,
-    ROIBasedTOAHistogram,
-)
-from ..kafka.helpers import beam_monitor_topic, detector_topic
-from .monitor_data_handler import MonitorDataPreprocessor
-
-
-# Idea:
-# We need to handle monitors and detectors with separate source names. The need to be
-# passed into the same StreamProcessor (or rather one per detector, multiplixing the
-# monitors). We thus need several handlers that set the data, but one leader that
-# performs the actual reduction. The other handlers should generally not return any
-# messages.
-# What if we get monitors before detectors?
-
-# We probably want to avoid duplicate processing of monitors. We can either use a single
-# Scline workflow for all detector banks, or somehow extract the monitor workflow.
-# Both is awkward, since it forces some synchronization.
-
-
-# Alternatively, we could return the same handler *instance* for all keys, but how do we
-# avoid duplicate `get` calls for each message?
-# Or is PeriodicAccumulatingHandler simply not the right abstraction in this case?
-# Let us check, what does it do:
-# 1. preprocess all messages.
-# 2. preprocess.get(). This could perform merging of ev44.
-# 3. accumulate preprocessed. <-> StreamProcessor.accumulate
-# 4. IF UPDATE: accumulator.get() and return results <-> StreamProcessor.finalize
-
-# backwards need many preprocessors, one accumulator, one finalizer.
-# current is opposite: one preprocessor, many accumulators, many finalizers.
-
-# ... but we can have multiple handlers, giving us multiple preprocessors.
-# The accumulators across all handlers should feed into the same underlying
-# StreamProcessor.accumulate. The question is how to trigger this.
-# Also, StreamProcessor is not really supporting mapped keys, do we need to run one
-# wf per detector? Can we extract the monitor workflow?
-#
-# Let us assume StreamProcessor was more powerful, allowing for more independent updates
-# of keys.
-#
-# 1. Monitor handlers: We want to run the part of the workflow that does not depend on
-#    any detector (dynamic or static).
-# 2. Detectors: We would like to insert monitor wf results into each detector wf.
-
-# Note scipp/essreduce#191
+from .accumulators import DetectorEvents, ToNXevent_data
 
 
 class ReductionHandlerFactory(
     HandlerFactory[DetectorEvents, sc.DataGroup[sc.DataArray]]
 ):
     """
-    Factory for detector data handlers.
-
-    Handlers are created based on the instrument name in the message key which should
-    identify the detector name. Depending on the configured detector views a NeXus file
-    with geometry information may be required to setup the view. Currently the NeXus
-    files are always obtained via Pooch. Note that this may need to be refactored to a
-    more dynamic approach in the future.
+    Factory for data reduction handlers.
     """
 
     def __init__(
@@ -94,33 +36,42 @@ class ReductionHandlerFactory(
     ) -> None:
         self._logger = logger or logging.getLogger(__name__)
         self._config = config
-        # TODO need a copy for every detector! muliplex monitor data into each!
-        # copying stream processor not trivial accumulators need to be able to be copied
-        # actually we may need different workflow for each detector (say diffraction vs
-        # sans, different mask files, ...), so automatic mechanism may be futile anyway.
         self._processors = processors
         self._source_to_key = source_to_key
-
-    def _is_monitor(self, key: MessageKey) -> bool:
-        return key.topic == beam_monitor_topic(self._instrument)
-
-    def _is_detector(self, key: MessageKey) -> bool:
-        return key.topic == detector_topic(self._instrument)
-
-    def _workflow_key(self, key: MessageKey) -> str:
-        return self._source_to_key[key.source_name]
 
     def make_handler(
         self, key: MessageKey
     ) -> Handler[DetectorEvents, sc.DataGroup[sc.DataArray]]:
-        self._logger.info(f"Creating handler for {key}")
-        wf_key = self._workflow_key(key)
+        self._logger.info("Creating handler for %s", key)
+        wf_key = self._source_to_key[key.source_name]
         if (processor := self._processors.get(key.source_name)) is not None:
             accumulator = StreamProcessorProxy(processor, key=wf_key)
-            self._logger.info(f"Using existing processor for {wf_key}")
+            self._logger.info(
+                "Source name %s is mapped to input %s of stream processor %s",
+                key.source_name,
+                wf_key,
+                key.source_name,
+            )
         else:
+            # Note the inefficiency here, of processing these sources in multiple
+            # workflows. This is typically once per detector. If monitors are large this
+            # can turn into a problem. At the same time, we want to keep flexibile to
+            # allow for
+            # 1. Different workflows for different detector banks, e.g., for diffraction
+            #    and SANS detectors.
+            # 2. Simple scaling, by processing different detectors on different nodes.
+            #
+            # Both could probably also be achieved with a non-duplicate processing of
+            # monitors, but we keep it simple until proven to be necessary. Note that
+            # an alternative would be to move some cost into the preprocessor, which
+            # could, e.g., histogram large monitors to reduce the duplicate cost in the
+            # stream processors.
             accumulator = MultiplexingProxy(list(self._processors.values()), key=wf_key)
-            self._logger.info(f"Creating multiplexing processor for {wf_key}")
+            self._logger.info(
+                "Source name %s is mapped to input %s in all stream processors",
+                key.source_name,
+                wf_key,
+            )
         return PeriodicAccumulatingHandler(
             logger=self._logger,
             config=self._config,
@@ -134,10 +85,7 @@ class MultiplexingProxy(Accumulator[sc.DataArray, sc.DataGroup[sc.DataArray]]):
         self._stream_processors = stream_processors
         self._key = key
 
-    def append(self, stream_processor: StreamProcessor) -> None:
-        self._stream_processors.append(stream_processor)
-
-    def accumulate(self, data: sc.DataArray) -> None:
+    def add(self, timestamp: int, data: sc.DataArray) -> None:
         for stream_processor in self._stream_processors:
             stream_processor.accumulate({self._key: data})
 
@@ -150,8 +98,10 @@ class StreamProcessorProxy(Accumulator[sc.DataArray, sc.DataGroup[sc.DataArray]]
         self._processor = processor
         self._key = key
 
-    def accumulate(self, data: sc.DataArray) -> None:
+    def add(self, timestamp: int, data: sc.DataArray) -> None:
         self._processor.accumulate({self._key: data})
 
     def get(self) -> sc.DataGroup[sc.DataArray]:
-        return self._processor.finalize()
+        return sc.DataGroup(
+            {str(key): val for key, val in self._processor.finalize().items()}
+        )

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -55,8 +55,9 @@ class ReductionHandlerFactory(
         else:
             # Note the inefficiency here, of processing these sources in multiple
             # workflows. This is typically once per detector. If monitors are large this
-            # can turn into a problem. At the same time, we want to keep flexibile to
+            # can turn into a problem. At the same time, we want to keep flexible to
             # allow for
+            #
             # 1. Different workflows for different detector banks, e.g., for diffraction
             #    and SANS detectors.
             # 2. Simple scaling, by processing different detectors on different nodes.

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -77,7 +77,7 @@ class ReductionHandlerFactory(
             logger=self._logger,
             config=self._config,
             preprocessor=ToNXevent_data(),
-            accumulators={'reduced': accumulator},
+            accumulators={f'reduced/{key.source_name}': accumulator},
         )
 
 

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from __future__ import annotations
+
+import logging
+from sciline.typing import Key
+
+import scipp as sc
+from ess.reduce.streaming import StreamProcessor
+
+from ..config import models
+from ..config.raw_detectors import get_detector_config
+from ..core.handler import (
+    Accumulator,
+    Config,
+    ConfigModelAccessor,
+    Handler,
+    HandlerFactory,
+    PeriodicAccumulatingHandler,
+)
+from ..core.message import MessageKey
+from .accumulators import (
+    DetectorEvents,
+    ToNXevent_data,
+    GroupIntoPixels,
+    NullAccumulator,
+    ROIBasedTOAHistogram,
+)
+from ..kafka.helpers import beam_monitor_topic, detector_topic
+from .monitor_data_handler import MonitorDataPreprocessor
+
+
+# Idea:
+# We need to handle monitors and detectors with separate source names. The need to be
+# passed into the same StreamProcessor (or rather one per detector, multiplixing the
+# monitors). We thus need several handlers that set the data, but one leader that
+# performs the actual reduction. The other handlers should generally not return any
+# messages.
+# What if we get monitors before detectors?
+
+# We probably want to avoid duplicate processing of monitors. We can either use a single
+# Scline workflow for all detector banks, or somehow extract the monitor workflow.
+# Both is awkward, since it forces some synchronization.
+
+
+# Alternatively, we could return the same handler *instance* for all keys, but how do we
+# avoid duplicate `get` calls for each message?
+# Or is PeriodicAccumulatingHandler simply not the right abstraction in this case?
+# Let us check, what does it do:
+# 1. preprocess all messages.
+# 2. preprocess.get(). This could perform merging of ev44.
+# 3. accumulate preprocessed. <-> StreamProcessor.accumulate
+# 4. IF UPDATE: accumulator.get() and return results <-> StreamProcessor.finalize
+
+# backwards need many preprocessors, one accumulator, one finalizer.
+# current is opposite: one preprocessor, many accumulators, many finalizers.
+
+# ... but we can have multiple handlers, giving us multiple preprocessors.
+# The accumulators across all handlers should feed into the same underlying
+# StreamProcessor.accumulate. The question is how to trigger this.
+# Also, StreamProcessor is not really supporting mapped keys, do we need to run one
+# wf per detector? Can we extract the monitor workflow?
+#
+# Let us assume StreamProcessor was more powerful, allowing for more independent updates
+# of keys.
+#
+# 1. Monitor handlers: We want to run the part of the workflow that does not depend on
+#    any detector (dynamic or static).
+# 2. Detectors: We would like to insert monitor wf results into each detector wf.
+
+# Note scipp/essreduce#191
+
+
+class ReductionHandlerFactory(
+    HandlerFactory[DetectorEvents, sc.DataGroup[sc.DataArray]]
+):
+    """
+    Factory for detector data handlers.
+
+    Handlers are created based on the instrument name in the message key which should
+    identify the detector name. Depending on the configured detector views a NeXus file
+    with geometry information may be required to setup the view. Currently the NeXus
+    files are always obtained via Pooch. Note that this may need to be refactored to a
+    more dynamic approach in the future.
+    """
+
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        config: Config,
+        processors: dict[Key, StreamProcessor],
+        source_to_key: dict[str, Key],
+    ) -> None:
+        self._logger = logger or logging.getLogger(__name__)
+        self._config = config
+        # TODO need a copy for every detector! muliplex monitor data into each!
+        # copying stream processor not trivial accumulators need to be able to be copied
+        # actually we may need different workflow for each detector (say diffraction vs
+        # sans, different mask files, ...), so automatic mechanism may be futile anyway.
+        self._processors = processors
+        self._source_to_key = source_to_key
+
+    def _is_monitor(self, key: MessageKey) -> bool:
+        return key.topic == beam_monitor_topic(self._instrument)
+
+    def _is_detector(self, key: MessageKey) -> bool:
+        return key.topic == detector_topic(self._instrument)
+
+    def _workflow_key(self, key: MessageKey) -> str:
+        return self._source_to_key[key.source_name]
+
+    def make_handler(
+        self, key: MessageKey
+    ) -> Handler[DetectorEvents, sc.DataGroup[sc.DataArray]]:
+        self._logger.info(f"Creating handler for {key}")
+        wf_key = self._workflow_key(key)
+        if (processor := self._processors.get(key.source_name)) is not None:
+            accumulator = StreamProcessorProxy(processor, key=wf_key)
+            self._logger.info(f"Using existing processor for {wf_key}")
+        else:
+            accumulator = MultiplexingProxy(list(self._processors.values()), key=wf_key)
+            self._logger.info(f"Creating multiplexing processor for {wf_key}")
+        return PeriodicAccumulatingHandler(
+            logger=self._logger,
+            config=self._config,
+            preprocessor=ToNXevent_data(),
+            accumulators={'reduced': accumulator},
+        )
+
+
+class MultiplexingProxy(Accumulator[sc.DataArray, sc.DataGroup[sc.DataArray]]):
+    def __init__(self, stream_processors: list[StreamProcessor], key: Key) -> None:
+        self._stream_processors = stream_processors
+        self._key = key
+
+    def append(self, stream_processor: StreamProcessor) -> None:
+        self._stream_processors.append(stream_processor)
+
+    def accumulate(self, data: sc.DataArray) -> None:
+        for stream_processor in self._stream_processors:
+            stream_processor.accumulate({self._key: data})
+
+    def get(self) -> sc.DataGroup[sc.DataArray]:
+        return sc.DataGroup()
+
+
+class StreamProcessorProxy(Accumulator[sc.DataArray, sc.DataGroup[sc.DataArray]]):
+    def __init__(self, processor: StreamProcessor, *, key: type) -> None:
+        self._processor = processor
+        self._key = key
+
+    def accumulate(self, data: sc.DataArray) -> None:
+        self._processor.accumulate({self._key: data})
+
+    def get(self) -> sc.DataGroup[sc.DataArray]:
+        return self._processor.finalize()

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -11,7 +11,7 @@ import scipp as sc
 from ess.reduce.live import raw
 
 from ..config import models
-from ..config.raw_detectors import get_detector_config
+from ..config.raw_detectors import get_config
 from ..core.handler import (
     Accumulator,
     Config,
@@ -49,7 +49,7 @@ class DetectorHandlerFactory(HandlerFactory[DetectorEvents, sc.DataArray]):
     ) -> None:
         self._logger = logger or logging.getLogger(__name__)
         self._config = config
-        self._detector_config = get_detector_config(instrument)['detectors']
+        self._detector_config = get_config(instrument).detectors_config['detectors']
         self._nexus_file = _try_get_nexus_geometry_filename(instrument)
         self._window_length = 128
 

--- a/src/beamlime/kafka/message_adapter.py
+++ b/src/beamlime/kafka/message_adapter.py
@@ -180,6 +180,18 @@ class RoutingAdapter(MessageAdapter[KafkaMessage, T]):
         return self._routes[schema].adapt(message)
 
 
+class RouteByTopicAdapter(MessageAdapter[KafkaMessage, T]):
+    """
+    Routes messages to different adapters based on the topic.
+    """
+
+    def __init__(self, routes: dict[str, MessageAdapter[KafkaMessage, T]]):
+        self._routes = routes
+
+    def adapt(self, message: KafkaMessage) -> Message[T]:
+        return self._routes[message.topic()].adapt(message)
+
+
 class AdaptingMessageSource(MessageSource[U]):
     """
     Wraps a source of messages and adapts them to a different type.

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Service that runs a data reduction workflow."""
+
+import argparse
+import logging
+from contextlib import ExitStack
+from functools import partial
+from typing import Literal, NewType, NoReturn
+
+import sciline
+import scipp as sc
+from ess.reduce.streaming import StreamProcessor
+
+from beamlime import Service
+from beamlime.config import config_names
+from beamlime.config.config_loader import load_config
+from beamlime.handlers.data_reduction_handler import ReductionHandlerFactory
+from beamlime.kafka import consumer as kafka_consumer
+from beamlime.kafka.message_adapter import (
+    ChainedAdapter,
+    Ev44ToDetectorEventsAdapter,
+    KafkaToEv44Adapter,
+)
+from beamlime.kafka.sink import KafkaSink, UnrollingSinkAdapter
+from beamlime.service_factory import DataServiceBuilder
+from beamlime.sinks import PlotToPngSink
+
+
+def setup_arg_parser() -> argparse.ArgumentParser:
+    parser = Service.setup_arg_parser(description='Detector Data Service')
+    parser.add_argument(
+        '--sink-type',
+        choices=['kafka', 'png'],
+        default='kafka',
+        help='Select sink type: kafka or png',
+    )
+    return parser
+
+
+DetectorData = NewType('DetectorData', sc.DataArray)
+Mon1 = NewType('Mon1', sc.DataArray)
+Mon2 = NewType('Mon2', sc.DataArray)
+TransmissionFraction = NewType('TransmissionFraction', sc.DataArray)
+IofQ = NewType('IofQ', sc.DataArray)
+
+
+def transmission_fraction(mon1: Mon1, mon2: Mon2) -> TransmissionFraction:
+    return mon1.sum() / mon2.sum()
+
+
+def iofq(data: DetectorData, transmission_fraction: TransmissionFraction) -> IofQ:
+    return data / transmission_fraction
+
+
+wf = sciline.Pipeline((transmission_fraction, iofq))
+processor = StreamProcessor(
+    wf,
+    dynamic_keys=(Mon1, Mon2, DetectorData),
+    accumulators=(IofQ,),
+    target_keys=(IofQ,),
+)
+# TODO using wf key for processors does not work, since several source_names can map
+# to the same workflow key. Use source name here!
+processors = {
+    'mantle_detector': processor,
+    'endcap_backward_detector': processor,
+    'endcap_forward_detector': processor,
+    'high_resolution_detector': processor,
+}
+
+
+# source_to_key = {'loki_detector_0': NeXusData[NXdetector, SampleRun]}
+source_to_key = {
+    'mantle_detector': DetectorData,
+    'endcap_backward_detector': DetectorData,
+    'endcap_forward_detector': DetectorData,
+    'high_resolution_detector': DetectorData,
+}
+
+
+def make_reduction_service_builder(
+    *, instrument: str, log_level: int = logging.INFO
+) -> DataServiceBuilder:
+    adapter = ChainedAdapter(
+        first=KafkaToEv44Adapter(), second=Ev44ToDetectorEventsAdapter()
+    )
+    handler_factory_cls = partial(
+        ReductionHandlerFactory, processors=processors, source_to_key=source_to_key
+    )
+    return DataServiceBuilder(
+        instrument=instrument,
+        name='data_reduction',
+        log_level=log_level,
+        adapter=adapter,
+        handler_factory_cls=handler_factory_cls,
+    )
+
+
+def run_service(
+    *,
+    sink_type: Literal['kafka', 'png'],
+    instrument: str,
+    log_level: int = logging.INFO,
+) -> NoReturn:
+    config = load_config(namespace=config_names.detector_data, env='')
+    consumer_config = load_config(namespace=config_names.raw_data_consumer, env='')
+    kafka_downstream_config = load_config(namespace=config_names.kafka_downstream)
+    kafka_upstream_config = load_config(namespace=config_names.kafka_upstream)
+
+    if sink_type == 'kafka':
+        sink = KafkaSink(kafka_config=kafka_downstream_config)
+    else:
+        sink = PlotToPngSink()
+    sink = UnrollingSinkAdapter(sink)
+
+    builder = make_reduction_service_builder(instrument=instrument, log_level=log_level)
+
+    with ExitStack() as stack:
+        control_consumer = stack.enter_context(
+            kafka_consumer.make_control_consumer(instrument=instrument)
+        )
+        consumer = stack.enter_context(
+            kafka_consumer.make_consumer_from_config(
+                topics=config['topics'],
+                config={**consumer_config, **kafka_upstream_config},
+                instrument=instrument,
+                group='data_reduction',
+            )
+        )
+        service = builder.build(
+            control_consumer=control_consumer, consumer=consumer, sink=sink
+        )
+        service.start()
+
+
+def main() -> NoReturn:
+    parser = setup_arg_parser()
+    run_service(**vars(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -31,7 +31,7 @@ from beamlime.sinks import PlotToPngSink
 
 
 def setup_arg_parser() -> argparse.ArgumentParser:
-    parser = Service.setup_arg_parser(description='Detector Data Service')
+    parser = Service.setup_arg_parser(description='Data Reduction Service')
     parser.add_argument(
         '--sink-type',
         choices=['kafka', 'png'],
@@ -78,17 +78,22 @@ def iofq(data: DetectorData, transmission_fraction: TransmissionFraction) -> Iof
 wf = sciline.Pipeline(
     (process_detector_data, process_mon1, process_mon2, transmission_fraction, iofq)
 )
-processor = StreamProcessor(
-    wf,
-    dynamic_keys=(RawMon1, RawMon2, RawDetectorData),
-    accumulators=(Mon1, Mon2, DetectorData),
-    target_keys=(IofQ,),
-)
+
+
+def make_processor():
+    return StreamProcessor(
+        wf,
+        dynamic_keys=(RawMon1, RawMon2, RawDetectorData),
+        accumulators=(Mon1, Mon2, DetectorData),
+        target_keys=(IofQ,),
+    )
+
+
 processors = {
-    'mantle_detector': processor,
-    'endcap_backward_detector': processor,
-    'endcap_forward_detector': processor,
-    'high_resolution_detector': processor,
+    'mantle_detector': make_processor(),
+    'endcap_backward_detector': make_processor(),
+    'endcap_forward_detector': make_processor(),
+    'high_resolution_detector': make_processor(),
 }
 
 

--- a/tests/handlers/accumulators_test.py
+++ b/tests/handlers/accumulators_test.py
@@ -8,9 +8,11 @@ from streaming_data_types import eventdata_ev44
 from beamlime.core.handler import Accumulator
 from beamlime.handlers.accumulators import (
     Cumulative,
+    DetectorEvents,
     MonitorEvents,
     SlidingWindow,
     TOAHistogrammer,
+    ToNXevent_data,
 )
 
 
@@ -28,11 +30,11 @@ def test_MonitorEvents_from_ev44() -> None:
     assert monitor_events.unit == 'ns'
 
 
-@pytest.mark.parametrize('accumulator_cls', [Cumulative, SlidingWindow])
+@pytest.mark.parametrize('accumulator_cls', [Cumulative, SlidingWindow, ToNXevent_data])
 def test_accumulator_raises_if_get_before_add(
     accumulator_cls: type[Accumulator],
 ) -> None:
-    accumulator = accumulator_cls(config={})
+    accumulator = accumulator_cls()
     with pytest.raises(ValueError, match="No data has been added"):
         accumulator.get()
 
@@ -127,3 +129,72 @@ def test_histogrammer_raises_if_unit_is_not_ns() -> None:
     histogrammer = TOAHistogrammer(config={'time_of_arrival_bins': 7})
     with pytest.raises(ValueError, match="Expected unit 'ns'"):
         histogrammer.add(0, MonitorEvents(time_of_arrival=[1.0, 10.0], unit='ms'))
+
+
+def test_MonitorEvents_ToNXevent_data() -> None:
+    to_nx = ToNXevent_data()
+    to_nx.add(0, MonitorEvents(time_of_arrival=[1.0, 10.0], unit='ns'))
+    to_nx.add(1000, MonitorEvents(time_of_arrival=[2.0], unit='ns'))
+    events = to_nx.get()
+    content = sc.DataArray(
+        data=sc.ones(dims=['event'], shape=[3], unit='counts', dtype='float32'),
+        coords={
+            'event_time_offset': sc.array(
+                dims=['event'], values=[1.0, 10.0, 2.0], unit='ns'
+            )
+        },
+    )
+    assert_identical(
+        events,
+        sc.DataArray(
+            data=sc.bins(
+                begin=sc.array(dims=['event'], values=[0, 2], unit=None),
+                dim='event',
+                data=content,
+            ),
+            coords={
+                'event_time_zero': sc.epoch(unit='ns')
+                + sc.array(dims=['event_time_zero'], values=[0, 1000], unit='ns')
+            },
+        ),
+    )
+    empty_events = to_nx.get()
+    assert empty_events.sizes == {'event_time_zero': 0}
+    assert_identical(empty_events, events[0:0])
+
+
+def test_DetectorEvents_ToNXevent_data() -> None:
+    to_nx = ToNXevent_data()
+    to_nx.add(
+        0, DetectorEvents(time_of_arrival=[1.0, 10.0], pixel_id=[2, 1], unit='ns')
+    )
+    to_nx.add(1000, DetectorEvents(time_of_arrival=[2.0], pixel_id=[1], unit='ns'))
+    events = to_nx.get()
+    content = sc.DataArray(
+        data=sc.ones(dims=['event'], shape=[3], unit='counts', dtype='float32'),
+        coords={
+            'event_time_offset': sc.array(
+                dims=['event'], values=[1.0, 10.0, 2.0], unit='ns'
+            ),
+            'event_id': sc.array(
+                dims=['event'], values=[2, 1, 1], unit=None, dtype='int32'
+            ),
+        },
+    )
+    assert_identical(
+        events,
+        sc.DataArray(
+            data=sc.bins(
+                begin=sc.array(dims=['event'], values=[0, 2], unit=None),
+                dim='event',
+                data=content,
+            ),
+            coords={
+                'event_time_zero': sc.epoch(unit='ns')
+                + sc.array(dims=['event_time_zero'], values=[0, 1000], unit='ns')
+            },
+        ),
+    )
+    empty_events = to_nx.get()
+    assert empty_events.sizes == {'event_time_zero': 0}
+    assert_identical(empty_events, events[0:0])

--- a/tests/handlers/detector_data_handler_test.py
+++ b/tests/handlers/detector_data_handler_test.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import scipp as sc
 
-from beamlime.config.raw_detectors import available_instruments, get_detector_config
+from beamlime.config.raw_detectors import available_instruments, get_config
 from beamlime.core.handler import Message, MessageKey
 from beamlime.handlers.accumulators import DetectorEvents
 from beamlime.handlers.detector_data_handler import (
@@ -60,7 +60,7 @@ def test_get_nexus_filename_raises_if_datetime_out_of_range() -> None:
 
 @pytest.mark.parametrize('instrument', available_instruments())
 def test_factory_can_create_handler(instrument: str) -> None:
-    config = get_detector_config(instrument)
+    config = get_config(instrument).detectors_config
     detectors = {view['detector_name'] for view in config['detectors'].values()}
     assert len(detectors) > 0
     factory = DetectorHandlerFactory(instrument=instrument, config={})

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from streaming_data_types import eventdata_ev44
 
-from beamlime.config.raw_detectors import available_instruments, get_detector_config
+from beamlime.config.raw_detectors import available_instruments, get_config
 from beamlime.fakes import FakeMessageSink
 from beamlime.kafka.message_adapter import FakeKafkaMessage, KafkaMessage
 from beamlime.kafka.sink import UnrollingSinkAdapter
@@ -166,7 +166,7 @@ def test_detector_data_service(instrument: str) -> None:
     service.stop()
     source_names = [msg.key.source_name for msg in sink.messages]
 
-    detectors = get_detector_config(instrument)['detectors']
+    detectors = get_config(instrument).detectors_config['detectors']
     for view_name, view_config in detectors.items():
         base_key = f"{view_config['detector_name']}/{view_name}"
         assert f'{base_key}/cumulative' in source_names

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -35,7 +35,7 @@ class Ev44Consumer(KafkaConsumer):
         self._events_per_message = events_per_message
         self._max_events = max_events
         self._pixel_id = np.ones(events_per_message, dtype=np.int32)
-        self._rng = np.random.default_rng()
+        self._rng = np.random.default_rng(seed=1234)  # Avoid test flakiness
 
         self._reference_time = 0
         self._running = False


### PR DESCRIPTION
This adds a basic data reduction service. Unlike `monitor_data` and `detector_data`, we need to feed multiple data sources into the same underlying workflow. The handler factory therefore creates proxy objects that deal with this.

What is implemented here assumes that we are running one workflow per detector bank. Some instruments may also need to combine banks. This will be explored in future work.

See also #324 on limitations.

To try this out, you can run `fake_monitors --mode ev44`, `fake_detectors`, `data_reduction`, and the `dashboard` services, each with `--instrument dream`. You should see 4 (fake) I(Q) plots, one for each bank.