### PR TITLE
Fix timeseries jobs not receiving data on late config arrival

### DIFF
--- a/src/ess/livedata/config/instruments/dummy/specs.py
+++ b/src/ess/livedata/config/instruments/dummy/specs.py
@@ -35,7 +35,7 @@ instrument = Instrument(
     name='dummy',
     detector_names=detector_names,
     monitors=['monitor1', 'monitor2'],
-    f144_attribute_registry={'motion1': {'units': 'mm'}},
+    f144_attribute_registry={'motion1': {'units': 'mm'}, 'motion2': {'units': 'deg'}},
 )
 
 # Register instrument

--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -352,15 +352,16 @@ class JobManager:
             if job.reset_on_run_transition:
                 self.reset_job(job.job_id)
 
-    def peek_pending_aux_streams(self, start_time: int) -> set[str]:
-        """Return aux stream names needed by jobs that would activate at start_time.
+    def peek_pending_streams(self, start_time: int) -> set[str]:
+        """Return all stream names needed by jobs that would activate at start_time.
 
-        This is a read-only query with no side effects. It does not activate
-        jobs or mutate any state.
+        Includes both primary and auxiliary stream names. This is a read-only
+        query with no side effects. It does not activate jobs or mutate any state.
         """
         names: set[str] = set()
         for job_id, job in self._scheduled_jobs.items():
             if self._job_schedules[job_id].should_start(start_time):
+                names.update(job.source_names)
                 names.update(job.aux_source_names)
         return names
 

--- a/src/ess/livedata/core/orchestrating_processor.py
+++ b/src/ess/livedata/core/orchestrating_processor.py
@@ -238,7 +238,12 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         # Seed context data for jobs about to activate.
         # peek uses the batch start_time to predict which jobs will activate
         # in the upcoming process_jobs call (which uses the same start_time).
-        needed = self._job_manager.peek_pending_aux_streams(workflow_data.start_time)
+        # This covers both auxiliary streams (e.g., log data for detector
+        # workflows) and primary streams (e.g., log data for the timeseries
+        # service). Without primary stream seeding, a timeseries job that
+        # activates after its data was already consumed will never receive
+        # historical data from the preprocessor's context accumulators.
+        needed = self._job_manager.peek_pending_streams(workflow_data.start_time)
         if needed:
             missing = needed - {s.name for s in workflow_data.data}
             if missing:

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -1947,12 +1947,14 @@ class TestJobManagerThreading:
         manager.shutdown()  # Should not raise
 
 
-class TestPeekPendingAuxStreams:
+class TestPeekPendingStreams:
     def test_returns_empty_when_no_scheduled_jobs(self, fake_job_factory):
         manager = JobManager(fake_job_factory)
-        assert manager.peek_pending_aux_streams(start_time=100) == set()
+        assert manager.peek_pending_streams(start_time=100) == set()
 
-    def test_returns_aux_streams_for_job_ready_to_activate(self, fake_job_factory):
+    def test_returns_aux_and_primary_streams_for_job_ready_to_activate(
+        self, fake_job_factory
+    ):
         manager = JobManager(fake_job_factory)
         config = WorkflowConfig(
             identifier=WorkflowId(
@@ -1966,8 +1968,9 @@ class TestPeekPendingAuxStreams:
         )
         manager.schedule_job("src", config)
 
-        assert manager.peek_pending_aux_streams(start_time=50) == set()
-        assert manager.peek_pending_aux_streams(start_time=100) == {
+        assert manager.peek_pending_streams(start_time=50) == set()
+        assert manager.peek_pending_streams(start_time=100) == {
+            "src",
             "temp_stream",
             "speed_stream",
         }
@@ -1987,9 +1990,9 @@ class TestPeekPendingAuxStreams:
         )
         manager.schedule_job("src", config)
 
-        result1 = manager.peek_pending_aux_streams(start_time=100)
-        result2 = manager.peek_pending_aux_streams(start_time=100)
-        assert result1 == result2 == {"stream_a"}
+        result1 = manager.peek_pending_streams(start_time=100)
+        result2 = manager.peek_pending_streams(start_time=100)
+        assert result1 == result2 == {"src", "stream_a"}
 
     def test_returns_union_of_multiple_jobs(self, fake_job_factory):
         manager = JobManager(fake_job_factory)
@@ -2014,10 +2017,18 @@ class TestPeekPendingAuxStreams:
         manager.schedule_job("src_a", config_a)
         manager.schedule_job("src_b", config_b)
 
-        result = manager.peek_pending_aux_streams(start_time=100)
-        assert result == {"temperature", "chopper_speed", "pressure"}
+        result = manager.peek_pending_streams(start_time=100)
+        assert result == {
+            "src_a",
+            "src_b",
+            "temperature",
+            "chopper_speed",
+            "pressure",
+        }
 
-    def test_returns_empty_for_jobs_without_aux_sources(self, fake_job_factory):
+    def test_returns_primary_streams_for_jobs_without_aux_sources(
+        self, fake_job_factory
+    ):
         manager = JobManager(fake_job_factory)
         config = WorkflowConfig(
             identifier=WorkflowId(
@@ -2029,4 +2040,4 @@ class TestPeekPendingAuxStreams:
         )
         manager.schedule_job("src", config)
 
-        assert manager.peek_pending_aux_streams(start_time=100) == set()
+        assert manager.peek_pending_streams(start_time=100) == {"src"}

--- a/tests/services/timeseries_test.py
+++ b/tests/services/timeseries_test.py
@@ -37,6 +37,7 @@ def make_timeseries_app(instrument: str) -> LivedataApp:
 
 
 first_motion_source_name = {'dummy': 'motion1'}
+second_motion_source_name = {'dummy': 'motion2'}
 
 
 @pytest.mark.parametrize("instrument", ['dummy'])
@@ -126,3 +127,133 @@ def test_duplicate_f144_messages_do_not_trigger_workflow() -> None:
     service.step()
     assert len(sink.messages) == 2
     assert sink.messages[-1].value.values.sum() == 3.0
+
+
+class TestDataBeforeConfig:
+    """Tests for the race condition where f144 data arrives before WorkflowConfig.
+
+    When the timeseries service starts, Kafka may deliver f144 data before the
+    dashboard's WorkflowConfig arrives. The ToNXlog accumulator consumes this data
+    but no jobs exist yet. These tests verify that jobs still receive the data
+    via context seeding once they are created.
+
+    The bug only manifests with multiple streams: if stream A has data before
+    config but no new data after, and stream B has new data after config, only
+    B's job receives data. A's job "hangs" because:
+    - The preprocessor only outputs data for streams with messages in the current
+      batch (A has none)
+    - The duplicate guard in ToNXlog rejects resends (same timestamp)
+    - Context seeding was limited to auxiliary streams, not primary streams
+    """
+
+    @staticmethod
+    def _make_config_key(
+        source_name: str,
+    ) -> ConfigKey:
+        return ConfigKey(
+            source_name=source_name,
+            service_name="timeseries",
+            key="workflow_config",
+        )
+
+    @staticmethod
+    def _setup() -> tuple:
+        instrument = 'dummy'
+        app = make_timeseries_app(instrument)
+        workflow_id, _ = _get_workflow_from_registry(instrument)
+        source_a = first_motion_source_name[instrument]
+        source_b = second_motion_source_name[instrument]
+        workflow_config = workflow_spec.WorkflowConfig(identifier=workflow_id)
+        return app, source_a, source_b, workflow_config
+
+    def test_data_in_accumulator_without_resend(self) -> None:
+        """Data for stream A arrives before config. After config, only stream B
+        gets new data. Stream A's job should receive historical data via context
+        seeding when stream B's data triggers job activation."""
+        app, source_a, source_b, workflow_config = self._setup()
+
+        # Data arrives first for both streams — accumulators store it, no jobs
+        app.publish_log_message(source_name=source_a, time=1, value=42.0)
+        app.publish_log_message(source_name=source_b, time=1, value=10.0)
+        app.service.step()
+        assert len(app.sink.messages) == 0
+
+        # Config arrives for both sources — jobs scheduled
+        app.publish_config_message(
+            key=self._make_config_key(source_a),
+            value=workflow_config.model_dump(),
+        )
+        app.publish_config_message(
+            key=self._make_config_key(source_b),
+            value=workflow_config.model_dump(),
+        )
+        app.service.step()
+
+        # Only stream B gets new data — this triggers activation of ALL
+        # scheduled jobs. Context seeding should provide stream A's historical
+        # data to its job.
+        app.publish_log_message(source_name=source_b, time=2, value=11.0)
+        app.service.step()
+
+        # Both jobs should have produced results
+        result_streams = {msg.stream.name for msg in app.sink.messages}
+        assert source_a in str(result_streams), (
+            f"Job for {source_a} should have received data via context seeding"
+        )
+
+    def test_data_in_accumulator_with_resend(self) -> None:
+        """Data for stream A arrives before config. After config, only a resend
+        (same timestamp) arrives for A plus new data for B. The resend is
+        rejected by ToNXlog's duplicate guard, but A's job should still
+        receive historical data via context seeding."""
+        app, source_a, source_b, workflow_config = self._setup()
+
+        # Data for stream A arrives first
+        app.publish_log_message(source_name=source_a, time=1, value=42.0)
+        app.service.step()
+        assert len(app.sink.messages) == 0
+
+        # Config for both sources
+        app.publish_config_message(
+            key=self._make_config_key(source_a),
+            value=workflow_config.model_dump(),
+        )
+        app.publish_config_message(
+            key=self._make_config_key(source_b),
+            value=workflow_config.model_dump(),
+        )
+        app.service.step()
+
+        # Stream A: resend (same timestamp, rejected by accumulator)
+        # Stream B: new data (triggers job activation)
+        app.publish_log_message(source_name=source_a, time=1, value=42.0)
+        app.publish_log_message(source_name=source_b, time=2, value=11.0)
+        app.service.step()
+
+        # Both jobs should have produced results
+        result_streams = {msg.stream.name for msg in app.sink.messages}
+        assert source_a in str(result_streams), (
+            f"Job for {source_a} should have received data via context seeding "
+            "even though resend was rejected"
+        )
+
+    def test_data_not_in_accumulator_with_resend(self) -> None:
+        """Data was never consumed by accumulator. Resend with old timestamp
+        arrives after job is created — accumulator accepts it normally."""
+        app, source_a, _, workflow_config = self._setup()
+
+        # Config arrives first — job is created, no data yet
+        app.publish_config_message(
+            key=self._make_config_key(source_a),
+            value=workflow_config.model_dump(),
+        )
+        app.service.step()
+        assert len(app.sink.messages) == 0
+
+        # "Resend" arrives — accumulator has never seen it, accepted normally
+        app.publish_log_message(source_name=source_a, time=1, value=42.0)
+        app.service.step()
+        assert len(app.sink.messages) == 1
+        result = app.sink.messages[-1].value
+        assert result.sizes == {'time': 1}
+        assert result.values[0] == 42.0


