### PR TITLE
Fix service heartbeat crash: payload timestamp fields

### DIFF
--- a/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
@@ -830,7 +830,7 @@ class WorkflowStatusWidget:
         if earliest_start is None:
             timing_text = 'Starting...'
         else:
-            start_dt = datetime.fromtimestamp(earliest_start / 1e9, tz=UTC)
+            start_dt = earliest_start.to_datetime(tz=UTC)
             now = datetime.now(tz=UTC)
             duration_secs = int((now - start_dt).total_seconds())
 

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -243,7 +243,7 @@ class X5f2ToStatusAdapter(
 
     def adapt(self, message: KafkaMessage) -> Message[JobStatus | ServiceStatus]:
         return Message(
-            timestamp=Timestamp(message.timestamp()[1]),
+            timestamp=Timestamp.from_ms(message.timestamp()[1]),
             stream=STATUS_STREAM_ID,
             value=x5f2_to_status(message.value()),
         )

--- a/src/ess/livedata/kafka/x5f2_compat.py
+++ b/src/ess/livedata/kafka/x5f2_compat.py
@@ -22,6 +22,7 @@ from ess.livedata.core.job import (
     StreamStat,
     StreamStats,
 )
+from ess.livedata.core.timestamp import Timestamp
 
 
 class ServiceId(pydantic.BaseModel):
@@ -81,11 +82,11 @@ class JobStatusPayload(pydantic.BaseModel):
     error: str | None = pydantic.Field(default=None, description="Error message if any")
     job_id: JobId = pydantic.Field(description="Job identifier")
     workflow_id: str = pydantic.Field(description="Workflow identifier as string")
-    start_time: int | None = pydantic.Field(
-        default=None, description="Job start time in nanoseconds since epoch"
+    start_time: Timestamp | None = pydantic.Field(
+        default=None, description="Job start time"
     )
-    end_time: int | None = pydantic.Field(
-        default=None, description="Job end time in nanoseconds since epoch"
+    end_time: Timestamp | None = pydantic.Field(
+        default=None, description="Job end time"
     )
 
 
@@ -205,7 +206,7 @@ class ServiceStatusPayload(pydantic.BaseModel):
     namespace: str = pydantic.Field(description="Service namespace")
     worker_id: str = pydantic.Field(description="Worker UUID as string")
     state: ServiceState = pydantic.Field(description="Current state of the service")
-    started_at: int = pydantic.Field(description="Service start time in nanoseconds")
+    started_at: Timestamp = pydantic.Field(description="Service start time")
     active_job_count: int = pydantic.Field(description="Number of active jobs")
     error: str | None = pydantic.Field(default=None, description="Error message if any")
     batch_interval_s: float = pydantic.Field(

--- a/tests/dashboard/widgets/workflow_status_widget_test.py
+++ b/tests/dashboard/widgets/workflow_status_widget_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from ess.livedata.config.workflow_spec import JobId, WorkflowId
 from ess.livedata.core.job import JobState, JobStatus
+from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.dashboard.job_service import JobService
 from ess.livedata.dashboard.widgets.icons import get_icon
 from ess.livedata.dashboard.widgets.workflow_status_widget import (
@@ -417,7 +418,7 @@ class TestWorkflowStatusWidgetWithJobs:
             job_id=job_id,
             workflow_id=workflow_id,
             state=JobState.active,
-            start_time=1000000000000,
+            start_time=Timestamp.from_ns(1000000000000),
         )
         job_service.status_updated(job_status)
 
@@ -449,7 +450,7 @@ class TestWorkflowStatusWidgetWithJobs:
             workflow_id=workflow_id,
             state=JobState.error,
             error_message='Something went wrong',
-            start_time=1000000000000,
+            start_time=Timestamp.from_ns(1000000000000),
         )
         job_service.status_updated(job_status)
 
@@ -523,7 +524,7 @@ class TestWorkflowStatusWidgetWithJobs:
             job_id=job_id,
             workflow_id=workflow_id,
             state=JobState.active,
-            start_time=1000000000000,
+            start_time=Timestamp.from_ns(1000000000000),
         )
         job_service.status_updated(job_status)
 
@@ -585,7 +586,7 @@ class TestWorkflowStatusWidgetWithJobs:
             job_id=job_id,
             workflow_id=workflow_id,
             state=JobState.active,
-            start_time=1000000000000,
+            start_time=Timestamp.from_ns(1000000000000),
         )
         job_service.status_updated(job_status)
 
@@ -671,7 +672,7 @@ class TestPerSourceStatus:
                     job_id=JobId(source_name=name, job_number=job_number),
                     workflow_id=workflow_id,
                     state=JobState.active,
-                    start_time=1000000000000,
+                    start_time=Timestamp.from_ns(1000000000000),
                 )
             )
 
