### PR TITLE
Change reset button icon to 'backspace'

### DIFF
--- a/src/ess/livedata/dashboard/icons.py
+++ b/src/ess/livedata/dashboard/icons.py
@@ -71,6 +71,12 @@ _ICONS: dict[str, str] = {
         '<path d="M14 5m0 1a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v12a1 1 0 0 1 -1 1h-2a1 '
         '1 0 0 1 -1 -1z"/>'
     ),
+    # Backspace (reset/clear)
+    'backspace': _svg(
+        '<path d="M20 6a1 1 0 0 1 1 1v10a1 1 0 0 1 -1 1h-11l-5 -5a1.5 1.5 0 0 1 0 -2l5 '
+        '-5l11 0"/>'
+        '<path d="M12 10l4 4m0 -4l-4 4"/>'
+    ),
     # Refresh/reset
     'refresh': _svg(
         '<path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4"/>'
@@ -98,8 +104,9 @@ def get_icon(name: str) -> str:
     Parameters
     ----------
     name:
-        Icon name. Available icons: x, settings, plus, download, player-play,
-        player-stop, player-pause, refresh, chevron-down, chevron-right, trash.
+        Icon name. Available icons: backspace, chevron-down, chevron-right,
+        download, player-pause, player-play, player-stop, plus, refresh,
+        settings, trash, x.
 
     Returns
     -------

--- a/src/ess/livedata/dashboard/widgets/job_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/job_status_widget.py
@@ -59,7 +59,7 @@ class UIConstants:
     JOB_NUMBER_MAX_LENGTH = 8
 
     # Button icons (Tabler icon names)
-    RESET_ICON = 'refresh'
+    RESET_ICON = 'backspace'
     PAUSE_ICON = 'player-pause'
     PLAY_ICON = 'player-play'
     STOP_ICON = 'player-stop'
@@ -164,12 +164,6 @@ class JobStatusWidget:
         """Get button widgets based on current job state."""
         buttons = []
 
-        # Reset button - always available for non-removed jobs
-        reset_btn = self._create_button(
-            UIConstants.RESET_ICON, lambda event: self._send_action(JobAction.reset)
-        )
-        buttons.append(reset_btn)
-
         # Stop/Remove button - dual purpose
         if self._job_status.state == JobState.stopped:
             remove_btn = self._create_button(
@@ -182,6 +176,12 @@ class JobStatusWidget:
                 UIConstants.STOP_ICON, lambda event: self._send_action(JobAction.stop)
             )
             buttons.append(stop_btn)
+
+        # Reset button - always available for non-removed jobs
+        reset_btn = self._create_button(
+            UIConstants.RESET_ICON, lambda event: self._send_action(JobAction.reset)
+        )
+        buttons.append(reset_btn)
 
         # TODO Do we need to be able to pause jobs that have errors/warnings?
         # Currently JobState is insufficient to determine if a job is running or
@@ -453,8 +453,8 @@ class JobStatusListWidget:
             self._select_none_btn,
             self._invert_selection_btn,
             pn.Spacer(width=20),
-            self._bulk_reset_btn,
             self._bulk_stop_btn,
+            self._bulk_reset_btn,
             margin=(5, 10),
         )
 

--- a/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
@@ -364,16 +364,8 @@ class WorkflowStatusWidget:
             )
             buttons.append(play_btn)
 
-        # Show reset and stop buttons if workflow is running
+        # Show stop and reset buttons if workflow is running
         if active_job_number is not None:
-            reset_btn = create_tool_button(
-                icon_name='refresh',
-                button_color='#6c757d',
-                hover_color='rgba(108, 117, 125, 0.1)',
-                on_click_callback=self._on_reset_click,
-            )
-            buttons.append(reset_btn)
-
             stop_btn = create_tool_button(
                 icon_name='player-stop',
                 button_color=ButtonStyles.DANGER_RED,
@@ -381,6 +373,14 @@ class WorkflowStatusWidget:
                 on_click_callback=self._on_stop_click,
             )
             buttons.append(stop_btn)
+
+            reset_btn = create_tool_button(
+                icon_name='backspace',
+                button_color='#6c757d',
+                hover_color='rgba(108, 117, 125, 0.1)',
+                on_click_callback=self._on_reset_click,
+            )
+            buttons.append(reset_btn)
 
         return pn.Row(*buttons, margin=0)
 


### PR DESCRIPTION
- Change reset button icon from 'refresh' to 'backspace'
- The backspace icon (←✕) more clearly conveys that data will be cleared/deleted

<img width="179" height="215" alt="Screenshot 2026-01-05 at 08 20 03" src="https://github.com/user-attachments/assets/2edd15ff-6b8c-458b-b474-2bdd8511c6e8" />