### PR DESCRIPTION
## Summary

Fixes a bug where most timeseries jobs on Bifrost hang after service restart, with only `slit_position` producing results.

**Two compounding issues** cause the problem:

1. **Data-before-config race condition:** When the timeseries service starts, Kafka may deliver f144 data before the dashboard's `WorkflowConfig` arrives. The `ToNXlog` accumulators consume this data, but since no jobs exist yet, the preprocessed data goes nowhere. Once jobs are created, only streams with ongoing publications (e.g., `slit_position`) receive new messages — stale streams never get their historical data.

2. **Resends rejected by duplicate guard:** Upstream producers resend the same value with the original timestamp every ~10s. Normally this would recover stale streams, but `ToNXlog.add()` rejects messages with duplicate timestamps (`return False`), causing `_preprocess_stream` to return `None` for the stream. The accumulator *has* the data from before the job existed, but refuses to accept the resend.

**The fix:** Extend context seeding to cover primary streams, not just auxiliary streams. Rename `peek_pending_aux_streams` → `peek_pending_streams` to include both primary and auxiliary stream names for about-to-activate jobs. This allows `OrchestratingProcessor` to seed newly activated jobs with accumulated `ToNXlog` data that was consumed before the job existed.

This is safe for non-timeseries services because `get_context` only reads from accumulators with `is_context = True` — the primary stream accumulators for detector/monitor services (`ToNXevent_data`, `Cumulative`, `GroupByPixel`) all have `is_context = False` and are skipped.

## Test plan

- [x] All 2917 existing tests pass
- [x] New tests verified to fail without the fix (only the stream with new data gets results)
- [ ] Deploy to Bifrost and verify all timeseries streams receive initial data after service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
