### PR TITLE
Make motion topic subscription selective for detector and monitor services

### DIFF
--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -86,6 +86,8 @@ class Instrument:
     monitors: list[str] = field(default_factory=list)
     workflow_factory: WorkflowFactory = field(default_factory=WorkflowFactory)
     f144_attribute_registry: dict[str, dict[str, Any]] = field(default_factory=dict)
+    has_detector_motion: bool = False
+    has_monitor_motion: bool = False
     source_metadata: dict[str, SourceMetadata] = field(default_factory=dict)
     _detector_numbers: dict[str, sc.Variable] = field(default_factory=dict)
     _nexus_file: str | None = None

--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -201,6 +201,8 @@ instrument = Instrument(
     f144_attribute_registry={
         name: {'units': info['units']} for name, info in f144_log_streams.items()
     },
+    has_detector_motion=True,
+    has_monitor_motion=True,
     source_metadata={
         'loki_detector_0': SourceMetadata(title='Rear'),
         'loki_detector_1': SourceMetadata(title='Mid Top'),

--- a/src/ess/livedata/services/detector_data.py
+++ b/src/ess/livedata/services/detector_data.py
@@ -21,21 +21,22 @@ def make_detector_service_builder(
     group_by_pixel: bool = True,
 ) -> DataServiceBuilder:
     stream_mapping = get_stream_mapping(instrument=instrument, dev=dev)
+    instrument_obj = instrument_registry[instrument]
+    instrument_obj.load_factories()
     stream_counter = StreamCounter()
-    adapter = (
-        RoutingAdapterBuilder(
-            stream_mapping=stream_mapping, stream_counter=stream_counter
-        )
-        .with_detector_route()
+    builder = RoutingAdapterBuilder(
+        stream_mapping=stream_mapping, stream_counter=stream_counter
+    )
+    builder = (
+        builder.with_detector_route()
         .with_area_detector_route()
-        .with_logdata_route()
         .with_livedata_commands_route()
         .with_livedata_roi_route()
         .with_run_control_route()
-        .build()
     )
-    instrument_obj = instrument_registry[instrument]
-    instrument_obj.load_factories()
+    if instrument_obj.has_detector_motion:
+        builder = builder.with_logdata_route()
+    adapter = builder.build()
     service_name = 'detector_data'
     preprocessor_factory = DetectorHandlerFactory(
         instrument=instrument_obj, group_by_pixel=group_by_pixel

--- a/src/ess/livedata/services/monitor_data.py
+++ b/src/ess/livedata/services/monitor_data.py
@@ -15,19 +15,20 @@ def make_monitor_service_builder(
     *, instrument: str, dev: bool = True, log_level: int = logging.INFO
 ) -> DataServiceBuilder:
     stream_mapping = get_stream_mapping(instrument=instrument, dev=dev)
-    stream_counter = StreamCounter()
-    adapter = (
-        RoutingAdapterBuilder(
-            stream_mapping=stream_mapping, stream_counter=stream_counter
-        )
-        .with_beam_monitor_route()
-        .with_logdata_route()
-        .with_livedata_commands_route()
-        .with_run_control_route()
-        .build()
-    )
     instrument_obj = instrument_registry[instrument]
     instrument_obj.load_factories()
+    stream_counter = StreamCounter()
+    builder = RoutingAdapterBuilder(
+        stream_mapping=stream_mapping, stream_counter=stream_counter
+    )
+    builder = (
+        builder.with_beam_monitor_route()
+        .with_livedata_commands_route()
+        .with_run_control_route()
+    )
+    if instrument_obj.has_monitor_motion:
+        builder = builder.with_logdata_route()
+    adapter = builder.build()
     service_name = 'monitor_data'
     preprocessor_factory = ReductionHandlerFactory(instrument=instrument_obj)
     return DataServiceBuilder(

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -8,6 +8,7 @@ from structlog.testing import capture_logs
 
 from ess.livedata.config import instrument_registry, workflow_spec
 from ess.livedata.config.models import ConfigKey
+from ess.livedata.config.streams import get_stream_mapping
 from ess.livedata.core.job_manager import JobAction, JobCommand
 from ess.livedata.services.detector_data import make_detector_service_builder
 from tests.helpers.livedata_app import LivedataApp
@@ -267,3 +268,17 @@ def test_message_that_cannot_be_decoded_is_ignored(
     error_logs = [log for log in captured if log['log_level'] == 'error']
     assert any("Error adapting message" in log['event'] for log in error_logs)
     assert any("unpack_from requires a buffer" in str(log) for log in error_logs)
+
+
+def test_loki_detector_service_subscribes_to_motion_topic() -> None:
+    builder = make_detector_service_builder(instrument='loki')
+    stream_mapping = get_stream_mapping(instrument='loki', dev=True)
+    assert stream_mapping.log_topics
+    assert stream_mapping.log_topics <= set(builder._adapter.topics)
+
+
+def test_dummy_detector_service_does_not_subscribe_to_motion_topic() -> None:
+    builder = make_detector_service_builder(instrument='dummy')
+    stream_mapping = get_stream_mapping(instrument='dummy', dev=True)
+    assert stream_mapping.log_topics
+    assert stream_mapping.log_topics.isdisjoint(builder._adapter.topics)

--- a/tests/services/monitor_data_test.py
+++ b/tests/services/monitor_data_test.py
@@ -14,6 +14,7 @@ import pytest
 
 from ess.livedata.config import instrument_registry, workflow_spec
 from ess.livedata.config.models import ConfigKey
+from ess.livedata.config.streams import get_stream_mapping
 from ess.livedata.core.job_manager import JobAction, JobCommand
 from ess.livedata.services.monitor_data import make_monitor_service_builder
 from tests.helpers.livedata_app import LivedataApp
@@ -104,3 +105,17 @@ def test_can_configure_and_stop_monitor_workflow(
     app.publish_monitor_events(size=1000, time=20)
     service.step()
     assert len(sink.messages) == 12
+
+
+def test_loki_monitor_service_subscribes_to_motion_topic() -> None:
+    builder = make_monitor_service_builder(instrument='loki')
+    stream_mapping = get_stream_mapping(instrument='loki', dev=True)
+    assert stream_mapping.log_topics
+    assert stream_mapping.log_topics <= set(builder._adapter.topics)
+
+
+def test_dummy_monitor_service_does_not_subscribe_to_motion_topic() -> None:
+    builder = make_monitor_service_builder(instrument='dummy')
+    stream_mapping = get_stream_mapping(instrument='dummy', dev=True)
+    assert stream_mapping.log_topics
+    assert stream_mapping.log_topics.isdisjoint(builder._adapter.topics)


### PR DESCRIPTION
## Summary

- Add `has_detector_motion` and `has_monitor_motion` flags to `Instrument`
- `detector_data` and `monitor_data` services only subscribe to f144 motion topics when the corresponding flag is set, avoiding unnecessary Kafka subscriptions for instruments without moving detectors or monitors
- `data_reduction` and `timeseries` services are unchanged (unconditional subscription)
- Both flags set for LOKI (detector carriage + future monitor motion)

## Test plan

- [ ] Verify LOKI detector and monitor services still receive motion data correctly
- [ ] Verify other instruments (e.g., dummy) do not subscribe to motion topics


🤖 Generated with [Claude Code](https://claude.com/claude-code)