### PR TITLE
Shorten dev version strings in dashboard UI

### DIFF
--- a/src/ess/livedata/__init__.py
+++ b/src/ess/livedata/__init__.py
@@ -3,6 +3,7 @@
 # ruff: noqa: E402, I
 
 import importlib.metadata
+import re
 
 try:
     __version__ = importlib.metadata.version("esslivedata")
@@ -10,6 +11,25 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
 del importlib
+
+# Pattern for setuptools_scm dev versions:
+#   "26.4.2.dev0+g68b165851.d20260410" → base="26.4.2", hash="68b16585"
+_DEV_VERSION_RE = re.compile(
+    r'^(?P<base>\d+\.\d+\.\d+)\.dev\d+\+g(?P<hash>[0-9a-f]{7,})'
+)
+
+
+def format_version(version: str) -> str:
+    """Format a version string for display, shortening dev versions.
+
+    Release versions pass through unchanged. Dev versions are shortened from
+    e.g. ``26.4.2.dev0+g68b165851.d20260410`` to ``26.4.2-dev (68b16585)``.
+    """
+    m = _DEV_VERSION_RE.match(version)
+    if m is None:
+        return version
+    return f"{m['base']}-dev ({m['hash'][:8]})"
+
 
 from .core import (
     Accumulator,
@@ -41,4 +61,5 @@ __all__ = [
     "StreamId",
     "StreamKind",
     "compact_messages",
+    "format_version",
 ]

--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import panel as pn
 from holoviews import Dimension
 
-from ess.livedata import ServiceBase, __version__
+from ess.livedata import ServiceBase, __version__, format_version
 
 from .config_store import ConfigStoreManager
 from .dashboard_services import DashboardServices
@@ -210,7 +210,7 @@ class DashboardBase(ServiceBase, ABC):
         # causes layout overflow and a vertical scrollbar.
         version_label = pn.pane.HTML(
             f'<div style="font-size: 11px; color: #888; padding: 10px;">'
-            f'v{__version__}</div>',
+            f'v{format_version(__version__)}</div>',
         )
         sidebar_with_heartbeat = pn.Column(
             sidebar_content,

--- a/src/ess/livedata/dashboard/widgets/backend_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/backend_status_widget.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 
 import panel as pn
 
+from ess.livedata import format_version
 from ess.livedata.core.job import ServiceState, ServiceStatus, StreamStats
 from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.dashboard.service_registry import ServiceRegistry
@@ -252,7 +253,7 @@ class WorkerStatusRow:
         self._status_pane.object = f'<div style="{status_style}">{status_text}</div>'
 
         # Version
-        self._version_pane.object = f"<code>{status.version}</code>"
+        self._version_pane.object = f"<code>{format_version(status.version)}</code>"
 
         # Time info: show "Last seen X ago" for non-running workers, uptime otherwise
         show_last_seen = is_stale or status.state in (

--- a/tests/format_version_test.py
+++ b/tests/format_version_test.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+import pytest
+
+from ess.livedata import format_version
+
+
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [
+        ('26.4.2', '26.4.2'),
+        ('1.0.0', '1.0.0'),
+        ('0.0.0', '0.0.0'),
+        ('26.4.2.dev0+g68b165851.d20260410', '26.4.2-dev (68b16585)'),
+        ('1.2.3.dev42+gabcdef012.d20250101', '1.2.3-dev (abcdef01)'),
+    ],
+)
+def test_format_version(raw: str, expected: str) -> None:
+    assert format_version(raw) == expected

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -7,11 +7,28 @@ Note that additional imports need to be added for repositories that
 contain multiple packages.
 """
 
+import pytest
+
 from ess import livedata as pkg
+from ess.livedata import format_version
 
 
 def test_has_version():
     assert hasattr(pkg, '__version__')
+
+
+@pytest.mark.parametrize(
+    ('raw', 'expected'),
+    [
+        ('26.4.2', '26.4.2'),
+        ('1.0.0', '1.0.0'),
+        ('0.0.0', '0.0.0'),
+        ('26.4.2.dev0+g68b165851.d20260410', '26.4.2-dev (68b16585)'),
+        ('1.2.3.dev42+gabcdef012.d20250101', '1.2.3-dev (abcdef01)'),
+    ],
+)
+def test_format_version(raw: str, expected: str) -> None:
+    assert format_version(raw) == expected
 
 
 # This is for CI package tests. They need to run tests with minimal dependencies,

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -7,28 +7,11 @@ Note that additional imports need to be added for repositories that
 contain multiple packages.
 """
 
-import pytest
-
 from ess import livedata as pkg
-from ess.livedata import format_version
 
 
 def test_has_version():
     assert hasattr(pkg, '__version__')
-
-
-@pytest.mark.parametrize(
-    ('raw', 'expected'),
-    [
-        ('26.4.2', '26.4.2'),
-        ('1.0.0', '1.0.0'),
-        ('0.0.0', '0.0.0'),
-        ('26.4.2.dev0+g68b165851.d20260410', '26.4.2-dev (68b16585)'),
-        ('1.2.3.dev42+gabcdef012.d20250101', '1.2.3-dev (abcdef01)'),
-    ],
-)
-def test_format_version(raw: str, expected: str) -> None:
-    assert format_version(raw) == expected
 
 
 # This is for CI package tests. They need to run tests with minimal dependencies,


### PR DESCRIPTION
## Summary

- Dev versions like `v26.4.2.dev0+g68b165851.d20260410` are now displayed as `v26.4.2-dev (68b16585)` in the sidebar and backend worker status table
- Release versions are unchanged

## Motivation

The raw `setuptools_scm` dev version string is long and hard to read. The only useful parts for operators are the base version (to know roughly which release they're near) and the commit hash (to identify the exact code). The distance count and date are noise.

## Test plan

- [x] Unit tests for `format_version` with release and dev version strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)