### PR TITLE
Add tests for data reduction service

### DIFF
--- a/docs/user-guide/adding-new-instruments.md
+++ b/docs/user-guide/adding-new-instruments.md
@@ -7,12 +7,30 @@ This guide explains how to add support for a new instrument in Beamlime.
 1. Create a new configuration file in `src/beamlime/config/instruments/<instrument>.py`
    - The filename will be used as the instrument identifier
    - Beamlime automatically detects and loads all Python files in this directory
-2. Add detector configuration including:
+2. Import and create and instance of the `Instrument` class in the new file.
+3. Add detector configuration including:
    - Detector names and pixel ID ranges
    - View configurations (resolution, projection type)
    - Optional pixel noise settings
 
-## Detector Configuration Example
+## Creating the Instrument instance
+
+Example of creating an instrument instance:
+
+```python
+from beamlime.config import Instrument
+
+instrument = Instrument(name='instrument_name')
+```
+
+Creating the instance registers the instrument with Beamlime and makes it available for use.
+The variable name (`instrument`) is irrelevant.
+The instrument instance provides further configuration options as well as a decorator for registering data reduction workflows.
+We refer to the API documentation for the `Instrument` class for more details.
+
+## Detector Configuration
+
+### Example
 
 Example for a new instrument with two detector panels:
 
@@ -55,7 +73,7 @@ To enable development without real detector data, you can add your instrument to
 - The pixel IDs must match your detector configuration and should not overlap
 - The fake detector service will generate random events within these ID ranges
 
-## View Types
+### View Types
 
 Beamlime supports different view types for detectors:
 
