### PR TITLE
Add configurable tick count for plot axes

### DIFF
--- a/src/ess/livedata/dashboard/plot_params.py
+++ b/src/ess/livedata/dashboard/plot_params.py
@@ -103,6 +103,35 @@ class PlotAspect(pydantic.BaseModel):
     )
 
 
+class TickParams(pydantic.BaseModel):
+    """Parameters for axis tick configuration."""
+
+    custom_xticks: bool = pydantic.Field(
+        default=False,
+        description="Enable custom x-axis tick count instead of automatic.",
+        title="Custom X Ticks",
+    )
+    xticks: int = pydantic.Field(
+        default=5,
+        description="Number of ticks on x-axis (when custom ticks enabled).",
+        title="X Ticks",
+        ge=2,
+        le=20,
+    )
+    custom_yticks: bool = pydantic.Field(
+        default=False,
+        description="Enable custom y-axis tick count instead of automatic.",
+        title="Custom Y Ticks",
+    )
+    yticks: int = pydantic.Field(
+        default=5,
+        description="Number of ticks on y-axis (when custom ticks enabled).",
+        title="Y Ticks",
+        ge=2,
+        le=20,
+    )
+
+
 class PlotScaleParams(pydantic.BaseModel):
     x_scale: PlotScale = pydantic.Field(
         default=PlotScale.linear, description="Scale for x-axis", title="X Axis Scale"
@@ -187,6 +216,10 @@ class PlotParams1d(PlotParamsBase):
         default_factory=PlotScaleParams,
         description="Scaling options for the plot axes.",
     )
+    ticks: TickParams = pydantic.Field(
+        default_factory=TickParams,
+        description="Tick configuration for plot axes.",
+    )
 
 
 class PlotParams2d(PlotParamsBase):
@@ -200,6 +233,10 @@ class PlotParams2d(PlotParamsBase):
         default_factory=PlotScaleParams2d,
         description="Scaling options for the plot and color axes.",
     )
+    ticks: TickParams = pydantic.Field(
+        default_factory=TickParams,
+        description="Tick configuration for plot axes.",
+    )
 
 
 class PlotParams3d(PlotParamsBase):
@@ -212,6 +249,10 @@ class PlotParams3d(PlotParamsBase):
     plot_scale: PlotScaleParams2d = pydantic.Field(
         default_factory=PlotScaleParams2d,
         description="Scaling options for the plot axes and color.",
+    )
+    ticks: TickParams = pydantic.Field(
+        default_factory=TickParams,
+        description="Tick configuration for plot axes.",
     )
 
 

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -23,6 +23,7 @@ from .plot_params import (
     PlotScale,
     PlotScaleParams,
     PlotScaleParams2d,
+    TickParams,
 )
 from .scipp_to_holoviews import to_holoviews
 
@@ -69,7 +70,33 @@ class Plotter(ABC):
         self._sizing_opts['responsive'] = True
 
     @staticmethod
-    def _make_2d_base_opts(scale_opts: PlotScaleParams2d) -> dict[str, Any]:
+    def _make_tick_opts(tick_params: TickParams | None) -> dict[str, Any]:
+        """
+        Create tick options from TickParams.
+
+        Parameters
+        ----------
+        tick_params:
+            Tick configuration parameters.
+
+        Returns
+        -------
+        :
+            Dictionary of tick options for HoloViews plots.
+        """
+        if tick_params is None:
+            return {}
+        opts: dict[str, Any] = {}
+        if tick_params.custom_xticks:
+            opts['xticks'] = tick_params.xticks
+        if tick_params.custom_yticks:
+            opts['yticks'] = tick_params.yticks
+        return opts
+
+    @staticmethod
+    def _make_2d_base_opts(
+        scale_opts: PlotScaleParams2d, tick_params: TickParams | None = None
+    ) -> dict[str, Any]:
         """
         Create base options for 2D image plots.
 
@@ -77,19 +104,27 @@ class Plotter(ABC):
         ----------
         scale_opts:
             Scaling options for axes and color.
+        tick_params:
+            Tick configuration parameters.
 
         Returns
         -------
         :
             Dictionary of base options for HoloViews image plots.
         """
