### PR TITLE
Update source name in result to follow updated schema

### DIFF
--- a/src/beamlime/core/handler.py
+++ b/src/beamlime/core/handler.py
@@ -26,6 +26,11 @@ class ConfigRegistry(Protocol):
     based on the source name of the messages they are processing.
     """
 
+    @property
+    def service_name(self) -> str:
+        """Name of the service this registry is associated with."""
+        pass
+
     def get_config(self, source_name: str) -> Config:
         pass
 
@@ -38,7 +43,12 @@ class FakeConfigRegistry(ConfigRegistry):
     """
 
     def __init__(self):
+        self._service_name = 'fake_service'
         self._configs: dict[str, Config] = {}
+
+    @property
+    def service_name(self) -> str:
+        return self._service_name
 
     def get_config(self, source_name: str) -> Config:
         return self._configs.setdefault(source_name, {})
@@ -200,11 +210,13 @@ class PeriodicAccumulatingHandler(Handler[T, U]):
         self,
         *,
         logger: logging.Logger | None = None,
+        service_name: str,
         config: Config,
         preprocessor: Accumulator[T, U],
         accumulators: Mapping[str, Accumulator[U, V]],
     ):
         super().__init__(logger=logger, config=config)
+        self._service_name = service_name
         self._preprocessor = preprocessor
         self._accumulators = accumulators
         self._next_update = 0

--- a/src/beamlime/handlers/config_handler.py
+++ b/src/beamlime/handlers/config_handler.py
@@ -61,6 +61,11 @@ class ConfigHandler(Handler[bytes, None]):
         self._stores: dict[str, dict[str, Any]] = {}
         self._actions: dict[str, list[Callable[[str, Any], None]]] = {}
 
