### PR TITLE
Use DETECTOR_BANK_SIZES from ess.dream.workflows in DREAM views

### DIFF
--- a/src/ess/livedata/config/instruments/dream/views.py
+++ b/src/ess/livedata/config/instruments/dream/views.py
@@ -9,22 +9,13 @@ in specs.py.
 
 import scipp as sc
 
-# Bank sizes for mantle detector logical views
-_bank_sizes = {
-    'mantle_detector': {
-        'wire': 32,
-        'module': 5,
-        'segment': 6,
-        'strip': 256,
-        'counter': 2,
-    },
-}
-
 
 def get_mantle_front_layer(da: sc.DataArray) -> sc.DataArray:
     """Transform to extract mantle front layer."""
+    from ess.dream.workflows import DETECTOR_BANK_SIZES
+
     return (
-        da.fold(dim=da.dim, sizes=_bank_sizes['mantle_detector'])
+        da.fold(dim=da.dim, sizes=DETECTOR_BANK_SIZES['mantle_detector'])
         .transpose(('wire', 'module', 'segment', 'counter', 'strip'))['wire', 0]
         .flatten(('module', 'segment', 'counter'), to='mod/seg/cntr')
     )
@@ -32,8 +23,10 @@ def get_mantle_front_layer(da: sc.DataArray) -> sc.DataArray:
 
 def get_wire_view(da: sc.DataArray) -> sc.DataArray:
     """Transform to extract wire view."""
+    from ess.dream.workflows import DETECTOR_BANK_SIZES
+
     return (
-        da.fold(dim=da.dim, sizes=_bank_sizes['mantle_detector'])
+        da.fold(dim=da.dim, sizes=DETECTOR_BANK_SIZES['mantle_detector'])
         .sum('strip')
         .flatten(('module', 'segment', 'counter'), to='mod/seg/cntr')
         # Transpose so that wire is the "x" dimension for more natural plotting.
@@ -43,6 +36,8 @@ def get_wire_view(da: sc.DataArray) -> sc.DataArray:
 
 def get_strip_view(da: sc.DataArray) -> sc.DataArray:
     """Transform to extract strip view (sum over all but strip)."""
-    return da.fold(dim=da.dim, sizes=_bank_sizes['mantle_detector']).sum(
+    from ess.dream.workflows import DETECTOR_BANK_SIZES
+
+    return da.fold(dim=da.dim, sizes=DETECTOR_BANK_SIZES['mantle_detector']).sum(
         ('wire', 'module', 'segment', 'counter')
     )


### PR DESCRIPTION
## Summary
- Replace hard-coded `_bank_sizes` dictionary with import from `ess.dream.workflows.DETECTOR_BANK_SIZES`
- Ensures consistency with upstream definitions and avoids duplication
- Uses lazy import pattern (inside functions) following the estia views convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)