### PR TITLE
Add basic password auth to the reduction dashboard

### DIFF
--- a/src/ess/livedata/core/service.py
+++ b/src/ess/livedata/core/service.py
@@ -176,7 +176,7 @@ class Service(ServiceBase):
 
     @staticmethod
     def setup_arg_parser(
-        description: str, *, dev_flag: bool = True
+        description: str, *, dev_flag: bool = True, dashboard_auth: bool = False
     ) -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser(
             description=description,
@@ -201,6 +201,17 @@ class Service(ServiceBase):
             default='INFO',
             help='Set the logging level',
         )
+        if dashboard_auth:
+            parser.add_argument(
+                '--basic-auth-password',
+                default=None,
+                help='Basic authentication password for the dashboard',
+            )
+            parser.add_argument(
+                '--basic-auth-cookie-secret',
+                default=None,
+                help='Basic authentication cookie secret for the dashboard',
+            )
         return parser
 
 
@@ -218,7 +229,6 @@ def get_env_defaults(
         # Convert --arg-name to LIVEDATA_ARG_NAME
         env_name = f"{prefix}_{action.dest.upper().replace('-', '_')}"
         env_val = os.getenv(env_name)
-
         # Override with environment variable if present
         if env_val is not None:
             if isinstance(default_value, bool):

--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -54,13 +54,16 @@ class DashboardBase(ServiceBase, ABC):
         log_level: int = logging.INFO,
         dashboard_name: str,
         port: int = 5007,
+        basic_auth_password: str | None = None,
+        basic_auth_cookie_secret: str | None = None,
     ):
         name = f'{instrument}_{dashboard_name}'
         super().__init__(name=name, log_level=log_level)
         self._instrument = instrument
         self._port = port
         self._dev = dev
-
+        self._basic_auth_password = basic_auth_password
+        self._basic_auth_cookie_secret = basic_auth_cookie_secret
         self._exit_stack = ExitStack()
         self._exit_stack.__enter__()
 
@@ -258,6 +261,8 @@ class DashboardBase(ServiceBase, ABC):
             show=False,
             autoreload=False,
             dev=self._dev,
+            basic_auth=self._basic_auth_password,
+            cookie_secret=self._basic_auth_cookie_secret,
         )
 
     def _start_impl(self) -> None:
@@ -276,6 +281,8 @@ class DashboardBase(ServiceBase, ABC):
                 show=False,
                 autoreload=True,
                 dev=self._dev,
+                basic_auth=self._basic_auth_password,
+                cookie_secret=self._basic_auth_cookie_secret,
             )
         except KeyboardInterrupt:
             self._logger.info("Keyboard interrupt received, shutting down...")

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -16,13 +16,23 @@ hv.extension('bokeh')
 class ReductionApp(DashboardBase):
     """Reduction dashboard application."""
 
-    def __init__(self, *, instrument: str = 'dummy', dev: bool = False, log_level: int):
+    def __init__(
+        self,
+        *,
+        instrument: str = 'dummy',
+        dev: bool = False,
+        log_level: int,
+        basic_auth_password: str | None = None,
+        basic_auth_cookie_secret: str | None = None,
+    ):
         super().__init__(
             instrument=instrument,
             dev=dev,
             log_level=log_level,
             dashboard_name='reduction_dashboard',
             port=5009,  # Default port for reduction dashboard
+            basic_auth_password=basic_auth_password,
+            basic_auth_cookie_secret=basic_auth_cookie_secret,
         )
         self._logger.info("Reduction dashboard initialized")
 
@@ -39,7 +49,9 @@ class ReductionApp(DashboardBase):
 
 
 def get_arg_parser() -> argparse.ArgumentParser:
-    return Service.setup_arg_parser(description='ESSlivedata Dashboard')
+    return Service.setup_arg_parser(
+        description='ESSlivedata Dashboard', dashboard_auth=True
+    )
 
 
 def main() -> None:


### PR DESCRIPTION
This adds some minimal auth in front of the panel dashboard. Running the dashboard with `LIVEDATA_BASIC_AUTH_COOKIE_SECRET` and `LIVEDATA_BASIC_AUTH_PASSWORD` env variable should set a password (and login with any random username).

It will give a screen like this
<img width="2316" height="1208" alt="Screenshot 2025-09-22 at 14 41 15" src="https://github.com/user-attachments/assets/99ad0038-e972-4879-9493-3e25dd05a749" />

Before adding ESS SSO I want to test this out with DST infra.