### PR TITLE
Document context_keys statefulness and aux_sources gap in WorkflowFactory

### DIFF
--- a/src/ess/livedata/handlers/stream_processor_workflow.py
+++ b/src/ess/livedata/handlers/stream_processor_workflow.py
@@ -41,8 +41,18 @@ class StreamProcessorWorkflow(Workflow):
             The sciline Pipeline to wrap.
         dynamic_keys:
             Mapping from stream names to sciline keys for dynamic inputs.
+            Dynamic inputs are accumulated across calls via
+            ``StreamProcessor.accumulate()``.
         context_keys:
             Mapping from stream names to sciline keys for context inputs.
+            Context inputs update pipeline parameters via
+            ``StreamProcessor.set_context()``. Unlike dynamic inputs, context
+            values are **stateful**: a value set in one ``accumulate()`` call
+            persists into all subsequent calls until explicitly overwritten.
+            If data for a context key is absent from a given batch, the key
+            retains its previous value. If ``set_context`` was never called
+            for a key and the underlying sciline pipeline has no default for
+            it, ``finalize()`` will raise an ``UnsatisfiedGraphError``.
         target_keys:
             Mapping from output names to sciline keys for target outputs.
         window_outputs:
@@ -73,6 +83,14 @@ class StreamProcessorWorkflow(Workflow):
             self._current_start_time = start_time
         self._current_end_time = end_time
 
+        # Context data (e.g., positions from f144 streams) is injected via
+        # set_context, which updates the sciline pipeline parameters. Only keys
+        # present in this batch are updated; absent keys retain the value from
+        # the most recent set_context call, or the pipeline's init-time value.
+        # If a key has no init-time value and has never been set, finalize()
+        # will fail. See aux_sources / render() in workflow_spec.py for how
+        # the routing layer ensures only jobs that subscribed to a stream
+        # receive its data.
         context = {
             sciline_key: data[key]
             for key, sciline_key in self._context_keys.items()

--- a/src/ess/livedata/handlers/workflow_factory.py
+++ b/src/ess/livedata/handlers/workflow_factory.py
@@ -157,7 +157,13 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         else:
             workflow_params = model_cls.model_validate(config.params)
 
-        # Validate aux_sources configuration (but don't pass to workflow)
+        # Validate aux_sources configuration but do not pass rendered names to
+        # the factory. This is a known gap: factories that need to configure
+        # sciline pipeline keys from aux source names (e.g.,
+        # wf[NeXusMonitorName[Incident]] = aux_source_names['incident_monitor'])
+        # currently work around this by relying on hardcoded defaults in the
+        # underlying science workflow. The fix — passing rendered aux_source_names
+        # into the factory via signature introspection — is tracked in #694.
         if (aux_model_cls := workflow_spec.aux_sources) is None:
             if config.aux_source_names:
                 raise ValueError(


### PR DESCRIPTION
## Summary

- `StreamProcessorWorkflow`: document that `context_keys` values are stateful (`set_context` persists across `accumulate` calls), that absent keys retain their previous or init-time value, and that a key with no pipeline default that was never explicitly set will cause `finalize()` to raise `UnsatisfiedGraphError`.
- `WorkflowFactory.create`: explain *why* rendered `aux_source_names` are validated but not forwarded to the factory function, with a concrete example of what this means for instrument factories. Points to #694 for the fix.

## Motivation

These non-obvious behaviors caused confusion when planning how to route f144 position streams into monitor and detector view workflows (#782). The comments make the constraints and failure modes visible to the next developer working in this area without requiring a multi-file archaeology expedition.