@@ -711,7 +712,7 @@ class TestPerSourceStatus:
                 job_id=JobId(source_name='source2', job_number=job_number),
                 workflow_id=workflow_id,
                 state=JobState.active,
-                start_time=1000000000000,
+                start_time=Timestamp.from_ns(1000000000000),
             )
         )
         job_service.status_updated(
@@ -720,7 +721,7 @@ class TestPerSourceStatus:
                 workflow_id=workflow_id,
                 state=JobState.error,
                 error_message='ZeroDivisionError',
-                start_time=1000000000000,
+                start_time=Timestamp.from_ns(1000000000000),
             )
         )
 
@@ -756,7 +757,7 @@ class TestPerSourceStatus:
                 error_message=(
                     'Traceback:\n  File "x.py"\nZeroDivisionError: division by zero'
                 ),
-                start_time=1000000000000,
+                start_time=Timestamp.from_ns(1000000000000),
             )
         )
 
@@ -893,7 +894,7 @@ class TestPerSourceStatus:
                     job_id=JobId(source_name=name, job_number=job_number),
                     workflow_id=workflow_id,
                     state=JobState.active,
-                    start_time=1000000000000,
+                    start_time=Timestamp.from_ns(1000000000000),
                 )
             )
 
@@ -1027,7 +1028,7 @@ class TestWorkflowStatusListWidget:
                 workflow_id=workflow_id,
                 job_id=job_id,
                 state=JobState.active,
-                start_time=1000000000000,
+                start_time=Timestamp.from_ns(1000000000000),
             )
         )
 

--- a/tests/kafka/status_message_test.py
+++ b/tests/kafka/status_message_test.py
@@ -16,6 +16,7 @@ from ess.livedata.core.job import (
     StreamStat,
     StreamStats,
 )
+from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.kafka.x5f2_compat import (
     JobStatusJSON,
     JobStatusMessage,
@@ -62,7 +63,7 @@ def make_service_status(**overrides) -> ServiceStatus:
         "namespace": "data_reduction",
         "worker_id": str(uuid.uuid4()),
         "state": ServiceState.running,
-        "started_at": 1000000000,
+        "started_at": Timestamp.from_ns(1000000000),
         "active_job_count": 3,
         "error": None,
     }
@@ -176,15 +177,15 @@ class TestJobStatusPayload:
             error="Test error",
             job_id=job_id,
             workflow_id="instrument/namespace/workflow/1",
-            start_time=1000000000,
-            end_time=2000000000,
+            start_time=Timestamp.from_ns(1000000000),
+            end_time=Timestamp.from_ns(2000000000),
         )
 
         assert message.state == JobState.warning
         assert message.warning == "Test warning"
         assert message.error == "Test error"
-        assert message.start_time == 1000000000
-        assert message.end_time == 2000000000
+        assert message.start_time == Timestamp.from_ns(1000000000)
+        assert message.end_time == Timestamp.from_ns(2000000000)
 
 
 class TestJobStatusMessage:
@@ -229,11 +230,16 @@ class TestJobStatusMessage:
 
     def test_from_job_status_with_times(self):
         """Test converting JobStatus with start/end times to JobStatusMessage."""
-        job_status = make_job_status(start_time=1000000000, end_time=2000000000)
+        job_status = make_job_status(
+            start_time=Timestamp.from_ns(1000000000),
+            end_time=Timestamp.from_ns(2000000000),
+        )
         status_msg = JobStatusMessage.from_job_status(job_status)
 
