### PR TITLE
Fix monitor histogram output losing user-configured edge unit

### DIFF
--- a/src/ess/livedata/handlers/monitor_workflow.py
+++ b/src/ess/livedata/handlers/monitor_workflow.py
@@ -57,9 +57,9 @@ def _histogram_monitor(
             {target_dim: event_coord}
         )
         hist = data.hist({event_coord: edges_converted}, dim=data.dims)
-        # Rename dimension and coordinate to target dimension
+        # Rename dimension and coordinate back to target dimension and unit
         hist = hist.rename_dims({event_coord: target_dim})
-        hist.coords[target_dim] = hist.coords.pop(event_coord)
+        hist.coords[target_dim] = hist.coords.pop(event_coord).to(unit=edges.unit)
     else:
         # Histogram-mode: already histogrammed from Cumulative preprocessor
         # Rename dimension if needed

--- a/tests/handlers/monitor_workflow_test.py
+++ b/tests/handlers/monitor_workflow_test.py
@@ -166,6 +166,11 @@ class TestMonitorWorkflowProviders:
         # All 5 events should be histogrammed
         assert result.sum().value == 5.0
 
+    def test_histogram_raw_monitor_preserves_edge_unit(self, sample_events):
+        edges = sc.linspace('time_of_arrival', 0, 10, num=6, unit='us')
+        result = histogram_raw_monitor(sample_events, edges)
+        assert result.coords['time_of_arrival'].unit == 'us'
+
     def test_histogram_raw_monitor_histogram_mode(self, toa_edges):
         """Test rebinning of already-histogrammed monitor data."""
         # Create input histogram with different edges (finer binning)


### PR DESCRIPTION
## Summary

- c319ffc4 fixed wavelength-mode `UnitError` by dynamically inferring the event coordinate unit, but forgot to convert the histogram coordinate back to the user's requested unit — output was always in the event unit (e.g., nanoseconds)
- The detector view already handled this correctly; apply the same pattern to the monitor workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)