### PR TITLE
Fix broken unit in DREAM I(d) workflow

### DIFF
--- a/src/ess/livedata/config/instruments/dream/factories.py
+++ b/src/ess/livedata/config/instruments/dream/factories.py
@@ -129,7 +129,6 @@ def setup_factories(instrument: Instrument) -> None:
         normalization is fixed and/or we have setup a proton-charge stream.
         """
         fake_charge = sc.values(data.data).sum()
-        fake_charge.unit = 'counts/µAh'
         return powder.types.AccumulatedProtonCharge[RunType](fake_charge)
 
     _reduction_workflow.insert(_total_counts)


### PR DESCRIPTION
## Summary

- `_fake_proton_charge` force-set the fake charge unit to `counts/µAh`, but its input (`CorrectedDspacing`) already carries Lorentz-corrected units (`m^4·counts`). Dividing by the wrong-unit charge produced `3.6e-43*m^4*s*A` instead of dimensionless values.
- Removed the unit override so the fake charge retains the data's actual unit, making `data / proton_charge` dimensionless.

## Test plan

- [ ] Manual: verify DREAM I(d) dashboard shows dimensionless (or sensible) units instead of `[3.6e-43*m^4*s*A]`

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)