### PR TITLE
Fix, improve, and test the Scipp -> Holoviews converters

### DIFF
--- a/src/ess/livedata/dashboard/scipp_to_holoviews.py
+++ b/src/ess/livedata/dashboard/scipp_to_holoviews.py
@@ -4,14 +4,14 @@ import holoviews as hv
 import scipp as sc
 
 
-def _coord_to_dimension(var: sc.Variable) -> hv.Dimension:
+def coord_to_dimension(var: sc.Variable) -> hv.Dimension:
     """Create a Holoviews Dimension for the coordinate."""
     dim = var.dim
     unit = str(var.unit) if var.unit is not None else None
     return hv.Dimension(dim, label=dim, unit=unit)
 
 
-def _create_value_dimension(data: sc.DataArray) -> hv.Dimension:
+def create_value_dimension(data: sc.DataArray) -> hv.Dimension:
     """Create a Holoviews Dimension for the values."""
     label = data.name if data.name else 'values'
     unit = str(data.unit) if data.unit is not None else None
@@ -29,8 +29,8 @@ def convert_histogram_1d(data: sc.DataArray) -> hv.Histogram:
     """
     dim = data.dim
     coord = data.coords[dim]
-    kdims = [_coord_to_dimension(coord)]
-    vdims = [_create_value_dimension(data)]
+    kdims = [coord_to_dimension(coord)]
+    vdims = [create_value_dimension(data)]
 
     return hv.Histogram(data=(coord.values, data.values), kdims=kdims, vdims=vdims)
 
@@ -46,8 +46,8 @@ def convert_curve_1d(data: sc.DataArray) -> hv.Curve:
     """
     dim = data.dim
     coord = data.coords[dim]
-    kdims = [_coord_to_dimension(coord)]
-    vdims = [_create_value_dimension(data)]
+    kdims = [coord_to_dimension(coord)]
+    vdims = [create_value_dimension(data)]
 
     return hv.Curve(data=(coord.values, data.values), kdims=kdims, vdims=vdims)
 
@@ -63,8 +63,8 @@ def convert_quadmesh_2d(data: sc.DataArray) -> hv.QuadMesh:
     hv.QuadMesh
         A Holoviews QuadMesh object.
     """
-    kdims = [_coord_to_dimension(data.coords[dim]) for dim in reversed(data.dims)]
-    vdims = [_create_value_dimension(data)]
+    kdims = [coord_to_dimension(data.coords[dim]) for dim in reversed(data.dims)]
+    vdims = [create_value_dimension(data)]
     coords = [data.coords[dim].values for dim in reversed(data.dims)]
 
     # QuadMesh expects (x, y, values) format
@@ -89,8 +89,8 @@ def convert_image_2d(data: sc.DataArray) -> hv.Image:
     hv.Image
         A Holoviews Image object.
     """
