### PR TITLE
Filter noise from stream stats and fix invisible HTML row

### DIFF
--- a/src/ess/livedata/dashboard/widgets/backend_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/backend_status_widget.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from html import escape
 from typing import ClassVar
 
 import panel as pn
@@ -117,7 +118,7 @@ def _format_stream_stats_details(stats: StreamStats | None) -> str:
             f'<span style="color: {StatusColors.ERROR}">unmapped</span>'
         )
         rows.append(
-            f"<tr><td>{s.topic}</td><td>{s.source_name}</td>"
+            f"<tr><td>{escape(s.topic)}</td><td>{escape(s.source_name)}</td>"
             f"<td>{stream_cell}</td><td style='text-align:right'>"
             f"{_format_messages(s.count)}</td></tr>"
         )

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -95,6 +95,14 @@ class FakeKafkaMessage(KafkaMessage):
         return self._value == other._value and self._topic == other._topic
 
 
+class UnmappedStreamError(KeyError):
+    """Raised when a (topic, source_name) pair has no mapping in the stream LUT.
+
+    Already recorded as unmapped in the stream counter before raising, so
+    callers should not record a second ``<error>`` entry.
+    """
+
+
 class MessageAdapter(Protocol, Generic[T, U]):
     def adapt(self, message: T) -> U: ...
 
@@ -131,7 +139,7 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
             except KeyError:
                 if self._stream_counter is not None:
                     self._stream_counter.record(topic, source_name, None)
-                raise
+                raise UnmappedStreamError(source_name) from None
             stream_id = StreamId(kind=self._stream_kind, name=resolved)
         if self._stream_counter is not None:
             self._stream_counter.record(topic, source_name, resolved)
@@ -511,6 +519,10 @@ class AdaptingMessageSource(MessageSource[U]):
         for msg in raw_messages:
             try:
                 adapted.append(self._adapter.adapt(msg))
+            except UnmappedStreamError:
+                # Already recorded in the stream counter by get_stream_id.
+                if self._raise_on_error:
+                    raise
             except streaming_data_types.exceptions.WrongSchemaException:
                 logger.warning('Message %s has an unknown schema. Skipping.', msg)
                 self._record_error(msg)

--- a/src/ess/livedata/kafka/stream_counter.py
+++ b/src/ess/livedata/kafka/stream_counter.py
@@ -9,6 +9,11 @@ from dataclasses import dataclass
 
 from ess.livedata.core.job import StreamStat, StreamStats
 
+# EPICS PV field suffixes that are noise for reporting.
+# Only .RBV (Read Back Value) carries the actual readback; .VAL (setpoint)
+# and .DMOV (done-moving flag) are redundant in our dashboards.
+_IGNORED_SOURCE_SUFFIXES = ('.DMOV', '.VAL')
+
 
 @dataclass(slots=True)
 class _Entry:
@@ -30,7 +35,13 @@ class StreamCounter:
         )
 
     def record(self, topic: str, source_name: str, stream: str | None) -> None:
-        """Increment count for a (topic, source_name) combination."""
+        """Increment count for a (topic, source_name) combination.
+
+        Sources whose names end with known EPICS noise suffixes (.DMOV, .VAL)
+        are silently dropped to reduce clutter in status displays.
+        """
+        if source_name.endswith(_IGNORED_SOURCE_SUFFIXES):
+            return
         key = (topic, source_name)
         entry = self._counts[key]
         entry.count += 1

--- a/tests/dashboard/widgets/backend_status_widget_test.py
+++ b/tests/dashboard/widgets/backend_status_widget_test.py
@@ -4,10 +4,13 @@
 
 import time
 
-from ess.livedata.core.job import ServiceState, ServiceStatus
+from ess.livedata.core.job import ServiceState, ServiceStatus, StreamStat, StreamStats
 from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.dashboard.service_registry import ServiceRegistry
