### PR TITLE
Fix cbm monitor source names to use 1-indexed naming

### DIFF
--- a/src/ess/livedata/config/instruments/_ess.py
+++ b/src/ess/livedata/config/instruments/_ess.py
@@ -19,10 +19,10 @@ def _make_cbm_monitors(
     # Might also be MONITOR_COUNTS, but topic is supposedly the same.
     topic = stream_kind_to_topic(instrument=instrument, kind=StreamKind.MONITOR_EVENTS)
     if monitor_names is None:
-        monitor_names = [f'monitor{monitor}' for monitor in range(monitor_count)]
+        monitor_names = [f'monitor{i}' for i in range(1, monitor_count + 1)]
     return {
         InputStreamKey(topic=topic, source_name=f'cbm{monitor}'): name
-        for monitor, name in enumerate(monitor_names)
+        for monitor, name in enumerate(monitor_names, start=1)
     }
 
 
@@ -52,10 +52,10 @@ def _make_dev_beam_monitors(
     # Might also be MONITOR_COUNTS, but topic is supposedly the same.
     topic = stream_kind_to_topic(instrument=instrument, kind=StreamKind.MONITOR_EVENTS)
     if monitor_names is None:
-        monitor_names = [f'monitor{monitor}' for monitor in range(10)]
+        monitor_names = [f'monitor{i}' for i in range(1, 11)]
     return {
-        InputStreamKey(topic=topic, source_name=f'monitor{monitor + 1}'): name
-        for monitor, name in enumerate(monitor_names)
+        InputStreamKey(topic=topic, source_name=f'monitor{i}'): name
+        for i, name in enumerate(monitor_names, start=1)
     }
 
 

--- a/tests/config/monitor_source_names_test.py
+++ b/tests/config/monitor_source_names_test.py
@@ -94,9 +94,9 @@ def test_bifrost_monitors_correctly_mapped() -> None:
 
 
 def test_dream_monitors_use_correct_cbm_indices() -> None:
-    """DREAM uses default monitor names (monitor0, monitor1, ...).
+    """DREAM uses default monitor names (monitor1, monitor2, ...).
 
-    These should map to cbm1, cbm2, ... (not cbm0, cbm1, ...).
+    These should map to cbm1, cbm2, ... with consistent 1-based indexing.
     """
     stream_mapping = streams.get_stream_mapping(instrument='dream', dev=False)
 
@@ -106,9 +106,9 @@ def test_dream_monitors_use_correct_cbm_indices() -> None:
         if key.source_name.startswith('cbm')
     }
 
-    # First monitor should be cbm1 -> monitor0
+    # First monitor should be cbm1 -> monitor1 (consistent 1-based indexing)
     assert (
-        cbm_to_monitor.get('cbm1') == 'monitor0'
-    ), "DREAM's first monitor (monitor0) should be mapped to cbm1"
+        cbm_to_monitor.get('cbm1') == 'monitor1'
+    ), "DREAM's first monitor (monitor1) should be mapped to cbm1"
     # cbm0 should not exist
     assert 'cbm0' not in cbm_to_monitor, "cbm0 should not exist in DREAM's mapping"


### PR DESCRIPTION
## Summary

- Fix production monitor mappings to use 1-indexed cbm source names (cbm1, cbm2, ...) matching Kafka production setup
- Fix off-by-one mapping errors for instruments with named monitors (e.g., Bifrost)
- Align default monitor names with cbm indexing (monitor1↔cbm1, monitor2↔cbm2, etc.)

Production Kafka uses 1-indexed cbm source names for beam monitors. The code was using 0-indexed naming which caused:
1. A dead cbm0 entry with no producer in Kafka
2. Off-by-one mapping errors for instruments with named monitors (e.g., Bifrost's `090_frame_1` was mapped to cbm0 instead of cbm1)

Reference: https://confluence.ess.eu/display/ECDC/Kafka+Topics+Overview+for+Instruments

## Test plan

- [x] Added tests verifying no instrument uses cbm0
- [x] Added tests verifying all instruments start at cbm1  
- [x] Added specific test for Bifrost's named monitors
- [x] Added specific test for DREAM's default monitors
- [x] Verified fake_monitors service already uses 1-indexed naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)