-        return {
+        opts: dict[str, Any] = {
             'colorbar': True,
             'cmap': 'viridis',
             'logx': scale_opts.x_scale == PlotScale.log,
             'logy': scale_opts.y_scale == PlotScale.log,
             'logz': scale_opts.color_scale == PlotScale.log,
         }
+        if tick_params is not None:
+            if tick_params.custom_xticks:
+                opts['xticks'] = tick_params.xticks
+            if tick_params.custom_yticks:
+                opts['yticks'] = tick_params.yticks
+        return opts
 
     @staticmethod
     def _convert_bin_edges_to_midpoints(
@@ -237,20 +272,26 @@ class LinePlotter(Plotter):
     def __init__(
         self,
         scale_opts: PlotScaleParams,
+        tick_params: TickParams | None = None,
         **kwargs,
     ):
         """
-        Initialize the image plotter.
+        Initialize the line plotter.
 
         Parameters
         ----------
+        scale_opts:
+            Scaling options for axes.
+        tick_params:
+            Tick configuration parameters.
         **kwargs:
             Additional keyword arguments passed to the base class.
         """
         super().__init__(**kwargs)
-        self._base_opts = {
+        self._base_opts: dict[str, Any] = {
             'logx': True if scale_opts.x_scale == PlotScale.log else False,
             'logy': True if scale_opts.y_scale == PlotScale.log else False,
+            **self._make_tick_opts(tick_params),
         }
 
     @classmethod
@@ -261,6 +302,7 @@ class LinePlotter(Plotter):
             layout_params=params.layout,
             aspect_params=params.plot_aspect,
             scale_opts=params.plot_scale,
+            tick_params=params.ticks,
         )
 
     def plot(self, data: sc.DataArray, data_key: ResultKey, **kwargs) -> hv.Curve:
@@ -278,6 +320,7 @@ class ImagePlotter(Plotter):
     def __init__(
         self,
         scale_opts: PlotScaleParams2d,
+        tick_params: TickParams | None = None,
         **kwargs,
     ):
         """
@@ -285,12 +328,16 @@ class ImagePlotter(Plotter):
 
         Parameters
         ----------
+        scale_opts:
+            Scaling options for axes and color.
+        tick_params:
+            Tick configuration parameters.
         **kwargs:
             Additional keyword arguments passed to the base class.
         """
         super().__init__(**kwargs)
         self._scale_opts = scale_opts
-        self._base_opts = self._make_2d_base_opts(scale_opts)
+        self._base_opts = self._make_2d_base_opts(scale_opts, tick_params)
 
     @classmethod
     def from_params(cls, params: PlotParams2d):
@@ -300,6 +347,7 @@ class ImagePlotter(Plotter):
             layout_params=params.layout,
             aspect_params=params.plot_aspect,
             scale_opts=params.plot_scale,
+            tick_params=params.ticks,
         )
 
     def plot(self, data: sc.DataArray, data_key: ResultKey, **kwargs) -> hv.Image:
@@ -323,6 +371,7 @@ class SlicerPlotter(Plotter):
     def __init__(
         self,
         scale_opts: PlotScaleParams2d,
+        tick_params: TickParams | None = None,
         **kwargs,
     ):
         """
@@ -332,13 +381,15 @@ class SlicerPlotter(Plotter):
         ----------
         scale_opts:
             Scaling options for axes and color.
+        tick_params:
+            Tick configuration parameters.
         **kwargs:
             Additional keyword arguments passed to the base class.
         """
         super().__init__(**kwargs)
         self._scale_opts = scale_opts
         self._kdims: list[hv.Dimension] | None = None
-        self._base_opts = self._make_2d_base_opts(scale_opts)
+        self._base_opts = self._make_2d_base_opts(scale_opts, tick_params)
         self._last_slice_dim: str | None = None
 
     @classmethod
@@ -346,6 +397,7 @@ class SlicerPlotter(Plotter):
         """Create SlicerPlotter from PlotParams3d."""
         return cls(
             scale_opts=params.plot_scale,
+            tick_params=params.ticks,
             value_margin_factor=0.1,
             layout_params=params.layout,
             aspect_params=params.plot_aspect,
@@ -559,6 +611,7 @@ class Overlay1DPlotter(Plotter):
     def __init__(
         self,
         scale_opts: PlotScaleParams,
+        tick_params: TickParams | None = None,
         **kwargs,
     ):
         """
@@ -568,13 +621,16 @@ class Overlay1DPlotter(Plotter):
         ----------
         scale_opts:
             Scaling options for axes.
+        tick_params:
+            Tick configuration parameters.
         **kwargs:
             Additional keyword arguments passed to the base class.
         """
         super().__init__(**kwargs)
-        self._base_opts = {
+        self._base_opts: dict[str, Any] = {
             'logx': scale_opts.x_scale == PlotScale.log,
             'logy': scale_opts.y_scale == PlotScale.log,
+            **self._make_tick_opts(tick_params),
         }
         self._colors = hv.Cycle.default_cycles["default_colors"]
 
@@ -588,6 +644,7 @@ class Overlay1DPlotter(Plotter):
             layout_params=LayoutParams(combine_mode=CombineMode.overlay),
             aspect_params=params.plot_aspect,
             scale_opts=params.plot_scale,
+            tick_params=params.ticks,
         )
 
     def plot(

--- a/src/ess/livedata/dashboard/roi_detector_plot_factory.py
+++ b/src/ess/livedata/dashboard/roi_detector_plot_factory.py
@@ -942,6 +942,7 @@ class ROIDetectorPlotFactory:
             layout_params=params.layout,
             aspect_params=params.plot_aspect,
             scale_opts=params.plot_scale,
+            tick_params=params.ticks,
         )
         # Use extracted data from pipe for plotter initialization
         detector_plotter.initialize_from_data(detector_pipe.data)


### PR DESCRIPTION
## Summary

- Add `TickParams` model with `custom_xticks`/`custom_yticks` boolean flags and `xticks`/`yticks` integer fields (range 2-20)
- When the custom flag is enabled, the tick count is passed to Holoviews `.opts()`; otherwise automatic ticking is used
- Available for all plot types via `PlotParams1d`, `PlotParams2d`, and `PlotParams3d`

This came out of a request for the Bifrost detector plot (PR #629) where users wanted control over tick frequency. The current implementation supports only integer tick counts (number of ticks). This may need to be refined in the future to support explicit tick positions or custom labels if needed.

## Test plan

- [x] Existing tests pass
- [x] Verified Holoviews accepts the `xticks`/`yticks` options
- [x] Verified Pydantic validation works (bounds 2-20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)