### PR TITLE
Implement more fine-grained config mechanism

### DIFF
--- a/src/beamlime/config/models.py
+++ b/src/beamlime/config/models.py
@@ -112,12 +112,3 @@ class ROIAxisRange(BaseModel):
 class ROIRectangle(BaseModel):
     x: ROIAxisRange = Field(default_factory=ROIAxisRange)
     y: ROIAxisRange = Field(default_factory=ROIAxisRange)
-
-
-class WorkflowControl(BaseModel):
-    source_name: str = Field(
-        description="Name of the source to control.",
-    )
-    workflow_name: str | None = Field(
-        description="Name of the workflow to control.",
-    )

--- a/src/beamlime/config/models.py
+++ b/src/beamlime/config/models.py
@@ -112,3 +112,70 @@ class ROIAxisRange(BaseModel):
 class ROIRectangle(BaseModel):
     x: ROIAxisRange = Field(default_factory=ROIAxisRange)
     y: ROIAxisRange = Field(default_factory=ROIAxisRange)
+
+
+class ConfigKey(BaseModel):
+    """
+    Model for configuration key structure.
+
+    Configuration keys follow the format 'source_name/service_name/key', where:
+    - source_name can be a specific source name or '*' for all sources
+    - service_name can be a specific service name or '*' for all services
+    - key is the specific configuration parameter name
+    """
+
+    source_name: str | None = Field(
+        default=None,
+        description="Source name, or None for wildcard (*) matching all sources",
+    )
+    service_name: str | None = Field(
+        default=None,
+        description="Service name, or None for wildcard (*) matching all services",
+    )
+    key: str = Field(description="Configuration parameter name/key")
+
+    def __str__(self) -> str:
+        """
+        Convert the configuration key to its string representation.
+
+        Returns
+        -------
+        :
+            String in the format source_name/service_name/key with '*' for None values
+        """
+        source = '*' if self.source_name is None else self.source_name
+        service = '*' if self.service_name is None else self.service_name
+        return f"{source}/{service}/{self.key}"
+
+    @classmethod
+    def from_string(cls, key_str: str) -> ConfigKey:
+        """
+        Create a ConfigKey from its string representation.
+
+        Parameters
+        ----------
+        key_str:
+            String in the format 'source_name/service_name/key'
+
+        Returns
+        -------
+        :
+            A ConfigKey instance parsed from the string
+
+        Raises
+        ------
+        ValueError:
+            If the key format is invalid
+        """
+        parts = key_str.split('/')
+        if len(parts) != 3:
+            raise ValueError(
+                "Invalid key format, expected 'source_name/service_name/key', "
+                f"got {key_str}"
+            )
+        source_name, service_name, key = parts
+        if source_name == '*':
+            source_name = None
+        if service_name == '*':
+            service_name = None
+        return cls(source_name=source_name, service_name=service_name, key=key)

--- a/src/beamlime/core/handler.py
+++ b/src/beamlime/core/handler.py
@@ -18,6 +18,16 @@ class Config(Protocol):
 
 
 class ConfigRegistry(Protocol):
+    """
+    Registry for configuration for different sources.
+
+    This is used by handlers to obtain configuration specific to a source. This protocol
+    is first and foremostly implemented by :py:class:`ConfigHandler`, which is used to
+    handle configuration messages, providing a mechanism to update the configuration
+    dynamically. The configuration is then used by the handlers to configure themselves
+    based on the source name of the messages they are processing.
+    """
+
     def get_config(self, source_name: str) -> Config:
         pass
 
@@ -81,19 +91,6 @@ class CommonHandlerFactory(HandlerFactory[Tin, Tout]):
             logger=self._logger,
             config=self._config_registry.get_config(key.source_name),
         )
-
-    @staticmethod
-    def from_handler(
-        handler_cls: type[Handler[Tin, Tout]],
-    ) -> Callable[[logging.Logger | None, Config], CommonHandlerFactory[Tin, Tout]]:
-        def make(
-            *, logger: logging.Logger | None = None, config: Config
-        ) -> CommonHandlerFactory[Tin, Tout]:
-            return CommonHandlerFactory(
-                logger=logger, config_handler=config, handler_cls=handler_cls
-            )
-
-        return make
 
 
 class HandlerRegistry(Generic[Tin, Tout]):

--- a/src/beamlime/handlers/config_handler.py
+++ b/src/beamlime/handlers/config_handler.py
@@ -72,6 +72,10 @@ class ConfigHandler(Handler[bytes, None]):
         """
         Get the configuration store for a specific source name.
 
+        If not configured, a new store is created and returned, based on the current
+        global store. This method always returns a store for the given source name,
+        i.e., there is not mechanism to check if the source name is valid.
+
         Parameters
         ----------
         source_name:

--- a/src/beamlime/handlers/config_handler.py
+++ b/src/beamlime/handlers/config_handler.py
@@ -11,6 +11,7 @@ from ..config.models import ConfigKey
 from ..core.handler import Config, Handler
 from ..core.message import Message, MessageKey
 from ..kafka.helpers import beamlime_command_topic
+from ..kafka.message_adapter import RawConfigItem
 
 
 @dataclass
@@ -31,9 +32,9 @@ class ConfigUpdate:
         return self.config_key.key
 
     @staticmethod
-    def from_raw(message: dict[str, str | bytes]) -> ConfigUpdate:
-        config_key = ConfigKey.from_string(message['key'])
-        value = json.loads(message['value'].decode('utf-8'))
+    def from_raw(item: RawConfigItem) -> ConfigUpdate:
+        config_key = ConfigKey.from_string(item.key.decode('utf-8'))
+        value = json.loads(item.value.decode('utf-8'))
         return ConfigUpdate(config_key=config_key, value=value)
 
 
@@ -90,7 +91,7 @@ class ConfigHandler(Handler[bytes, None]):
         """
         self._actions.setdefault(key, []).append(callback)
 