-    kdims = [_coord_to_dimension(data.coords[dim]) for dim in reversed(data.dims)]
-    vdims = [_create_value_dimension(data)]
+    kdims = [coord_to_dimension(data.coords[dim]) for dim in reversed(data.dims)]
+    vdims = [create_value_dimension(data)]
     return hv.Image(
         data=(
             _get_midpoints(data, data.dims[1]).values,

--- a/src/ess/livedata/dashboard/scipp_to_holoviews.py
+++ b/src/ess/livedata/dashboard/scipp_to_holoviews.py
@@ -144,8 +144,10 @@ def to_holoviews(
         The input scipp DataArray to convert.
     preserve_edges:
         If True, use QuadMesh for 2D data with bin edges instead of Image.
-        Default is False, which favors Image for better plotting performance.
-        Edges are always preserved for 1D histogram data.
+        Default is False, which favors Image for better plotting performance. An Image
+        can only be used with "midpoint" coords so this is slightly lossy. This option
+        allows for preserving edges when needed.
+        Edges are always preserved for 1D histogram data and this option is ignored.
 
     Returns
     -------

--- a/tests/dashboard/scipp_to_holoviews_test.py
+++ b/tests/dashboard/scipp_to_holoviews_test.py
@@ -11,7 +11,7 @@ from ess.livedata.dashboard import scipp_to_holoviews
 class TestHelperFunctions:
     @pytest.mark.parametrize("unit", ['m', 'dimensionless', None])
     def test_coord_to_dimension(self, unit: str | None):
-        coord = sc.Variable(dims=['x'], values=[1, 2, 3], unit=unit)
+        coord = sc.array(dims=['x'], values=[1, 2, 3], unit=unit)
         dim = scipp_to_holoviews.coord_to_dimension(coord)
 
         assert dim.name == 'x'
@@ -21,8 +21,8 @@ class TestHelperFunctions:
     @pytest.mark.parametrize("unit", ['m', 'dimensionless', None])
     def test_value_dimension_with_name_and_unit(self, unit: str | None):
         data = sc.DataArray(
-            data=sc.Variable(dims=['x'], values=[1, 2, 3], unit=unit),
-            coords={'x': sc.Variable(dims=['x'], values=[0, 1, 2])},
+            data=sc.array(dims=['x'], values=[1, 2, 3], unit=unit),
+            coords={'x': sc.array(dims=['x'], values=[0, 1, 2])},
             name='intensity',
         )
         dim = scipp_to_holoviews.create_value_dimension(data)
@@ -33,8 +33,8 @@ class TestHelperFunctions:
 
     def test_value_dimension_without_name(self):
         data = sc.DataArray(
-            data=sc.Variable(dims=['x'], values=[1, 2, 3], unit='m/s'),
-            coords={'x': sc.Variable(dims=['x'], values=[0, 1, 2])},
+            data=sc.array(dims=['x'], values=[1, 2, 3], unit='m/s'),
+            coords={'x': sc.array(dims=['x'], values=[0, 1, 2])},
         )
         dim = scipp_to_holoviews.create_value_dimension(data)
 
@@ -46,8 +46,8 @@ class TestHelperFunctions:
 class TestConvertHistogram1d:
     def test_basic_conversion(self):
         # Create histogram data with bin edges
-        edges = sc.Variable(dims=['x'], values=[0, 1, 2, 3], unit='m')
-        values = sc.Variable(dims=['x'], values=[10, 20, 30], unit='counts')
+        edges = sc.array(dims=['x'], values=[0, 1, 2, 3], unit='m')
+        values = sc.array(dims=['x'], values=[10, 20, 30], unit='counts')
         data = sc.DataArray(data=values, coords={'x': edges})
 
         result = scipp_to_holoviews.convert_histogram_1d(data)
@@ -65,8 +65,8 @@ class TestConvertHistogram1d:
         np.testing.assert_array_equal(hist_data['values'], [10, 20, 30])
 
     def test_with_named_data(self):
-        edges = sc.Variable(dims=['energy'], values=[0, 1, 2, 3], unit='eV')
-        values = sc.Variable(dims=['energy'], values=[100, 200, 300], unit='Hz')
+        edges = sc.array(dims=['energy'], values=[0, 1, 2, 3], unit='eV')
+        values = sc.array(dims=['energy'], values=[100, 200, 300], unit='Hz')
         data = sc.DataArray(data=values, coords={'energy': edges}, name='spectrum')
 
         result = scipp_to_holoviews.convert_histogram_1d(data)
@@ -77,8 +77,8 @@ class TestConvertHistogram1d:
 
 class TestConvertCurve1d:
     def test_basic_conversion(self):
-        x_coord = sc.Variable(dims=['x'], values=[1, 2, 3, 4], unit='s')
-        y_values = sc.Variable(dims=['x'], values=[10, 15, 20, 25], unit='V')
+        x_coord = sc.array(dims=['x'], values=[1, 2, 3, 4], unit='s')
+        y_values = sc.array(dims=['x'], values=[10, 15, 20, 25], unit='V')
         data = sc.DataArray(data=y_values, coords={'x': x_coord})
 
         result = scipp_to_holoviews.convert_curve_1d(data)
@@ -96,8 +96,8 @@ class TestConvertCurve1d:
         np.testing.assert_array_equal(curve_data['values'], [10, 15, 20, 25])
 
     def test_with_named_data(self):
-        coord = sc.Variable(dims=['time'], values=[0, 1, 2])
-        values = sc.Variable(dims=['time'], values=[5, 10, 15])
+        coord = sc.array(dims=['time'], values=[0, 1, 2])
+        values = sc.array(dims=['time'], values=[5, 10, 15])
         data = sc.DataArray(data=values, coords={'time': coord}, name='signal')
 
         result = scipp_to_holoviews.convert_curve_1d(data)
@@ -107,9 +107,9 @@ class TestConvertCurve1d:
 
 class TestConvertQuadMesh2d:
     def test_basic_conversion(self):
-        x_coord = sc.Variable(dims=['x'], values=[1, 2, 3], unit='m')
-        y_coord = sc.Variable(dims=['y'], values=[4, 5], unit='s')
-        values = sc.Variable(
+        x_coord = sc.array(dims=['x'], values=[1, 2, 3], unit='m')
+        y_coord = sc.array(dims=['y'], values=[4, 5], unit='s')
+        values = sc.array(
             dims=['y', 'x'], values=[[10, 20, 30], [40, 50, 60]], unit='K'
         )
         data = sc.DataArray(data=values, coords={'x': x_coord, 'y': y_coord})
@@ -129,9 +129,9 @@ class TestConvertQuadMesh2d:
 
     def test_irregular_coordinates(self):
         # Non-evenly spaced coordinates
-        x_coord = sc.Variable(dims=['x'], values=[1, 3, 10], unit='mm')
-        y_coord = sc.Variable(dims=['y'], values=[0, 2, 5, 20], unit='Hz')
-        values = sc.Variable(
+        x_coord = sc.array(dims=['x'], values=[1, 3, 10], unit='mm')
+        y_coord = sc.array(dims=['y'], values=[0, 2, 5, 20], unit='Hz')
+        values = sc.array(
             dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
         )
         data = sc.DataArray(data=values, coords={'x': x_coord, 'y': y_coord})
@@ -143,14 +143,28 @@ class TestConvertQuadMesh2d:
         np.testing.assert_array_equal(mesh_data['x'], [1, 3, 10])  # x coords
         np.testing.assert_array_equal(mesh_data['y'], [0, 2, 5, 20])  # y coords
 
+    def test_with_bin_edges(self):
+        # Test with bin edges (N+1 coordinates for N bins)
+        x_edges = sc.array(dims=['x'], values=[0, 1, 2, 3], unit='m')
+        y_edges = sc.array(dims=['y'], values=[0, 10, 20], unit='s')
+        values = sc.array(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]], unit='counts')
+        data = sc.DataArray(data=values, coords={'x': x_edges, 'y': y_edges})
+
+        result = scipp_to_holoviews.convert_quadmesh_2d(data)
+
+        assert isinstance(result, hv.QuadMesh)
+        mesh_data = result.data
+        # QuadMesh should preserve the bin edges
+        np.testing.assert_array_equal(mesh_data['x'], [0, 1, 2, 3])  # x edges
+        np.testing.assert_array_equal(mesh_data['y'], [0, 10, 20])  # y edges
+        np.testing.assert_array_equal(mesh_data['values'], [[1, 2, 3], [4, 5, 6]])
+
 
 class TestConvertImage2d:
     def test_basic_conversion(self):
-        x_coord = sc.Variable(dims=['x'], values=[0, 1, 2], unit='m')
-        y_coord = sc.Variable(dims=['y'], values=[10, 20], unit='s')
-        values = sc.Variable(
-            dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]], unit='counts'
-        )
+        x_coord = sc.array(dims=['x'], values=[0, 1, 2], unit='m')
+        y_coord = sc.array(dims=['y'], values=[10, 20], unit='s')
+        values = sc.array(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]], unit='counts')
         data = sc.DataArray(data=values, coords={'x': x_coord, 'y': y_coord})
 
         result = scipp_to_holoviews.convert_image_2d(data)
