### PR TITLE
Add SANS detector to DREAM powder workflows

### DIFF
--- a/src/ess/livedata/config/instruments/dream/specs.py
+++ b/src/ess/livedata/config/instruments/dream/specs.py
@@ -289,9 +289,10 @@ class PowderReductionWithVanadiumOutputs(PowderReductionOutputs):
 
 
 # Register powder reduction workflow specs
-_powder_detector_names = [
-    name for name in instrument.detector_names if 'sans' not in name
-]
+# The SANS detector is included here because the instrument scientist confirmed
+# that even though it is primarily a SANS detector, it may also be used for powder
+# diffraction measurements.
+_powder_detector_names = instrument.detector_names
 
 powder_reduction_handle = instrument.register_spec(
     name='powder_reduction',


### PR DESCRIPTION
## Motivation

The instrument scientist confirmed that the SANS detector may also be used for powder diffraction measurements, so it should be included alongside the other detectors in the DREAM powder reduction workflows.

This removes the filter that excluded detectors with `'sans'` in their name from `_powder_detector_names`, and adds a code comment documenting the reasoning.

Closes #706

## Test plan

- [x] Verify that the SANS detector appears as a selectable source in the DREAM powder reduction workflows