-    def handle(self, messages: list[Message[bytes]]) -> list[Message[None]]:
+    def handle(self, messages: list[Message[RawConfigItem]]) -> list[Message[None]]:
         """
         Process configuration messages and update the configuration.
 

--- a/src/beamlime/handlers/config_handler.py
+++ b/src/beamlime/handlers/config_handler.py
@@ -1,12 +1,42 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from __future__ import annotations
+
 import json
 import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 
 from ..core.handler import Config, Handler
 from ..core.message import Message, MessageKey
 from ..kafka.helpers import beamlime_command_topic
+
+
+@dataclass
+class ConfigUpdate:
+    source_name: str | None
+    service_name: str | None  # Used for filtering
+    key: str
+    value: Any
+
+    @staticmethod
+    def from_raw(message: dict[str, str | bytes]) -> ConfigUpdate:
+        key_parts = message['key'].split('/')
+        if len(key_parts) != 3:
+            raise ValueError(
+                "Invalid key format, expected 'source_name/service_name/key', "
+                f"got {message['key']}"
+            )
+        source_name, service_name, key = key_parts
+        if source_name == '*':
+            source_name = None
+        if service_name == '*':
+            service_name = None
+        value = json.loads(message['value'].decode('utf-8'))
+        return ConfigUpdate(
+            source_name=source_name, service_name=service_name, key=key, value=value
+        )
 
 
 class ConfigHandler(Handler[bytes, None]):
@@ -27,21 +57,34 @@ class ConfigHandler(Handler[bytes, None]):
 
     @staticmethod
     def message_key(instrument: str) -> MessageKey:
-        return MessageKey(topic=beamlime_command_topic(instrument), source_name='')
+        return MessageKey(
+            topic=beamlime_command_topic(instrument), source_name='config'
+        )
 
-    def __init__(self, *, logger: logging.Logger | None = None, config: Config):
-        super().__init__(logger=logger, config=config)
-        self._store = config
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        source_names: Sequence[str],
+        service_name: str,
+    ):
+        super().__init__(logger=logger, config={})
+        self._service_name = service_name
+        self._stores = {name: {} for name in source_names}
         self._actions: dict[str, list[callable]] = {}
 
-    def get(self, key: str, default=None):
-        return self._store.get(key, default)
+    def get_config(self, source_name: str) -> Config | None:
+        """
+        Get the configuration store for a specific source name.
 
-    def register_action(
-        self,
-        key: str,
-        callback: callable,
-    ):
+        Parameters
+        ----------
+        source_name:
+            Name of the source to get the configuration for
+        """
+        return self._stores.get(source_name)
+
+    def register_action(self, *, key: str, callback: callable):
         """
         Register an action to be called when a specific key is updated.
 