-from ess.livedata.dashboard.widgets.backend_status_widget import BackendStatusWidget
+from ess.livedata.dashboard.widgets.backend_status_widget import (
+    BackendStatusWidget,
+    _format_stream_stats_details,
+)
 
 
 def _make_status(
@@ -110,3 +113,32 @@ class TestBackendStatusWidgetClearButton:
         widget._on_clear_stopped()
         widget.refresh()
         assert len(widget._worker_rows) == 0
+
+
+class TestFormatStreamStatsDetails:
+    def test_html_escapes_source_name(self) -> None:
+        stats = StreamStats(
+            window_seconds=30.0,
+            streams=(
+                StreamStat(
+                    topic="t",
+                    source_name="<script>alert(1)</script>",
+                    stream=None,
+                    count=1,
+                ),
+            ),
+        )
+        html = _format_stream_stats_details(stats)
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_html_escapes_topic(self) -> None:
+        stats = StreamStats(
+            window_seconds=30.0,
+            streams=(
+                StreamStat(topic="<b>bad</b>", source_name="src", stream="s", count=1),
+            ),
+        )
+        html = _format_stream_stats_details(stats)
+        assert "<b>bad</b>" not in html
+        assert "&lt;b&gt;" in html

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -45,6 +45,7 @@ from ess.livedata.kafka.message_adapter import (
     RouteBySchemaAdapter,
     RouteByTopicAdapter,
 )
+from ess.livedata.kafka.stream_counter import StreamCounter
 
 
 def make_serialized_ev44() -> bytes:
@@ -628,6 +629,37 @@ class TestAdaptingMessageSource:
         exception_logs = [log for log in captured if log['log_level'] == 'error']
         assert len(exception_logs) == 1
         assert "error adapting message" in exception_logs[0]['event'].lower()
+
+    def test_unmapped_stream_does_not_double_count(self) -> None:
+        """UnmappedStreamError is already recorded by get_stream_id, so
+        AdaptingMessageSource must not record a second '<error>' entry."""
+        f144_bytes = logdata_f144.serialise_f144(
+            source_name="PV:Mtr.RBV", value=1.0, timestamp_unix_ns=1000
+        )
+
+        class Source(MessageSource[KafkaMessage]):
+            def get_messages(self):
+                return [FakeKafkaMessage(value=f144_bytes, topic="motion")]
+
+        stream_counter = StreamCounter()
+        adapter = KafkaToF144Adapter(
+            stream_lut={},  # empty LUT → every source is unmapped
+            stream_counter=stream_counter,
+        )
+        adapting_source = AdaptingMessageSource(
+            source=Source(),
+            adapter=ChainedAdapter(first=adapter, second=F144ToLogDataAdapter()),
+            stream_counter=stream_counter,
+        )
+
+        messages = adapting_source.get_messages()
+        assert len(messages) == 0
+
+        stats = stream_counter.drain(window_seconds=30.0)
+        # Only one entry (the real source), no '<error>' duplicate
+        assert len(stats.streams) == 1
+        assert stats.streams[0].source_name == "PV:Mtr.RBV"
+        assert stats.streams[0].stream is None
 
 
 def fake_message_with_value(message: KafkaMessage, value: str) -> Message[str]:

--- a/tests/kafka/stream_counter_test.py
+++ b/tests/kafka/stream_counter_test.py
@@ -72,3 +72,27 @@ class TestStreamCounter:
         counter = StreamCounter()
         stats = counter.drain(window_seconds=42.5)
         assert stats.window_seconds == 42.5
+
+    def test_ignores_epics_dmov_suffix(self) -> None:
+        counter = StreamCounter()
+        counter.record("motion", "INST-Dev:Mtr.DMOV", None)
+        counter.record("motion", "INST-Dev:Mtr.RBV", "stream_1")
+        stats = counter.drain(window_seconds=30.0)
+        assert len(stats.streams) == 1
+        assert stats.streams[0].source_name == "INST-Dev:Mtr.RBV"
+
+    def test_ignores_epics_val_suffix(self) -> None:
+        counter = StreamCounter()
+        counter.record("motion", "INST-Dev:Mtr.VAL", None)
+        counter.record("motion", "INST-Dev:Mtr.RBV", "stream_1")
+        stats = counter.drain(window_seconds=30.0)
+        assert len(stats.streams) == 1
+        assert stats.streams[0].source_name == "INST-Dev:Mtr.RBV"
+
+    def test_ignores_dmov_and_val_on_any_topic(self) -> None:
+        counter = StreamCounter()
+        counter.record("other_topic", "PV.DMOV", None)
+        counter.record("other_topic", "PV.VAL", None)
+        counter.record("other_topic", "PV.RBV", "resolved")
+        stats = counter.drain(window_seconds=30.0)
+        assert len(stats.streams) == 1


### PR DESCRIPTION
## Summary

- Filter out EPICS `.DMOV` and `.VAL` source suffixes in `StreamCounter`, keeping only `.RBV` and other non-noise sources
- Fix the mysterious empty-source row in System Status: `AdaptingMessageSource._record_error()` was recording `'<error>'` as source_name, which the browser rendered as an invisible HTML tag. Introduced `UnmappedStreamError` to avoid this double-counting, and added HTML escaping as defense-in-depth
- Eliminate `logger.exception` spam for unmapped streams — previously every unmapped source logged a full ERROR-level traceback; now `UnmappedStreamError` is caught silently since the stream counter already reports these via heartbeats

## Test plan

- [ ] Verify in the dashboard that `.DMOV`/`.VAL` rows no longer appear in the stream stats table
- [ ] Verify the empty-source row is gone

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)