### PR TITLE
Add grid templates for Bifrost instrument

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/bragg_peak_monitor.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/bragg_peak_monitor.yaml
@@ -1,0 +1,62 @@
+# Bragg peak monitor histograms and time series
+title: Bragg Peak Monitor
+description: Bragg peak monitor counts, histograms, and time series
+nrows: 4
+ncols: 4
+cells:
+- geometry:
+    row: 0
+    col: 0
+    row_span: 2
+    col_span: 2
+  config:
+    workflow_id: bifrost/monitor_data/monitor_histogram/1
+    output_name: counts_in_toa_range
+    source_names:
+    - bragg_peak_monitor
+    plot_name: timeseries
+    params:
+      plot_aspect:
+        aspect_type: Free
+- geometry:
+    row: 0
+    col: 2
+    row_span: 2
+    col_span: 2
+  config:
+    workflow_id: bifrost/monitor_data/monitor_histogram/1
+    output_name: current
+    source_names:
+    - bragg_peak_monitor
+    plot_name: lines
+    params:
+      plot_aspect:
+        aspect_type: Free
+- geometry:
+    row: 2
+    col: 0
+    row_span: 2
+    col_span: 2
+  config:
+    workflow_id: bifrost/monitor_data/monitor_histogram/1
+    output_name: counts_total
+    source_names:
+    - bragg_peak_monitor
+    plot_name: timeseries
+    params:
+      plot_aspect:
+        aspect_type: Free
+- geometry:
+    row: 2
+    col: 2
+    row_span: 2
+    col_span: 2
+  config:
+    workflow_id: bifrost/monitor_data/monitor_histogram/1
+    output_name: cumulative
+    source_names:
+    - bragg_peak_monitor
+    plot_name: lines
+    params:
+      plot_aspect:
+        aspect_type: Free

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/detectors.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/detectors.yaml
@@ -1,0 +1,64 @@
+# Detector views with rate meter
+title: Detectors
+description: Unified detector views (current and cumulative) with rate meter
+nrows: 3
+ncols: 3
+cells:
+- geometry:
+    row: 0
+    col: 0
+    row_span: 1
+    col_span: 3
+  config:
+    workflow_id: bifrost/detector_data/unified_detector_view/1
+    output_name: current
+    source_names:
+    - unified_detector
+    plot_name: image
+    params:
+      plot_aspect:
+        aspect_type: Free
+- geometry:
+    row: 1
+    col: 0
+    row_span: 1
+    col_span: 3
+  config:
+    workflow_id: bifrost/detector_data/unified_detector_view/1
+    output_name: cumulative
+    source_names:
+    - unified_detector
+    plot_name: image
+    params:
+      plot_aspect:
+        aspect_type: Free
+- geometry:
+    row: 2
+    col: 0
+    row_span: 1
+    col_span: 1
+  config:
+    workflow_id: bifrost/data_reduction/detector_ratemeter/1
+    output_name: detector_region_counts
+    source_names:
+    - unified_detector
+    plot_name: bars
+    params:
+      plot_aspect:
+        aspect_type: Free
+      orientation:
+        horizontal: true
+- geometry:
+    row: 2
+    col: 1
+    row_span: 1
+    col_span: 2
+  config:
+    workflow_id: bifrost/data_reduction/detector_ratemeter/1
+    output_name: detector_region_counts
+    source_names:
+    - unified_detector
+    plot_name: timeseries
+    params:
+      plot_aspect:
+        aspect_type: Free

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/monitors.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/monitors.yaml
@@ -1,0 +1,60 @@
+# Frame monitors overview
+title: Monitors
+description: Frame monitors with current, rolling window, and cumulative views
+nrows: 3
+ncols: 2
+cells:
+- geometry:
+    row: 0
+    col: 0
+    row_span: 1
+    col_span: 2
+  config:
+    workflow_id: bifrost/monitor_data/monitor_histogram/1
+    output_name: current
+    source_names:
+    - 090_frame_1
+    - 097_frame_2
+    - 110_frame_3
+    - 111_psd0
+    plot_name: lines
+    params:
+      plot_aspect:
+        aspect_type: Free
+- geometry:
+    row: 1
+    col: 0
+    row_span: 1
+    col_span: 2
+  config:
+    workflow_id: bifrost/monitor_data/monitor_histogram/1
+    output_name: current
+    source_names:
+    - 090_frame_1
+    - 097_frame_2
+    - 110_frame_3
+    - 111_psd0
+    plot_name: lines
+    params:
+      plot_aspect:
+        aspect_type: Free
+      window:
+        mode: window
+        window_duration_seconds: 30.0
+- geometry:
+    row: 2
+    col: 0
+    row_span: 1
+    col_span: 2
+  config:
+    workflow_id: bifrost/monitor_data/monitor_histogram/1
+    output_name: cumulative
+    source_names:
+    - 090_frame_1
+    - 097_frame_2
+    - 110_frame_3
+    - 111_psd0
+    plot_name: lines
+    params:
+      plot_aspect:
+        aspect_type: Free

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/spectrum_view.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/spectrum_view.yaml
@@ -1,0 +1,20 @@
+# Full-screen spectrum view slicer
+title: Spectrum View
+description: Interactive spectrum view with slicing
+nrows: 3
+ncols: 3
+cells:
+- geometry:
+    row: 0
+    col: 0
+    row_span: 3
+    col_span: 3
+  config:
+    workflow_id: bifrost/data_reduction/spectrum_view/1
+    output_name: spectrum_view
+    source_names:
+    - unified_detector
+    plot_name: slicer
+    params:
+      plot_aspect:
+        aspect_type: Free


### PR DESCRIPTION
## Summary
- Add 4 pre-configured grid templates for Bifrost extracted from a working dashboard configuration
- Templates include: Detectors, Spectrum View, Bragg Peak Monitor, and Monitors
- Uses minimal params (only non-defaults like window mode and aspect type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)