@@ -165,11 +179,9 @@ class TestConvertImage2d:
 
     def test_with_bin_edges(self):
         # Test with bin edges
-        x_edges = sc.Variable(dims=['x'], values=[0, 1, 2, 3], unit='m')
-        y_edges = sc.Variable(dims=['y'], values=[0, 10, 20], unit='s')
-        values = sc.Variable(
-            dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]], unit='counts'
-        )
+        x_edges = sc.array(dims=['x'], values=[0, 1, 2, 3], unit='m')
+        y_edges = sc.array(dims=['y'], values=[0, 10, 20], unit='s')
+        values = sc.array(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]], unit='counts')
         data = sc.DataArray(data=values, coords={'x': x_edges, 'y': y_edges})
 
         result = scipp_to_holoviews.convert_image_2d(data)
@@ -183,8 +195,8 @@ class TestConvertImage2d:
 
 class TestToHoloviews:
     def test_1d_histogram(self):
-        edges = sc.Variable(dims=['x'], values=[0, 1, 2, 3])
-        values = sc.Variable(dims=['x'], values=[10, 20, 30])
+        edges = sc.array(dims=['x'], values=[0, 1, 2, 3])
+        values = sc.array(dims=['x'], values=[10, 20, 30])
         data = sc.DataArray(data=values, coords={'x': edges})
 
         result = scipp_to_holoviews.to_holoviews(data)
