### PR TITLE
Fix LinePlotter crash when data has no dimension coordinate

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -262,7 +262,7 @@ class LinePlotter(Plotter):
         """Create a line plot from a scipp DataArray."""
         # TODO Currently we do not plot histograms or else we get a bar chart that is
         # not looking great if we have many bins.
-        if data.coords.is_edges(data.dim):
+        if data.dim in data.coords and data.coords.is_edges(data.dim):
             da = data.assign_coords({data.dim: sc.midpoints(data.coords[data.dim])})
         else:
             da = data


### PR DESCRIPTION
## Summary
- Fix `LinePlotter.plot()` crashing with `KeyError` when plotting 1D data without dimension coordinates
- The issue occurred because `data.coords.is_edges(data.dim)` was called without first checking if the dimension has a coordinate
- This affected data with only metadata coordinates (e.g., a `time` coord but no coord for the actual dimension like `strip`)

## Test plan
- Added 4 new tests covering: no coord, metadata-only coord, normal coord, and bin-edge coord cases
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)