### PR TITLE
Shut down ThreadPoolExecutor on service shutdown

### DIFF
--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -464,6 +464,12 @@ class JobManager:
             # first auxiliary data.
             self._jobs_with_primary_data.remove(job.job_id)
 
+    def shutdown(self) -> None:
+        """Shut down the thread pool executor, if one was created."""
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None
+
     def _map(self, fn: Callable, items: list) -> list:
         if self._executor is not None:
             return list(self._executor.map(fn, items))

--- a/src/ess/livedata/core/orchestrating_processor.py
+++ b/src/ess/livedata/core/orchestrating_processor.py
@@ -269,6 +269,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         logger.info('service_shutting_down')
         self._service_state = ServiceState.stopping
         self._send_final_heartbeat()
+        self._job_manager.shutdown()
 
     def report_stopped(self) -> None:
         """Transition to stopped state and send final heartbeat.

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -1923,3 +1923,16 @@ class TestJobManagerThreading:
 
         status = manager.get_job_status(job_ids[1])
         assert status.state == JobState.warning
+
+    def test_shutdown_terminates_executor(self):
+        """Calling shutdown cleans up the thread pool executor."""
+        manager, _, _ = self._setup_threaded_manager(n_jobs=1, job_threads=2)
+        assert manager._executor is not None
+        manager.shutdown()
+        assert manager._executor is None
+
+    def test_shutdown_without_executor_is_noop(self):
+        """Shutdown is safe when no executor was created (job_threads=1)."""
+        manager, _, _ = self._setup_threaded_manager(n_jobs=1, job_threads=1)
+        assert manager._executor is None
+        manager.shutdown()  # Should not raise


### PR DESCRIPTION
## Summary

- `JobManager` creates a `ThreadPoolExecutor` when `job_threads > 1` but never shuts it down. While Python's `atexit` handler provides a safety net, explicit shutdown makes the lifecycle clear and avoids blocking process exit if a job happens to be stuck.
- Adds `JobManager.shutdown()` and calls it from `OrchestratingProcessor.shutdown()`.

## Test plan

- [x] New unit tests for shutdown with and without an executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)