### PR TITLE
Fix Bokeh logo removal for Layout-based plots

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -27,11 +27,6 @@ from .plot_params import (
 from .scipp_to_holoviews import to_holoviews
 
 
-def remove_bokeh_logo(plot, element):
-    """Remove Bokeh logo from plots."""
-    plot.state.toolbar.logo = None
-
-
 class Plotter(ABC):
     """
     Base class for plots that support autoscaling.
@@ -193,11 +188,7 @@ class Plotter(ABC):
 
     def _apply_generic_options(self, plot_element: hv.Element) -> hv.Element:
         """Apply generic options like aspect ratio to a plot element."""
-        base_opts = {
-            'hooks': [remove_bokeh_logo],
-            **self._sizing_opts,
-        }
-        return plot_element.opts(**base_opts)
+        return plot_element.opts(**self._sizing_opts)
 
     def _update_autoscaler_and_get_framewise(
         self, data: sc.DataArray, data_key: ResultKey

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -4,6 +4,7 @@ import argparse
 
 import holoviews as hv
 import panel as pn
+from holoviews.plotting.bokeh.plot import LayoutPlot
 
 from ess.livedata import Service
 
@@ -15,6 +16,20 @@ from .widgets.reduction_widget import ReductionWidget
 
 pn.extension('holoviews', 'modal', notifications=True, template='material')
 hv.extension('bokeh')
+
+# Remove Bokeh logo from Layout toolbars by patching LayoutPlot.initialize_plot
+
+_original_layout_initialize = LayoutPlot.initialize_plot
+
+
+def _patched_layout_initialize(self, *args, **kwargs):
+    result = _original_layout_initialize(self, *args, **kwargs)
+    if hasattr(self, 'state') and hasattr(self.state, 'toolbar'):
+        self.state.toolbar.logo = None
+    return result
+
+
+LayoutPlot.initialize_plot = _patched_layout_initialize
 
 
 class ReductionApp(DashboardBase):


### PR DESCRIPTION
## Summary

- Fixed Bokeh logo removal which stopped working with PlotGridTabs-based plot setup
- Removed defunct `remove_bokeh_logo` function and its element-level hook usage

## Background

The previous approach used HoloViews `.opts(hooks=[remove_bokeh_logo])` on individual plot elements. This stopped working because:

1. When plots are wrapped in `hv.Layout`, HoloViews creates a Bokeh `GridPlot` with its own separate toolbar
2. Element-level hooks only affect individual figure toolbars, not the GridPlot's combined toolbar
3. CSS-based approaches also failed because Bokeh's toolbar rendering is isolated from global CSS rules

## Solution

Patch `LayoutPlot.initialize_plot` to set `toolbar.logo = None` directly on the Bokeh `GridPlot` after initialization. This works because it modifies the actual Bokeh model before rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)