### PR TITLE
Fix: Do not sum over time dimension by accident

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost.py
+++ b/src/ess/livedata/config/instruments/bifrost.py
@@ -165,7 +165,7 @@ def _bank_counts(analyzer_counts: AnalyzerCounts) -> BankCounts:
 
 
 def _detector_counts(bank_counts: BankCounts) -> DetectorCounts:
-    return DetectorCounts(bank_counts.sum())
+    return DetectorCounts(bank_counts.sum(dim='sector'))
 
 
 _reduction_workflow = TofWorkflow(run_types=(SampleRun,), monitor_types=())


### PR DESCRIPTION
Broken by a "cleanup" commit in a previous PR.

Note that it is close to certain that this code will be replaced anyway once we got scientist feedback on what the detector ratemeter should actually do.