### PR TITLE
Extract duplicate route setup code

### DIFF
--- a/src/beamlime/handlers/config_handler.py
+++ b/src/beamlime/handlers/config_handler.py
@@ -11,7 +11,7 @@ from typing import Any
 from ..config.models import ConfigKey
 from ..core.handler import Config, Handler
 from ..core.message import Message, MessageKey
-from ..kafka.helpers import beamlime_command_topic
+from ..kafka.helpers import beamlime_config_topic
 from ..kafka.message_adapter import RawConfigItem
 
 
@@ -57,9 +57,7 @@ class ConfigHandler(Handler[bytes, None]):
 
     @staticmethod
     def message_key(instrument: str) -> MessageKey:
-        return MessageKey(
-            topic=beamlime_command_topic(instrument), source_name='config'
-        )
+        return MessageKey(topic=beamlime_config_topic(instrument), source_name='config')
 
     def __init__(self, *, logger: logging.Logger | None = None, service_name: str):
         super().__init__(logger=logger, config={})

--- a/src/beamlime/kafka/helpers.py
+++ b/src/beamlime/kafka/helpers.py
@@ -41,9 +41,9 @@ def motion_topic(instrument: str) -> str:
     return topic_for_instrument(topic='motion', instrument=instrument)
 
 
-def beamlime_command_topic(instrument: str) -> str:
+def beamlime_config_topic(instrument: str) -> str:
     """
-    Return the topic name for the beamlime command data of an instrument.
+    Return the topic name for the beamlime configuration of an instrument.
     """
     return topic_for_instrument(topic='beamlime_commands', instrument=instrument)
 

--- a/src/beamlime/kafka/message_adapter.py
+++ b/src/beamlime/kafka/message_adapter.py
@@ -233,7 +233,7 @@ class ChainedAdapter(MessageAdapter[T, V]):
         return self._second.adapt(intermediate)
 
 
-class RoutingAdapter(MessageAdapter[KafkaMessage, T]):
+class RouteBySchemaAdapter(MessageAdapter[KafkaMessage, T]):
     """
     Routes messages to different adapters based on the schema.
     """

--- a/src/beamlime/kafka/routes.py
+++ b/src/beamlime/kafka/routes.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+from .helpers import (
+    beam_monitor_topic,
+    beamlime_config_topic,
+    detector_topic,
+    motion_topic,
+)
+from .message_adapter import (
+    BeamlimeConfigMessageAdapter,
+    ChainedAdapter,
+    Da00ToScippAdapter,
+    Ev44ToDetectorEventsAdapter,
+    F144ToLogDataAdapter,
+    KafkaToDa00Adapter,
+    KafkaToEv44Adapter,
+    KafkaToF144Adapter,
+    KafkaToMonitorEventsAdapter,
+    MessageAdapter,
+    RouteBySchemaAdapter,
+)
+
+
+def beamlime_config_route(instrument: str) -> dict[str, MessageAdapter]:
+    """Returns a dictionary of routes for beamlime configuration."""
+    return {beamlime_config_topic(instrument): BeamlimeConfigMessageAdapter()}
+
+
+def beam_monitor_route(instrument: str) -> dict[str, MessageAdapter]:
+    """Returns a dictionary of routes for monitor data."""
+    monitors = RouteBySchemaAdapter(
+        routes={
+            'ev44': KafkaToMonitorEventsAdapter(),
+            'da00': ChainedAdapter(
+                first=KafkaToDa00Adapter(), second=Da00ToScippAdapter()
+            ),
+        }
+    )
+    return {beam_monitor_topic(instrument): monitors}
+
+
+def detector_route(instrument: str) -> dict[str, MessageAdapter]:
+    """Returns a dictionary of routes for detector data."""
+    detectors = ChainedAdapter(
+        first=KafkaToEv44Adapter(),
+        second=Ev44ToDetectorEventsAdapter(merge_detectors=instrument == 'bifrost'),
+    )
+    return {detector_topic(instrument): detectors}
+
+
+def logdata_route(instrument: str) -> dict[str, MessageAdapter]:
+    """Returns a dictionary of routes for log data."""
+    return {
+        motion_topic(instrument): ChainedAdapter(
+            first=KafkaToF144Adapter(), second=F144ToLogDataAdapter()
+        )
+    }

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -125,7 +125,7 @@ def message_with_schema(schema: str) -> KafkaMessage:
     return FakeKafkaMessage(value=f"xxxx{schema}".encode(), topic=schema)
 
 
-def test_routing_adapter_raises_KeyError_if_no_route_found() -> None:
+def test_RouteBySchemaAdapter_raises_KeyError_if_no_route_found() -> None:
     adapter = RouteBySchemaAdapter(routes={})
     with pytest.raises(KeyError, match="ev44"):
         adapter.adapt(message_with_schema("ev44"))
@@ -139,7 +139,7 @@ def fake_message_with_value(message: KafkaMessage, value: str) -> Message[str]:
     )
 
 
-def test_routing_adapter_calls_adapter_based_on_route() -> None:
+def test_RouteBySchemaAdapter_calls_adapter_based_on_route() -> None:
     class Adapter:
         def __init__(self, value: str):
             self._value = value

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -18,7 +18,7 @@ from beamlime.kafka.message_adapter import (
     KafkaToF144Adapter,
     KafkaToMonitorEventsAdapter,
     RawConfigItem,
-    RoutingAdapter,
+    RouteBySchemaAdapter,
 )
 
 
@@ -126,7 +126,7 @@ def message_with_schema(schema: str) -> KafkaMessage:
 
 
 def test_routing_adapter_raises_KeyError_if_no_route_found() -> None:
-    adapter = RoutingAdapter(routes={})
+    adapter = RouteBySchemaAdapter(routes={})
     with pytest.raises(KeyError, match="ev44"):
         adapter.adapt(message_with_schema("ev44"))
 
@@ -147,7 +147,7 @@ def test_routing_adapter_calls_adapter_based_on_route() -> None:
         def adapt(self, message: KafkaMessage) -> Message[str]:
             return fake_message_with_value(message, self._value)
 
-    adapter = RoutingAdapter(
+    adapter = RouteBySchemaAdapter(
         routes={"ev44": Adapter('adapter1'), "da00": Adapter('adapter2')}
     )
     assert adapter.adapt(message_with_schema('ev44')).value == "adapter1"


### PR DESCRIPTION
There is no functional change here, simply extracting common code, keeping the follow-up PR easier to review.