### PR TITLE
Define f144 attrs in instrument config modules

### DIFF
--- a/src/beamlime/config/raw_detectors/bifrost.py
+++ b/src/beamlime/config/raw_detectors/bifrost.py
@@ -43,14 +43,14 @@ detectors_config['detectors']['unified_detector'] = {
 
 # Would like to use a 2-D scipp.Variable, but GenericNeXusWorkflow does not accept
 # detector names as scalar variables.
-detector_names = [
+_detector_names = [
     f'{123+4*(analyzer-1)+(5*4+1)*(sector-1)}_channel_{sector}_{analyzer}_triplet'
     for analyzer in range(1, 6)
     for sector in range(1, 10)
 ]
 
 
-def combine_banks(*bank: sc.DataArray) -> sc.DataArray:
+def _combine_banks(*bank: sc.DataArray) -> sc.DataArray:
     return (
         sc.concat(bank, dim='')
         .fold('', sizes={'analyzer': 5, 'sector': 9})
@@ -64,7 +64,7 @@ DetectorRotation = NewType('DetectorRotation', sc.DataArray)
 CountsPerAngle = NewType('CountsPerAngle', sc.DataArray)
 
 
-def make_spectrum_view(data: DetectorData[SampleRun]) -> SpectrumView:
+def _make_spectrum_view(data: DetectorData[SampleRun]) -> SpectrumView:
     edges = sc.linspace('event_time_offset', 0, 71_000_000, num=701, unit='ns')
     # Combine 10 pixels into 1, so we have tubes with 10 pixels each
     return (
@@ -77,7 +77,7 @@ def make_spectrum_view(data: DetectorData[SampleRun]) -> SpectrumView:
     )
 
 
-def make_counts_per_angle(
+def _make_counts_per_angle(
     data: DetectorData[SampleRun], rotation: DetectorRotation
 ) -> CountsPerAngle:
     edges = sc.linspace('angle', 0, 91, num=46, unit='deg')
@@ -89,21 +89,21 @@ def make_counts_per_angle(
     return da
 
 
-reduction_workflow = bifrost.io.nexus.LoadNeXusWorkflow()
-reduction_workflow[Filename[SampleRun]] = get_nexus_geometry_filename('bifrost')
-reduction_workflow[CalibratedBeamline[SampleRun]] = (
-    reduction_workflow[CalibratedBeamline[SampleRun]]
-    .map({NeXusName[NXdetector]: detector_names})
-    .reduce(func=combine_banks)
+_reduction_workflow = bifrost.io.nexus.LoadNeXusWorkflow()
+_reduction_workflow[Filename[SampleRun]] = get_nexus_geometry_filename('bifrost')
+_reduction_workflow[CalibratedBeamline[SampleRun]] = (
+    _reduction_workflow[CalibratedBeamline[SampleRun]]
+    .map({NeXusName[NXdetector]: _detector_names})
+    .reduce(func=_combine_banks)
 )
 
-reduction_workflow.insert(make_spectrum_view)
-reduction_workflow.insert(make_counts_per_angle)
+_reduction_workflow.insert(_make_spectrum_view)
+_reduction_workflow.insert(_make_counts_per_angle)
 
 
 def _make_processor():
     return StreamProcessor(
-        reduction_workflow,
+        _reduction_workflow,
         dynamic_keys=(NeXusData[NXdetector, SampleRun],),
         accumulators=(SpectrumView, CountsPerAngle),
         context_keys=(DetectorRotation,),

--- a/src/beamlime/config/raw_detectors/bifrost.py
+++ b/src/beamlime/config/raw_detectors/bifrost.py
@@ -80,7 +80,7 @@ def make_spectrum_view(data: DetectorData[SampleRun]) -> SpectrumView:
 def make_counts_per_angle(
     data: DetectorData[SampleRun], rotation: DetectorRotation
 ) -> CountsPerAngle:
-    edges = sc.linspace('angle', 0, 91, num=46, unit='')
+    edges = sc.linspace('angle', 0, 91, num=46, unit='deg')
     da = sc.DataArray(
         sc.zeros(dims=['angle'], shape=[45], unit='counts'), coords={'angle': edges}
     )
@@ -118,4 +118,8 @@ def make_stream_processors():
 source_to_key = {
     'unified_detector': NeXusData[NXdetector, SampleRun],
     'detector_rotation': DetectorRotation,
+}
+
+f144_attribute_registry = {
+    'detector_rotation': {'units': 'deg'},
 }

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from typing import Any
 
 import scipp as sc
@@ -39,17 +38,16 @@ class ReductionHandlerFactory(
         self,
         *,
         instrument: str,
-        attrs_registry: Mapping[str, Mapping[str, Any]],
         logger: logging.Logger | None = None,
         config: Config,
     ) -> None:
         self._logger = logger or logging.getLogger(__name__)
         self._config = config
         self._instrument = instrument
-        self._attrs_registry = attrs_registry
-        instrument_config = get_config(instrument)
-        self._processors = instrument_config.make_stream_processors()
-        self._source_to_key = instrument_config.source_to_key
+        self._instrument_config = get_config(instrument)
+        self._processors = self._instrument_config.make_stream_processors()
+        self._source_to_key = self._instrument_config.source_to_key
+        self._attrs_registry = self._instrument_config.f144_attribute_registry
 
     def _is_nxlog(self, key: MessageKey) -> bool:
         return key.topic in (f'{self._instrument}_motion',)

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
+from types import ModuleType
 from typing import Any
 
 import scipp as sc
 from ess.reduce.streaming import StreamProcessor
 from sciline.typing import Key
 
-from ..config.raw_detectors import get_config
 from ..core.handler import (
     Accumulator,
     Config,
@@ -37,20 +37,19 @@ class ReductionHandlerFactory(
     def __init__(
         self,
         *,
-        instrument: str,
+        instrument_config: ModuleType,
         logger: logging.Logger | None = None,
         config: Config,
     ) -> None:
         self._logger = logger or logging.getLogger(__name__)
         self._config = config
-        self._instrument = instrument
-        self._instrument_config = get_config(instrument)
+        self._instrument_config = instrument_config
         self._processors = self._instrument_config.make_stream_processors()
         self._source_to_key = self._instrument_config.source_to_key
         self._attrs_registry = self._instrument_config.f144_attribute_registry
 
     def _is_nxlog(self, key: MessageKey) -> bool:
-        return key.topic in (f'{self._instrument}_motion',)
+        return key.topic.split('_', maxsplit=1)[1] in ('motion',)
 
     def make_handler(
         self, key: MessageKey

--- a/src/beamlime/handlers/timeseries_handler.py
+++ b/src/beamlime/handlers/timeseries_handler.py
@@ -6,6 +6,7 @@ import logging
 
 import scipp as sc
 
+from ..config.raw_detectors import get_config
 from ..core.handler import (
     Config,
     Handler,
@@ -31,7 +32,7 @@ class LogdataHandlerFactory(HandlerFactory[LogData, sc.DataArray]):
         instrument: str,
         logger: logging.Logger | None = None,
         config: Config,
-        attribute_registry: dict[str, dict[str, any]],
+        attribute_registry: dict[str, dict[str, any]] | None = None,
     ) -> None:
         """
         Initialize the LogdataHandlerFactory.
@@ -56,7 +57,10 @@ class LogdataHandlerFactory(HandlerFactory[LogData, sc.DataArray]):
         self._logger = logger or logging.getLogger(__name__)
         self._config = config
         self._instrument = instrument
-        self._attribute_registry = attribute_registry
+        if attribute_registry is None:
+            self._attribute_registry = get_config(instrument).f144_attribute_registry
+        else:
+            self._attribute_registry = attribute_registry
 
     def make_handler(self, key: MessageKey) -> Handler[LogData, sc.DataArray] | None:
         source_name = key.source_name

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -27,6 +27,8 @@ from beamlime.kafka.sink import KafkaSink, UnrollingSinkAdapter
 from beamlime.service_factory import DataServiceBuilder
 from beamlime.sinks import PlotToPngSink
 
+from ..config.raw_detectors import get_config
+
 
 def setup_arg_parser() -> argparse.ArgumentParser:
     parser = Service.setup_arg_parser(description='Data Reduction Service')
@@ -58,7 +60,9 @@ def make_reduction_service_builder(
             ),
         }
     )
-    handler_factory_cls = partial(ReductionHandlerFactory, instrument=instrument)
+    handler_factory_cls = partial(
+        ReductionHandlerFactory, instrument_config=get_config(instrument)
+    )
     return DataServiceBuilder(
         instrument=instrument,
         name='data_reduction',

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -27,8 +27,6 @@ from beamlime.kafka.sink import KafkaSink, UnrollingSinkAdapter
 from beamlime.service_factory import DataServiceBuilder
 from beamlime.sinks import PlotToPngSink
 
-from .timeseries import FallbackAttributeRegistry
-
 
 def setup_arg_parser() -> argparse.ArgumentParser:
     parser = Service.setup_arg_parser(description='Data Reduction Service')
@@ -60,11 +58,7 @@ def make_reduction_service_builder(
             ),
         }
     )
-    handler_factory_cls = partial(
-        ReductionHandlerFactory,
-        instrument=instrument,
-        attrs_registry=FallbackAttributeRegistry(),
-    )
+    handler_factory_cls = partial(ReductionHandlerFactory, instrument=instrument)
     return DataServiceBuilder(
         instrument=instrument,
         name='data_reduction',

--- a/src/beamlime/services/timeseries.py
+++ b/src/beamlime/services/timeseries.py
@@ -35,24 +35,6 @@ def setup_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-class FallbackAttributeRegistry:
-    """
-    Fallback attribute registry that returns a default value for any attribute.
-
-    This is used as a fallback until reading attributes from a template file or from
-    Kafka messages is implemented. This is a temporary solution.
-    """
-
-    def __getitem__(self, item):
-        return {'units': ''}
-
-    def __contains__(self, item):
-        return True
-
-    def get(self, item, default=None):
-        return self[item]
-
-
 def make_timeseries_service_builder(
     *,
     instrument: str,
@@ -63,7 +45,7 @@ def make_timeseries_service_builder(
     handler_factory_cls = partial(
         LogdataHandlerFactory,
         instrument=instrument,
-        attribute_registry=attribute_registry or FallbackAttributeRegistry(),
+        attribute_registry=attribute_registry,
     )
     return DataServiceBuilder(
         instrument=instrument,

--- a/tests/bifrost_test.py
+++ b/tests/bifrost_test.py
@@ -9,7 +9,7 @@ from beamlime.config.raw_detectors import bifrost
 
 
 def test_workflow_produces_detector_with_consecutive_detector_number():
-    wf = bifrost.reduction_workflow
+    wf = bifrost._reduction_workflow
     da = wf.compute(CalibratedBeamline[SampleRun])
     assert_identical(
         da.coords['detector_number'].transpose(da.dims),


### PR DESCRIPTION
Could be part of #348, but #349 is in the middle and easier review independently.

We might want to read this from JSON or HDF template files (see #345) but defining it in the config is much easier for now. We may actually need very few logs, or they may rarely change. We may learn more about requirements and the template files as we progress to more complex use cases. I feel it can be an advantage to postpone a template-file-based implementation until then.