### PR TITLE
ci: remove unused test arg

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps = -r requirements/nightly.txt
 setenv =
   PIP_INDEX_URL = https://pypi.anaconda.org/scipp-nightly-wheels/simple
   PIP_EXTRA_INDEX_URL = https://pypi.org/simple
-commands = pytest {posargs} --large-file-test
+commands = pytest {posargs}
 
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.


### PR DESCRIPTION
Seems the `--large-file-test` flag is not used and it causes a test failure in the nightlies. Should it be removed?