@@ -68,24 +111,37 @@ class ConfigHandler(Handler[bytes, None]):
         :
             Empty list as this handler doesn't produce output messages
         """
-        updated: dict[str, Any] = {}
+        updated: dict[str, ConfigUpdate] = {}
         for message in messages:
             try:
-                key = message.value['key']
-                value = json.loads(message.value['value'].decode('utf-8'))
+                update = ConfigUpdate.from_raw(message.value)
+                if update.service_name not in (None, self._service_name):
+                    # Ignore messages not for this service
+                    continue
+                source_name = update.source_name
+                key = update.key
+                value = update.value
                 self._logger.info(
-                    'Updating config: %s = %s at %s', key, value, message.timestamp
+                    'Updating config for source_name = %s: %s = %s at %s',
+                    source_name,
+                    key,
+                    value,
+                    message.timestamp,
                 )
-                self._store[key] = value
-                updated[key] = value
-            except Exception:  # noqa: PERF203
+                updated[key] = update
+                if source_name is None:
+                    for store in self._stores.values():
+                        store[key] = value
+                else:
+                    self._stores[source_name][key] = value
+            except Exception:
                 self._logger.exception('Error processing config message:')
         # Delay action calls until all messages are processed to reduce triggering
         # multiple calls for the same key in case of multiple messages with same key.
-        for key, value in updated.items():
+        for key, update in updated.items():
             for action in self._actions.get(key, []):
                 try:
-                    action(value)
+                    action(source_name=update.source_name, value=update.value)
                 except KeyError:  # noqa: PERF203
                     self._logger.exception(
                         'Error processing config action for %s:', key

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -63,6 +63,12 @@ class ReductionHandlerFactory(
             )
             return NullHandler(logger=self._logger, config={})
 
+        # Note we are setting config = {} unless we are processing detector data. The
+        # config is used, e.g., to implement a "clear" mechanism. For data reduction,
+        # clearing is however handled by "clearing" the entire data reduction workflow
+        # for a detector, i.e., auxiliary data such as logs and monitors are cleared
+        # when the workflow is cleared. This is done via the proxy the workflow manager
+        # returns for the detector data accumulator.
         if self._is_nxlog(key):
             attrs = self._f144_attribute_registry[key.source_name]
             preprocessor = ToNXlog(attrs=attrs)

--- a/src/beamlime/handlers/workflow_manager.py
+++ b/src/beamlime/handlers/workflow_manager.py
@@ -137,6 +137,14 @@ class WorkflowManager:
         if (proxy := self._proxies.get(source_name)) is not None:
             proxy.set_processor(self._processors.get(source_name))
 
+    def set_workflow_from_name(self, source_name: str, value: str | None) -> None:
+        self.set_worklow(
+            source_name,
+            processor=None
+            if value is None
+            else processor_factory.create(workflow_name=value, source_name=source_name),
+        )
+
     def set_workflow_from_command(self, command: Any) -> None:
         decoded = WorkflowControl.model_validate(command)
         if decoded.workflow_name is None:

--- a/src/beamlime/handlers/workflow_manager.py
+++ b/src/beamlime/handlers/workflow_manager.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable, Iterator, MutableMapping, Sequence
 from functools import wraps
-from typing import Any
 
 import scipp as sc
 from ess.reduce.streaming import StreamProcessor
 from sciline.typing import Key
 
-from ..config.models import WorkflowControl
 from ..core.handler import Accumulator
 
 
@@ -144,16 +142,6 @@ class WorkflowManager:
             if value is None
             else processor_factory.create(workflow_name=value, source_name=source_name),
         )
-
-    def set_workflow_from_command(self, command: Any) -> None:
-        decoded = WorkflowControl.model_validate(command)
-        if decoded.workflow_name is None:
-            processor = None
-        else:
-            processor = processor_factory.create(
-                workflow_name=decoded.workflow_name, source_name=decoded.source_name
-            )
-        self.set_worklow(decoded.source_name, processor)
 
     def get_accumulator(
         self, source_name: str

--- a/src/beamlime/kafka/message_adapter.py
+++ b/src/beamlime/kafka/message_adapter.py
@@ -30,7 +30,7 @@ class KafkaMessage(Protocol):
     def value(self) -> bytes:
         pass
 
-    def timestamp(self) -> int:
+    def timestamp(self) -> tuple[int, int]:
         pass
 
     def topic(self) -> str:
@@ -91,7 +91,7 @@ class KafkaToEv44Adapter(
         if ev44.reference_time.size > 0:
             timestamp = ev44.reference_time[-1]
         else:
-            timestamp = message.timestamp()
+            timestamp = message.timestamp()[1]
         return Message(timestamp=timestamp, key=key, value=ev44)
 
 
@@ -156,7 +156,7 @@ class KafkaToMonitorEventsAdapter(MessageAdapter[KafkaMessage, Message[MonitorEv
         if reference_time.size > 0:
             timestamp = reference_time[-1]
         else:
-            timestamp = message.timestamp()
+            timestamp = message.timestamp()[1]
         return Message(
             timestamp=timestamp,
             key=key,

--- a/src/beamlime/services/dashboard.py
+++ b/src/beamlime/services/dashboard.py
@@ -399,7 +399,9 @@ class DashboardApp(ServiceBase):
             x=models.ROIAxisRange(low=x_min / 100, high=x_max / 100),
             y=models.ROIAxisRange(low=y_min / 100, high=y_max / 100),
         )
-        self._config_service.update_config('roi_rectangle', roi.model_dump())
+        self._config_service.update_config(
+            '*/detector_data/roi_rectangle', roi.model_dump()
+        )
 
         # Update ROI rectangles in all 2D plots
         for fig in self._plots.values():
@@ -429,12 +431,16 @@ class DashboardApp(ServiceBase):
         model = models.TOARange(
             enabled=len(toa_enabled) > 0, low=low, high=high, unit='us'
         )
-        self._config_service.update_config('toa_range', model.model_dump())
+        self._config_service.update_config(
+            '*/detector_data/toa_range', model.model_dump()
+        )
         return center, delta
 
     def update_use_weights(self, value: list[str]) -> list[str]:
         model = models.PixelWeighting(enabled=len(value) > 0)
-        self._config_service.update_config('pixel_weighting', model.model_dump())
+        self._config_service.update_config(
+            '*/detector_data/pixel_weighting', model.model_dump()
+        )
         return value
 
     @staticmethod
@@ -568,18 +574,20 @@ class DashboardApp(ServiceBase):
 
     def update_timing_settings(self, update_speed: float) -> float:
         update_every = models.UpdateEvery(value=2**update_speed, unit='ms')
-        self._config_service.update_config('update_every', update_every.model_dump())
+        self._config_service.update_config(
+            '*/*/update_every', update_every.model_dump()
+        )
         return 2**update_speed
 
     def update_num_points(self, value: int) -> int:
-        self._config_service.update_config('time_of_arrival_bins', value)
+        self._config_service.update_config('*/*/time_of_arrival_bins', value)
         return value
 
     def clear_data(self, n_clicks: int | None) -> int:
         if n_clicks is None or n_clicks == 0:
             raise PreventUpdate
         model = models.StartTime(value=int(time.time_ns()), unit='ns')
-        self._config_service.update_config('start_time', model.model_dump())
+        self._config_service.update_config('*/*/start_time', model.model_dump())
         return 0
 
     def send_workflow_control(
@@ -594,20 +602,8 @@ class DashboardApp(ServiceBase):
             raise PreventUpdate
 
         actual_workflow_name = workflow_name if enable_workflow else None
-
-        self._logger.info(
-            "Sending workflow control message: source=%s, workflow=%s",
-            source_name,
-            actual_workflow_name,
-        )
-
-        workflow_control = models.WorkflowControl(
-            source_name=source_name,
-            workflow_name=actual_workflow_name,
-        )
-
         self._config_service.update_config(
-            f'{source_name}:workflow_control', workflow_control.model_dump()
+            f'{source_name}/data_reduction/workflow_name', actual_workflow_name
         )
 
         return 0

--- a/src/beamlime/services/dashboard.py
+++ b/src/beamlime/services/dashboard.py
@@ -14,6 +14,7 @@ from dash.exceptions import PreventUpdate
 from beamlime import Service, ServiceBase
 from beamlime.config import config_names, models
 from beamlime.config.config_loader import load_config
+from beamlime.config.models import ConfigKey
 from beamlime.config.raw_detectors import get_config
 from beamlime.core.config_service import ConfigService
 from beamlime.core.message import compact_messages
@@ -399,9 +400,8 @@ class DashboardApp(ServiceBase):
             x=models.ROIAxisRange(low=x_min / 100, high=x_max / 100),
             y=models.ROIAxisRange(low=y_min / 100, high=y_max / 100),
         )
-        self._config_service.update_config(
-            '*/detector_data/roi_rectangle', roi.model_dump()
-        )
+        config_key = ConfigKey(service_name="detector_data", key="roi_rectangle")
+        self._config_service.update_config(config_key, roi.model_dump())
 
         # Update ROI rectangles in all 2D plots
         for fig in self._plots.values():
@@ -431,16 +431,14 @@ class DashboardApp(ServiceBase):
         model = models.TOARange(
             enabled=len(toa_enabled) > 0, low=low, high=high, unit='us'
         )
-        self._config_service.update_config(
-            '*/detector_data/toa_range', model.model_dump()
-        )
+        config_key = ConfigKey(service_name="detector_data", key="toa_range")
+        self._config_service.update_config(config_key, model.model_dump())
         return center, delta
 
     def update_use_weights(self, value: list[str]) -> list[str]:
         model = models.PixelWeighting(enabled=len(value) > 0)
-        self._config_service.update_config(
-            '*/detector_data/pixel_weighting', model.model_dump()
-        )
+        config_key = ConfigKey(service_name="detector_data", key="pixel_weighting")
+        self._config_service.update_config(config_key, model.model_dump())
         return value
 
     @staticmethod
@@ -574,20 +572,21 @@ class DashboardApp(ServiceBase):
 
     def update_timing_settings(self, update_speed: float) -> float:
         update_every = models.UpdateEvery(value=2**update_speed, unit='ms')
-        self._config_service.update_config(
-            '*/*/update_every', update_every.model_dump()
-        )
+        config_key = ConfigKey(key="update_every")
+        self._config_service.update_config(config_key, update_every.model_dump())
         return 2**update_speed
 
     def update_num_points(self, value: int) -> int:
-        self._config_service.update_config('*/*/time_of_arrival_bins', value)
+        config_key = ConfigKey(key="time_of_arrival_bins")
+        self._config_service.update_config(config_key, value)
         return value
 
     def clear_data(self, n_clicks: int | None) -> int:
         if n_clicks is None or n_clicks == 0:
             raise PreventUpdate
         model = models.StartTime(value=int(time.time_ns()), unit='ns')
-        self._config_service.update_config('*/*/start_time', model.model_dump())
+        config_key = ConfigKey(key="start_time")
+        self._config_service.update_config(config_key, model.model_dump())
         return 0
 
     def send_workflow_control(
@@ -602,9 +601,10 @@ class DashboardApp(ServiceBase):
             raise PreventUpdate
 
         actual_workflow_name = workflow_name if enable_workflow else None
-        self._config_service.update_config(
-            f'{source_name}/data_reduction/workflow_name', actual_workflow_name
+        config_key = ConfigKey(
+            source_name=source_name, service_name="data_reduction", key="workflow_name"
         )
+        self._config_service.update_config(config_key, actual_workflow_name)
 
         return 0
 

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -85,7 +85,7 @@ def make_reduction_service_builder(
     service_name = 'data_reduction'
     config_handler = ConfigHandler(service_name=service_name)
     config_handler.register_action(
-        key='workflow_name', callback=workflow_manager.set_workflow_from_name
+        key='workflow_name', action=workflow_manager.set_workflow_from_name
     )
     handler_factory = ReductionHandlerFactory(
         config_registry=config_handler,

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -82,25 +82,25 @@ def make_reduction_service_builder(
         source_names=instrument_config.source_names,
         source_to_key=instrument_config.source_to_key,
     )
-    config = {}
+    service_name = 'data_reduction'
+    config_handler = ConfigHandler(
+        service_name=service_name, source_names=instrument_config.source_names
+    )
+    config_handler.register_action(
+        key='workflow_name', callback=workflow_manager.set_workflow_from_name
+    )
     handler_factory = ReductionHandlerFactory(
-        config=config,
+        config_handler=config_handler,
         workflow_manager=workflow_manager,
         f144_attribute_registry=instrument_config.f144_attribute_registry,
     )
     builder = DataServiceBuilder(
         instrument=instrument,
-        name='data_reduction',
+        name=service_name,
         log_level=log_level,
         adapter=adapter,
         handler_factory=handler_factory,
     )
-    config_handler = ConfigHandler(config=config)
-    for source_name in instrument_config.source_names:
-        config_handler.register_action(
-            key=f'{source_name}:workflow_control',
-            callback=workflow_manager.set_workflow_from_command,
-        )
     builder.add_handler(ConfigHandler.message_key(instrument), config_handler)
     return builder
 

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -22,7 +22,7 @@ from beamlime.kafka.helpers import (
     motion_topic,
 )
 from beamlime.kafka.message_adapter import (
-    BeamlimeCommandsAdapter,
+    BeamlimeConfigMessageAdapter,
     ChainedAdapter,
     Da00ToScippAdapter,
     Ev44ToDetectorEventsAdapter,
@@ -74,7 +74,7 @@ def make_reduction_service_builder(
             motion_topic(instrument): ChainedAdapter(
                 first=KafkaToF144Adapter(), second=F144ToLogDataAdapter()
             ),
-            beamlime_command_topic(instrument): BeamlimeCommandsAdapter(),
+            beamlime_command_topic(instrument): BeamlimeConfigMessageAdapter(),
         }
     )
     instrument_config = get_config(instrument)

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -83,14 +83,12 @@ def make_reduction_service_builder(
         source_to_key=instrument_config.source_to_key,
     )
     service_name = 'data_reduction'
-    config_handler = ConfigHandler(
-        service_name=service_name, source_names=instrument_config.source_names
-    )
+    config_handler = ConfigHandler(service_name=service_name)
     config_handler.register_action(
         key='workflow_name', callback=workflow_manager.set_workflow_from_name
     )
     handler_factory = ReductionHandlerFactory(
-        config_handler=config_handler,
+        config_registry=config_handler,
         workflow_manager=workflow_manager,
         f144_attribute_registry=instrument_config.f144_attribute_registry,
     )

--- a/src/beamlime/services/detector_data.py
+++ b/src/beamlime/services/detector_data.py
@@ -54,12 +54,14 @@ def make_detector_data_adapter(instrument: str) -> RouteByTopicAdapter:
 def make_detector_service_builder(
     *, instrument: str, log_level: int = logging.INFO
 ) -> DataServiceBuilder:
-    config = {}
-    config_handler = ConfigHandler(config=config)
-    handler_factory = DetectorHandlerFactory(instrument=instrument, config=config)
+    service_name = 'detector_data'
+    config_handler = ConfigHandler(service_name=service_name)
+    handler_factory = DetectorHandlerFactory(
+        instrument=instrument, config_registry=config_handler
+    )
     builder = DataServiceBuilder(
         instrument=instrument,
-        name='detector_data',
+        name=service_name,
         log_level=log_level,
         adapter=make_detector_data_adapter(instrument=instrument),
         handler_factory=handler_factory,

--- a/src/beamlime/services/detector_data.py
+++ b/src/beamlime/services/detector_data.py
@@ -15,7 +15,7 @@ from beamlime.handlers.detector_data_handler import DetectorHandlerFactory
 from beamlime.kafka import consumer as kafka_consumer
 from beamlime.kafka.helpers import beamlime_command_topic, detector_topic
 from beamlime.kafka.message_adapter import (
-    BeamlimeCommandsAdapter,
+    BeamlimeConfigMessageAdapter,
     ChainedAdapter,
     Ev44ToDetectorEventsAdapter,
     KafkaToEv44Adapter,
@@ -46,7 +46,7 @@ def make_detector_data_adapter(instrument: str) -> RouteByTopicAdapter:
     return RouteByTopicAdapter(
         routes={
             detector_topic(instrument): detectors,
-            beamlime_command_topic(instrument): BeamlimeCommandsAdapter(),
+            beamlime_command_topic(instrument): BeamlimeConfigMessageAdapter(),
         },
     )
 

--- a/src/beamlime/services/fake_detectors.py
+++ b/src/beamlime/services/fake_detectors.py
@@ -173,7 +173,7 @@ def run_service(*, instrument: str, log_level: int = logging.INFO) -> NoReturn:
         instrument=instrument,
         name='fake_producer',
         log_level=log_level,
-        handler_factory=CommonHandlerFactory(config={}, handler_cls=IdentityHandler),
+        handler_factory=CommonHandlerFactory(handler_cls=IdentityHandler),
     )
     service = builder.from_source(
         source=FakeDetectorSource(instrument=instrument),

--- a/src/beamlime/services/fake_logdata.py
+++ b/src/beamlime/services/fake_logdata.py
@@ -131,7 +131,7 @@ def run_service(*, instrument: str, log_level: int = logging.INFO) -> NoReturn:
         instrument=instrument,
         name='fake_f144_producer',
         log_level=log_level,
-        handler_factory=CommonHandlerFactory(config={}, handler_cls=IdentityHandler),
+        handler_factory=CommonHandlerFactory(handler_cls=IdentityHandler),
     )
     service = builder.from_source(
         source=FakeLogdataSource(instrument=instrument),

--- a/src/beamlime/services/fake_monitors.py
+++ b/src/beamlime/services/fake_monitors.py
@@ -127,7 +127,7 @@ def run_service(
         name=f'fake_{mode}_producer',
         log_level=log_level,
         adapter=adapter,
-        handler_factory=CommonHandlerFactory(config={}, handler_cls=IdentityHandler),
+        handler_factory=CommonHandlerFactory(handler_cls=IdentityHandler),
     )
     service = builder.from_source(
         source=FakeMonitorSource(instrument=instrument),

--- a/src/beamlime/services/local_demo_da00.py
+++ b/src/beamlime/services/local_demo_da00.py
@@ -61,7 +61,7 @@ def main() -> NoReturn:
         ),
         sink=PlotToPngSink(),
         handler_factory=CommonHandlerFactory(
-            config={}, handler_cls=create_monitor_data_handler
+            config_handler={}, handler_cls=create_monitor_data_handler
         ),
     )
     service = Service(processor=processor, name="local_demo_da00")

--- a/src/beamlime/services/local_demo_ev44.py
+++ b/src/beamlime/services/local_demo_ev44.py
@@ -54,7 +54,7 @@ def main() -> NoReturn:
         ),
         sink=PlotToPngSink(),
         handler_factory=CommonHandlerFactory(
-            config={}, handler_cls=create_monitor_data_handler
+            config_handler={}, handler_cls=create_monitor_data_handler
         ),
     )
     service = Service(processor=processor, name="local_demo_ev44")

--- a/src/beamlime/services/monitor_data.py
+++ b/src/beamlime/services/monitor_data.py
@@ -58,14 +58,14 @@ def make_monitor_data_adapter(instrument: str) -> RoutingAdapter:
 def make_monitor_service_builder(
     *, instrument: str, log_level: int = logging.INFO
 ) -> DataServiceBuilder:
-    config = {}
-    config_handler = ConfigHandler(config=config)
+    service_name = 'monitor_data'
+    config_handler = ConfigHandler(service_name=service_name)
     handler_factory = CommonHandlerFactory(
-        handler_cls=create_monitor_data_handler, config=config
+        handler_cls=create_monitor_data_handler, config_registry=config_handler
     )
     builder = DataServiceBuilder(
         instrument=instrument,
-        name='monitor_data',
+        name=service_name,
         log_level=log_level,
         adapter=make_monitor_data_adapter(instrument=instrument),
         handler_factory=handler_factory,

--- a/src/beamlime/services/monitor_data.py
+++ b/src/beamlime/services/monitor_data.py
@@ -13,7 +13,7 @@ from beamlime.handlers.monitor_data_handler import create_monitor_data_handler
 from beamlime.kafka import consumer as kafka_consumer
 from beamlime.kafka.helpers import beam_monitor_topic, beamlime_command_topic
 from beamlime.kafka.message_adapter import (
-    BeamlimeCommandsAdapter,
+    BeamlimeConfigMessageAdapter,
     ChainedAdapter,
     Da00ToScippAdapter,
     KafkaToDa00Adapter,
@@ -50,7 +50,7 @@ def make_monitor_data_adapter(instrument: str) -> RoutingAdapter:
     return RouteByTopicAdapter(
         routes={
             beam_monitor_topic(instrument): monitors,
-            beamlime_command_topic(instrument): BeamlimeCommandsAdapter(),
+            beamlime_command_topic(instrument): BeamlimeConfigMessageAdapter(),
         },
     )
 

--- a/src/beamlime/services/plot_da00_to_png.py
+++ b/src/beamlime/services/plot_da00_to_png.py
@@ -45,7 +45,7 @@ def run_service(*, instrument: str, log_level: int = logging.INFO) -> NoReturn:
             ),
             sink=PlotToPngSink(),
             handler_factory=CommonHandlerFactory(
-                config=handler_config, handler_cls=IdentityHandler
+                config_handler=handler_config, handler_cls=IdentityHandler
             ),
         )
         service = Service(

--- a/src/beamlime/services/timeseries.py
+++ b/src/beamlime/services/timeseries.py
@@ -15,7 +15,7 @@ from beamlime.handlers.timeseries_handler import LogdataHandlerFactory
 from beamlime.kafka import consumer as kafka_consumer
 from beamlime.kafka.helpers import beamlime_command_topic, motion_topic
 from beamlime.kafka.message_adapter import (
-    BeamlimeCommandsAdapter,
+    BeamlimeConfigMessageAdapter,
     ChainedAdapter,
     F144ToLogDataAdapter,
     KafkaToF144Adapter,
@@ -44,7 +44,7 @@ def make_timeseries_adapter(instrument: str) -> RouteByTopicAdapter:
             motion_topic(instrument): ChainedAdapter(
                 first=KafkaToF144Adapter(), second=F144ToLogDataAdapter()
             ),
-            beamlime_command_topic(instrument): BeamlimeCommandsAdapter(),
+            beamlime_command_topic(instrument): BeamlimeConfigMessageAdapter(),
         },
     )
 

--- a/tests/handlers/config_handler_test.py
+++ b/tests/handlers/config_handler_test.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import json
+
+import pytest
+
+from beamlime.config.models import ConfigKey
+from beamlime.handlers.config_handler import ConfigUpdate
+
+
+class TestConfigUpdate:
+    def test_init(self):
+        config_key = ConfigKey(
+            source_name="source1", service_name="service1", key="test_key"
+        )
+        value = {"param": 42}
+        update = ConfigUpdate(config_key=config_key, value=value)
+
+        assert update.config_key is config_key
+        assert update.value is value
+
+        # Test properties
+        assert update.source_name == "source1"
+        assert update.service_name == "service1"
+        assert update.key == "test_key"
+
+    def test_from_raw(self):
+        # Create a mock message
+        raw_message = {
+            'key': 'source1/service1/test_key',
+            'value': json.dumps({'param': 42}).encode('utf-8'),
+        }
+
+        update = ConfigUpdate.from_raw(raw_message)
+
+        assert update.source_name == "source1"
+        assert update.service_name == "service1"
+        assert update.key == "test_key"
+        assert update.value == {'param': 42}
+
+    def test_from_raw_with_wildcards(self):
+        # Create a mock message with wildcards
+        raw_message = {
+            'key': '*/*/test_key',
+            'value': json.dumps({'param': 42}).encode('utf-8'),
+        }
+
+        update = ConfigUpdate.from_raw(raw_message)
+
+        assert update.source_name is None
+        assert update.service_name is None
+        assert update.key == "test_key"
+        assert update.value == {'param': 42}
+
+    def test_from_raw_invalid_key(self):
+        raw_message = {
+            'key': 'invalid_key_format',
+            'value': json.dumps({'param': 42}).encode('utf-8'),
+        }
+
+        with pytest.raises(ValueError, match="Invalid key format"):
+            ConfigUpdate.from_raw(raw_message)
+
+    def test_from_raw_invalid_json(self):
+        raw_message = {'key': 'source1/service1/test_key', 'value': b'not valid json'}
+
+        with pytest.raises(json.JSONDecodeError):
+            ConfigUpdate.from_raw(raw_message)

--- a/tests/handlers/config_handler_test.py
+++ b/tests/handlers/config_handler_test.py
@@ -5,7 +5,8 @@ import json
 import pytest
 
 from beamlime.config.models import ConfigKey
-from beamlime.handlers.config_handler import ConfigUpdate
+from beamlime.core.message import Message, MessageKey
+from beamlime.handlers.config_handler import ConfigHandler, ConfigUpdate
 from beamlime.kafka.message_adapter import RawConfigItem
 
 
@@ -65,3 +66,432 @@ class TestConfigUpdate:
 
         with pytest.raises(json.JSONDecodeError):
             ConfigUpdate.from_raw(item)
+
+
+class TestConfigHandler:
+    def test_init(self):
+        handler = ConfigHandler(service_name="my_service")
+        config = handler.get_config("source1")
+        assert config == {}
+
+    def test_get_config_returns_isolated_copies(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Add a global config value
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'*/my_service/key1',
+                    value=json.dumps("value1").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="config"),
+            )
+        ]
+        handler.handle(messages)
+
+        # Get config for specific source
+        config1 = handler.get_config("source1")
+
+        # Verify it contains the global values
+        assert config1["key1"] == "value1"
+
+        # Modify the returned config
+        config1["key2"] = "local_value"
+
+        # Get config for another source, should not have the local changes
+        config2 = handler.get_config("source2")
+        assert config2["key1"] == "value1"
+        assert "key2" not in config2
+
+    def test_handle_for_specific_source(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/key1',
+                    value=json.dumps("value1").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+
+        handler.handle(messages)
+
+        # Check that source-specific config has been updated
+        assert handler.get_config("source1")["key1"] == "value1"
+
+        # Other sources should not have this config
+        assert "key1" not in handler.get_config("source2")
+
+    def test_handle_for_all_sources(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Add a source-specific config first
+        source_messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/key1',
+                    value=json.dumps("source1-value").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+        handler.handle(source_messages)
+
+        # Now add a global config
+        global_messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'*/my_service/key1',
+                    value=json.dumps("global-value").encode('utf-8'),
+                ),
+                timestamp=123456790,
+                key=MessageKey(topic="test_topic", source_name="config"),
+            )
+        ]
+        handler.handle(global_messages)
+
+        # Check that source-specific config is updated
+        assert handler.get_config("source1")["key1"] == "global-value"
+
+        # Check that new sources get the global config
+        assert handler.get_config("new_source")["key1"] == "global-value"
+
+    def test_get_config_after_updates(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Add global config first
+        global_messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'*/my_service/common_key',
+                    value=json.dumps("common-value").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="config"),
+            )
+        ]
+        handler.handle(global_messages)
+
+        # Add source-specific configs
+        source_messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/specific_key',
+                    value=json.dumps("specific-value").encode('utf-8'),
+                ),
+                timestamp=123456790,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+        handler.handle(source_messages)
+
+        # Get config for a completely new source
+        new_source_config = handler.get_config("new_source")
+
+        # Should have global keys but not source-specific ones
+        assert new_source_config["common_key"] == "common-value"
+        assert "specific_key" not in new_source_config
+
+        # The original source should have both keys
+        source1_config = handler.get_config("source1")
+        assert source1_config["common_key"] == "common-value"
+        assert source1_config["specific_key"] == "specific-value"
+
+    def test_register_and_trigger_action(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Set up a mock action
+        action_calls = []
+
+        def mock_action(source_name: str, value):
+            action_calls.append((source_name, value))
+
+        # Register the action
+        handler.register_action(key="test_key", action=mock_action)
+
+        # Send a message that should trigger the action
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/test_key',
+                    value=json.dumps(42).encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+
+        handler.handle(messages)
+
+        # Verify action was called with correct parameters
+        assert len(action_calls) == 1
+        assert action_calls[0] == ("source1", 42)
+
+    def test_multiple_actions_for_same_key(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Set up mock actions
+        action1_calls = []
+        action2_calls = []
+
+        def mock_action1(source_name: str, value):
+            action1_calls.append((source_name, value))
+
+        def mock_action2(source_name: str, value):
+            action2_calls.append((source_name, value))
+
+        # Register both actions for the same key
+        handler.register_action(key="test_key", action=mock_action1)
+        handler.register_action(key="test_key", action=mock_action2)
+
+        # Send a message that should trigger both actions
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/test_key',
+                    value=json.dumps(42).encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+
+        handler.handle(messages)
+
+        # Verify both actions were called
+        assert len(action1_calls) == 1
+        assert len(action2_calls) == 1
+        assert action1_calls[0] == ("source1", 42)
+        assert action2_calls[0] == ("source1", 42)
+
+    def test_ignore_messages_for_other_services(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/other_service/key1',
+                    value=json.dumps("value1").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+
+        handler.handle(messages)
+
+        # Config should not be updated for any source
+        assert "key1" not in handler.get_config("source1")
+        assert "key1" not in handler.get_config("other_source")
+
+    def test_global_service_wildcard(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Send a message with service wildcard
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/*/key1',
+                    value=json.dumps("value1").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+
+        handler.handle(messages)
+
+        # Should be processed (wildcard matches any service)
+        assert handler.get_config("source1")["key1"] == "value1"
+
+        # But should not apply to other sources
+        assert "key1" not in handler.get_config("source2")
+
+    def test_global_source_wildcard(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Send a message with source wildcard
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'*/my_service/key1',
+                    value=json.dumps("global-value").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="config"),
+            )
+        ]
+
+        handler.handle(messages)
+
+        # Should be available for any source
+        assert handler.get_config("source1")["key1"] == "global-value"
+        assert handler.get_config("source2")["key1"] == "global-value"
+        assert handler.get_config("new_source")["key1"] == "global-value"
+
+    def test_action_exception_handling(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Set up an action that will raise an exception
+        def failing_action(source_name: str, value):
+            raise KeyError("Test exception")
+
+        # Register the action
+        handler.register_action(key="test_key", action=failing_action)
+
+        # Send a message that should trigger the action
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/test_key',
+                    value=json.dumps(42).encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+
+        # Exception should be caught, not propagated
+        handler.handle(messages)
+
+        # Config should still be updated despite action failure
+        assert handler.get_config("source1")["test_key"] == 42
+
+    def test_message_exception_handling(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Send a message with invalid JSON
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/key1',
+                    value=b'not valid json',
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+
+        # Exception should be caught, not propagated
+        handler.handle(messages)
+
+        # No config should be updated due to the error
+        assert "key1" not in handler.get_config("source1")
+
+    def test_global_config_override_local_config(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Add source-specific config first
+        source_messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/key1',
+                    value=json.dumps("source1-value").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+        handler.handle(source_messages)
+
+        # Later add global config with same key
+        global_messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'*/my_service/key1',
+                    value=json.dumps("global-value").encode('utf-8'),
+                ),
+                timestamp=123456890,  # Later timestamp
+                key=MessageKey(topic="test_topic", source_name="config"),
+            )
+        ]
+        handler.handle(global_messages)
+
+        # All sources should now have the global value
+        assert handler.get_config("source1")["key1"] == "global-value"
+        assert handler.get_config("source2")["key1"] == "global-value"
+
+        # Now override with a new source-specific value
+        override_messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/key1',
+                    value=json.dumps("override-value").encode('utf-8'),
+                ),
+                timestamp=123456900,  # Even later timestamp
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+        handler.handle(override_messages)
+
+        # Source1 should have the override, other sources should keep the global value
+        assert handler.get_config("source1")["key1"] == "override-value"
+        assert handler.get_config("source2")["key1"] == "global-value"
+
+    def test_process_messages_with_none_service(self):
+        handler = ConfigHandler(service_name="my_service")
+        config_key = ConfigKey(source_name="source1", service_name=None, key="key1")
+        key_str = str(config_key)
+
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=key_str.encode('utf-8'),
+                    value=json.dumps("value1").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            )
+        ]
+
+        handler.handle(messages)
+
+        # Should be processed since None service_name applies to all services
+        assert handler.get_config("source1")["key1"] == "value1"
+
+    def test_filter_mixed_service_messages(self):
+        handler = ConfigHandler(service_name="my_service")
+
+        # Create a batch of messages with different service targets
+        messages = [
+            # This one is for our service and should be processed
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/my_service/key1',
+                    value=json.dumps("value1").encode('utf-8'),
+                ),
+                timestamp=123456789,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            ),
+            # This one is for a different service and should be ignored
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/other_service/key2',
+                    value=json.dumps("value2").encode('utf-8'),
+                ),
+                timestamp=123456790,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            ),
+            # This one has a wildcard service and should be processed
+            Message(
+                value=RawConfigItem(
+                    key=b'source1/*/key3',
+                    value=json.dumps("value3").encode('utf-8'),
+                ),
+                timestamp=123456791,
+                key=MessageKey(topic="test_topic", source_name="source1"),
+            ),
+        ]
+
+        handler.handle(messages)
+
+        config = handler.get_config("source1")
+        # Should have processed key1 and key3, but not key2
+        assert config["key1"] == "value1"
+        assert "key2" not in config
+        assert config["key3"] == "value3"

--- a/tests/handlers/detector_data_handler_test.py
+++ b/tests/handlers/detector_data_handler_test.py
@@ -5,7 +5,7 @@ import pytest
 import scipp as sc
 
 from beamlime.config.raw_detectors import available_instruments, get_config
-from beamlime.core.handler import Message, MessageKey
+from beamlime.core.handler import FakeConfigRegistry, Message, MessageKey
 from beamlime.handlers.accumulators import DetectorEvents
 from beamlime.handlers.detector_data_handler import (
     DetectorHandlerFactory,
@@ -14,7 +14,9 @@ from beamlime.handlers.detector_data_handler import (
 
 
 def test_factory_can_fall_back_to_configured_detector_number_for_LogicalView() -> None:
-    factory = DetectorHandlerFactory(instrument='dummy', config={})
+    factory = DetectorHandlerFactory(
+        instrument='dummy', config_registry=FakeConfigRegistry()
+    )
     handler = factory.make_handler(
         MessageKey(topic='detector_data', source_name='panel_0')
     )
@@ -63,6 +65,8 @@ def test_factory_can_create_handler(instrument: str) -> None:
     config = get_config(instrument).detectors_config
     detectors = {view['detector_name'] for view in config['detectors'].values()}
     assert len(detectors) > 0
-    factory = DetectorHandlerFactory(instrument=instrument, config={})
+    factory = DetectorHandlerFactory(
+        instrument=instrument, config_registry=FakeConfigRegistry()
+    )
     for name in detectors:
         _ = factory.make_handler(MessageKey(topic='ignored', source_name=name))

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -8,7 +8,7 @@ from streaming_data_types import eventdata_ev44, logdata_f144
 from beamlime.core.message import Message, MessageKey, MessageSource
 from beamlime.kafka.message_adapter import (
     AdaptingMessageSource,
-    BeamlimeCommandsAdapter,
+    BeamlimeConfigMessageAdapter,
     ChainedAdapter,
     Ev44ToMonitorEventsAdapter,
     F144ToLogDataAdapter,
@@ -17,6 +17,7 @@ from beamlime.kafka.message_adapter import (
     KafkaToEv44Adapter,
     KafkaToF144Adapter,
     KafkaToMonitorEventsAdapter,
+    RawConfigItem,
     RoutingAdapter,
 )
 
@@ -154,13 +155,12 @@ def test_routing_adapter_calls_adapter_based_on_route() -> None:
 
 
 def test_BeamlimeCommandsAdapter() -> None:
-    base_key = 'my_source/my_service/my_key'
-    key = base_key.encode('utf-8')
+    key = b'my_source/my_service/my_key'
     encoded = json.dumps('my_value').encode('utf-8')
     message = FakeKafkaMessage(key=key, value=encoded, topic="dummy_beamlime_commands")
-    adapter = BeamlimeCommandsAdapter()
+    adapter = BeamlimeConfigMessageAdapter()
     adapted_message = adapter.adapt(message)
     assert adapted_message.key.topic == 'dummy_beamlime_commands'
     # So it gets routed to config handler
     assert adapted_message.key.source_name == 'config'
-    assert adapted_message.value == {'key': base_key, 'value': encoded}
+    assert adapted_message.value == RawConfigItem(key=key, value=encoded)

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import json
+
 import pytest
 from streaming_data_types import eventdata_ev44, logdata_f144
 
 from beamlime.core.message import Message, MessageKey, MessageSource
 from beamlime.kafka.message_adapter import (
     AdaptingMessageSource,
+    BeamlimeCommandsAdapter,
     ChainedAdapter,
     Ev44ToMonitorEventsAdapter,
     F144ToLogDataAdapter,
@@ -148,3 +151,16 @@ def test_routing_adapter_calls_adapter_based_on_route() -> None:
     )
     assert adapter.adapt(message_with_schema('ev44')).value == "adapter1"
     assert adapter.adapt(message_with_schema('da00')).value == "adapter2"
+
+
+def test_BeamlimeCommandsAdapter() -> None:
+    base_key = 'my_source/my_service/my_key'
+    key = base_key.encode('utf-8')
+    encoded = json.dumps('my_value').encode('utf-8')
+    message = FakeKafkaMessage(key=key, value=encoded, topic="dummy_beamlime_commands")
+    adapter = BeamlimeCommandsAdapter()
+    adapted_message = adapter.adapt(message)
+    assert adapted_message.key.topic == 'dummy_beamlime_commands'
+    # So it gets routed to config handler
+    assert adapted_message.key.source_name == 'config'
+    assert adapted_message.value == {'key': base_key, 'value': encoded}

--- a/tests/processor_test.py
+++ b/tests/processor_test.py
@@ -27,19 +27,19 @@ class ValueToStringHandler(Handler[T, str]):
 
 
 def test_consumes_and_produces_messages() -> None:
-    config = {}
+    key = MessageKey(topic='topic', source_name='source')
     source = FakeMessageSource(
         messages=[
             [],
-            [Message(timestamp=0, key='topic', value=111)],
+            [Message(timestamp=0, key=key, value=111)],
             [
-                Message(timestamp=0, key='topic', value=222),
-                Message(timestamp=0, key='topic', value=333),
+                Message(timestamp=0, key=key, value=222),
+                Message(timestamp=0, key=key, value=333),
             ],
         ]
     )
     sink = FakeMessageSink()
-    factory = CommonHandlerFactory(config=config, handler_cls=ValueToStringHandler)
+    factory = CommonHandlerFactory(handler_cls=ValueToStringHandler)
     registry = HandlerRegistry(factory=factory)
     processor = StreamProcessor(source=source, sink=sink, handler_registry=registry)
     processor.process()

--- a/tests/services/data_service_test.py
+++ b/tests/services/data_service_test.py
@@ -59,7 +59,7 @@ def test_basics() -> None:
         instrument='instrument',
         name='name',
         adapter=ForwardingAdapter(),
-        handler_factory=CommonHandlerFactory(handler_cls=ForwardingHandler, config={}),
+        handler_factory=CommonHandlerFactory(handler_cls=ForwardingHandler),
     )
     sink = FakeMessageSink()
     consumer = IntConsumer()


### PR DESCRIPTION
- Config keys now include source name and service name.
- Service name is used to filter messages. We can thus, e.g., clear the live detector view without clearing the data reduction (note the dashboard only implements a wildcard clear for now).
- Source name is used to configure individual handlers. Main driver for this is (for now) data reduction, where previously the source name was encoded in the message value. This was insufficient since due to Kafka topic compaction we would thus only see a subset of config messages.

Fixes #288.