### PR TITLE
Fix Kafka broker timestamps treated as ns instead of ms

### DIFF
--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -146,7 +146,7 @@ class KafkaToEv44Adapter(KafkaAdapter[eventdata_ev44.EventData]):
         if ev44.reference_time.size > 0:
             timestamp = Timestamp.from_ns(ev44.reference_time[-1])
         else:
-            timestamp = Timestamp.from_ns(message.timestamp()[1])
+            timestamp = Timestamp.from_ms(message.timestamp()[1])
         return Message(timestamp=timestamp, stream=stream, value=ev44)
 
 
@@ -259,7 +259,7 @@ class RunControlAdapter(MessageAdapter[KafkaMessage, Message[RunStart | RunStop]
     def adapt(self, message: KafkaMessage) -> Message[RunStart | RunStop]:
         buf = message.value()
         schema = streaming_data_types.utils.get_schema(buf)
-        timestamp = Timestamp.from_ns(message.timestamp()[1])
+        timestamp = Timestamp.from_ms(message.timestamp()[1])
         if schema == 'pl72':
             info = run_start_pl72.deserialise_pl72(buf)
             stop_time = (
@@ -319,7 +319,7 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents]):
         if reference_time.size > 0:
             timestamp = Timestamp.from_ns(reference_time[-1])
         else:
-            timestamp = Timestamp.from_ns(message.timestamp()[1])
+            timestamp = Timestamp.from_ms(message.timestamp()[1])
         return Message(
             timestamp=timestamp,
             stream=stream,
@@ -399,7 +399,7 @@ class CommandsAdapter(MessageAdapter[KafkaMessage, Message[RawConfigItem]]):
     """Adapts Kafka messages from the livedata commands topic."""
 
     def adapt(self, message: KafkaMessage) -> Message[RawConfigItem]:
-        timestamp = Timestamp.from_ns(message.timestamp()[1])
+        timestamp = Timestamp.from_ms(message.timestamp()[1])
         # Livedata configuration uses a compacted Kafka topic. The Kafka message key
         # is the encoded string representation of a :py:class:`ConfigKey` object.
         item = RawConfigItem(key=message.key(), value=message.value())
@@ -410,7 +410,7 @@ class ResponsesAdapter(MessageAdapter[KafkaMessage, Message[CommandAcknowledgeme
     """Adapts Kafka messages from the livedata responses topic."""
 
     def adapt(self, message: KafkaMessage) -> Message[CommandAcknowledgement]:
-        timestamp = Timestamp.from_ns(message.timestamp()[1])
+        timestamp = Timestamp.from_ms(message.timestamp()[1])
         ack = CommandAcknowledgement.model_validate_json(message.value())
         return Message(stream=RESPONSES_STREAM_ID, timestamp=timestamp, value=ack)
 

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -141,8 +141,10 @@ class TestKafkaToMonitorEventsAdapter:
             pixel_id=np.array([1]),
         )
 
+        # Realistic broker timestamp: ms since epoch, ~2023-11-14.
+        broker_ts_ms = 1_700_000_000_000
         message = FakeKafkaMessage(
-            value=empty_ref_time_ev44, topic="monitors", timestamp=9999
+            value=empty_ref_time_ev44, topic="monitors", timestamp=broker_ts_ms
         )
 
         adapter = KafkaToMonitorEventsAdapter(
@@ -152,8 +154,10 @@ class TestKafkaToMonitorEventsAdapter:
         )
         result = adapter.adapt(message)
 
-        # Kafka broker timestamps are ms since epoch, not ns.
-        assert result.timestamp == Timestamp.from_ms(9999)
+        assert result.timestamp == Timestamp.from_ms(broker_ts_ms)
+        # Guard against reintroducing a ns-vs-ms unit error: the converted value
+        # must land in a realistic epoch-ns range, not ~year 56 or ~1970.
+        assert result.timestamp.to_ns() == broker_ts_ms * 1_000_000
 
     def test_wrong_schema_raises_exception(self, monkeypatch) -> None:
         """Test that providing wrong schema raises exception."""
@@ -546,15 +550,19 @@ class TestKafkaToEv44Adapter:
             pixel_id=np.array([1]),
         )
 
+        # Realistic broker timestamp: ms since epoch, ~2023-11-14.
+        broker_ts_ms = 1_700_000_000_000
         message = FakeKafkaMessage(
-            value=empty_ref_time_ev44, topic="monitors", timestamp=9999
+            value=empty_ref_time_ev44, topic="monitors", timestamp=broker_ts_ms
         )
 
         adapter = KafkaToEv44Adapter(stream_kind=StreamKind.MONITOR_EVENTS)
         result = adapter.adapt(message)
 
-        # Kafka broker timestamps are ms since epoch, not ns.
-        assert result.timestamp == Timestamp.from_ms(9999)
+        assert result.timestamp == Timestamp.from_ms(broker_ts_ms)
+        # Guard against reintroducing a ns-vs-ms unit error: the converted value
+        # must land in a realistic epoch-ns range, not ~year 56 or ~1970.
+        assert result.timestamp.to_ns() == broker_ts_ms * 1_000_000
 
 
 class TestAdaptingMessageSource:

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -152,7 +152,7 @@ class TestKafkaToMonitorEventsAdapter:
         )
         result = adapter.adapt(message)
 
-        # Kafka broker timestamps are ms since epoch, not ns (issue #848).
+        # Kafka broker timestamps are ms since epoch, not ns.
         assert result.timestamp == Timestamp.from_ms(9999)
 
     def test_wrong_schema_raises_exception(self, monkeypatch) -> None:
@@ -553,7 +553,7 @@ class TestKafkaToEv44Adapter:
         adapter = KafkaToEv44Adapter(stream_kind=StreamKind.MONITOR_EVENTS)
         result = adapter.adapt(message)
 
-        # Kafka broker timestamps are ms since epoch, not ns (issue #848).
+        # Kafka broker timestamps are ms since epoch, not ns.
         assert result.timestamp == Timestamp.from_ms(9999)
 
 

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -152,7 +152,8 @@ class TestKafkaToMonitorEventsAdapter:
         )
         result = adapter.adapt(message)
 
-        assert result.timestamp == Timestamp.from_ns(9999)
+        # Kafka broker timestamps are ms since epoch, not ns (issue #848).
+        assert result.timestamp == Timestamp.from_ms(9999)
 
     def test_wrong_schema_raises_exception(self, monkeypatch) -> None:
         """Test that providing wrong schema raises exception."""
@@ -552,7 +553,8 @@ class TestKafkaToEv44Adapter:
         adapter = KafkaToEv44Adapter(stream_kind=StreamKind.MONITOR_EVENTS)
         result = adapter.adapt(message)
 
-        assert result.timestamp == Timestamp.from_ns(9999)
+        # Kafka broker timestamps are ms since epoch, not ns (issue #848).
+        assert result.timestamp == Timestamp.from_ms(9999)
 
 
 class TestAdaptingMessageSource:


### PR DESCRIPTION
## Summary

`confluent_kafka.Message.timestamp()` returns milliseconds since epoch, but five adapters in `message_adapter.py` wrapped the value with `Timestamp.from_ns`, producing a silent 1e6× unit error. Switches all five sites to `Timestamp.from_ms`.

## Impact

Only two of the five sites actually had observable effect:

- **`KafkaToEv44Adapter` and `KafkaToMonitorEventsAdapter` fallback paths** (when `ev44.reference_time` is empty) — the envelope timestamp flows into downstream batching/ordering, so the bug bit here. These fallbacks exist mainly for replaying serialized test data, but are the critical case to get right.
- **`RunControlAdapter`, `CommandsAdapter`, `ResponsesAdapter`** — latent. Tracing the consumers shows `Message.timestamp` is never read for these streams:
  - `RunStart`/`RunStop` consumers in `JobManager` only read the payload `start_time`/`stop_time` (already correctly converted from ms).
  - `ConfigProcessor` reads only `message.value` (`RawConfigItem`) and does not propagate the timestamp into the responses it emits.
  - The dashboard `Orchestrator` forwards only `stream_id` + `value` for responses.

  Fixing these anyway to remove the landmine for any future consumer.

## Tests

The existing fallback tests for ev44/monitor adapters already exercised the relevant code path, but baked in the buggy `from_ns` expectation. Updated them to assert `from_ms`, which is what exercises the fix.

Closes #848