### PR TITLE
Support multi-pulse ev44 messages via Sequence-based MessageAdapter

### DIFF
--- a/docs/developer/design/message-flow-and-transformation.md
+++ b/docs/developer/design/message-flow-and-transformation.md
@@ -111,7 +111,7 @@ Isolates ESSlivedata from Kafka topic structure: Kafka uses `(topic, source_name
 
 ### Adapter Pattern
 
-`MessageAdapter` protocol: `adapt(message: T) -> U`. Benefits: composable, type-safe, testable, reusable.
+`MessageAdapter` protocol: `adapt(message: T) -> Sequence[U]`. Each adapter returns a sequence, enabling 1:N message expansion (e.g., splitting multi-pulse ev44 messages into one message per pulse). Most adapters return a single-element tuple. Benefits: composable, type-safe, testable, reusable.
 
 ### Core Adapters
 
@@ -127,7 +127,7 @@ Isolates ESSlivedata from Kafka topic structure: Kafka uses `(topic, source_name
 
 ### Adapter Composition
 
-**ChainedAdapter**: Chains two adapters sequentially (`second.adapt(first.adapt(message))`).
+**ChainedAdapter**: Chains two adapters with flatmap semantics — for each intermediate result from the first adapter, all results from the second adapter are collected into a flat sequence.
 
 **RouteByTopicAdapter**: Routes by Kafka topic to different adapters. Provides `.topics` list for subscription.
 

--- a/src/ess/livedata/services/fake_monitors.py
+++ b/src/ess/livedata/services/fake_monitors.py
@@ -90,11 +90,13 @@ class EventsToHistogramAdapter(
     def __init__(self, toa: sc.Variable):
         self._toa = toa
 
-    def adapt(self, message: Message[sc.Variable]) -> Message[sc.DataArray]:
-        return replace(
-            message,
-            stream=replace(message.stream, kind=StreamKind.MONITOR_COUNTS),
-            value=message.value.hist({self._toa.dim: self._toa}),
+    def adapt(self, message: Message[sc.Variable]) -> tuple[Message[sc.DataArray], ...]:
+        return (
+            replace(
+                message,
+                stream=replace(message.stream, kind=StreamKind.MONITOR_COUNTS),
+                value=message.value.hist({self._toa.dim: self._toa}),
+            ),
         )
 
 

--- a/tests/kafka/sink_test.py
+++ b/tests/kafka/sink_test.py
@@ -48,7 +48,7 @@ class TestDa00Serializer:
         )
 
         # Deserialize back to scipp
-        result_msg = roundtrip_adapter.adapt(kafka_msg)
+        [result_msg] = roundtrip_adapter.adapt(kafka_msg)
 
         # Verify the roundtrip preserved the data and payload timestamp
         assert sc.identical(result_msg.value, original_data)
@@ -85,7 +85,7 @@ class TestDa00Serializer:
             timestamp=kafka_timestamp,  # Should be ignored
         )
 
-        result_msg = roundtrip_adapter.adapt(kafka_msg)
+        [result_msg] = roundtrip_adapter.adapt(kafka_msg)
 
         # Verify roundtrip uses payload timestamp, not Kafka timestamp
         assert sc.identical(result_msg.value, original_data)
@@ -124,7 +124,7 @@ class TestF144Serializer:
         )
 
         # Deserialize back to f144 log data
-        result_msg = f144_adapter.adapt(kafka_msg)
+        [result_msg] = f144_adapter.adapt(kafka_msg)
 
         # Verify the roundtrip preserved the value and used time coordinate as timestamp
         assert result_msg.value.value == 42.5  # Value preserved
@@ -156,7 +156,7 @@ class TestF144Serializer:
             timestamp=2222222222,  # Should be ignored
         )
 
-        result_msg = f144_adapter.adapt(kafka_msg)
+        [result_msg] = f144_adapter.adapt(kafka_msg)
 
         # Verify array values are preserved and timestamp comes from time coordinate
         np.testing.assert_array_equal(result_msg.value.value, [1.0, 2.0, 3.0])
@@ -180,7 +180,7 @@ class TestF144Serializer:
             value=serialized_bytes, topic='log_topic', timestamp=0
         )
 
-        result_msg = f144_adapter.adapt(kafka_msg)
+        [result_msg] = f144_adapter.adapt(kafka_msg)
 
         # Time should be converted to nanoseconds
         expected_time_ns = time_us * 1000  # us to ns conversion


### PR DESCRIPTION
## Summary

Alternative to #728. Closes #708.

- Restructure the `MessageAdapter` protocol so `adapt()` returns `Sequence[U]`, making 1:N message expansion a natural part of the adapter chain
- Add `split_ev44_pulses()` utility that slices multi-pulse ev44 messages into individual single-pulse `EventData` objects
- Multi-pulse splitting happens at the Kafka boundary (`KafkaToEv44Adapter`, `KafkaToMonitorEventsAdapter`); all domain adapters stay semantically unchanged with single-element tuple wrapping
- `ChainedAdapter` uses flatmap semantics; `AdaptingMessageSource` uses `extend()` instead of `append()`

The key difference from #728: instead of changing `from_ev44()` return types, duplicating splitting logic across adapters, and adding `isinstance` branching in `AdaptingMessageSource`, all adapters uniformly return sequences and the splitting is localized to the two Kafka-level ev44 adapters.

## Test plan

- [x] New unit tests for `split_ev44_pulses()` (single-pulse passthrough, empty reference_time, multi-pulse slicing)
- [x] New tests for multi-pulse `KafkaToEv44Adapter` and `KafkaToMonitorEventsAdapter`
- [x] Chain integration test: multi-pulse ev44 through `ChainedAdapter` produces multiple `DetectorEvents`
- [x] Full test suite passes (2472 passed, 0 failures)


🤖 Generated with [Claude Code](https://claude.com/claude-code)