### PR TITLE
Include output title in correlation plot axis labels

### DIFF
--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -13,21 +13,15 @@ Correlation histograms receive pre-structured data from DataSubscriber:
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pydantic
 import scipp as sc
 
-from ess.livedata.config.workflow_spec import ResultKey, WorkflowId, WorkflowSpec
+from ess.livedata.config.workflow_spec import ResultKey
 
 from .data_roles import PRIMARY, X_AXIS, Y_AXIS
-
-if TYPE_CHECKING:
-    from ess.livedata.config import Instrument
-
-    from .plot_orchestrator import DataSourceConfig
 from .plot_params import (
     Line1dParams,
     Line1dRenderMode,
@@ -141,78 +135,6 @@ class CorrelationHistogram2dParams(_CorrelationHistogramBase, PlotDisplayParams2
 CORRELATION_HISTOGRAM_PLOTTERS = frozenset(
     {'correlation_histogram_1d', 'correlation_histogram_2d'}
 )
-
-
-def resolve_axis_source_titles(
-    axis_sources: dict[str, DataSourceConfig],
-    instrument_config: Instrument,
-    workflow_registry: Mapping[WorkflowId, WorkflowSpec] | None = None,
-) -> dict[str, str]:
-    """Build a mapping from bins field name to display title for axis sources.
-
-    Parameters
-    ----------
-    axis_sources:
-        Axis role -> DataSourceConfig mapping.
-    instrument_config:
-        Instrument config to resolve source names to titles.
-    workflow_registry:
-        Optional registry used to look up output titles. When provided and the
-        workflow has multiple outputs, the output title is appended to the source
-        title to disambiguate (e.g. "Cave Monitor (wavelength)").
-
-    Returns
-    -------
-    :
-        Mapping of bins field name (e.g. 'x_axis_source') to display title.
-    """
-    role_to_field = {X_AXIS: 'x_axis_source', Y_AXIS: 'y_axis_source'}
-    result: dict[str, str] = {}
-    for role, field_name in role_to_field.items():
-        if role in axis_sources and axis_sources[role].source_names:
-            ds = axis_sources[role]
-            source_name = ds.source_names[0]
-            title = instrument_config.get_source_title(source_name)
-            if workflow_registry is not None:
-                spec = workflow_registry.get(ds.workflow_id)
-                if (
-                    spec is not None
-                    and spec.outputs is not None
-                    and len(spec.outputs.model_fields) > 1
-                ):
-                    output_title = spec.get_output_title(ds.output_name)
-                    title = f"{title} ({output_title})"
-            result[field_name] = title
-    return result
-
-
-def inject_axis_source_titles(
-    params: pydantic.BaseModel | dict,
-    axis_sources: dict[str, DataSourceConfig],
-    instrument_config: Instrument,
-    workflow_registry: Mapping[WorkflowId, WorkflowSpec] | None = None,
-) -> pydantic.BaseModel | dict:
-    """Inject axis source titles into correlation histogram params.
-
-    Updates the bins.x_axis_source and bins.y_axis_source fields with
-    human-readable titles resolved from axis_sources.
-    Accepts either a pydantic model or a plain dict of params.
-    """
-    titles = resolve_axis_source_titles(
-        axis_sources, instrument_config, workflow_registry
-    )
-    if not titles:
-        return params
-
-    if isinstance(params, dict):
-        if 'bins' in params and isinstance(params['bins'], dict):
-            params['bins'].update(titles)
-        return params
-
-    if not hasattr(params, 'bins'):
-        return params
-    new_bins = params.bins.model_copy(update=titles)
-    return params.model_copy(update={'bins': new_bins})
 
 
 def _make_lookup(axis_data: sc.DataArray, data_max_time: sc.Variable) -> sc.bins.Lookup:

--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -26,11 +26,7 @@ from ess.livedata.config.workflow_spec import (
     WorkflowSpec,
     find_timeseries_outputs,
 )
-from ess.livedata.dashboard.correlation_plotter import (
-    CORRELATION_HISTOGRAM_PLOTTERS,
-    inject_axis_source_titles,
-    resolve_axis_source_titles,
-)
+from ess.livedata.dashboard.correlation_plotter import CORRELATION_HISTOGRAM_PLOTTERS
 from ess.livedata.dashboard.data_roles import PRIMARY, X_AXIS, Y_AXIS
 
 if TYPE_CHECKING:
@@ -64,6 +60,78 @@ _NO_TRANSITION_CSS = """
     transition: none !important;
 }
 """
+
+
+def _resolve_axis_source_titles(
+    axis_sources: dict[str, DataSourceConfig],
+    instrument_config: Instrument,
+    workflow_registry: Mapping[WorkflowId, WorkflowSpec] | None = None,
+) -> dict[str, str]:
+    """Build a mapping from bins field name to display title for axis sources.
+
+    Parameters
+    ----------
+    axis_sources:
+        Axis role -> DataSourceConfig mapping.
+    instrument_config:
+        Instrument config to resolve source names to titles.
+    workflow_registry:
+        Optional registry used to look up output titles. When provided and the
+        workflow has multiple outputs, the output title is appended to the source
+        title to disambiguate (e.g. "Cave Monitor (wavelength)").
+
+    Returns
+    -------
+    :
+        Mapping of bins field name (e.g. 'x_axis_source') to display title.
+    """
+    role_to_field = {X_AXIS: 'x_axis_source', Y_AXIS: 'y_axis_source'}
+    result: dict[str, str] = {}
+    for role, field_name in role_to_field.items():
+        if role in axis_sources and axis_sources[role].source_names:
+            ds = axis_sources[role]
+            source_name = ds.source_names[0]
+            title = instrument_config.get_source_title(source_name)
+            if workflow_registry is not None:
+                spec = workflow_registry.get(ds.workflow_id)
+                if (
+                    spec is not None
+                    and spec.outputs is not None
+                    and len(spec.outputs.model_fields) > 1
+                ):
+                    output_title = spec.get_output_title(ds.output_name)
+                    title = f"{title} ({output_title})"
+            result[field_name] = title
+    return result
+
+
+def _inject_axis_source_titles(
+    params: pydantic.BaseModel | dict,
+    axis_sources: dict[str, DataSourceConfig],
+    instrument_config: Instrument,
+    workflow_registry: Mapping[WorkflowId, WorkflowSpec] | None = None,
+) -> pydantic.BaseModel | dict:
+    """Inject axis source titles into correlation histogram params.
+
+    Updates the bins.x_axis_source and bins.y_axis_source fields with
+    human-readable titles resolved from axis_sources.
+    Accepts either a pydantic model or a plain dict of params.
+    """
+    titles = _resolve_axis_source_titles(
+        axis_sources, instrument_config, workflow_registry
+    )
+    if not titles:
+        return params
+
+    if isinstance(params, dict):
+        if 'bins' in params and isinstance(params['bins'], dict):
+            params['bins'].update(titles)
+        return params
+
+    if not hasattr(params, 'bins'):
+        return params
+    new_bins = params.bins.model_copy(update=titles)
+    return params.model_copy(update={'bins': new_bins})
 
 
 def _build_timeseries_options(
@@ -1042,7 +1110,7 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
                 else dict(self._initial_config.params)
             )
             if axis_sources:
-                inject_axis_source_titles(
+                _inject_axis_source_titles(
                     params_dict,
                     axis_sources,
                     self._instrument_config,
@@ -1057,7 +1125,7 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
             # For new correlation histograms, pre-populate axis source titles
             from ess.livedata.dashboard.configuration_adapter import ConfigurationState
 
-            titles = resolve_axis_source_titles(
+            titles = _resolve_axis_source_titles(
                 axis_sources, self._instrument_config, self._workflow_registry
             )
             if titles:
@@ -1104,7 +1172,7 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
         ):
             data_sources.update(axis_sources)
             if isinstance(params, pydantic.BaseModel):
-                params = inject_axis_source_titles(
+                params = _inject_axis_source_titles(
                     params,
                     axis_sources,
                     self._instrument_config,

--- a/tests/dashboard/widgets/plot_config_modal_test.py
+++ b/tests/dashboard/widgets/plot_config_modal_test.py
@@ -8,14 +8,12 @@ from ess.livedata.config.workflow_spec import (
     WorkflowOutputsBase,
     WorkflowSpec,
 )
-from ess.livedata.dashboard.correlation_plotter import (
-    inject_axis_source_titles,
-    resolve_axis_source_titles,
-)
 from ess.livedata.dashboard.data_roles import X_AXIS, Y_AXIS
 from ess.livedata.dashboard.plot_orchestrator import DataSourceConfig
 from ess.livedata.dashboard.widgets.plot_config_modal import (
     _build_timeseries_options,
+    _inject_axis_source_titles,
+    _resolve_axis_source_titles,
 )
 
 
@@ -66,7 +64,7 @@ class TestResolveAxisSourceTitles:
         instrument = FakeInstrumentConfig(
             {"monitor_cave": "Cave Monitor", "monitor_bunker": "Bunker Monitor"}
         )
-        result = resolve_axis_source_titles(axis_sources, instrument)
+        result = _resolve_axis_source_titles(axis_sources, instrument)
         assert result == {
             "x_axis_source": "Cave Monitor",
             "y_axis_source": "Bunker Monitor",
@@ -75,12 +73,12 @@ class TestResolveAxisSourceTitles:
     def test_falls_back_to_source_name_when_title_not_found(self):
         axis_sources = _make_axis_sources("unknown_source")
         instrument = FakeInstrumentConfig({})
-        result = resolve_axis_source_titles(axis_sources, instrument)
+        result = _resolve_axis_source_titles(axis_sources, instrument)
         assert result == {"x_axis_source": "unknown_source"}
 
     def test_empty_axis_sources_returns_empty(self):
         instrument = FakeInstrumentConfig({})
-        assert resolve_axis_source_titles({}, instrument) == {}
+        assert _resolve_axis_source_titles({}, instrument) == {}
 
     def test_single_output_workflow_omits_output_title(self):
         class SingleOutput(WorkflowOutputsBase):
@@ -94,7 +92,7 @@ class TestResolveAxisSourceTitles:
         axis_sources = _make_axis_sources("monitor_cave")
         instrument = FakeInstrumentConfig({"monitor_cave": "Cave Monitor"})
 
-        result = resolve_axis_source_titles(axis_sources, instrument, {wf_id: spec})
+        result = _resolve_axis_source_titles(axis_sources, instrument, {wf_id: spec})
         assert result == {"x_axis_source": "Cave Monitor"}
 
     def test_multi_output_workflow_appends_output_title(self):
@@ -113,14 +111,14 @@ class TestResolveAxisSourceTitles:
         axis_sources = _make_axis_sources("monitor_cave")
         instrument = FakeInstrumentConfig({"monitor_cave": "Cave Monitor"})
 
-        result = resolve_axis_source_titles(axis_sources, instrument, {wf_id: spec})
+        result = _resolve_axis_source_titles(axis_sources, instrument, {wf_id: spec})
         assert result == {"x_axis_source": "Cave Monitor (Delta)"}
 
     def test_without_workflow_registry_omits_output_title(self):
         axis_sources = _make_axis_sources("monitor_cave")
         instrument = FakeInstrumentConfig({"monitor_cave": "Cave Monitor"})
 
-        result = resolve_axis_source_titles(axis_sources, instrument)
+        result = _resolve_axis_source_titles(axis_sources, instrument)
         assert result == {"x_axis_source": "Cave Monitor"}
 
     def test_multi_output_both_axes(self):
@@ -141,7 +139,7 @@ class TestResolveAxisSourceTitles:
             {"monitor_cave": "Cave Monitor", "monitor_bunker": "Bunker Monitor"}
         )
 
-        result = resolve_axis_source_titles(axis_sources, instrument, {wf_id: spec})
+        result = _resolve_axis_source_titles(axis_sources, instrument, {wf_id: spec})
         assert result == {
             "x_axis_source": "Cave Monitor (Delta)",
             "y_axis_source": "Bunker Monitor (Delta)",
@@ -153,13 +151,13 @@ class TestInjectAxisSourceTitles:
         params = Params()
         axis_sources = _make_axis_sources("monitor_cave")
         instrument = FakeInstrumentConfig({"monitor_cave": "Cave Monitor"})
-        result = inject_axis_source_titles(params, axis_sources, instrument)
+        result = _inject_axis_source_titles(params, axis_sources, instrument)
         assert result.bins.x_axis_source == "Cave Monitor"
 
     def test_no_change_when_no_axis_sources(self):
         params = Params(bins=Bins(x_axis_source="existing"))
         instrument = FakeInstrumentConfig({})
-        result = inject_axis_source_titles(params, {}, instrument)
+        result = _inject_axis_source_titles(params, {}, instrument)
         assert result.bins.x_axis_source == "existing"
 
     def test_no_change_when_no_bins(self):
@@ -169,14 +167,14 @@ class TestInjectAxisSourceTitles:
         params = NoBinsParams()
         axis_sources = _make_axis_sources("monitor_cave")
         instrument = FakeInstrumentConfig({"monitor_cave": "Cave Monitor"})
-        result = inject_axis_source_titles(params, axis_sources, instrument)
+        result = _inject_axis_source_titles(params, axis_sources, instrument)
         assert result.color == "red"
 
     def test_injects_titles_into_dict(self):
         params = {"bins": {"x_axis_source": "old", "n_bins": 50}}
         axis_sources = _make_axis_sources("monitor_cave")
         instrument = FakeInstrumentConfig({"monitor_cave": "Cave Monitor"})
-        result = inject_axis_source_titles(params, axis_sources, instrument)
+        result = _inject_axis_source_titles(params, axis_sources, instrument)
         assert result["bins"]["x_axis_source"] == "Cave Monitor"
         assert result["bins"]["n_bins"] == 50
 
@@ -184,7 +182,7 @@ class TestInjectAxisSourceTitles:
         params = {"color": "red"}
         axis_sources = _make_axis_sources("monitor_cave")
         instrument = FakeInstrumentConfig({"monitor_cave": "Cave Monitor"})
-        result = inject_axis_source_titles(params, axis_sources, instrument)
+        result = _inject_axis_source_titles(params, axis_sources, instrument)
         assert result == {"color": "red"}
 
     def test_injects_output_title_for_multi_output_workflow(self):
@@ -203,7 +201,7 @@ class TestInjectAxisSourceTitles:
         params = Params()
         axis_sources = _make_axis_sources("monitor_cave")
         instrument = FakeInstrumentConfig({"monitor_cave": "Cave Monitor"})
-        result = inject_axis_source_titles(
+        result = _inject_axis_source_titles(
             params, axis_sources, instrument, {wf_id: spec}
         )
         assert result.bins.x_axis_source == "Cave Monitor (Delta)"


### PR DESCRIPTION
## Summary

- For multi-output workflows, correlation plot axis labels and the wizard's "Histogram Bins" fields now include the output title (e.g., "Cave Monitor (Delta)" instead of just "Cave Monitor")
- Axis titles are resolved at plotter creation time in the orchestrator, ensuring correctness for configs loaded from persistence or templates — not just the wizard flow

## Motivation

Fixes #757 — the correlation plot wizard and rendered axis labels were missing the output title, making it ambiguous which output a given axis referred to when the workflow produces multiple outputs.

## Test plan

- [x] Unit tests for `resolve_axis_source_titles` / `inject_axis_source_titles` (single-output, multi-output, both axes, dict/model params)
- [x] End-to-end test verifying the HoloViews kdim label matches `x_axis_source` with output title
- [x] Manual: create a correlation plot from a multi-output workflow — verify step 3 "Histogram Bins" and the plot X-axis both show the output title
- [x] Manual: reload from persisted config — verify X-axis still includes the output title. NOTE: **decided to not support legacy config. Old plots still load, but need to recreate plots to get full name!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)