### PR TITLE
Hide window and rate params from timeseries plotter config

### DIFF
--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -279,7 +279,7 @@ class CorrelationHistogram1dPlotter(CorrelationHistogramPlotter):
                 bins=params.bins.x_bins,
             )
         ]
-        renderer = LinePlotter.from_params(params)
+        renderer = LinePlotter.from_display_params(params)
         super().__init__(
             axes=axes, normalize=params.normalization.per_second, renderer=renderer
         )

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -20,6 +20,7 @@ from .autoscaler import Autoscaler
 from .plot_params import (
     LayoutParams,
     PlotAspect,
+    PlotDisplayParams1d,
     PlotParams1d,
     PlotParams2d,
     PlotParamsBars,
@@ -600,9 +601,10 @@ class LinePlotter(Plotter):
         }
 
     @classmethod
-    def from_params(cls, params: PlotParams1d):
-        """Create LinePlotter from PlotParams1d."""
-        rate = getattr(params, 'rate', None)
+    def from_display_params(
+        cls, params: PlotDisplayParams1d, *, normalize_to_rate: bool = False
+    ):
+        """Create LinePlotter from display parameters."""
         return cls(
             grow_threshold=0.1,
             layout_params=params.layout,
@@ -611,7 +613,14 @@ class LinePlotter(Plotter):
             tick_params=params.ticks,
             mode=params.line.mode,
             errors=params.line.errors,
-            normalize_to_rate=rate.normalize_to_rate if rate is not None else False,
+            normalize_to_rate=normalize_to_rate,
+        )
+
+    @classmethod
+    def from_params(cls, params: PlotParams1d):
+        """Create LinePlotter from PlotParams1d."""
+        return cls.from_display_params(
+            params, normalize_to_rate=params.rate.normalize_to_rate
         )
 
     _BASE_METHOD: ClassVar[dict[str, str]] = {

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -355,7 +355,7 @@ def _register_all_plotters() -> None:
             multiple_datasets=True,
             required_extractor=FullHistoryExtractor,
         ),
-        factory=LinePlotter.from_params,
+        factory=LinePlotter.from_display_params,
     )
 
     plotter_registry.register_plotter(

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -345,6 +345,9 @@ def _register_all_plotters() -> None:
         factory=LinePlotter.from_params,
     )
 
+    # Uses from_display_params (no window/rate config) because FullHistoryExtractor
+    # collapses start_time/end_time to the full buffer range. Rate normalization
+    # would divide every point by the total buffer duration, giving wrong results.
     plotter_registry.register_plotter(
         name='timeseries',
         title='Timeseries',


### PR DESCRIPTION
## Summary

The timeseries plotter uses `FullHistoryExtractor`, which collapses per-frame `start_time`/`end_time` coords into a single pair spanning the entire buffer. Rate normalization would therefore divide every point by the total buffer duration rather than each point's own frame duration, giving wrong results. Hide the "Counts Per Second" toggle from the timeseries config to prevent this.

Windowing is also not applicable — the timeseries plotter always shows the full time history via `FullHistoryExtractor`.

The plotter registry derives the config UI model from the factory's type hint, so switching to `PlotDisplayParams1d` (which lacks `window` and `rate`) removes both fields from the config modal. Existing saved configs with old `window`/`rate` keys load cleanly — Pydantic silently discards unknown fields.

## Test plan

- [x] Open the plot config modal and add a Timeseries plot — confirm the modal has no windowing or rate normalization options
- [x] Check that Lines / Bars plotters still show the windowing and rate options as before
- [x] Load an existing dashboard config that has a timeseries plot — verify it loads without errors and displays correctly

Closes #844