### PR TITLE
Rename LOKI wire view to tube view

### DIFF
--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -19,7 +19,7 @@ from ess.livedata.handlers.monitor_workflow_specs import (
     register_monitor_workflow_specs,
 )
 
-from .views import get_wire_view
+from .views import get_tube_view
 
 
 class TransmissionMode(StrEnum):
@@ -210,13 +210,13 @@ xy_projection_handle = register_detector_view_spec(
     source_names=detector_names,
 )
 
-# Register wire view for all detector banks
+# Register tube view for all detector banks
 instrument.add_logical_view(
-    name='wire_view',
-    title='Wire View',
+    name='tube_view',
+    title='Tube View',
     description='Sum over straw and pixel dimensions to show layer x tube counts.',
     source_names=detector_names,
-    transform=get_wire_view,
+    transform=get_tube_view,
     output_ndim=2,
     reduction_dim=['straw', 'pixel'],
 )

--- a/src/ess/livedata/config/instruments/loki/views.py
+++ b/src/ess/livedata/config/instruments/loki/views.py
@@ -10,8 +10,8 @@ in specs.py.
 import scipp as sc
 
 
-def get_wire_view(da: sc.DataArray, source_name: str) -> sc.DataArray:
-    """Transform to fold detector data for wire view.
+def get_tube_view(da: sc.DataArray, source_name: str) -> sc.DataArray:
+    """Transform to fold detector data for tube view.
 
     Folds raw detector data into (layer, straw, tube, pixel) dimensions using
     bank-specific sizes from DETECTOR_BANK_SIZES. The subsequent summing over


### PR DESCRIPTION
## Summary

The LOKI detector view was misnamed: on LOKI, wires run through straws within tubes, and the view sums over the straw and pixel dimensions to produce a layer × tube representation. "Wire view" was therefore incorrect — "tube view" is the right term.

Renames the function (`get_wire_view` → `get_tube_view`), the view identifier (`wire_view` → `tube_view`), the displayed title, and updates the docstring accordingly.

DREAM's wire view is a genuinely different concept and is not affected.

## Test plan

- [x] Visual check: the view tab label in the LOKI dashboard shows "Tube View"

🤖 Generated with [Claude Code](https://claude.com/claude-code)