@@ -192,8 +204,8 @@ class TestToHoloviews:
         assert isinstance(result, hv.Histogram)
 
     def test_1d_curve(self):
-        coord = sc.Variable(dims=['x'], values=[0, 1, 2])
-        values = sc.Variable(dims=['x'], values=[10, 20, 30])
+        coord = sc.array(dims=['x'], values=[0, 1, 2])
+        values = sc.array(dims=['x'], values=[10, 20, 30])
         data = sc.DataArray(data=values, coords={'x': coord})
 
         result = scipp_to_holoviews.to_holoviews(data)
@@ -203,7 +215,7 @@ class TestToHoloviews:
     def test_2d_image_evenly_spaced(self):
         x_coord = sc.linspace('x', 0, 2, 3)
         y_coord = sc.linspace('y', 0, 10, 2)
-        values = sc.Variable(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]])
+        values = sc.array(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]])
         data = sc.DataArray(data=values, coords={'x': x_coord, 'y': y_coord})
 
         result = scipp_to_holoviews.to_holoviews(data)
@@ -211,13 +223,46 @@ class TestToHoloviews:
         assert isinstance(result, hv.Image)
 
     def test_2d_quadmesh_irregular(self):
-        x_coord = sc.Variable(dims=['x'], values=[0, 1, 5])  # Non-evenly spaced
-        y_coord = sc.Variable(dims=['y'], values=[0, 10])
-        values = sc.Variable(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]])
+        x_coord = sc.array(dims=['x'], values=[0, 1, 5])  # Non-evenly spaced
+        y_coord = sc.array(dims=['y'], values=[0, 10])
+        values = sc.array(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]])
         data = sc.DataArray(data=values, coords={'x': x_coord, 'y': y_coord})
 
         result = scipp_to_holoviews.to_holoviews(data)
 
