### PR TITLE
Update LOKI geometry and monitor config from latest CODA file

### DIFF
--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -228,8 +228,8 @@ instrument = Instrument(
             description='Downstream, movable (on detector carriage)',
         ),
         'detector_carriage': SourceMetadata(
-            title='Sample-Rear Distance',
-            description='Rear detector carriage position along the beam axis (z).',
+            title='Rear Detector Carriage',
+            description='Rear detector carriage position (5.098 m offset from origin).',
         ),
     },
 )

--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -229,7 +229,8 @@ instrument = Instrument(
         ),
         'detector_carriage': SourceMetadata(
             title='Rear Detector Carriage',
-            description='Rear detector carriage position w.r.t. its zero at z=5.098 m after the sample.',
+            description='Rear detector carriage position w.r.t. its zero at z=5.098 m '
+            'after the sample.',
         ),
     },
 )

--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -229,7 +229,7 @@ instrument = Instrument(
         ),
         'detector_carriage': SourceMetadata(
             title='Rear Detector Carriage',
-            description='Rear detector carriage position (5.098 m offset from origin).',
+            description='Rear detector carriage position w.r.t. its zero at z=5.098 m after the sample.',
         ),
     },
 )

--- a/src/ess/livedata/config/instruments/loki/streams.py
+++ b/src/ess/livedata/config/instruments/loki/streams.py
@@ -24,10 +24,8 @@ detector_fakes = {
 
 
 # Monitor names use 0-based indices matching the NeXus beam monitor groups
-# (beam_monitor_mN). The underlying Kafka source names are currently 0-based
-# (cbm0..4) during the commissioning period; cbm_start=0 is passed below.
-# Once producers rename to cbm1..5, revert cbm_start to 1 and close #806.
-# Ref: ``coda_loki_999999_00020680.hdf``
+# (beam_monitor_mN). Kafka source names are 1-based (cbm1..5).
+# Ref: ``coda_loki_999999_00026352.hdf``
 monitor_names = [
     'beam_monitor_m0',
     'beam_monitor_m1',
@@ -61,7 +59,7 @@ def _make_loki_detectors() -> StreamLUT:
 
 
 _common_prod = make_common_stream_mapping_inputs(
-    instrument='loki', monitor_names=monitor_names, cbm_start=0
+    instrument='loki', monitor_names=monitor_names
 )
 _common_prod['detectors'] = _make_loki_detectors()
 

--- a/src/ess/livedata/handlers/detector_data_handler.py
+++ b/src/ess/livedata/handlers/detector_data_handler.py
@@ -74,6 +74,7 @@ _registry = {
     'geometry-loki-2026-02-11.nxs': 'md5:0b40ba0ec640f1c497ec02b233f42ec6',
     'geometry-loki-2026-02-23.nxs': 'md5:5110801aa7c7d79a32cb73b9fb71f167',
     'geometry-loki-2026-03-11.nxs': 'md5:fc0dafdea9a3f66b3003a5d5b7e66698',
+    'geometry-loki-2026-04-13.nxs': 'md5:5c4a6883cf34cee9836f543f4d70ae5c',
     'geometry-bifrost-2025-01-01.nxs': 'md5:ae3caa99dd56de9495b9321eea4e4fef',
     'geometry-odin-2025-09-25.nxs': 'md5:5615a6203813b4ab84a191f7478ceb3c',
     'geometry-tbl-2025-12-03.nxs': 'md5:040a70659155eb386245755455ee3e62',

--- a/tests/config/monitor_source_names_test.py
+++ b/tests/config/monitor_source_names_test.py
@@ -17,14 +17,10 @@ from ess.livedata.config.instruments import available_instruments
 
 @pytest.mark.parametrize(
     'instrument',
-    [i for i in available_instruments() if i != 'loki'],
+    available_instruments(),
 )
 def test_production_monitors_do_not_use_cbm0(instrument: str) -> None:
-    """All instruments except LOKI use 1-based cbm source names (cbm1, cbm2, ...).
-
-    LOKI is excluded: it temporarily uses 0-based cbm source names (cbm0..4)
-    during the commissioning period. See tracking issue #806.
-    """
+    """All instruments use 1-based cbm source names (cbm1, cbm2, ...)."""
     stream_mapping = streams.get_stream_mapping(instrument=instrument, dev=False)
     cbm_source_names = [
         key.source_name
@@ -38,11 +34,7 @@ def test_production_monitors_do_not_use_cbm0(instrument: str) -> None:
 
 
 def test_loki_monitors_correctly_mapped() -> None:
-    """LOKI monitors use 0-based cbm source names during the commissioning period.
-
-    Producers currently send cbm0..4. Once they rename to cbm1..5, update this
-    test and remove cbm_start=0 from loki/streams.py (see #806).
-    """
+    """LOKI monitors use 1-based cbm source names (cbm1..5)."""
     stream_mapping = streams.get_stream_mapping(instrument='loki', dev=False)
     actual_mapping = {
         key.source_name: value
@@ -50,11 +42,11 @@ def test_loki_monitors_correctly_mapped() -> None:
         if key.source_name.startswith('cbm')
     }
     expected_mapping = {
-        'cbm0': 'beam_monitor_m0',
-        'cbm1': 'beam_monitor_m1',
-        'cbm2': 'beam_monitor_m2',
-        'cbm3': 'beam_monitor_m3',
-        'cbm4': 'beam_monitor_m4',
+        'cbm1': 'beam_monitor_m0',
+        'cbm2': 'beam_monitor_m1',
+        'cbm3': 'beam_monitor_m2',
+        'cbm4': 'beam_monitor_m3',
+        'cbm5': 'beam_monitor_m4',
     }
     assert actual_mapping == expected_mapping
 


### PR DESCRIPTION
## Summary

- Revert LOKI cbm monitor indexing from 0-based back to 1-based — producers have shipped the rename (cbm1..5), confirmed in `coda_loki_999999_00026352.hdf`
- Add new geometry file `geometry-loki-2026-04-13.nxs` with consistent monitor naming (no duplicates)
- Fix detector_carriage label and description to reflect it is a translation from instrument origin, not a sample-read distance

Closes #781
Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)