### PR TITLE
Update Bifrost monitors list to match NeXus file

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -223,12 +223,11 @@ class QMapOutputs(WorkflowOutputsBase):
 
 # Monitor names matching group names in Nexus files
 monitors = [
-    '007_frame_0',
     '090_frame_1',
     '097_frame_2',
     '110_frame_3',
     '111_psd0',
-    '113_psd1',
+    'bragg_peak_monitor',
 ]
 
 # Some example motions used for testing, probably not reflecting reality

--- a/tests/services/monitor_data_test.py
+++ b/tests/services/monitor_data_test.py
@@ -40,7 +40,7 @@ def make_monitor_app(instrument: str) -> LivedataApp:
 first_monitor_source_name = {
     'dummy': 'monitor1',
     'dream': 'monitor1',
-    'bifrost': '007_frame_0',
+    'bifrost': '090_frame_1',
     'loki': 'monitor1',
 }
 


### PR DESCRIPTION
## Summary

- Synchronize monitor names with actual entries in `bifrost_999999_00009631.hdf`
- Remove `007_frame_0` and `113_psd1` (not present in NeXus file)
- Add `bragg_peak_monitor` (present in NeXus file but was missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)