### PR TITLE
Improve tab styling in PlotGridTabs

### DIFF
--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -105,7 +105,26 @@ class PlotGridTabs:
         # of near-total UI freezes when there are many active plots. With dynamic=True,
         # only the visible tab is rendered; hidden tabs are rendered on-demand when
         # selected. Downside: slight delay when switching to a tab.
-        self._tabs = pn.Tabs(sizing_mode='stretch_both', dynamic=True)
+        self._tabs = pn.Tabs(
+            sizing_mode='stretch_both',
+            dynamic=True,
+            stylesheets=[
+                """
+                .bk-tab:nth-child(1),
+                .bk-tab:nth-child(2) {
+                    font-weight: bold;
+                }
+                .bk-tab {
+                    border-bottom: 1px solid #2c5aa0 !important;
+                }
+                .bk-tab.bk-active {
+                    background-color: #e8f4f8 !important;
+                    border: 1px solid #2c5aa0 !important;
+                    border-bottom: none !important;
+                }
+                """
+            ],
+        )
 
         # Modal container for plot configuration
         # IMPORTANT: Use height=0 to ensure the modal is in the component tree


### PR DESCRIPTION
## Summary

Enhances the visual design of tabs in PlotGridTabs to improve navigation and clarity:

- **Static tabs (Jobs, Manage Plots)**: Now displayed in bold to indicate they are permanent tabs
- **Active tab**: Light blue background (#e8f4f8) with blue border frame for clear visual distinction
- **Inactive tabs**: Thin bottom border to maintain visual separation from content
- **Active tab connection**: No bottom border on active tab creates seamless connection to content area

These styling improvements make it immediately clear which tab is active and help users navigate the dashboard more intuitively.

Before:
<img width="366" height="201" alt="image" src="https://github.com/user-attachments/assets/ae5286b8-2908-4887-a8fe-cd236e39e309" />

After:
<img width="370" height="182" alt="image" src="https://github.com/user-attachments/assets/bfd2658b-7102-49d0-9d66-39f714cb8108" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)