### PR TITLE
Do not add start_time/end_time to data with time coordinate

### DIFF
--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -131,10 +131,17 @@ def _add_time_coords(
     These coordinates provide temporal provenance for each output, enabling lag
     calculation in the dashboard (lag = current_time - end_time).
 
-    DataArrays that already have start_time or end_time coordinates are skipped.
-    This allows workflows to set their own time coords for outputs that represent
-    different time ranges (e.g., "current" outputs that only cover the period
-    since the last finalize, not the entire job duration).
+    DataArrays are skipped in two cases:
+
+    - Already have start_time or end_time coordinates. This allows workflows to
+      set their own time coords for outputs that represent different time ranges
+      (e.g., "current" outputs that only cover the period since the last finalize,
+      not the entire job duration).
+    - Have a 'time' coordinate. A 'time' coordinate means the data carries its
+      own timestamps (e.g., timeseries log data), making start_time/end_time
+      redundant. Adding scalar start_time/end_time to such data would also cause
+      a dimension mismatch in TemporalBuffer, which accumulates data along the
+      'time' dimension.
     """
     if start_time is None or end_time is None:
         return data
@@ -145,6 +152,11 @@ def _add_time_coords(
         # Skip if workflow already set time coords - we have no idea what they
         # mean, and adding our own would create an inconsistent pair.
         if 'start_time' in val.coords or 'end_time' in val.coords:
+            return val
+        # Skip if data carries a 'time' coordinate. A 'time' coordinate means
+        # the data has its own timestamps (e.g., timeseries log data), making
+        # start_time/end_time redundant.
+        if 'time' in val.coords:
             return val
         return val.assign_coords(start_time=start_coord, end_time=end_coord)
 

--- a/src/ess/livedata/handlers/timeseries_workflow_specs.py
+++ b/src/ess/livedata/handlers/timeseries_workflow_specs.py
@@ -13,7 +13,15 @@ from ..handlers.workflow_factory import SpecHandle
 
 
 class TimeseriesOutputs(WorkflowOutputsBase):
-    """Outputs for the timeseries workflow."""
+    """Outputs for the timeseries workflow.
+
+    The template defines a 0-D DataArray with a scalar ``time`` coordinate.
+    Conceptually, each timeseries value is a timestamped scalar. In practice,
+    ``TimeseriesStreamProcessor.finalize()`` returns batches (1-D along ``time``)
+    for efficiency, but the ``time`` coordinate remains the defining property:
+    it signals that the data carries its own wall-clock timestamps, so
+    ``_add_time_coords`` will not attach ``start_time``/``end_time``.
+    """
 
     delta: sc.DataArray = pydantic.Field(
         default_factory=lambda: sc.DataArray(

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -404,6 +404,79 @@ class TestJob:
         assert cumulative.coords["start_time"].value == 1000
         assert cumulative.coords["end_time"].value == 2000
 
+    def test_get_does_not_add_time_coords_to_data_with_time_coordinate(
+        self, fake_processor, sample_workflow_id
+    ):
+        """Data with a 'time' coordinate already carries its own timestamps.
+
+        Adding start_time/end_time would be redundant and causes structural
+        issues in TemporalBuffer (scalar coord vs multi-element time dim).
+        """
+        job_id = JobId(source_name="test_source", job_number=1)
+        job = Job(
+            job_id=job_id,
+            workflow_id=sample_workflow_id,
+            processor=fake_processor,
+            source_names=["test_source"],
+        )
+
+        # Timeseries-like output: data indexed by wall-clock timestamps
+        fake_processor.data = {
+            "delta": sc.DataArray(
+                data=sc.array(dims=["time"], values=[1.0, 2.0, 3.0]),
+                coords={
+                    "time": sc.array(dims=["time"], values=[100, 200, 300], unit="ns")
+                },
+            ),
+        }
+
+        data = JobData(
+            start_time=1000,
+            end_time=2000,
+            primary_data={"test_source": sc.scalar(42.0)},
+            aux_data={},
+        )
+        job.add(data)
+
+        result = job.get()
+        output = result.data["delta"]
+
+        assert "start_time" not in output.coords
+        assert "end_time" not in output.coords
+
+    def test_get_does_not_add_time_coords_to_data_with_scalar_time_coordinate(
+        self, fake_processor, sample_workflow_id
+    ):
+        """Even a scalar 'time' coordinate signals timestamped data."""
+        job_id = JobId(source_name="test_source", job_number=1)
+        job = Job(
+            job_id=job_id,
+            workflow_id=sample_workflow_id,
+            processor=fake_processor,
+            source_names=["test_source"],
+        )
+
+        fake_processor.data = {
+            "delta": sc.DataArray(
+                data=sc.scalar(1.0),
+                coords={"time": sc.scalar(100, unit="ns")},
+            ),
+        }
+
+        data = JobData(
+            start_time=1000,
+            end_time=2000,
+            primary_data={"test_source": sc.scalar(42.0)},
+            aux_data={},
+        )
+        job.add(data)
+
+        result = job.get()
+        output = result.data["delta"]
+
+        assert "start_time" not in output.coords
+        assert "end_time" not in output.coords
+
     def test_get_does_not_add_time_coords_when_no_data_added(
         self, fake_processor, sample_workflow_id
     ):


### PR DESCRIPTION
## Summary

This fixes issues with outputs of the `timeseries` service in production, where we get errors such as
```
Error: scipp._scipp.core.DimensionError: Cannot add coord 'start_time' of dims (time: 6) to DataArray with 
 dims (time: 5238)`.
```
when plotting a timeseries as `Bars`. It may also explain why plotting it as `timeseries` does not show any but the initial point.

- `_add_time_coords` now skips DataArrays that have a `time` coordinate, since these carry their own timestamps (e.g., timeseries log data), making `start_time`/`end_time` redundant
- Fixes a `DimensionError` in the timeseries service when plotting as Bars: `TemporalBuffer` accumulated scalar `start_time` (1 per frame) alongside multi-element data (N per frame) on the same `time` dimension, causing a size mismatch (e.g., `time: 6` vs `time: 5238`)
- Documents the relationship between `time` coordinate and `start_time`/`end_time` skipping on `TimeseriesOutputs`

## Test plan

- [x] New unit tests for `_add_time_coords` skipping (1-D and scalar `time` coord)
- [x] All existing tests pass (1945 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)