### PR TITLE
Change default plot aspect from square to free

### DIFF
--- a/src/ess/livedata/dashboard/plot_params.py
+++ b/src/ess/livedata/dashboard/plot_params.py
@@ -81,7 +81,7 @@ class StretchMode(str, enum.Enum):
 
 class PlotAspect(pydantic.BaseModel):
     aspect_type: PlotAspectType = pydantic.Field(
-        default=PlotAspectType.square,
+        default=PlotAspectType.free,
         description="Aspect type for the plot.",
         title="Aspect Type",
     )


### PR DESCRIPTION
## Summary

- Changes the default `PlotAspect.aspect_type` from `square` to `free`

## Motivation

Unless plotting an image representing some real-space detector properties, square is not useful. Free fits grid cells naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)