### PR TITLE
Add explicit dask dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ requires-python = ">=3.11"
 dependencies = [
   "PyYAML",
   "confluent_kafka",
+  "dask>=2026.3.0",
   "ess-streaming-data-types",
   "essreduce>=26.4.0",
   "jinja2",


### PR DESCRIPTION
Relied on instrument packages to pull this in so far, but this is brittle and `essspectroscopy` lacked the dependency.