### PR TITLE
Replace "sliding window" views with views of current counts

### DIFF
--- a/src/beamlime/config/models.py
+++ b/src/beamlime/config/models.py
@@ -87,13 +87,6 @@ class UpdateEvery(TimeModel):
     unit: TimeUnit = Field(default="s", description="Physical unit for the time value.")
 
 
-class SlidingWindow(TimeModel):
-    """Setting for the sliding window."""
-
-    value: float = Field(default=5.0, ge=0.05, description="Time value.")
-    unit: TimeUnit = Field(default="s", description="Physical unit for the time value.")
-
-
 class ROIAxisRange(BaseModel):
     """
     Setting for the range of an axis to use for a rectangular ROI.

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -52,7 +52,7 @@ class DetectorHandlerFactory(HandlerFactory[DetectorEvents, sc.DataArray]):
         self._instrument = instrument
         self._detector_config = get_config(instrument).detectors_config['detectors']
         self._nexus_file = _try_get_nexus_geometry_filename(instrument)
-        self._window_length = 128
+        self._window_length = 1
 
     def _key_to_detector_name(self, key: MessageKey) -> str:
         return key.source_name

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -189,6 +189,8 @@ class DetectorCounts(Accumulator[sc.DataArray, sc.DataGroup[sc.DataArray]]):
 
     def get(self) -> sc.DataGroup[sc.DataArray]:
         cumulative = self._view.cumulative.copy()
+        # This is a hack to get the current counts. Should be updated once
+        # ess.reduce.live.raw.RollingDetectorView has been modified to support this.
         current = cumulative
         if self._previous is not None:
             current = current - self._previous

--- a/src/beamlime/handlers/monitor_data_handler.py
+++ b/src/beamlime/handlers/monitor_data_handler.py
@@ -64,6 +64,7 @@ def create_monitor_data_handler(
     accumulators = {
         'cumulative': Cumulative(config=config),
         'sliding': SlidingWindow(config=config),
+        'current': Cumulative(config=config, clear_on_get=True),
     }
     preprocessor = MonitorDataPreprocessor(config=config)
     return PeriodicAccumulatingHandler(

--- a/src/beamlime/handlers/monitor_data_handler.py
+++ b/src/beamlime/handlers/monitor_data_handler.py
@@ -8,7 +8,7 @@ from typing import TypeVar
 import scipp as sc
 
 from ..core.handler import Accumulator, Config, PeriodicAccumulatingHandler
-from .accumulators import Cumulative, MonitorEvents, SlidingWindow, TOAHistogrammer
+from .accumulators import Cumulative, MonitorEvents, TOAHistogrammer
 
 
 class MonitorDataPreprocessor(Accumulator[MonitorEvents | sc.DataArray, sc.DataArray]):
@@ -63,7 +63,6 @@ def create_monitor_data_handler(
     """Create a handler for monitor data."""
     accumulators = {
         'cumulative': Cumulative(config=config),
-        'sliding': SlidingWindow(config=config),
         'current': Cumulative(config=config, clear_on_get=True),
     }
     preprocessor = MonitorDataPreprocessor(config=config)

--- a/src/beamlime/services/dashboard.py
+++ b/src/beamlime/services/dashboard.py
@@ -142,15 +142,6 @@ class DashboardApp(ServiceBase):
                 value=10,
                 marks={i: {'label': f'{2**i}'} for i in range(8, 14)},
             ),
-            html.Label('Sliding Window (ms)'),
-            dcc.Slider(
-                id='sliding-window',
-                min=8,
-                max=13,
-                step=1,
-                value=10,
-                marks={i: {'label': f'{2**i}'} for i in range(8, 14)},
-            ),
             dcc.Checklist(
                 id='bins-checkbox',
                 options=[
@@ -295,9 +286,7 @@ class DashboardApp(ServiceBase):
         )(self.update_plots)
 
         self._app.callback(
-            Output('interval-component', 'interval'),
-            Input('update-speed', 'value'),
-            Input('sliding-window', 'value'),
+            Output('interval-component', 'interval'), Input('update-speed', 'value')
         )(self.update_timing_settings)
 
         self._app.callback(Output('num-points', 'value'), Input('num-points', 'value'))(
@@ -505,11 +494,9 @@ class DashboardApp(ServiceBase):
         graphs = [dcc.Graph(figure=fig) for fig in self._plots.values()]
         return [html.Div(graphs, style={'display': 'flex', 'flexWrap': 'wrap'})]
 
-    def update_timing_settings(self, update_speed: float, window_size: float) -> float:
+    def update_timing_settings(self, update_speed: float) -> float:
         update_every = models.UpdateEvery(value=2**update_speed, unit='ms')
         self._config_service.update_config('update_every', update_every.model_dump())
-        sliding = models.SlidingWindow(value=2**window_size, unit='ms')
-        self._config_service.update_config('sliding_window', sliding.model_dump())
         return 2**update_speed
 
     def update_num_points(self, value: int) -> int:

--- a/tests/config/models_test.py
+++ b/tests/config/models_test.py
@@ -62,12 +62,6 @@ def test_update_every_defaults():
     assert model.unit == "s"
 
 
-def test_sliding_window_defaults():
-    model = models.SlidingWindow()
-    assert model.value == 5.0
-    assert model.unit == "s"
-
-
 @pytest.mark.parametrize(
     ("value", "unit", "expected_ns"),
     [
@@ -85,11 +79,6 @@ def test_time_model_conversions(value, unit, expected_ns):
 def test_update_every_validation():
     with pytest.raises(ValidationError):
         models.UpdateEvery(value=0.05)  # Below minimum of 0.1
-
-
-def test_sliding_window_validation():
-    with pytest.raises(ValidationError):
-        models.SlidingWindow(value=0.04)  # Below minimum of 0.05
 
 
 def test_roi_axis_percentage_defaults():

--- a/tests/handlers/accumulators_test.py
+++ b/tests/handlers/accumulators_test.py
@@ -10,7 +10,6 @@ from beamlime.handlers.accumulators import (
     Cumulative,
     DetectorEvents,
     MonitorEvents,
-    SlidingWindow,
     TOAHistogrammer,
     ToNXevent_data,
 )
@@ -30,7 +29,7 @@ def test_MonitorEvents_from_ev44() -> None:
     assert monitor_events.unit == 'ns'
 
 
-@pytest.mark.parametrize('accumulator_cls', [Cumulative, SlidingWindow, ToNXevent_data])
+@pytest.mark.parametrize('accumulator_cls', [Cumulative, ToNXevent_data])
 def test_accumulator_raises_if_get_before_add(
     accumulator_cls: type[Accumulator],
 ) -> None:
@@ -71,7 +70,7 @@ def test_cumulative_clear_on_get() -> None:
     )
 
 
-@pytest.mark.parametrize('accumulator_cls', [Cumulative, SlidingWindow])
+@pytest.mark.parametrize('accumulator_cls', [Cumulative])
 def test_accumulator_clears_when_data_sizes_changes(
     accumulator_cls: type[Accumulator],
 ) -> None:

--- a/tests/handlers/detector_data_handler_test.py
+++ b/tests/handlers/detector_data_handler_test.py
@@ -30,7 +30,7 @@ def test_factory_can_fall_back_to_configured_detector_number_for_LogicalView() -
     )
     results = handler.handle([message])
     assert len(results) == 2  # Detector view and ROI-based TOA histogram
-    counts = results[0].value.sum()['sliding'].data
+    counts = results[0].value.sum()['current'].data
     assert sc.identical(counts, sc.scalar(3, unit='counts', dtype='int32'))
 
 

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -171,7 +171,7 @@ def test_detector_data_service(instrument: str) -> None:
     for view_name, view_config in detectors.items():
         base_key = source_name(device=view_config['detector_name'], signal=view_name)
         assert f'{base_key}/cumulative' in source_names
-        assert f'{base_key}/sliding' in source_names
+        assert f'{base_key}/current' in source_names
         assert f'{base_key}/roi' in source_names
 
     # Implicitly yields the latest cumulative message for each detector

--- a/tests/services/monitor_data_test.py
+++ b/tests/services/monitor_data_test.py
@@ -145,8 +145,8 @@ def test_monitor_data_service() -> None:
     source_names = [msg.key.source_name for msg in sink.messages]
     assert source_name('monitor_0', 'cumulative') in source_names
     assert source_name('monitor_1', 'cumulative') in source_names
-    assert source_name('monitor_0', 'sliding') in source_names
-    assert source_name('monitor_1', 'sliding') in source_names
+    assert source_name('monitor_0', 'current') in source_names
+    assert source_name('monitor_1', 'current') in source_names
     size = len(sink.messages)
     start_and_wait_for_completion(consumer=consumer)
     assert len(sink.messages) > size


### PR DESCRIPTION
Fixes #336. See there for more motivation. This simplifies the controls as well as the reasoning about Beamlime mechanics, which should make things such as better timing controls easier to implement.