### PR TITLE
Remove `-v` from pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ addopts = """
 --benchmark-skip
 -m "not integration and not slow"
 -ra
--v
 """
 testpaths = "tests"
 markers = [


### PR DESCRIPTION
We have a many tests, having -`v` by default is wasting screen space and tokens.