### PR TITLE
Change performance flag defaults: sync-scheduler=True, job-threads=5

### DIFF
--- a/src/ess/livedata/service_factory.py
+++ b/src/ess/livedata/service_factory.py
@@ -48,7 +48,7 @@ class DataServiceBuilder(Generic[Traw, Tin, Tout]):
         preprocessor_factory: PreprocessorFactory[Tin, Tout],
         startup_messages: list[Message[Tout]] | None = None,
         processor_cls: type[Processor] = OrchestratingProcessor,
-        job_threads: int = 1,
+        job_threads: int = 5,
         stream_counter: StreamCounter | None = None,
     ) -> None:
         """
@@ -206,15 +206,15 @@ class DataServiceRunner:
         self._parser = Service.setup_arg_parser(description=f'{pretty_name} Service')
         self._parser.add_argument(
             '--sync-scheduler',
-            action='store_true',
-            default=False,
+            action=argparse.BooleanOptionalAction,
+            default=True,
             help='Use synchronous dask scheduler instead of threaded'
             ' (reduces GIL contention)',
         )
         self._parser.add_argument(
             '--job-threads',
             type=int,
-            default=1,
+            default=5,
             help='Number of threads for parallel job execution (1=sequential)',
         )
         self._parser.add_argument(

--- a/tests/service_factory_test.py
+++ b/tests/service_factory_test.py
@@ -27,9 +27,15 @@ def test_sync_scheduler_flag_is_registered():
     assert args.sync_scheduler is True
 
 
-def test_sync_scheduler_flag_defaults_to_false():
+def test_sync_scheduler_flag_defaults_to_true():
     runner = _make_runner()
     args = runner.parser.parse_args(['--instrument', 'dummy'])
+    assert args.sync_scheduler is True
+
+
+def test_sync_scheduler_can_be_disabled():
+    runner = _make_runner()
+    args = runner.parser.parse_args(['--no-sync-scheduler', '--instrument', 'dummy'])
     assert args.sync_scheduler is False
 
 
@@ -44,10 +50,10 @@ def test_job_threads_flag_is_registered():
     assert args.job_threads == 5
 
 
-def test_job_threads_flag_defaults_to_one():
+def test_job_threads_flag_defaults_to_five():
     runner = _make_runner()
     args = runner.parser.parse_args(['--instrument', 'dummy'])
-    assert args.job_threads == 1
+    assert args.job_threads == 5
 
 
 def test_sciline_with_sync_pool_runs_on_calling_thread():


### PR DESCRIPTION
## Summary

- `--sync-scheduler` now defaults to on (was off). Benchmarks showed it nearly halves service runtime by eliminating GIL contention from dask's threaded pool. Uses `BooleanOptionalAction` so `--no-sync-scheduler` is available to opt out.
- `--job-threads` now defaults to 5 (was 1). Improves lag for instruments with many concurrent workflows (e.g., LOKI's 18 jobs). For instruments with few jobs, the 1s update cycle dominates so the threading overhead should be negligible.

## Motivation

These flags were introduced as opt-in (#760, #763) to validate in production. The benchmarks in #766 confirmed the combination works well. No major downsides have been observed. To simplify deployment we change the defaults so we can gather more experience with these modes, but may need tuning in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)