### PR TITLE
Fix LOKI CBM monitor source names to 1-based indexing

### DIFF
--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -74,12 +74,12 @@ class BeamCenterXY(pydantic.BaseModel):
 class LokiAuxSources(AuxSourcesBase):
     """Auxiliary source names for LOKI SANS workflows."""
 
-    incident_monitor: Literal['beam_monitor_1'] = pydantic.Field(
-        default='beam_monitor_1',
+    incident_monitor: Literal['beam_monitor_m1'] = pydantic.Field(
+        default='beam_monitor_m1',
         description='Incident beam monitor for normalization.',
     )
-    transmission_monitor: Literal['beam_monitor_3'] = pydantic.Field(
-        default='beam_monitor_3',
+    transmission_monitor: Literal['beam_monitor_m3'] = pydantic.Field(
+        default='beam_monitor_m3',
         description='Transmission monitor for sample transmission calculation.',
     )
 
@@ -161,11 +161,11 @@ instrument = Instrument(
     name='loki',
     detector_names=detector_names,
     monitors=[
-        'beam_monitor_0',
-        'beam_monitor_1',
-        'beam_monitor_2',
-        'beam_monitor_3',
-        'beam_monitor_4',
+        'beam_monitor_m0',
+        'beam_monitor_m1',
+        'beam_monitor_m2',
+        'beam_monitor_m3',
+        'beam_monitor_m4',
     ],
     source_metadata={
         'loki_detector_0': SourceMetadata(title='Rear'),
@@ -177,19 +177,19 @@ instrument = Instrument(
         'loki_detector_6': SourceMetadata(title='Front Left'),
         'loki_detector_7': SourceMetadata(title='Front Top'),
         'loki_detector_8': SourceMetadata(title='Front Right'),
-        'beam_monitor_0': SourceMetadata(
+        'beam_monitor_m0': SourceMetadata(
             title='Beam Monitor 0', description='Upstream, z = -16.8 m'
         ),
-        'beam_monitor_1': SourceMetadata(
+        'beam_monitor_m1': SourceMetadata(
             title='Incident Monitor', description='Upstream, z = -8.4 m'
         ),
-        'beam_monitor_2': SourceMetadata(
+        'beam_monitor_m2': SourceMetadata(
             title='Beam Monitor 2', description='Upstream, z = -2.04 m'
         ),
-        'beam_monitor_3': SourceMetadata(
+        'beam_monitor_m3': SourceMetadata(
             title='Transmission Monitor', description='Downstream, z = +0.2 m'
         ),
-        'beam_monitor_4': SourceMetadata(
+        'beam_monitor_m4': SourceMetadata(
             title='Beam Monitor 4',
             description='Downstream, movable (on detector carriage)',
         ),

--- a/src/ess/livedata/config/instruments/loki/streams.py
+++ b/src/ess/livedata/config/instruments/loki/streams.py
@@ -4,9 +4,7 @@
 LOKI instrument stream mapping configuration.
 """
 
-from ess.livedata import StreamKind
 from ess.livedata.config.env import StreamingEnv
-from ess.livedata.config.streams import stream_kind_to_topic
 from ess.livedata.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from .._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
@@ -24,12 +22,16 @@ detector_fakes = {
 }
 
 
+# Monitor names use 0-based indices matching the NeXus beam monitor groups
+# (beam_monitor_mN). The underlying Kafka source names (cbm1 … cbm5) are
+# 1-based; the positional mapping is handled by ``_make_cbm_monitors``.
+# Ref: ``coda_loki_999999_00020680.hdf``
 monitor_names = [
-    'beam_monitor_0',
-    'beam_monitor_1',
-    'beam_monitor_2',
-    'beam_monitor_3',
-    'beam_monitor_4',
+    'beam_monitor_m0',
+    'beam_monitor_m1',
+    'beam_monitor_m2',
+    'beam_monitor_m3',
+    'beam_monitor_m4',
 ]
 
 
@@ -48,22 +50,10 @@ def _make_loki_detectors() -> StreamLUT:
     }
 
 
-def _make_loki_monitors() -> StreamLUT:
-    """Loki beam monitor mapping.
-
-    Source names and topic extracted from NeXus file
-    ``coda_loki_999999_00017735.hdf`` using ``nexus_helpers``.
-    """
-    topic = stream_kind_to_topic(instrument='loki', kind=StreamKind.MONITOR_EVENTS)
-    return {
-        InputStreamKey(topic=topic, source_name=f'cbm{i}'): f'beam_monitor_{i}'
-        for i in range(0, 5)
-    }
-
-
-_common_prod = make_common_stream_mapping_inputs(instrument='loki')
+_common_prod = make_common_stream_mapping_inputs(
+    instrument='loki', monitor_names=monitor_names
+)
 _common_prod['detectors'] = _make_loki_detectors()
-_common_prod['monitors'] = _make_loki_monitors()
 
 stream_mapping = {
     StreamingEnv.DEV: make_dev_stream_mapping(

--- a/tests/config/monitor_source_names_test.py
+++ b/tests/config/monitor_source_names_test.py
@@ -3,7 +3,7 @@
 """
 Tests for monitor source name indexing.
 
-These tests verify that monitor source names (cbm0, cbm1, cbm2, ...) are
+These tests verify that monitor source names (cbm1, cbm2, ...) are
 correctly mapped to internal monitor names.
 
 See https://confluence.ess.eu/display/ECDC/Kafka+Topics+Overview+for+Instruments
@@ -14,20 +14,10 @@ import pytest
 from ess.livedata.config import streams
 from ess.livedata.config.instruments import available_instruments
 
-# LOKI uses 0-based cbm source names (cbm0, cbm1, ...), verified against
-# NeXus data file ``coda_loki_999999_00019778.hdf``.
-_INSTRUMENTS_WITH_CBM0 = {'loki'}
 
-
-@pytest.mark.parametrize(
-    'instrument',
-    [i for i in available_instruments() if i not in _INSTRUMENTS_WITH_CBM0],
-)
+@pytest.mark.parametrize('instrument', available_instruments())
 def test_production_monitors_do_not_use_cbm0(instrument: str) -> None:
-    """Most instruments use 1-based cbm source names (cbm1, cbm2, ...).
-
-    LOKI is excluded because it uses 0-based indexing.
-    """
+    """All instruments use 1-based cbm source names (cbm1, cbm2, ...)."""
     stream_mapping = streams.get_stream_mapping(instrument=instrument, dev=False)
     cbm_source_names = [
         key.source_name
@@ -41,10 +31,10 @@ def test_production_monitors_do_not_use_cbm0(instrument: str) -> None:
 
 
 def test_loki_monitors_correctly_mapped() -> None:
-    """LOKI monitors use 0-based cbm source names matching NeXus group indices.
+    """LOKI monitors use 1-based cbm source names.
 
-    Verified against NeXus data file ``coda_loki_999999_00019778.hdf``:
-    cbm0 -> beam_monitor_0, ..., cbm4 -> beam_monitor_4.
+    Source names verified against NeXus data file
+    ``coda_loki_999999_00020680.hdf`` (cbm1 through cbm5).
     """
     stream_mapping = streams.get_stream_mapping(instrument='loki', dev=False)
     actual_mapping = {
@@ -53,11 +43,11 @@ def test_loki_monitors_correctly_mapped() -> None:
         if key.source_name.startswith('cbm')
     }
     expected_mapping = {
-        'cbm0': 'beam_monitor_0',
-        'cbm1': 'beam_monitor_1',
-        'cbm2': 'beam_monitor_2',
-        'cbm3': 'beam_monitor_3',
-        'cbm4': 'beam_monitor_4',
+        'cbm1': 'beam_monitor_m0',
+        'cbm2': 'beam_monitor_m1',
+        'cbm3': 'beam_monitor_m2',
+        'cbm4': 'beam_monitor_m3',
+        'cbm5': 'beam_monitor_m4',
     }
     assert actual_mapping == expected_mapping
 

--- a/tests/services/monitor_data_test.py
+++ b/tests/services/monitor_data_test.py
@@ -41,7 +41,7 @@ first_monitor_source_name = {
     'dummy': 'monitor1',
     'dream': 'monitor_bunker',
     'bifrost': '090_frame_1',
-    'loki': 'beam_monitor_1',
+    'loki': 'beam_monitor_m1',
 }
 
 


### PR DESCRIPTION
## Summary

- ECDC-5451 fixed the LOKI NeXus template so CBM source names are now 1-based (cbm1–cbm5) instead of 0-based (cbm0–cbm4), verified against `coda_loki_999999_00020680.hdf`
- Remove the custom `_make_loki_monitors()` override and use the generic `_make_cbm_monitors` helper, which already uses 1-based indexing
- Rename internal monitor names from `beam_monitor_N` to `beam_monitor_mN` to match the updated NeXus group names
- LOKI is no longer a special case in the monitor source name tests

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)