+        assert isinstance(result, hv.QuadMesh)
+
+    def test_2d_with_bin_edges_defaults_to_image(self):
+        x_edges = sc.array(dims=['x'], values=[0, 1, 2, 3], unit='m')
+        y_edges = sc.array(dims=['y'], values=[0, 10, 20], unit='s')
+        values = sc.array(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]], unit='counts')
+        data = sc.DataArray(data=values, coords={'x': x_edges, 'y': y_edges})
+
+        result = scipp_to_holoviews.to_holoviews(data)
+
+        # Should default to Image even with bin edges
+        assert isinstance(result, hv.Image)
+
+    def test_2d_with_bin_edges_preserve_edges(self):
+        x_edges = sc.array(dims=['x'], values=[0, 1, 2, 3], unit='m')
+        y_edges = sc.array(dims=['y'], values=[0, 10, 20], unit='s')
+        values = sc.array(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]], unit='counts')
+        data = sc.DataArray(data=values, coords={'x': x_edges, 'y': y_edges})
+
+        result = scipp_to_holoviews.to_holoviews(data, preserve_edges=True)
+
+        # Should use QuadMesh when explicitly requested
+        assert isinstance(result, hv.QuadMesh)
+
+    def test_2d_no_bin_edges_ignores_preserve_edges(self):
+        x_coord = sc.array(dims=['x'], values=[0, 1, 5])  # Non-evenly spaced, no edges
+        y_coord = sc.array(dims=['y'], values=[0, 10])
+        values = sc.array(dims=['y', 'x'], values=[[1, 2, 3], [4, 5, 6]])
+        data = sc.DataArray(data=values, coords={'x': x_coord, 'y': y_coord})
+
+        result = scipp_to_holoviews.to_holoviews(data, preserve_edges=True)
+
+        # Should use QuadMesh due to irregular spacing, regardless of preserve_edges
         assert isinstance(result, hv.QuadMesh)
 
     def test_0d_raises_error(self):
@@ -229,10 +274,10 @@ class TestToHoloviews:
             scipp_to_holoviews.to_holoviews(data)
 
     def test_3d_raises_error(self):
-        x_coord = sc.Variable(dims=['x'], values=[0, 1])
-        y_coord = sc.Variable(dims=['y'], values=[0, 1])
-        z_coord = sc.Variable(dims=['z'], values=[0, 1])
-        values = sc.Variable(
+        x_coord = sc.array(dims=['x'], values=[0, 1])
+        y_coord = sc.array(dims=['y'], values=[0, 1])
+        z_coord = sc.array(dims=['z'], values=[0, 1])
+        values = sc.array(
             dims=['z', 'y', 'x'], values=[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
         )
         data = sc.DataArray(
@@ -255,7 +300,7 @@ class TestAllCoordsEvenlySpaced:
         assert result is True
 
     def test_irregular_spacing_returns_false(self):
-        x_coord = sc.Variable(dims=['x'], values=[0, 1, 3, 10])  # Not evenly spaced
+        x_coord = sc.array(dims=['x'], values=[0, 1, 3, 10])  # Not evenly spaced
         y_coord = sc.linspace('y', 0, 5, 3)
         values = sc.zeros(dims=['y', 'x'], shape=[3, 4])
         data = sc.DataArray(data=values, coords={'x': x_coord, 'y': y_coord})
@@ -276,18 +321,18 @@ class TestAllCoordsEvenlySpaced:
 
 class TestGetMidpoints:
     def test_with_bin_edges(self):
-        edges = sc.Variable(dims=['x'], values=[0, 1, 2, 3])
-        values = sc.Variable(dims=['x'], values=[10, 20, 30])
+        edges = sc.array(dims=['x'], values=[0, 1, 2, 3])
+        values = sc.array(dims=['x'], values=[10, 20, 30])
         data = sc.DataArray(data=values, coords={'x': edges})
 
         result = scipp_to_holoviews._get_midpoints(data, 'x')
 
-        expected = sc.midpoints(edges, 'x')
+        expected = sc.array(dims=['x'], values=[0.5, 1.5, 2.5])
         assert sc.identical(result, expected)
 
     def test_with_point_coordinates(self):
-        coord = sc.Variable(dims=['x'], values=[1, 2, 3])
-        values = sc.Variable(dims=['x'], values=[10, 20, 30])
+        coord = sc.array(dims=['x'], values=[1, 2, 3])
+        values = sc.array(dims=['x'], values=[10, 20, 30])
         data = sc.DataArray(data=values, coords={'x': coord})
 
         result = scipp_to_holoviews._get_midpoints(data, 'x')


### PR DESCRIPTION
- Fixes #415, supporting missing coords.
- Work around scipp/scipp#3765.
- Support preserving bin edges instead of converting to image. This flag should allow for adding params to plotter configs for making this user-controller.