-        assert status_msg.status_json.message.start_time == 1000000000
-        assert status_msg.status_json.message.end_time == 2000000000
+        assert status_msg.status_json.message.start_time == Timestamp.from_ns(
+            1000000000
+        )
+        assert status_msg.status_json.message.end_time == Timestamp.from_ns(2000000000)
 
     def test_to_job_status_minimal(self):
         """Test converting minimal JobStatusMessage to JobStatus."""
@@ -279,8 +285,8 @@ class TestJobStatusMessage:
                     error="Test error",
                     job_id=job_id,
                     workflow_id=str(workflow_id),
-                    start_time=1000000000,
-                    end_time=2000000000,
+                    start_time=Timestamp.from_ns(1000000000),
+                    end_time=Timestamp.from_ns(2000000000),
                 ),
             ),
         )
@@ -292,8 +298,8 @@ class TestJobStatusMessage:
         assert job_status.state == JobState.warning
         assert job_status.error_message == "Test error"
         assert job_status.warning_message == "Test warning"
-        assert job_status.start_time == 1000000000
-        assert job_status.end_time == 2000000000
+        assert job_status.start_time == Timestamp.from_ns(1000000000)
+        assert job_status.end_time == Timestamp.from_ns(2000000000)
 
     def test_service_id_validation_from_string(self):
         """Test that service_id field accepts string input and converts to ServiceId."""
@@ -407,7 +413,10 @@ class TestRoundTripConversion:
 
     def test_round_trip_with_timestamps(self):
         """Test round-trip conversion with start and end times."""
-        original = make_job_status(start_time=1000000000, end_time=2000000000)
+        original = make_job_status(
+            start_time=Timestamp.from_ns(1000000000),
+            end_time=Timestamp.from_ns(2000000000),
+        )
 
         status_msg = JobStatusMessage.from_job_status(original)
         converted = status_msg.to_job_status()
@@ -488,8 +497,12 @@ class TestX5F2Integration:
     def test_x5f2_round_trip_with_timestamps(self):
         """Test x5f2 round-trip with timestamps."""
         original = make_job_status(
-            start_time=1640995200000000000,  # 2022-01-01 00:00:00 UTC in nanoseconds
-            end_time=1640995800000000000,  # 2022-01-01 00:10:00 UTC in nanoseconds
+            start_time=Timestamp.from_ns(
+                1640995200000000000
+            ),  # 2022-01-01 00:00:00 UTC in nanoseconds
+            end_time=Timestamp.from_ns(
+                1640995800000000000
+            ),  # 2022-01-01 00:10:00 UTC in nanoseconds
         )
 
         x5f2_data = job_status_to_x5f2(original)
@@ -541,7 +554,9 @@ class TestX5F2Integration:
     def test_x5f2_data_compatibility(self):
         """Test that x5f2 data is compatible with direct streaming_data_types usage."""
         job_status = make_job_status(
-            state=JobState.active, start_time=1000000000, end_time=2000000000
+            state=JobState.active,
+            start_time=Timestamp.from_ns(1000000000),
+            end_time=Timestamp.from_ns(2000000000),
         )
 
         # Serialize using our function
@@ -662,7 +677,7 @@ class TestServiceServiceId:
             namespace="data_reduction",
             worker_id=worker_id,
             state=ServiceState.running,
-            started_at=1000000000,
+            started_at=Timestamp.from_ns(1000000000),
             active_job_count=3,
         )
         service_id = ServiceServiceId.from_service_status(status)
@@ -710,7 +725,7 @@ class TestServiceStatusPayload:
             namespace="data_reduction",
             worker_id=worker_id,
             state=ServiceState.running,
-            started_at=1000000000,
+            started_at=Timestamp.from_ns(1000000000),
             active_job_count=5,
             error=None,
         )
@@ -729,7 +744,7 @@ class TestServiceStatusPayload:
             namespace="data_reduction",
             worker_id=str(uuid.uuid4()),
             state=ServiceState.error,