@@ -67,7 +85,7 @@ Geometric projections (`xy_plane`, `cylinder_mantle_z`) are used when detector p
 Projections are towards the sample position (assumed at the origin).
 For more details see [ess.reduce.live.raw](https://scipp.github.io/essreduce/generated/modules/ess.reduce.live.raw.html).
 
-## Geometry Files
+### Geometry Files
 
 If your instrument is configured to use `raw.LogicalView` *and* defined `detector_number` in the configuration, you do not need to provide a geometry file.
 Otherwise, you need to provide a NeXus geometry file for the instrument:

--- a/docs/user-guide/adding-new-instruments.md
+++ b/docs/user-guide/adding-new-instruments.md
@@ -7,7 +7,7 @@ This guide explains how to add support for a new instrument in Beamlime.
 1. Create a new configuration file in `src/beamlime/config/instruments/<instrument>.py`
    - The filename will be used as the instrument identifier
    - Beamlime automatically detects and loads all Python files in this directory
-2. Import and create and instance of the `Instrument` class in the new file.
+2. Import and create an instance of the `Instrument` class in the new file.
 3. Add detector configuration including:
    - Detector names and pixel ID ranges
    - View configurations (resolution, projection type)

--- a/src/beamlime/config/__init__.py
+++ b/src/beamlime/config/__init__.py
@@ -1,2 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+from .instrument import Instrument, instrument_registry
+
+__all__ = ['Instrument', 'instrument_registry']

--- a/src/beamlime/config/instrument.py
+++ b/src/beamlime/config/instrument.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections import UserDict
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -12,7 +13,7 @@ from beamlime.config.models import Parameter
 from beamlime.handlers.stream_processor_factory import StreamProcessorFactory
 
 
-class InstrumentRegistry(Mapping[str, 'Instrument']):
+class InstrumentRegistry(UserDict[str, 'Instrument']):
     """
     Registry for instrument configurations.
 
@@ -26,30 +27,11 @@ class InstrumentRegistry(Mapping[str, 'Instrument']):
     means that the registry will typically contain only a single instrument.
     """
 
-    def __init__(self) -> None:
-        self._instruments: dict[str, Instrument] = {}
-
     def register(self, instrument: Instrument) -> None:
         """Register an instrument configuration."""
-        if instrument.name in self._instruments:
+        if instrument.name in self:
             raise ValueError(f"Instrument {instrument.name} is already registered.")
-        self._instruments[instrument.name] = instrument
-
-    def __getitem__(self, name: str) -> Instrument:
-        """Get an instrument by name (implements Mapping)."""
-        return self._instruments[name]
-
-    def __iter__(self) -> Iterator[str]:
-        """Return an iterator over instrument names (implements Mapping)."""
-        return iter(self._instruments)
-
-    def __len__(self) -> int:
-        """Return the number of registered instruments (implements Mapping)."""
-        return len(self._instruments)
-
-    def __contains__(self, name: str) -> bool:
-        """Check if an instrument is registered."""
-        return name in self._instruments
+        self[instrument.name] = instrument
 
 
 instrument_registry = InstrumentRegistry()

--- a/src/beamlime/config/instrument.py
+++ b/src/beamlime/config/instrument.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from ess.reduce.streaming import StreamProcessor
+
+from beamlime.config.models import Parameter
+from beamlime.handlers.stream_processor_factory import StreamProcessorFactory
+
+
+class InstrumentRegistry(Mapping[str, 'Instrument']):
+    """
+    Registry for instrument configurations.
+
+    This class is used to register and retrieve instrument configurations
+    based on their names. It allows for easy access to the configuration
+    settings for different instruments.
+
+    Note that in practice instruments are registered only when their module, creating
+    an :py:class:`Instrument`, is imported. Beamlime does currently not import all
+    instrument modules but only the requested one (since importing can be slow). This
+    means that the registry will typically contain only a single instrument.
+    """
+
+    def __init__(self) -> None:
+        self._instruments: dict[str, Instrument] = {}
+
+    def register(self, instrument: Instrument) -> None:
+        """Register an instrument configuration."""
+        if instrument.name in self._instruments:
+            raise ValueError(f"Instrument {instrument.name} is already registered.")
+        self._instruments[instrument.name] = instrument
+
+    def __getitem__(self, name: str) -> Instrument:
+        """Get an instrument by name (implements Mapping)."""
+        return self._instruments[name]
+
+    def __iter__(self) -> Iterator[str]:
+        """Return an iterator over instrument names (implements Mapping)."""
+        return iter(self._instruments)
+
+    def __len__(self) -> int:
+        """Return the number of registered instruments (implements Mapping)."""
+        return len(self._instruments)
+
+    def __contains__(self, name: str) -> bool:
+        """Check if an instrument is registered."""
+        return name in self._instruments
+
+
+instrument_registry = InstrumentRegistry()
+
+
+@dataclass(frozen=True, kw_only=True)
+class Instrument:
+    """
+    Class for instrument configuration.
+
+    This class is used to define the configuration for a specific instrument.
+    It includes the stream mapping, processor factory, and other settings
+    required for the instrument to function correctly.
+
+    Instances are automatically registered with the global registry upon creation.
+    """
+
+    name: str
+    processor_factory: StreamProcessorFactory = field(
+        default_factory=StreamProcessorFactory
+    )
+    source_to_key: dict[str, type] = field(default_factory=dict)
+    f144_attribute_registry: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Register the instrument with the global registry after initialization."""
+        instrument_registry.register(self)
+
+    def register_workflow(
+        self,
+        name: str,
+        description: str = '',
+        source_names: Sequence[str] | None = None,
+        parameters: Sequence[Parameter] | None = None,
+    ) -> Callable[[Callable[[], StreamProcessor]], Callable[[], StreamProcessor]]:
+        """
+        Decorator to register a factory function for creating StreamProcessors.
+
+        Parameters
+        ----------
+        name:
+            Name to register the factory under.
+        description:
+            Optional description of the factory.
+        source_names:
+            Optional list of source names that the factory can handle. This is used to
+            create a workflow specification.
+        parameters:
+            Optional list of parameters that the factory accepts. This is used to
+            create a workflow specification.
+
+        Returns
+        -------
+        Decorator function that registers the factory and returns it unchanged.
+        """
+        return self.processor_factory.register(
+            name=name,
+            description=description,
+            source_names=source_names,
+            parameters=parameters,
+        )

--- a/src/beamlime/config/instruments/bifrost.py
+++ b/src/beamlime/config/instruments/bifrost.py
@@ -18,10 +18,10 @@ from ess.reduce.nexus.types import (
 from ess.reduce.streaming import StreamProcessor
 from scippnexus import NXdetector
 
+from beamlime.config import Instrument
 from beamlime.config.env import StreamingEnv
 from beamlime.config.models import Parameter, ParameterType
 from beamlime.handlers.detector_data_handler import get_nexus_geometry_filename
-from beamlime.handlers.stream_processor_factory import StreamProcessorFactory
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
@@ -159,10 +159,19 @@ spectrum_view_pixels_per_tube_param = Parameter(
     options=[1, 2, 5, 10, 20, 50, 100],  # Must be a divisor of 100
 )
 
-processor_factory = StreamProcessorFactory()
+instrument = Instrument(
+    name='bifrost',
+    source_to_key={
+        'unified_detector': NeXusData[NXdetector, SampleRun],
+        'detector_rotation': DetectorRotation,
+    },
+    f144_attribute_registry={
+        'detector_rotation': {'units': 'deg'},
+    },
+)
 
 
-@processor_factory.register(
+@instrument.register_workflow(
     name='spectrum-view',
     source_names=_source_names,
     parameters=(spectrum_view_time_bins_param, spectrum_view_pixels_per_tube_param),
@@ -181,7 +190,7 @@ def _spectrum_view(
     )
 
 
-@processor_factory.register(name='counts-per-angle', source_names=_source_names)
+@instrument.register_workflow(name='counts-per-angle', source_names=_source_names)
 def _counts_per_angle() -> StreamProcessor:
     return StreamProcessor(
         _reduction_workflow.copy(),
@@ -192,7 +201,7 @@ def _counts_per_angle() -> StreamProcessor:
     )
 
 
-@processor_factory.register(name='all', source_names=_source_names)
+@instrument.register_workflow(name='all', source_names=_source_names)
 def _all() -> StreamProcessor:
     return StreamProcessor(
         _reduction_workflow.copy(),
@@ -201,16 +210,6 @@ def _all() -> StreamProcessor:
         target_keys=(CountsPerAngle, SpectrumView),
         accumulators=(CountsPerAngle, SpectrumView),
     )
-
-
-source_to_key = {
-    'unified_detector': NeXusData[NXdetector, SampleRun],
-    'detector_rotation': DetectorRotation,
-}
-
-f144_attribute_registry = {
-    'detector_rotation': {'units': 'deg'},
-}
 
 
 def _make_bifrost_detectors() -> StreamLUT:

--- a/src/beamlime/config/instruments/bifrost.py
+++ b/src/beamlime/config/instruments/bifrost.py
@@ -21,7 +21,7 @@ from scippnexus import NXdetector
 from beamlime.config.env import StreamingEnv
 from beamlime.config.models import Parameter, ParameterType
 from beamlime.handlers.detector_data_handler import get_nexus_geometry_filename
-from beamlime.handlers.workflow_manager import processor_factory
+from beamlime.handlers.stream_processor_factory import StreamProcessorFactory
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
@@ -158,6 +158,8 @@ spectrum_view_pixels_per_tube_param = Parameter(
     default=10,
     options=[1, 2, 5, 10, 20, 50, 100],  # Must be a divisor of 100
 )
+
+processor_factory = StreamProcessorFactory()
 
 
 @processor_factory.register(

--- a/src/beamlime/config/instruments/dream.py
+++ b/src/beamlime/config/instruments/dream.py
@@ -7,10 +7,13 @@ import sciline
 import scipp as sc
 from ess.reduce.streaming import StreamProcessor
 
+from beamlime.config import Instrument
 from beamlime.config.env import StreamingEnv
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
+
+instrument = Instrument(name='dream')
 
 
 def _get_mantle_front_layer(da: sc.DataArray) -> sc.DataArray:

--- a/src/beamlime/config/instruments/dummy.py
+++ b/src/beamlime/config/instruments/dummy.py
@@ -4,9 +4,14 @@
 Detector configuration for a dummy instrument used for development and testing.
 """
 
+from typing import NewType
+
+import sciline
 import scipp as sc
+from ess.reduce.streaming import StreamProcessor
 
 from beamlime.config.env import StreamingEnv
+from beamlime.handlers.stream_processor_factory import StreamProcessorFactory
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
@@ -29,6 +34,37 @@ detectors_config = {
 def _make_dummy_detectors() -> StreamLUT:
     """Dummy detector mapping."""
     return {InputStreamKey(topic='dummy_detector', source_name='panel_0'): 'panel_0'}
+
+
+Events = NewType('Events', sc.DataArray)
+TotalCounts = NewType('TotalCounts', sc.DataArray)
+
+
+def _total_counts(events: Events) -> TotalCounts:
+    """Calculate total counts from events."""
+    return TotalCounts(events.sum())
+
+
+_total_counts_workflow = sciline.Pipeline((_total_counts,))
+
+processor_factory = StreamProcessorFactory()
+source_to_key = {'panel_0': Events}
+f144_attribute_registry = {}
+
+
+@processor_factory.register(
+    name='Total counts',
+    description='Dummy workflow that simply computes the total counts.',
+    source_names=['panel_0'],
+)
+def _total_counts() -> StreamProcessor:
+    """Dummy processor for development and testing."""
+    return StreamProcessor(
+        base_workflow=_total_counts_workflow.copy(),
+        dynamic_keys=(Events,),
+        target_keys=(TotalCounts,),
+        accumulators=(TotalCounts,),
+    )
 
 
 stream_mapping = {

--- a/src/beamlime/config/instruments/dummy.py
+++ b/src/beamlime/config/instruments/dummy.py
@@ -10,8 +10,8 @@ import sciline
 import scipp as sc
 from ess.reduce.streaming import StreamProcessor
 
+from beamlime.config import Instrument
 from beamlime.config.env import StreamingEnv
-from beamlime.handlers.stream_processor_factory import StreamProcessorFactory
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
@@ -47,12 +47,13 @@ def _total_counts(events: Events) -> TotalCounts:
 
 _total_counts_workflow = sciline.Pipeline((_total_counts,))
 
-processor_factory = StreamProcessorFactory()
-source_to_key = {'panel_0': Events}
-f144_attribute_registry = {}
+instrument = Instrument(
+    name='dummy',
+    source_to_key={'panel_0': Events},
+)
 
 
-@processor_factory.register(
+@instrument.register_workflow(
     name='Total counts',
     description='Dummy workflow that simply computes the total counts.',
     source_names=['panel_0'],

--- a/src/beamlime/config/instruments/loki.py
+++ b/src/beamlime/config/instruments/loki.py
@@ -20,7 +20,7 @@ from scippnexus import NXdetector
 from beamlime.config.env import StreamingEnv
 from beamlime.config.models import Parameter, ParameterType
 from beamlime.handlers.detector_data_handler import get_nexus_geometry_filename
-from beamlime.handlers.workflow_manager import processor_factory
+from beamlime.handlers.stream_processor_factory import StreamProcessorFactory
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
@@ -143,6 +143,8 @@ wav_bins_param = Parameter(
 # Created once outside workflow wrappers since this configures some files from pooch
 # where a checksum is needed, which takes significant time.
 _base_workflow = loki.live._configured_Larmor_AgBeh_workflow()
+
+processor_factory = StreamProcessorFactory()
 
 
 @processor_factory.register(name='I(Q)', source_names=_source_names)

--- a/src/beamlime/config/instruments/loki.py
+++ b/src/beamlime/config/instruments/loki.py
@@ -17,10 +17,10 @@ from ess.sans.types import (
 )
 from scippnexus import NXdetector
 
+from beamlime.config import Instrument
 from beamlime.config.env import StreamingEnv
 from beamlime.config.models import Parameter, ParameterType
 from beamlime.handlers.detector_data_handler import get_nexus_geometry_filename
-from beamlime.handlers.stream_processor_factory import StreamProcessorFactory
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
@@ -144,10 +144,25 @@ wav_bins_param = Parameter(
 # where a checksum is needed, which takes significant time.
 _base_workflow = loki.live._configured_Larmor_AgBeh_workflow()
 
-processor_factory = StreamProcessorFactory()
+instrument = Instrument(
+    name='loki',
+    source_to_key={
+        'loki_detector_0': NeXusData[NXdetector, SampleRun],
+        'loki_detector_1': NeXusData[NXdetector, SampleRun],
+        'loki_detector_2': NeXusData[NXdetector, SampleRun],
+        'loki_detector_3': NeXusData[NXdetector, SampleRun],
+        'loki_detector_4': NeXusData[NXdetector, SampleRun],
+        'loki_detector_5': NeXusData[NXdetector, SampleRun],
+        'loki_detector_6': NeXusData[NXdetector, SampleRun],
+        'loki_detector_7': NeXusData[NXdetector, SampleRun],
+        'loki_detector_8': NeXusData[NXdetector, SampleRun],
+        'monitor1': NeXusData[Incident, SampleRun],
+        'monitor2': NeXusData[Transmission, SampleRun],
+    },
+)
 
 
-@processor_factory.register(name='I(Q)', source_names=_source_names)
+@instrument.register_workflow(name='I(Q)', source_names=_source_names)
 def _i_of_q(source_name: str) -> StreamProcessor:
     wf = _base_workflow.copy()
     wf[Filename[SampleRun]] = get_nexus_geometry_filename('loki')
@@ -168,7 +183,7 @@ def _i_of_q(source_name: str) -> StreamProcessor:
 # auto-generate this, e.g., based on the widget-related components in ess.reduce.
 # On the other hand, a curated list of parameters may be useful and advantageous for
 # a simplified workflow control for live reduction.
-@processor_factory.register(
+@instrument.register_workflow(
     name='I(Q) with params',
     source_names=_source_names,
     parameters=(qbins_param, wav_min_param, wav_max_param, wav_bins_param),
@@ -204,22 +219,6 @@ def _i_of_q_with_params(
         target_keys=(IofQ[SampleRun],),
         accumulators=(ReducedQ[SampleRun, Numerator], ReducedQ[SampleRun, Denominator]),
     )
-
-
-source_to_key = {
-    'loki_detector_0': NeXusData[NXdetector, SampleRun],
-    'loki_detector_1': NeXusData[NXdetector, SampleRun],
-    'loki_detector_2': NeXusData[NXdetector, SampleRun],
-    'loki_detector_3': NeXusData[NXdetector, SampleRun],
-    'loki_detector_4': NeXusData[NXdetector, SampleRun],
-    'loki_detector_5': NeXusData[NXdetector, SampleRun],
-    'loki_detector_6': NeXusData[NXdetector, SampleRun],
-    'loki_detector_7': NeXusData[NXdetector, SampleRun],
-    'loki_detector_8': NeXusData[NXdetector, SampleRun],
-    'monitor1': NeXusData[Incident, SampleRun],
-    'monitor2': NeXusData[Transmission, SampleRun],
-}
-f144_attribute_registry = {}
 
 
 def _make_loki_detectors() -> StreamLUT:

--- a/src/beamlime/config/instruments/nmx.py
+++ b/src/beamlime/config/instruments/nmx.py
@@ -2,10 +2,13 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import scipp as sc
 
+from beamlime.config import Instrument
 from beamlime.config.env import StreamingEnv
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
+
+instrument = Instrument(name='nmx')
 
 # TODO Unclear if this is transposed or not. Wait for updated files.
 dim = 'detector_number'

--- a/src/beamlime/config/instruments/odin.py
+++ b/src/beamlime/config/instruments/odin.py
@@ -3,10 +3,13 @@
 
 import scipp as sc
 
+from beamlime.config import Instrument
 from beamlime.config.env import StreamingEnv
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
+
+instrument = Instrument(name='odin')
 
 # Note: Panel size is fake and does not correspond to production setting
 detectors_config = {

--- a/src/beamlime/config/instruments/tbl.py
+++ b/src/beamlime/config/instruments/tbl.py
@@ -3,10 +3,13 @@
 
 import scipp as sc
 
+from beamlime.config import Instrument
 from beamlime.config.env import StreamingEnv
 from beamlime.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from ._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
+
+instrument = Instrument(name='tbl')
 
 # Note: Panel size is fake and does not correspond to production setting
 detectors_config = {

--- a/src/beamlime/config/models.py
+++ b/src/beamlime/config/models.py
@@ -209,9 +209,7 @@ class Parameter(BaseModel, Generic[T]):
     unit: str | None = Field(default=None, description="Unit of the parameter.")
     description: str = Field(description="Description of the parameter.")
     param_type: ParameterType = Field(description="Type of the parameter.")
-    default: T | None = Field(
-        default=None, description="Default value of the parameter."
-    )
+    default: T = Field(description="Default value of the parameter.")
     options: list[T] | None = Field(
         default=None,
         description="List of options, if it is a parameter with options.",

--- a/src/beamlime/core/service.py
+++ b/src/beamlime/core/service.py
@@ -144,6 +144,12 @@ class Service(ServiceBase):
             except KeyboardInterrupt:  # noqa: PERF203
                 self.stop()
 
+    def step(self) -> None:
+        """Run one step of the service loop for testing purposes"""
+        if self.is_running:
+            raise RuntimeError("Service is running, cannot step")
+        self._processor.process()
+
     def _run_loop(self) -> None:
         """Main service loop"""
         try:

--- a/src/beamlime/fakes.py
+++ b/src/beamlime/fakes.py
@@ -33,7 +33,7 @@ class FakeMessageSink(Generic[T]):
     """
 
     def __init__(self) -> None:
-        self.messages = []
+        self.messages: list[Message[T]] = []
 
     def publish_messages(self, messages: list[Message[T]]) -> None:
         self.messages.extend(messages)

--- a/src/beamlime/handlers/data_reduction_handler.py
+++ b/src/beamlime/handlers/data_reduction_handler.py
@@ -64,18 +64,14 @@ class ReductionHandlerFactory(
         # when the workflow is cleared. This is done via the proxy the workflow manager
         # returns for the detector data accumulator.
         match key.kind:
-            case StreamKind.MONITOR_EVENTS | StreamKind.MONITOR_COUNTS:
-                # TODO The config for the preprocessor may need to be setup differently,
-                # e.g., to obtain the desired number of TOA bins. Or maybe we should
-                # not histogram in the preprocessor, i.e., not reuse the same
-                # preprocessor as in the monitor_data service.
+            case StreamKind.MONITOR_COUNTS:
                 preprocessor = make_monitor_data_preprocessor(key, config={})
                 config = {}
             case StreamKind.LOG:
                 attrs = self._f144_attribute_registry[key.name]
                 preprocessor = ToNXlog(attrs=attrs)
                 config = {}
-            case StreamKind.DETECTOR_EVENTS:
+            case StreamKind.MONITOR_EVENTS | StreamKind.DETECTOR_EVENTS:
                 preprocessor = ToNXevent_data()
                 config = self._config_registry.get_config(key.name)
             case _:

--- a/src/beamlime/handlers/workflow_manager.py
+++ b/src/beamlime/handlers/workflow_manager.py
@@ -48,15 +48,10 @@ class WorkflowManager:
         """
         Parameters
         ----------
-        source_names:
-            List of source names to attach workflows to. These need to be passed
-            explicitly, so we can distinguish source names that should not be handled
-            (to proxy and handler will be created) from source names that may later be
-            configured to use a workflow.
+        processor_factory:
+            Factory for creating stream processors.
         source_to_key:
             Dictionary mapping source names to workflow input keys.
-        dynamic_workflows:
-            Dictionary mapping source names to dynamic workflows.
         """
         self._processor_factory = processor_factory
         self._source_to_key = source_to_key

--- a/src/beamlime/handlers/workflow_manager.py
+++ b/src/beamlime/handlers/workflow_manager.py
@@ -92,7 +92,13 @@ class WorkflowManager:
         if (proxy := self._proxies.get(source_name)) is not None:
             proxy.set_processor(self._processors.get(source_name))
 
-    def set_workflow_with_config(self, source_name: str, value: dict | None) -> None:
+    def set_workflow_with_config(
+        self, source_name: str | None, value: dict | None
+    ) -> None:
+        if source_name is None:
+            for name in self._processor_factory.source_names:
+                self.set_workflow_with_config(name, value)
+            return
         if value is None:
             self.set_workflow(source_name, None)
             return

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -11,7 +11,7 @@ from beamlime.config.streams import get_stream_mapping
 from beamlime.core.message import CONFIG_STREAM_ID, Message
 from beamlime.handlers.config_handler import ConfigHandler, ConfigUpdate
 from beamlime.handlers.data_reduction_handler import ReductionHandlerFactory
-from beamlime.handlers.workflow_manager import WorkflowManager, get_workflow_specs
+from beamlime.handlers.workflow_manager import WorkflowManager
 from beamlime.kafka.routes import RoutingAdapterBuilder
 from beamlime.service_factory import DataServiceBuilder, DataServiceRunner
 
@@ -29,7 +29,10 @@ def make_reduction_service_builder(
         .build()
     )
     instrument_config = get_config(instrument)
-    workflow_manager = WorkflowManager(source_to_key=instrument_config.source_to_key)
+    workflow_manager = WorkflowManager(
+        processor_factory=instrument_config.processor_factory,
+        source_to_key=instrument_config.source_to_key,
+    )
     service_name = 'data_reduction'
     config_handler = ConfigHandler(service_name=service_name)
     config_handler.register_action(
@@ -45,7 +48,7 @@ def make_reduction_service_builder(
         stream=CONFIG_STREAM_ID,
         value=ConfigUpdate(
             config_key=ConfigKey(service_name=service_name, key='workflow_specs'),
-            value=get_workflow_specs(),
+            value=workflow_manager.get_workflow_specs(),
         ),
     )
     builder = DataServiceBuilder(

--- a/src/beamlime/services/data_reduction.py
+++ b/src/beamlime/services/data_reduction.py
@@ -5,6 +5,7 @@
 import logging
 from typing import NoReturn
 
+from beamlime.config import instrument_registry
 from beamlime.config.instruments import get_config
 from beamlime.config.models import ConfigKey
 from beamlime.config.streams import get_stream_mapping
@@ -28,7 +29,8 @@ def make_reduction_service_builder(
         .with_beamlime_config_route()
         .build()
     )
-    instrument_config = get_config(instrument)
+    _ = get_config(instrument)  # Load the module to register the instrument
+    instrument_config = instrument_registry[instrument]
     workflow_manager = WorkflowManager(
         processor_factory=instrument_config.processor_factory,
         source_to_key=instrument_config.source_to_key,

--- a/tests/handlers/config_handler_test.py
+++ b/tests/handlers/config_handler_test.py
@@ -588,7 +588,7 @@ class TestConfigHandler:
 
         assert len(action_calls) == 2
         assert ("source2", "source2-value") in action_calls
-        assert ("source1", "global-value") in action_calls
+        assert (None, "global-value") in action_calls
 
     def test_action_triggered_for_same_key_multiple_batches(self):
         handler = ConfigHandler(service_name="my_service")
@@ -743,5 +743,5 @@ class TestConfigHandler:
 
         # Verify action was called once per source with the final value
         assert len(action_calls) == 2  # One for each source
-        assert ("source1", "global-final") in action_calls
+        assert (None, "global-final") in action_calls
         assert ("source2", "source2-value") in action_calls

--- a/tests/helpers/beamlime_app.py
+++ b/tests/helpers/beamlime_app.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""
+Helper class for testing Beamlime services.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from streaming_data_types import eventdata_ev44
+
+from beamlime import Service, StreamKind
+from beamlime.config import models
+from beamlime.config.instruments import get_config
+from beamlime.config.streams import stream_kind_to_topic
+from beamlime.fakes import FakeMessageSink
+from beamlime.kafka.message_adapter import FakeKafkaMessage, KafkaMessage
+from beamlime.kafka.sink import UnrollingSinkAdapter
+from beamlime.kafka.source import KafkaConsumer
+from beamlime.service_factory import DataServiceBuilder
+
+
+class FakeConsumer(KafkaConsumer):
+    """Fake consumer that can be filled with custom messages for consumption."""
+
+    def __init__(self) -> None:
+        self._messages: list[KafkaMessage] = []
+
+    def add_message(self, message: KafkaMessage) -> None:
+        self._messages.append(message)
+
+    def consume(self, num_messages: int, timeout: float) -> list[KafkaMessage]:
+        _ = timeout  # Ignore timeout for the fake consumer
+        result = self._messages[:num_messages]
+        self._messages = self._messages[num_messages:]
+        return result
+
+
+@dataclass(kw_only=True)
+class BeamlimeApp:
+    """A testable "application" with a fake consumer and sink."""
+
+    service: Service
+    consumer: FakeConsumer
+    sink: FakeMessageSink
+    instrument: str
+
+    def __post_init__(self) -> None:
+        self._detector_topic = stream_kind_to_topic(
+            instrument=self.instrument, kind=StreamKind.DETECTOR_EVENTS
+        )
+        self._monitor_topic = stream_kind_to_topic(
+            instrument=self.instrument, kind=StreamKind.MONITOR_EVENTS
+        )
+        self._detector_config = get_config(self.instrument).detectors_config['fakes']
+        self._rng = np.random.default_rng(seed=1234)  # Avoid test flakiness
+
+    @staticmethod
+    def from_service_builder(builder: DataServiceBuilder) -> BeamlimeApp:
+        """
+        Create a BeamlimeApp from a service builder.
+
+        The app is created with a fake sink that allows to inspect the messages sent to
+        the sink. The consumer is a fake consumer that can be filled with custom
+        messages for consumption.
+        """
+        sink = FakeMessageSink()
+        consumer = FakeConsumer()
+        service = builder.from_consumer(
+            consumer=consumer,
+            sink=UnrollingSinkAdapter(sink),
+            raise_on_adapter_error=True,
+        )
+        return BeamlimeApp(
+            service=service, consumer=consumer, sink=sink, instrument=builder.instrument
+        )
+
+    def publish_config_message(self, key: models.ConfigKey, value: Any) -> None:
+        message = FakeKafkaMessage(
+            key=str(key).encode('utf-8'),
+            value=json.dumps(value).encode('utf-8'),
+            topic=stream_kind_to_topic(
+                instrument=self.instrument, kind=StreamKind.BEAMLIME_CONFIG
+            ),
+            timestamp=0,
+        )
+        self.consumer.add_message(message)
+
+    def publish_monitor_events(self, *, size: int, time: int) -> None:
+        monitor_message = FakeKafkaMessage(
+            value=self.make_serialized_ev44(name='monitor1', size=size, with_ids=False),
+            topic=self._monitor_topic,
+            timestamp=time * 1_000_000_000,
+        )
+        self.consumer.add_message(monitor_message)
+        monitor_message = FakeKafkaMessage(
+            value=self.make_serialized_ev44(name='monitor2', size=size, with_ids=False),
+            topic=self._monitor_topic,
+            timestamp=time * 1_000_000_000,
+        )
+        self.consumer.add_message(monitor_message)
+
+    def publish_events(self, *, size: int, time: int) -> None:
+        message = FakeKafkaMessage(
+            value=self.make_serialized_ev44(
+                name=next(iter(self._detector_config)), size=size, with_ids=True
+            ),
+            topic=self._detector_topic,
+            timestamp=time * 1_000_000_000,
+        )
+        self.consumer.add_message(message)
+
+    def make_serialized_ev44(self, name: str, size: int, with_ids: bool) -> bytes:
+        time_of_arrival = self._rng.uniform(0, 70_000_000, size).astype(np.int32)
+        if with_ids:
+            first, last = self._detector_config[name]
+            pixel_id = self._rng.integers(first, last + 1, size, dtype=np.int32)
+        else:
+            pixel_id = np.zeros(size, dtype=np.int32)
+        # Empty reference_time. KafkaToEv44Adapter falls back to message.timestamp().
+        return eventdata_ev44.serialise_ev44(
+            source_name=name,
+            message_id=0,
+            reference_time=[],
+            reference_time_index=0,
+            time_of_flight=time_of_arrival,
+            pixel_id=pixel_id,
+        )

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -153,7 +153,7 @@ def test_publishes_workflow_specs_on_startup(instrument: str) -> None:
     assert isinstance(message.value, ConfigUpdate)
     assert isinstance(message.value.config_key, ConfigKey)
     assert isinstance(message.value.value, WorkflowSpecs)
-    if instrument in ('bifrost', 'loki'):
+    if instrument in ('bifrost', 'dummy', 'loki'):
         assert len(message.value.value.workflows) > 0
 
 

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pytest
+from streaming_data_types import eventdata_ev44
+
+from beamlime import StreamKind
+from beamlime.config.instruments import available_instruments, get_config
+from beamlime.config.models import ConfigKey, WorkflowConfig, WorkflowSpecs
+from beamlime.config.streams import stream_kind_to_topic
+from beamlime.core.message import CONFIG_STREAM_ID
+from beamlime.fakes import FakeMessageSink
+from beamlime.handlers.config_handler import ConfigUpdate
+from beamlime.kafka.message_adapter import FakeKafkaMessage, KafkaMessage
+from beamlime.kafka.sink import UnrollingSinkAdapter
+from beamlime.kafka.source import KafkaConsumer
+from beamlime.services.data_reduction import make_reduction_service_builder
+
+
+class FakeConsumer(KafkaConsumer):
+    def __init__(self) -> None:
+        self._messages: list[KafkaMessage] = []
+
+    def add_message(self, message: KafkaMessage) -> None:
+        self._messages.append(message)
+
+    def consume(self, num_messages: int, timeout: float) -> list[KafkaMessage]:
+        _ = timeout  # Ignore timeout for the fake consumer
+        result = self._messages[:num_messages]
+        self._messages = self._messages[num_messages:]
+        return result
+
+
+@dataclass(kw_only=True)
+class ReductionApp:
+    """A testable "application" with a fake consumer and sink."""
+
+    service: KafkaConsumer
+    consumer: FakeConsumer
+    sink: FakeMessageSink
+    instrument: str
+
+    def __post_init__(self) -> None:
+        self._detector_topic = stream_kind_to_topic(
+            instrument=self.instrument, kind=StreamKind.DETECTOR_EVENTS
+        )
+        self._monitor_topic = stream_kind_to_topic(
+            instrument=self.instrument, kind=StreamKind.MONITOR_EVENTS
+        )
+        self._detector_config = get_config(self.instrument).detectors_config['fakes']
+        self._rng = np.random.default_rng(seed=1234)  # Avoid test flakiness
+
+    def publish_config_message(self, key: ConfigKey, value: Any) -> None:
+        message = FakeKafkaMessage(
+            key=str(key).encode('utf-8'),
+            value=json.dumps(value).encode('utf-8'),
+            topic=stream_kind_to_topic(
+                instrument=self.instrument, kind=StreamKind.BEAMLIME_CONFIG
+            ),
+            timestamp=0,
+        )
+        self.consumer.add_message(message)
+
+    def publish_events(self, *, size: int, time: int) -> None:
+        monitor_message = FakeKafkaMessage(
+            value=self.make_serialized_monitor_ev44(name='monitor1', size=size),
+            topic=self._monitor_topic,
+            timestamp=time * 1_000_000_000,
+        )
+        self.consumer.add_message(monitor_message)
+        monitor_message = FakeKafkaMessage(
+            value=self.make_serialized_monitor_ev44(name='monitor2', size=size),
+            topic=self._monitor_topic,
+            timestamp=time * 1_000_000_000,
+        )
+        self.consumer.add_message(monitor_message)
+        message = FakeKafkaMessage(
+            value=self.make_serialized_ev44(
+                name=next(iter(self._detector_config)), size=size
+            ),
+            topic=self._detector_topic,
+            timestamp=time * 1_000_000_000,
+        )
+        self.consumer.add_message(message)
+
+    def make_serialized_ev44(self, name: str, size: int) -> bytes:
+        time_of_arrival = self._rng.uniform(0, 70_000_000, size).astype(np.int32)
+        first, last = self._detector_config[name]
+        pixel_id = self._rng.integers(first, last + 1, size, dtype=np.int32)
+        # Note empty reference_time. KafkaToEv44Adapter uses message.timestamp(), which
+        # allows us to reuse the serialized content, to avoid seeing the cost in the
+        # benchmarks.
+        return eventdata_ev44.serialise_ev44(
+            source_name=name,
+            message_id=0,
+            reference_time=[],
+            reference_time_index=0,
+            time_of_flight=time_of_arrival,
+            pixel_id=pixel_id,
+        )
+
+    def make_serialized_monitor_ev44(self, name: str, size: int) -> bytes:
+        time_of_arrival = self._rng.uniform(0, 70_000_000, size).astype(np.int32)
+        pixel_id = np.zeros(size, dtype=np.int32)
+        # Note empty reference_time. KafkaToEv44Adapter uses message.timestamp(), which
+        # allows us to reuse the serialized content, to avoid seeing the cost in the
+        # benchmarks.
+        return eventdata_ev44.serialise_ev44(
+            source_name=name,
+            message_id=0,
+            reference_time=[],
+            reference_time_index=0,
+            time_of_flight=time_of_arrival,
+            pixel_id=pixel_id,
+        )
+
+
+def make_reduction_app(instrument: str) -> ReductionApp:
+    builder = make_reduction_service_builder(instrument=instrument)
+    sink = FakeMessageSink()
+    consumer = FakeConsumer()
+    service = builder.from_consumer(
+        consumer=consumer, sink=UnrollingSinkAdapter(sink), raise_on_adapter_error=True
+    )
+    return ReductionApp(
+        service=service, consumer=consumer, sink=sink, instrument=instrument
+    )
+
+
+@pytest.fixture(params=('bifrost', 'loki'))
+def reduction_app(request) -> ReductionApp:
+    """Create a testable service with a fake consumer and sink."""
+    return make_reduction_app(instrument=request.param)
+
+
+@pytest.mark.parametrize("instrument", available_instruments())
+def test_publishes_workflow_specs_on_startup(instrument: str) -> None:
+    app = make_reduction_app(instrument=instrument)
+    sink = app.sink
+    instrument = app.instrument
+
+    assert len(sink.messages) == 1
+    message = sink.messages[0]
+    assert message.stream == CONFIG_STREAM_ID
+    assert isinstance(message.value, ConfigUpdate)
+    assert isinstance(message.value.config_key, ConfigKey)
+    assert isinstance(message.value.value, WorkflowSpecs)
+    if instrument in ('bifrost', 'loki'):
+        assert len(message.value.value.workflows) > 0
+
+
+def test_can_configure_and_stop_workflow(
+    reduction_app: ReductionApp, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO)
+    sink = reduction_app.sink
+    service = reduction_app.service
+    workflow_specs = sink.messages[0].value.value
+    workflow_id, spec = next(iter(workflow_specs.workflows.items()))
+    sink.messages.clear()
+    service.step()
+    assert len(sink.messages) == 0
+
+    reduction_app.publish_events(size=1000, time=0)
+    service.step()
+    assert len(sink.messages) == 0
+
+    # Assume workflow is runnable for all source names
+    config_key = ConfigKey(
+        source_name=None, service_name="data_reduction", key="workflow_config"
+    )
+    workflow_config = WorkflowConfig(
+        identifier=workflow_id,
+        values={param.name: param.default for param in spec.parameters},
+    )
+    reduction_app.publish_config_message(
+        key=config_key, value=workflow_config.model_dump()
+    )
+    reduction_app.publish_events(size=2000, time=2)
+    service.step()
+    assert len(sink.messages) == 1
+    # Events before workflow config was published should not be included
+    assert sink.messages[0].value.values.sum() == 2000
+    service.step()
+    assert len(sink.messages) == 1
+    reduction_app.publish_events(size=3000, time=4)
+    service.step()
+    assert len(sink.messages) == 2
+    assert sink.messages[1].value.values.sum() == 5000
+
+    # More events but the same time, should not publish again
+    reduction_app.publish_events(size=1000, time=4)
+    service.step()
+    assert len(sink.messages) == 2
+
+    # Later time should publish again, including the previous events with duplicate time
+    reduction_app.publish_events(size=1000, time=5)
+    service.step()
+    assert len(sink.messages) == 3
+    assert sink.messages[2].value.values.sum() == 7000
+
+    # Stop workflow
+    reduction_app.publish_config_message(key=config_key, value=None)
+    reduction_app.publish_events(size=1000, time=10)
+    service.step()
+    reduction_app.publish_events(size=1000, time=20)
+    service.step()
+    assert len(sink.messages) == 3

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -1,26 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
-import json
 import logging
-from dataclasses import dataclass
-from typing import Any
 
-import numpy as np
 import pytest
-from streaming_data_types import eventdata_ev44
 
-from beamlime import Service, StreamKind
 from beamlime.config import models
-from beamlime.config.instruments import available_instruments, get_config
-from beamlime.config.streams import stream_kind_to_topic
+from beamlime.config.instruments import available_instruments
 from beamlime.core.message import CONFIG_STREAM_ID
-from beamlime.fakes import FakeMessageSink
 from beamlime.handlers.config_handler import ConfigUpdate
-from beamlime.kafka.message_adapter import FakeKafkaMessage, KafkaMessage
-from beamlime.kafka.sink import UnrollingSinkAdapter
-from beamlime.kafka.source import KafkaConsumer
 from beamlime.services.data_reduction import make_reduction_service_builder
+from tests.helpers.beamlime_app import BeamlimeApp
 
 
 def _get_workflow_by_name(
@@ -32,109 +22,15 @@ def _get_workflow_by_name(
     raise ValueError(f"Workflow {name} not found in specs")
 
 
-class FakeConsumer(KafkaConsumer):
-    def __init__(self) -> None:
-        self._messages: list[KafkaMessage] = []
-
-    def add_message(self, message: KafkaMessage) -> None:
-        self._messages.append(message)
-
-    def consume(self, num_messages: int, timeout: float) -> list[KafkaMessage]:
-        _ = timeout  # Ignore timeout for the fake consumer
-        result = self._messages[:num_messages]
-        self._messages = self._messages[num_messages:]
-        return result
-
-
-@dataclass(kw_only=True)
-class ReductionApp:
-    """A testable "application" with a fake consumer and sink."""
-
-    service: Service
-    consumer: FakeConsumer
-    sink: FakeMessageSink
-    instrument: str
-
-    def __post_init__(self) -> None:
-        self._detector_topic = stream_kind_to_topic(
-            instrument=self.instrument, kind=StreamKind.DETECTOR_EVENTS
-        )
-        self._monitor_topic = stream_kind_to_topic(
-            instrument=self.instrument, kind=StreamKind.MONITOR_EVENTS
-        )
-        self._detector_config = get_config(self.instrument).detectors_config['fakes']
-        self._rng = np.random.default_rng(seed=1234)  # Avoid test flakiness
-
-    def publish_config_message(self, key: models.ConfigKey, value: Any) -> None:
-        message = FakeKafkaMessage(
-            key=str(key).encode('utf-8'),
-            value=json.dumps(value).encode('utf-8'),
-            topic=stream_kind_to_topic(
-                instrument=self.instrument, kind=StreamKind.BEAMLIME_CONFIG
-            ),
-            timestamp=0,
-        )
-        self.consumer.add_message(message)
-
-    def publish_monitor_events(self, *, size: int, time: int) -> None:
-        monitor_message = FakeKafkaMessage(
-            value=self.make_serialized_ev44(name='monitor1', size=size, with_ids=False),
-            topic=self._monitor_topic,
-            timestamp=time * 1_000_000_000,
-        )
-        self.consumer.add_message(monitor_message)
-        monitor_message = FakeKafkaMessage(
-            value=self.make_serialized_ev44(name='monitor2', size=size, with_ids=False),
-            topic=self._monitor_topic,
-            timestamp=time * 1_000_000_000,
-        )
-        self.consumer.add_message(monitor_message)
-
-    def publish_events(self, *, size: int, time: int) -> None:
-        message = FakeKafkaMessage(
-            value=self.make_serialized_ev44(
-                name=next(iter(self._detector_config)), size=size, with_ids=True
-            ),
-            topic=self._detector_topic,
-            timestamp=time * 1_000_000_000,
-        )
-        self.consumer.add_message(message)
-
-    def make_serialized_ev44(self, name: str, size: int, with_ids: bool) -> bytes:
-        time_of_arrival = self._rng.uniform(0, 70_000_000, size).astype(np.int32)
-        if with_ids:
-            first, last = self._detector_config[name]
-            pixel_id = self._rng.integers(first, last + 1, size, dtype=np.int32)
-        else:
-            pixel_id = np.zeros(size, dtype=np.int32)
-        # Empty reference_time. KafkaToEv44Adapter falls back to message.timestamp().
-        return eventdata_ev44.serialise_ev44(
-            source_name=name,
-            message_id=0,
-            reference_time=[],
-            reference_time_index=0,
-            time_of_flight=time_of_arrival,
-            pixel_id=pixel_id,
-        )
-
-
-def make_reduction_app(instrument: str) -> ReductionApp:
+def make_reduction_app(instrument: str) -> BeamlimeApp:
     builder = make_reduction_service_builder(instrument=instrument)
-    sink = FakeMessageSink()
-    consumer = FakeConsumer()
-    service = builder.from_consumer(
-        consumer=consumer, sink=UnrollingSinkAdapter(sink), raise_on_adapter_error=True
-    )
-    return ReductionApp(
-        service=service, consumer=consumer, sink=sink, instrument=instrument
-    )
+    return BeamlimeApp.from_service_builder(builder)
 
 
 @pytest.mark.parametrize("instrument", available_instruments())
 def test_publishes_workflow_specs_on_startup(instrument: str) -> None:
     app = make_reduction_app(instrument=instrument)
     sink = app.sink
-    instrument = app.instrument
 
     assert len(sink.messages) == 1
     message = sink.messages[0]

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from streaming_data_types import eventdata_ev44
 
-from beamlime import StreamKind
+from beamlime import Service, StreamKind
 from beamlime.config.instruments import available_instruments, get_config
 from beamlime.config.models import ConfigKey, WorkflowConfig, WorkflowSpecs
 from beamlime.config.streams import stream_kind_to_topic
@@ -41,7 +41,7 @@ class FakeConsumer(KafkaConsumer):
 class ReductionApp:
     """A testable "application" with a fake consumer and sink."""
 
-    service: KafkaConsumer
+    service: Service
     consumer: FakeConsumer
     sink: FakeMessageSink
     instrument: str


### PR DESCRIPTION
Adding tests highlighted a few problems. Therefore this also includes the addition of `Instrument` for wrapping instrument config as well as making `StreamProcessor` and instrument-specific instance instead of a singleton.