### PR TITLE
Add --no-fetch-announcements flag to fix flaky dashboard test

### DIFF
--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -73,6 +73,7 @@ class ReductionApp(DashboardBase):
         dev: bool = False,
         log_level: int,
         transport: str = 'kafka',
+        fetch_announcements: bool = True,
     ):
         super().__init__(
             instrument=instrument,
@@ -82,10 +83,15 @@ class ReductionApp(DashboardBase):
             port=5009,  # Default port for reduction dashboard
             transport=transport,
         )
+        self._fetch_announcements = fetch_announcements
         self._logger.info("Reduction dashboard initialized")
 
     def _create_announcements_pane(self) -> pn.pane.Markdown:
         """Create a Markdown pane that periodically reloads from URL."""
+        if not self._fetch_announcements:
+            return pn.pane.Markdown(
+                "*Announcements disabled.*", sizing_mode='stretch_width'
+            )
 
         def read_announcements() -> str:
             try:
@@ -165,6 +171,12 @@ def get_arg_parser() -> argparse.ArgumentParser:
         choices=['kafka', 'none'],
         default='kafka',
         help='Transport backend for message handling',
+    )
+    parser.add_argument(
+        '--no-fetch-announcements',
+        action='store_false',
+        dest='fetch_announcements',
+        help='Disable fetching announcements from external URL',
     )
     return parser
 

--- a/tests/integration/dashboard_null_transport_test.py
+++ b/tests/integration/dashboard_null_transport_test.py
@@ -58,6 +58,7 @@ class TestDashboardNullTransport:
             'ess.livedata.dashboard.reduction',
             instrument='dummy',
             transport='none',
+            no_fetch_announcements=True,
         )
 
         with service:


### PR DESCRIPTION
- Add `fetch_announcements` parameter to `ReductionApp` to control whether announcements are fetched from external URL
- Add `--no-fetch-announcements` CLI flag to disable the blocking network call
- Update dashboard null transport test to use the new flag

The test was flaky because `read_announcements()` blocks for up to 10 seconds when the external URL is unreachable, causing the test's HTTP timeout to race against the SSL handshake timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)