-            started_at=1000000000,
+            started_at=Timestamp.from_ns(1000000000),
             active_job_count=0,
             error="Connection lost to Kafka",
         )
@@ -791,6 +806,38 @@ class TestServiceStatusX5F2Integration:
 
         assert isinstance(x5f2_data, bytes)
         assert len(x5f2_data) > 0
+
+    def test_service_status_to_x5f2_accepts_timestamp_now(self):
+        """Regression: OrchestratingProcessor builds ServiceStatus with
+        ``Timestamp.now()``. Serialization must accept the real domain type,
+        not only ints. See log at 2026-04-07 where the main loop died on the
+        first heartbeat after PR #829 introduced Timestamp."""
+        status = ServiceStatus(
+            instrument="dream",
+            namespace="data_reduction",
+            worker_id=str(uuid.uuid4()),
+            state=ServiceState.running,
+            started_at=Timestamp.now(),
+            active_job_count=0,
+        )
+        # Must not raise.
+        data = service_status_to_x5f2(status)
+        restored = x5f2_to_service_status(data)
+        assert restored.started_at == status.started_at
+        assert isinstance(restored.started_at, Timestamp)
+
+    def test_job_status_to_x5f2_accepts_timestamp_now(self):
+        """Regression sibling for JobStatusPayload start_time/end_time."""
+        status = make_job_status(
+            start_time=Timestamp.now(),
+            end_time=Timestamp.now(),
+        )
+        data = job_status_to_x5f2(status)
+        restored = x5f2_to_job_status(data)
+        assert isinstance(restored.start_time, Timestamp)
+        assert isinstance(restored.end_time, Timestamp)
+        assert restored.start_time == status.start_time
+        assert restored.end_time == status.end_time
 
     def test_service_status_x5f2_round_trip(self):
         """Test round-trip conversion through x5f2."""
@@ -962,7 +1009,7 @@ class TestX5f2ToStatusDiscriminator:
             namespace="data_reduction",
             worker_id=worker_id,
             state=ServiceState.running,
-            started_at=1000000000,
+            started_at=Timestamp.from_ns(1000000000),
             active_job_count=3,
         )
 


### PR DESCRIPTION
## Summary

After #829 introduced the `Timestamp` wrapper, `ServiceStatus.started_at` and `JobStatus.start_time`/`end_time` became `Timestamp` values, but the pydantic `ServiceStatusPayload` / `JobStatusPayload` still typed these fields as `int`. The first heartbeat from `OrchestratingProcessor._report_status` died with a pydantic `ValidationError`, taking the entire service loop down on `main` (observed on all backend services at startup).

Fix: retype the payload fields as `Timestamp` / `Timestamp | None`. `Timestamp` already provides a pydantic core schema, so serialization/round-trip is automatic.

## Why CI didn't catch it

Two independent gaps:

1. **Test factories used raw ints.** `make_service_status` / `make_job_status` in `status_message_test.py` constructed domain objects with `started_at=1000000000` etc., bypassing the real types that production code feeds in. Updated these (and the matching assertions) to use `Timestamp`, so the serializer is now always exercised against the same types `OrchestratingProcessor` uses. Added two focused regression tests that explicitly use `Timestamp.now()`, mirroring the call site that crashed.

2. **No KafkaSink coverage at all.** The crash happened in `KafkaSink.publish_messages` → `service_status_to_x5f2`. `FakeMessageSink` skips x5f2 serialization entirely, so every integration test that runs `OrchestratingProcessor.process()` silently avoids the failing code path. `grep -r KafkaSink tests/` returns nothing. This is a structural gap worth closing in a follow-up — e.g. a minimal `KafkaSink` test with a fake `confluent_kafka.Producer`, or a test-mode sink wrapper that runs x5f2 serialization so existing `LivedataApp`-based tests would exercise it transitively.

## Test plan

- [x] `pytest tests/kafka/ tests/core/` — 454 passing
- [x] New regression tests fail on `main` without the payload retyping and pass with it
- [x] Manual smoke: start a backend service locally and confirm heartbeats emit without crashing