### PR TITLE
[Bifrost] Change proton-charge unit from Ah to C to avoid scale factors in result units

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost/factories.py
+++ b/src/ess/livedata/config/instruments/bifrost/factories.py
@@ -154,8 +154,9 @@ def setup_factories(instrument: Instrument) -> None:
         workflow[Filename[SampleRun]] = fname
         workflow[TimeOfFlightLookupTableFilename] = tof_lookup_table_simulation()
         workflow[PreopenNeXusFile] = PreopenNeXusFile(True)
-        # ProtonCharge is not used in streaming normalization, set to 1
-        workflow[ProtonCharge[SampleRun]] = sc.scalar(1.0, unit='microampere*hour')
+        # ProtonCharge is not used in streaming normalization, set to 1. Revisit once
+        # there is a established stream for this.
+        workflow[ProtonCharge[SampleRun]] = sc.scalar(1.0, unit='pC')
         workflow[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.drop
         return workflow
 


### PR DESCRIPTION
Now using same unit as https://github.com/scipp/essspectroscopy/blob/8676040cb9c693f8a5d7d84330fe5c0b87119db4/src/ess/bifrost/workflow.py#L57.