+    @property
+    def service_name(self) -> str:
+        """Name of the service this handler is associated with."""
+        return self._service_name
+
     def get_config(self, source_name: str) -> Config:
         """
         Get the configuration store for a specific source name.

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -86,6 +86,7 @@ class ReductionHandlerFactory(
         self._logger.info("%s using accumulator %s", key.name, accumulator)
 
         return PeriodicAccumulatingHandler(
+            service_name=self._config_registry.service_name,
             logger=self._logger,
             config=config,
             preprocessor=preprocessor,

--- a/src/beamlime/handlers/detector_data_handler.py
+++ b/src/beamlime/handlers/detector_data_handler.py
@@ -112,6 +112,7 @@ class DetectorHandlerFactory(HandlerFactory[DetectorEvents, sc.DataArray]):
             )
 
         return PeriodicAccumulatingHandler(
+            service_name=self._config_registry.service_name,
             logger=self._logger,
             config=config,
             preprocessor=preprocessor,

--- a/src/beamlime/handlers/monitor_data_handler.py
+++ b/src/beamlime/handlers/monitor_data_handler.py
@@ -55,6 +55,7 @@ class MonitorHandlerFactory(HandlerFactory[MonitorEvents | sc.DataArray, sc.Data
         }
         preprocessor = make_monitor_data_preprocessor(key, config)
         return PeriodicAccumulatingHandler(
+            service_name=self._config_registry.service_name,
             logger=self._logger,
             config=config,
             preprocessor=preprocessor,

--- a/src/beamlime/services/dashboard.py
+++ b/src/beamlime/services/dashboard.py
@@ -542,7 +542,9 @@ class DashboardApp(ServiceBase):
                 "Got %d messages, showing most recent %d", num, len(messages)
             )
             for msg in messages:
-                orig_source_name, suffix = msg.stream.name.split(':', maxsplit=1)
+                orig_source_name, service_name, suffix = msg.stream.name.split(
+                    '/', maxsplit=2
+                )
                 key = f'Source name: {orig_source_name}<br>{suffix}'
                 data = msg.value
                 for dim in data.dims:

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -10,7 +10,7 @@ from streaming_data_types import eventdata_ev44
 from beamlime import StreamKind
 from beamlime.config.instruments import available_instruments, get_config
 from beamlime.config.streams import stream_kind_to_topic
-from beamlime.core.handler import source_name
+from beamlime.core.handler import output_stream_name
 from beamlime.fakes import FakeMessageSink
 from beamlime.kafka.message_adapter import FakeKafkaMessage, KafkaMessage
 from beamlime.kafka.sink import UnrollingSinkAdapter
@@ -168,7 +168,11 @@ def test_detector_data_service(instrument: str) -> None:
 
     detectors = get_config(instrument).detectors_config['detectors']
     for view_name, view_config in detectors.items():
-        base_key = source_name(device=view_config['detector_name'], signal=view_name)
+        base_key = output_stream_name(
+            service_name='detector_data',
+            stream_name=view_config['detector_name'],
+            signal_name=view_name,
+        )
         assert f'{base_key}/cumulative' in source_names
         assert f'{base_key}/current' in source_names
         assert f'{base_key}/roi' in source_names

--- a/tests/services/monitor_data_test.py
+++ b/tests/services/monitor_data_test.py
@@ -9,7 +9,7 @@ from streaming_data_types import eventdata_ev44
 
 from beamlime import StreamKind
 from beamlime.config.streams import stream_kind_to_topic
-from beamlime.core.handler import source_name
+from beamlime.core.handler import output_stream_name
 from beamlime.fakes import FakeMessageSink
 from beamlime.kafka.message_adapter import FakeKafkaMessage, KafkaMessage
 from beamlime.kafka.source import KafkaConsumer
@@ -144,10 +144,34 @@ def test_monitor_data_service() -> None:
     service.start(blocking=False)
     start_and_wait_for_completion(consumer=consumer)
     source_names = [msg.stream.name for msg in sink.messages]
-    assert source_name('monitor0', 'cumulative') in source_names
-    assert source_name('monitor1', 'cumulative') in source_names
-    assert source_name('monitor0', 'current') in source_names
-    assert source_name('monitor1', 'current') in source_names
+    assert (
+        output_stream_name(
+            service_name='monitor_data',
+            stream_name='monitor0',
+            signal_name='cumulative',
+        )
+        in source_names
+    )
+    assert (
+        output_stream_name(
+            service_name='monitor_data',
+            stream_name='monitor1',
+            signal_name='cumulative',
+        )
+        in source_names
+    )
+    assert (
+        output_stream_name(
+            service_name='monitor_data', stream_name='monitor0', signal_name='current'
+        )
+        in source_names
+    )
+    assert (
+        output_stream_name(
+            service_name='monitor_data', stream_name='monitor1', signal_name='current'
+        )
+        in source_names
+    )
     size = len(sink.messages)
     start_and_wait_for_completion(consumer=consumer)
     assert len(sink.messages) > size

--- a/tests/services/timeseries_test.py
+++ b/tests/services/timeseries_test.py
@@ -173,7 +173,7 @@ def test_timeseries_service(instrument: str) -> None:
     # Group messages by source name
     messages_by_source = {}
     for msg in sink.messages:
-        source_name = msg.stream.name.split(':')[0]
+        source_name = msg.stream.name.split('/')[0]
         if source_name not in messages_by_source:
             messages_by_source[source_name] = []
         messages_by_source[source_name].append(msg)
@@ -189,11 +189,11 @@ def test_timeseries_service(instrument: str) -> None:
             assert 'time' in data.dims
 
             # Check that the data has the expected units
-            if source_name == 'detector_rotation:timeseries':
+            if source_name == 'detector_rotation/timeseries/timeseries':
                 assert data.unit == sc.Unit('deg')
-            elif source_name == 'temperature:timeseries':
+            elif source_name == 'temperature/timeseries/timeseries':
                 assert data.unit == sc.Unit('C')
-            elif source_name == 'pressure:timeseries':
+            elif source_name == 'pressure/timeseries/timeseries':
                 assert data.unit == sc.Unit('kPa')
 
 
@@ -224,7 +224,7 @@ def test_timeseries_accumulation() -> None:
     messages = [
         msg
         for msg in sink.messages
-        if msg.stream.name == 'detector_rotation:timeseries'
+        if msg.stream.name == 'detector_rotation/timeseries/timeseries'
     ]
     assert len(messages) > 1
 


### PR DESCRIPTION
This brings the processed data in line with the recent update of the config message key schema. See also https://gitlab.esss.lu.se/ecdc/interface-specs/-/merge_requests/1.