### PR TITLE
Remove backwards-compatibility shims from dashboard APIs

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/bragg_peak_monitor.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/bragg_peak_monitor.yaml
@@ -9,11 +9,13 @@ cells:
     col: 0
     row_span: 2
     col_span: 2
-  config:
-    workflow_id: bifrost/monitor_data/monitor_histogram/1
-    output_name: counts_in_toa_range
-    source_names:
-    - bragg_peak_monitor
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        output_name: counts_in_toa_range
+        source_names:
+        - bragg_peak_monitor
     plot_name: timeseries
     params:
       plot_aspect:
@@ -23,11 +25,13 @@ cells:
     col: 2
     row_span: 2
     col_span: 2
-  config:
-    workflow_id: bifrost/monitor_data/monitor_histogram/1
-    output_name: current
-    source_names:
-    - bragg_peak_monitor
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        output_name: current
+        source_names:
+        - bragg_peak_monitor
     plot_name: lines
     params:
       plot_aspect:
@@ -37,11 +41,13 @@ cells:
     col: 0
     row_span: 2
     col_span: 2
-  config:
-    workflow_id: bifrost/monitor_data/monitor_histogram/1
-    output_name: counts_total
-    source_names:
-    - bragg_peak_monitor
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        output_name: counts_total
+        source_names:
+        - bragg_peak_monitor
     plot_name: timeseries
     params:
       plot_aspect:
@@ -51,11 +57,13 @@ cells:
     col: 2
     row_span: 2
     col_span: 2
-  config:
-    workflow_id: bifrost/monitor_data/monitor_histogram/1
-    output_name: cumulative
-    source_names:
-    - bragg_peak_monitor
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        output_name: cumulative
+        source_names:
+        - bragg_peak_monitor
     plot_name: lines
     params:
       plot_aspect:

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/detectors.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/detectors.yaml
@@ -10,36 +10,42 @@ cells:
     row_span: 2
     col_span: 3
   layers:
-    - workflow_id: bifrost/detector_data/unified_detector_view/1
-      output_name: current
-      source_names:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/detector_data/unified_detector_view/1
+        output_name: current
+        source_names:
         - unified_detector
-      plot_name: image
-      params:
-        plot_aspect:
-          aspect_type: Free
-    - workflow_id: static/static_overlay/geometric/1
-      output_name: Triplet bounds
-      source_names: []
-      plot_name: rectangles
-      params:
-        geometry:
-          coordinates: "[-0.5,-0.5,899.5,14.5], [-0.5,2.5,899.5,5.5], [-0.5,5.5,899.5,8.5], [-0.5,11.5,899.5,14.5], [99.5,-0.5,199.5,14.5], [199.5,-0.5,299.5,14.5], [399.5,-0.5,499.5,14.5], [599.5,-0.5,699.5,14.5], [799.5,-0.5,899.5,14.5]"
-        style:
-          color: "#ff0000"
-          line_width: 1.5
-          line_dash: solid
-          alpha: 0.0
+    plot_name: image
+    params:
+      plot_aspect:
+        aspect_type: Free
+  - data_sources:
+      primary:
+        workflow_id: static/static_overlay/geometric/1
+        output_name: Triplet bounds
+        source_names: []
+    plot_name: rectangles
+    params:
+      geometry:
+        coordinates: "[-0.5,-0.5,899.5,14.5], [-0.5,2.5,899.5,5.5], [-0.5,5.5,899.5,8.5], [-0.5,11.5,899.5,14.5], [99.5,-0.5,199.5,14.5], [199.5,-0.5,299.5,14.5], [399.5,-0.5,499.5,14.5], [599.5,-0.5,699.5,14.5], [799.5,-0.5,899.5,14.5]"
+      style:
+        color: "#ff0000"
+        line_width: 1.5
+        line_dash: solid
+        alpha: 0.0
 - geometry:
     row: 2
     col: 0
     row_span: 1
     col_span: 1
-  config:
-    workflow_id: bifrost/data_reduction/detector_ratemeter/1
-    output_name: detector_region_counts
-    source_names:
-    - unified_detector
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/data_reduction/detector_ratemeter/1
+        output_name: detector_region_counts
+        source_names:
+        - unified_detector
     plot_name: bars
     params:
       plot_aspect:
@@ -51,11 +57,13 @@ cells:
     col: 1
     row_span: 1
     col_span: 2
-  config:
-    workflow_id: bifrost/data_reduction/detector_ratemeter/1
-    output_name: detector_region_counts
-    source_names:
-    - unified_detector
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/data_reduction/detector_ratemeter/1
+        output_name: detector_region_counts
+        source_names:
+        - unified_detector
     plot_name: timeseries
     params:
       plot_aspect:

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/monitors.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/monitors.yaml
@@ -9,14 +9,16 @@ cells:
     col: 0
     row_span: 1
     col_span: 2
-  config:
-    workflow_id: bifrost/monitor_data/monitor_histogram/1
-    output_name: current
-    source_names:
-    - 090_frame_1
-    - 097_frame_2
-    - 110_frame_3
-    - 111_psd0
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        output_name: current
+        source_names:
+        - 090_frame_1
+        - 097_frame_2
+        - 110_frame_3
+        - 111_psd0
     plot_name: lines
     params:
       plot_aspect:
@@ -26,14 +28,16 @@ cells:
     col: 0
     row_span: 1
     col_span: 2
-  config:
-    workflow_id: bifrost/monitor_data/monitor_histogram/1
-    output_name: current
-    source_names:
-    - 090_frame_1
-    - 097_frame_2
-    - 110_frame_3
-    - 111_psd0
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        output_name: current
+        source_names:
+        - 090_frame_1
+        - 097_frame_2
+        - 110_frame_3
+        - 111_psd0
     plot_name: lines
     params:
       plot_aspect:
@@ -46,14 +50,16 @@ cells:
     col: 0
     row_span: 1
     col_span: 2
-  config:
-    workflow_id: bifrost/monitor_data/monitor_histogram/1
-    output_name: cumulative
-    source_names:
-    - 090_frame_1
-    - 097_frame_2
-    - 110_frame_3
-    - 111_psd0
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        output_name: cumulative
+        source_names:
+        - 090_frame_1
+        - 097_frame_2
+        - 110_frame_3
+        - 111_psd0
     plot_name: lines
     params:
       plot_aspect:

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/spectrum_view.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/spectrum_view.yaml
@@ -9,11 +9,13 @@ cells:
     col: 0
     row_span: 3
     col_span: 3
-  config:
-    workflow_id: bifrost/data_reduction/spectrum_view/1
-    output_name: spectrum_view
-    source_names:
-    - unified_detector
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: bifrost/data_reduction/spectrum_view/1
+        output_name: spectrum_view
+        source_names:
+        - unified_detector
     plot_name: slicer
     params:
       plot_aspect:

--- a/src/ess/livedata/config/instruments/dummy/grid_templates/detector_overview.yaml
+++ b/src/ess/livedata/config/instruments/dummy/grid_templates/detector_overview.yaml
@@ -10,11 +10,13 @@ cells:
     col: 0
     row_span: 2
     col_span: 1
-  config:
-    workflow_id: dummy/detector_data/area_panel_xy/1
-    output_name: current
-    source_names:
-    - area_panel
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: dummy/detector_data/area_panel_xy/1
+        output_name: current
+        source_names:
+        - area_panel
     plot_name: image
     params:
       layout:
@@ -40,11 +42,13 @@ cells:
     col: 1
     row_span: 2
     col_span: 1
-  config:
-    workflow_id: dummy/detector_data/panel_0_xy/1
-    output_name: current
-    source_names:
-    - panel_0
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: dummy/detector_data/panel_0_xy/1
+        output_name: current
+        source_names:
+        - panel_0
     plot_name: image
     params:
       layout:

--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -170,7 +170,7 @@ class AxisSpec:
 class CorrelationHistogramPlotter:
     """Base plotter for correlation histograms with arbitrary number of axes.
 
-    Receives pre-structured data from DataSubscriber (multi-role assembly):
+    Receives role-grouped data from DataSubscriber:
     - "primary": dict[ResultKey, DataArray] - data to histogram
     - One or more axis roles (e.g., "x_axis", "y_axis") containing correlation values
     """
@@ -201,7 +201,7 @@ class CorrelationHistogramPlotter:
         Parameters
         ----------
         data
-            Structured data from DataSubscriber with "primary" role and axis roles.
+            Role-grouped data with "primary" role and axis roles.
         title_resolver
             Resolves source/output names to display titles.
         """
@@ -246,7 +246,7 @@ class CorrelationHistogramPlotter:
             else:
                 histograms[key] = dependent.hist(bin_spec)
 
-        self._renderer.compute(histograms, title_resolver=title_resolver)
+        self._renderer.compute({PRIMARY: histograms}, title_resolver=title_resolver)
 
     def get_cached_state(self) -> Any | None:
         """Get the last computed state from the renderer."""

--- a/src/ess/livedata/dashboard/data_service.py
+++ b/src/ess/livedata/dashboard/data_service.py
@@ -56,21 +56,8 @@ class DataService(MutableMapping[K, V]):
     that returns the latest value for each key.
     """
 
-    def __init__(
-        self,
-        buffer_manager: TemporalBufferManager | None = None,
-    ) -> None:
-        """
-        Initialize DataService.
-
-        Parameters
-        ----------
-        buffer_manager:
-            Manager for buffer sizing. If None, creates a new TemporalBufferManager.
-        """
-        if buffer_manager is None:
-            buffer_manager = TemporalBufferManager()
-        self._buffer_manager = buffer_manager
+    def __init__(self) -> None:
+        self._buffer_manager = TemporalBufferManager()
         self._default_extractor = LatestValueExtractor()
         self._subscribers: list[DataServiceSubscriber[K]] = []
         self._pending_updates: set[K] = set()

--- a/src/ess/livedata/dashboard/data_subscriber.py
+++ b/src/ess/livedata/dashboard/data_subscriber.py
@@ -5,7 +5,7 @@ Data subscription and assembly for streaming plot updates.
 
 This module provides the core data flow components:
 - DataSubscriber: Connects to DataService, assembles data, invokes callback
-- Assembly is role-aware: single-role outputs flat dict, multi-role outputs grouped dict
+- Output is always role-grouped: dict[role, dict[ResultKey, data]]
 """
 
 from __future__ import annotations
@@ -19,11 +19,11 @@ from ess.livedata.dashboard.extractors import UpdateExtractor
 
 
 class DataSubscriber(DataServiceSubscriber[ResultKey]):
-    """Subscriber that assembles data by role and invokes a callback.
+    """Subscriber that groups data by role and invokes a callback.
 
-    Handles both single-role (standard plots) and multi-role (correlation plots):
-    - Single role: outputs flat dict[ResultKey, data] for backward compatibility
-    - Multiple roles: outputs dict[str, dict[ResultKey, data]] grouped by role
+    Output shape is always ``dict[role, dict[ResultKey, data]]``. Consumers
+    that care about a single role (e.g. standard plotters using ``primary``)
+    extract it explicitly.
 
     The ready_condition is built internally: requires at least one key from each role.
     """
@@ -32,7 +32,7 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
         self,
         keys_by_role: dict[str, list[ResultKey]],
         extractors: Mapping[ResultKey, UpdateExtractor],
-        on_data: Callable[[dict[ResultKey, Any]], None],
+        on_data: Callable[[dict[str, dict[ResultKey, Any]]], None],
     ) -> None:
         """
         Initialize the subscriber.
@@ -46,12 +46,11 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
         extractors
             Mapping from keys to their UpdateExtractor instances.
         on_data
-            Callback invoked on every data update with the assembled data.
+            Callback invoked on every data update with the grouped data.
             Called when at least one key from each role has data.
         """
         self._keys_by_role = keys_by_role
         self._all_keys = {key for keys in keys_by_role.values() for key in keys}
-        self._single_role = len(keys_by_role) == 1
 
         # Build ready_condition: need at least one key from each role
         self._key_sets_by_role = [set(keys) for keys in keys_by_role.values()]
@@ -76,31 +75,18 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
         """Check if we have at least one key from each role."""
         return all(bool(available_keys & ks) for ks in self._key_sets_by_role)
 
-    def _assemble(self, data: dict[ResultKey, Any]) -> Any:
-        """Assemble data based on role structure.
-
-        Single role: returns flat dict[ResultKey, data] for standard plotters.
-        Multiple roles: returns dict[str, dict[ResultKey, data]] for
-        correlation plotters.
-        """
-        if self._single_role:
-            # Flat output for standard plotters (sorted for deterministic ordering)
+    def _assemble(self, data: dict[ResultKey, Any]) -> dict[str, dict[ResultKey, Any]]:
+        """Group data by role, sorted deterministically within each role."""
+        result: dict[str, dict[ResultKey, Any]] = {}
+        for role, role_keys in self._keys_by_role.items():
             sorted_keys = sorted(
-                (k for k in self._all_keys if k in data),
+                role_keys,
                 key=lambda k: (str(k.workflow_id), str(k.job_id), k.output_name),
             )
-            return {k: data[k] for k in sorted_keys}
-        else:
-            # Grouped output for correlation plotters
-            result: dict[str, dict[ResultKey, Any]] = {}
-            for role, role_keys in self._keys_by_role.items():
-                sorted_keys = sorted(
-                    role_keys, key=lambda k: (str(k.workflow_id), str(k.job_id))
-                )
-                role_data = {k: data[k] for k in sorted_keys if k in data}
-                if role_data:
-                    result[role] = role_data
-            return result
+            role_data = {k: data[k] for k in sorted_keys if k in data}
+            if role_data:
+                result[role] = role_data
+        return result
 
     def trigger(self, store: dict[ResultKey, Any]) -> None:
         """Trigger the subscriber with the current data store."""

--- a/src/ess/livedata/dashboard/orchestrator.py
+++ b/src/ess/livedata/dashboard/orchestrator.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -41,8 +40,8 @@ class Orchestrator:
         data_service: DataService,
         job_service: JobService,
         service_registry: ServiceRegistry,
-        job_orchestrator: JobOrchestrator | None = None,
-        active_job_registry: ActiveJobRegistry | None = None,
+        job_orchestrator: JobOrchestrator,
+        active_job_registry: ActiveJobRegistry,
     ) -> None:
         self._message_source = message_source
         self._data_service = data_service
@@ -72,12 +71,7 @@ class Orchestrator:
         # - Some listeners depend on multiple streams.
         # - There may be multiple messages for the same stream, only the last one
         #   should trigger an update.
-        guard = (
-            self._active_job_registry.ingestion_guard()
-            if self._active_job_registry is not None
-            else nullcontext()
-        )
-        with guard:
+        with self._active_job_registry.ingestion_guard():
             with self._data_service.transaction():
                 for message in messages:
                     self.forward(stream_id=message.stream, value=message.value)
@@ -86,9 +80,9 @@ class Orchestrator:
         """
         Forward data to the appropriate data service based on the stream name.
 
-        Data and job status messages are filtered by active job number when an
-        ActiveJobRegistry is available. Messages from unknown or stopped jobs
-        are silently discarded.
+        Data and job status messages are filtered by active job number via the
+        :class:`ActiveJobRegistry`. Messages from unknown or stopped jobs are
+        silently discarded.
 
         Parameters
         ----------
@@ -113,19 +107,11 @@ class Orchestrator:
                 self._data_service[result_key] = value
 
     def _is_active_job(self, job_number: JobNumber) -> bool:
-        """Check if a job_number belongs to an active job.
-
-        Returns True if no ActiveJobRegistry is configured (permissive mode).
-        """
-        if self._active_job_registry is None:
-            return True
+        """Check if a job_number belongs to an active job."""
         return self._active_job_registry.is_active(job_number)
 
     def _process_response(self, ack: CommandAcknowledgement) -> None:
         """Process a command acknowledgement from the backend."""
-        if self._job_orchestrator is None:
-            return
-
         self._job_orchestrator.process_acknowledgement(
             message_id=ack.message_id,
             response=ack.response.value,

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -26,6 +26,7 @@ import structlog
 from ess.livedata.config.grid_template import GridSpec
 from ess.livedata.config.workflow_spec import (
     JobNumber,
+    ResultKey,
     WorkflowId,
     WorkflowSpec,
 )
@@ -868,7 +869,7 @@ class PlotOrchestrator:
         self,
         layer_id: LayerId,
         plotter: Any,
-        data: dict,
+        data: dict[str, dict[ResultKey, Any]],
     ) -> None:
         """
         Compute plot state and transition layer to READY.
@@ -883,7 +884,8 @@ class PlotOrchestrator:
         plotter
             The plotter instance to compute with.
         data
-            Data dict to pass to plotter.compute(). Empty dict for static plotters.
+            Role-grouped data to pass to plotter.compute(). Empty dict for
+            static plotters.
         """
         if layer_id not in self._layer_to_cell:
             return
@@ -1093,16 +1095,12 @@ class PlotOrchestrator:
         Use this to convert cells from templates or persisted configurations
         into typed objects that can be passed to :py:meth:`add_cell`.
 
-        Supports two formats:
-        - Legacy format: 'geometry' + 'config' (single layer)
-        - New format: 'geometry' + 'layers' (multiple layers)
-
         Parameters
         ----------
         cell_data
-            Cell configuration dict with 'geometry' and either 'config' or 'layers'.
-            Each layer/config must contain: workflow_id, source_names, plot_name.
-            Optional: output_name, params.
+            Cell configuration dict with 'geometry' and 'layers'. Each layer
+            must contain: data_sources (dict keyed by role), plot_name, and
+            optionally params.
 
         Returns
         -------
@@ -1116,18 +1114,8 @@ class PlotOrchestrator:
             col_span=cell_data['geometry']['col_span'],
         )
 
-        # Handle both legacy 'config' and new 'layers' format
-        if 'layers' in cell_data:
-            raw_layers = cell_data['layers']
-        elif 'config' in cell_data:
-            # Legacy format: wrap single config in list
-            raw_layers = [cell_data['config']]
-        else:
-            self._logger.warning('Cell has neither config nor layers, skipping')
-            return None
-
         layers: list[Layer] = []
-        for layer_data in raw_layers:
+        for layer_data in cell_data['layers']:
             layer = self._parse_raw_layer(layer_data)
             if layer is not None:
                 layers.append(layer)
@@ -1141,16 +1129,11 @@ class PlotOrchestrator:
         """
         Parse a raw layer dict into a typed Layer.
 
-        Supports two formats for backward compatibility:
-        - New format: 'data_sources' list containing workflow_id, source_names,
-          output_name
-        - Old format: 'workflow_id', 'source_names', 'output_name' at top level
-
         Parameters
         ----------
         layer_data
-            Layer configuration dict. Must contain 'plot_name' and either
-            'data_sources' (new format) or 'workflow_id' (old format).
+            Layer configuration dict. Must contain 'plot_name' and
+            'data_sources' (dict keyed by role: primary, x_axis, ...).
 
         Returns
         -------
@@ -1164,51 +1147,14 @@ class PlotOrchestrator:
         if params is None:
             return None
 
-        # Parse data sources: support dict, list, and legacy formats
-        data_sources: dict[str, DataSourceConfig]
-        if 'data_sources' in layer_data:
-            raw_sources = layer_data['data_sources']
-            if isinstance(raw_sources, dict):
-                # New format: data_sources dict with role keys
-                data_sources = {
-                    role: DataSourceConfig(
-                        workflow_id=WorkflowId.from_string(ds['workflow_id']),
-                        source_names=ds['source_names'],
-                        output_name=ds.get('output_name', 'result'),
-                    )
-                    for role, ds in raw_sources.items()
-                }
-            else:
-                # Legacy format: data_sources list (first entry is primary)
-                data_sources = (
-                    {
-                        PRIMARY: DataSourceConfig(
-                            workflow_id=WorkflowId.from_string(
-                                raw_sources[0]['workflow_id']
-                            ),
-                            source_names=raw_sources[0]['source_names'],
-                            output_name=raw_sources[0].get('output_name', 'result'),
-                        )
-                    }
-                    if raw_sources
-                    else {}
-                )
-        elif 'workflow_id' in layer_data:
-            # Legacy format: single workflow at top level
-            data_sources = {
-                PRIMARY: DataSourceConfig(
-                    workflow_id=WorkflowId.from_string(layer_data['workflow_id']),
-                    source_names=layer_data['source_names'],
-                    output_name=layer_data.get('output_name', 'result'),
-                )
-            }
-        else:
-            # Fallback for templates missing workflow specification.
-            # Note: This creates an invalid config - static overlays should use
-            # the data_sources format with a synthetic workflow ID. This branch
-            # exists for robustness but templates should always specify workflow_id
-            # or data_sources.
-            data_sources = {}
+        data_sources: dict[str, DataSourceConfig] = {
+            role: DataSourceConfig(
+                workflow_id=WorkflowId.from_string(ds['workflow_id']),
+                source_names=ds['source_names'],
+                output_name=ds.get('output_name', 'result'),
+            )
+            for role, ds in layer_data['data_sources'].items()
+        }
 
         supports_windowing = _resolve_supports_windowing(
             data_sources, self._job_orchestrator.get_workflow_registry()

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -17,6 +17,7 @@ from ess.livedata.config.workflow_spec import ResultKey
 from ess.livedata.core.timestamp import Timestamp
 
 from .autoscaler import Autoscaler
+from .data_roles import PRIMARY
 from .plot_params import (
     LayoutParams,
     PlotAspect,
@@ -406,7 +407,7 @@ class Plotter:
 
     def compute(
         self,
-        data: dict[ResultKey, sc.DataArray],
+        data: dict[str, dict[ResultKey, sc.DataArray]],
         *,
         title_resolver: TitleResolver | None = None,
         **kwargs,
@@ -421,13 +422,14 @@ class Plotter:
         Parameters
         ----------
         data:
-            Dictionary mapping ResultKeys to DataArrays.
+            Role-grouped data. Standard plotters consume the ``primary`` role.
         title_resolver:
             Resolves source/output names to display titles. If None, raw names
             are used.
         **kwargs:
             Additional keyword arguments passed to plot().
         """
+        data = data.get(PRIMARY, {})
         if self._normalize_to_rate:
             data = {key: _normalize_to_rate(da) for key, da in data.items()}
 

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -198,8 +198,9 @@ class PlottingController:
         params
             Plotter parameters as a dict or validated Pydantic model.
         on_data
-            Callback invoked on every data update with the assembled data.
-            Called when at least one key from each role has data.
+            Callback invoked on every data update with role-grouped data
+            (dict[role, dict[ResultKey, DataArray]]). Called when at least one
+            key from each role has data.
 
         Returns
         -------

--- a/src/ess/livedata/dashboard/roi_request_plots.py
+++ b/src/ess/livedata/dashboard/roi_request_plots.py
@@ -48,6 +48,7 @@ from ess.livedata.config.roi_names import (
     get_roi_mapper,
 )
 
+from .data_roles import PRIMARY
 from .plots import Plotter, PresenterBase
 from .static_plots import Color, LineDash, RectanglesCoordinates
 
@@ -590,7 +591,7 @@ class BaseROIRequestPlotter(Plotter, ABC, Generic[ROIType, ParamsType, Converter
         """Create a presenter for this plotter."""
 
     def compute(
-        self, data: dict[ResultKey, sc.DataArray], **kwargs
+        self, data: dict[str, dict[ResultKey, sc.DataArray]], **kwargs
     ) -> dict[ResultKey, sc.DataArray]:
         """
         Extract data-dependent info and forward data to presenter.
@@ -601,17 +602,18 @@ class BaseROIRequestPlotter(Plotter, ABC, Generic[ROIType, ParamsType, Converter
         Parameters
         ----------
         data:
-            Dictionary with ROI readback data.
+            Role-grouped data; the ``primary`` role contains the ROI readback.
         **kwargs:
             Unused.
 
         Returns
         -------
         :
-            The input data, forwarded for potential future use by presenter.
+            The primary-role data, forwarded for potential future use by presenter.
         """
         del kwargs
-        data_key, da = next(iter(data.items()))
+        primary = data.get(PRIMARY, {})
+        data_key, da = next(iter(primary.items()))
 
         # Store data-dependent info for edit handler
         self._data_key = data_key
@@ -627,8 +629,8 @@ class BaseROIRequestPlotter(Plotter, ABC, Generic[ROIType, ParamsType, Converter
         )
 
         # Forward data (presenter may use in future)
-        self._set_cached_state(data)
-        return data
+        self._set_cached_state(primary)
+        return primary
 
     def _create_edit_handler(self) -> Callable[[dict], None]:
         """

--- a/src/ess/livedata/dashboard/session_updater.py
+++ b/src/ess/livedata/dashboard/session_updater.py
@@ -56,7 +56,7 @@ class SessionUpdater:
         *,
         session_id: SessionId,
         session_registry: SessionRegistry,
-        notification_queue: NotificationQueue | None = None,
+        notification_queue: NotificationQueue,
         username: str | None = None,
     ) -> None:
         self._session_id = session_id
@@ -73,9 +73,7 @@ class SessionUpdater:
         self._heartbeat_widget = HeartbeatWidget(interval_ms=5000)
         self._last_heartbeat_value = 0
 
-        # Register with notification queue
-        if self._notification_queue is not None:
-            self._notification_queue.register_session(session_id)
+        self._notification_queue.register_session(session_id)
 
         # Auto-register this session with the registry
         self._session_registry.register(session_id, self, username=username)
@@ -167,9 +165,6 @@ class SessionUpdater:
 
     def _poll_notifications(self) -> list[NotificationEvent]:
         """Poll NotificationQueue for new events."""
-        if self._notification_queue is None:
-            return []
-
         return self._notification_queue.get_new_events(self._session_id)
 
     def _show_notifications(self, notifications: list[NotificationEvent]) -> None:
@@ -182,8 +177,7 @@ class SessionUpdater:
         if self._periodic_callback is not None:
             self._periodic_callback.stop()
 
-        if self._notification_queue is not None:
-            self._notification_queue.unregister_session(self._session_id)
+        self._notification_queue.unregister_session(self._session_id)
 
         self._custom_handlers.clear()
 

--- a/src/ess/livedata/dashboard/slicer_plotter.py
+++ b/src/ess/livedata/dashboard/slicer_plotter.py
@@ -13,6 +13,7 @@ import scipp as sc
 
 from ess.livedata.config.workflow_spec import ResultKey
 
+from .data_roles import PRIMARY
 from .plot_params import PlotParams3d, PlotScale, PlotScaleParams2d, TickParams
 from .plots import Plotter, PresenterBase, _normalize_to_rate
 from .scipp_to_holoviews import to_holoviews
@@ -279,7 +280,7 @@ class SlicerPlotter(Plotter):
             normalize_to_rate=params.rate.normalize_to_rate,
         )
 
-    def compute(self, data: dict[ResultKey, sc.DataArray], **kwargs) -> None:
+    def compute(self, data: dict[str, dict[ResultKey, sc.DataArray]], **kwargs) -> None:
         """
         Prepare 3D data for slicing with pre-computed color bounds.
 
@@ -292,11 +293,12 @@ class SlicerPlotter(Plotter):
         Parameters
         ----------
         data:
-            Dictionary of 3D DataArrays.
+            Role-grouped data; the ``primary`` role contains 3D DataArrays.
         **kwargs:
             Unused (required by base class signature).
         """
         del kwargs  # Unused for SlicerPlotter
+        data = data.get(PRIMARY, {})
         if self._normalize_to_rate:
             data = {key: _normalize_to_rate(da) for key, da in data.items()}
         clim = self._compute_global_clim(data)

--- a/src/ess/livedata/dashboard/stream_manager.py
+++ b/src/ess/livedata/dashboard/stream_manager.py
@@ -22,16 +22,14 @@ class StreamManager:
     def make_stream(
         self,
         keys_by_role: dict[str, list[ResultKey]],
-        on_data: Callable[[dict[ResultKey, Any]], None],
+        on_data: Callable[[dict[str, dict[ResultKey, Any]]], None],
         extractors: dict[ResultKey, Any] | None = None,
     ) -> DataServiceSubscriber[ResultKey]:
         """
         Create a data stream for the given result keys organized by role.
 
-        Registers a subscriber that assembles data and invokes the callback.
-        Assembly format depends on role count:
-        - Single role: flat dict[ResultKey, data] (standard plotters)
-        - Multiple roles: dict[str, dict[ResultKey, data]] (correlation plotters)
+        Registers a subscriber that groups data by role and invokes the
+        callback with ``dict[role, dict[ResultKey, data]]``.
 
         Parameters
         ----------
@@ -40,7 +38,7 @@ class StreamManager:
             this is {"primary": [keys...]}. For correlation plots, includes
             additional roles like "x_axis", "y_axis".
         on_data
-            Callback invoked on every data update with the assembled data.
+            Callback invoked on every data update with the grouped data.
             Called when at least one key from each role has data.
         extractors
             Optional dict mapping keys to UpdateExtractor instances. If not

--- a/tests/config/grid_template_test.py
+++ b/tests/config/grid_template_test.py
@@ -172,15 +172,17 @@ class TestLoadRawGridTemplates:
         templates = load_raw_grid_templates('nonexistent_instrument_xyz')
         assert templates == []
 
-    def test_loaded_cells_have_geometry_and_config(self):
-        """Loaded template cells have geometry and config dicts."""
+    def test_loaded_cells_have_geometry_and_layers(self):
+        """Loaded template cells have geometry dict and layers list."""
         templates = load_raw_grid_templates('dummy')
         assert len(templates) >= 1
         template = templates[0]
         assert len(template['cells']) >= 1
         cell = template['cells'][0]
         assert 'geometry' in cell
-        assert 'config' in cell
+        assert 'layers' in cell
+        assert isinstance(cell['layers'], list)
+        assert len(cell['layers']) >= 1
         geometry = cell['geometry']
         assert 'row' in geometry
         assert 'col' in geometry

--- a/tests/dashboard/data_subscriber_test.py
+++ b/tests/dashboard/data_subscriber_test.py
@@ -57,8 +57,8 @@ class TestDataSubscriberSingleRole:
 
         assert subscriber.keys == {key1, key2}
 
-    def test_on_data_called_with_assembled_data(self, make_result_key):
-        """Test that on_data callback receives assembled data."""
+    def test_on_data_called_with_grouped_data(self, make_result_key):
+        """on_data receives role-grouped data even for a single role."""
         received_data: list[Any] = []
 
         key1 = make_result_key('detector1')
@@ -75,34 +75,9 @@ class TestDataSubscriberSingleRole:
         subscriber.trigger({key1: 'value1', key2: 'value2'})
 
         assert len(received_data) == 1
-        assert key1 in received_data[0]
-        assert key2 in received_data[0]
-        assert received_data[0][key1] == 'value1'
-        assert received_data[0][key2] == 'value2'
-
-    def test_single_role_assembles_flat_dict(self, make_result_key):
-        """Single role outputs flat dict[ResultKey, data] for standard plotters."""
-        received_data: list[Any] = []
-
-        key1 = make_result_key('detector1')
-        key2 = make_result_key('detector2')
-        keys_by_role = {'primary': [key1, key2]}
-        extractors = {k: LatestValueExtractor() for k in [key1, key2]}
-
-        subscriber = DataSubscriber(
-            keys_by_role=keys_by_role,
-            extractors=extractors,
-            on_data=lambda d: received_data.append(d),
-        )
-
-        subscriber.trigger({key1: 'value1', key2: 'value2'})
-
-        # Should receive flat dict (not grouped by role)
-        data = received_data[0]
-        assert key1 in data
-        assert key2 in data
-        assert data[key1] == 'value1'
-        assert data[key2] == 'value2'
+        primary = received_data[0]['primary']
+        assert primary[key1] == 'value1'
+        assert primary[key2] == 'value2'
 
     def test_multiple_triggers_call_on_data_each_time(self, make_result_key):
         """Test that each trigger calls on_data."""
@@ -123,9 +98,9 @@ class TestDataSubscriberSingleRole:
         subscriber.trigger({key: 'value3'})
 
         assert len(received_data) == 3
-        assert received_data[0][key] == 'value1'
-        assert received_data[1][key] == 'value2'
-        assert received_data[2][key] == 'value3'
+        assert received_data[0]['primary'][key] == 'value1'
+        assert received_data[1]['primary'][key] == 'value2'
+        assert received_data[2]['primary'][key] == 'value3'
 
     def test_partial_data_included(self, make_result_key):
         """Test that partial data is included in assembly."""
@@ -145,9 +120,9 @@ class TestDataSubscriberSingleRole:
         # Only provide data for key1
         subscriber.trigger({key1: 'value1'})
 
-        data = received_data[0]
-        assert key1 in data
-        assert key2 not in data
+        primary = received_data[0]['primary']
+        assert key1 in primary
+        assert key2 not in primary
 
     def test_keys_sorted_deterministically(self, workflow_id):
         """Test that keys are sorted deterministically in output."""
@@ -171,7 +146,7 @@ class TestDataSubscriberSingleRole:
 
         subscriber.trigger({key_a: 'value_a', key_b: 'value_b'})
 
-        result_keys = list(received_data[0].keys())
+        result_keys = list(received_data[0]['primary'].keys())
         # Should be sorted alphabetically by source_name
         assert result_keys[0].job_id.source_name == 'a_detector'
         assert result_keys[1].job_id.source_name == 'b_detector'

--- a/tests/dashboard/orchestrator_test.py
+++ b/tests/dashboard/orchestrator_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import uuid
+from contextlib import contextmanager
 
 import pytest
 import scipp as sc
@@ -28,6 +29,49 @@ def make_job_number() -> uuid.UUID:
 def make_service_registry() -> ServiceRegistry:
     """Create a service registry for testing."""
     return ServiceRegistry()
+
+
+class FakeJobOrchestrator:
+    """Fake job orchestrator that records processed acknowledgements."""
+
+    def __init__(self):
+        self.acknowledgements: list[tuple[str, str, str | None]] = []
+
+    def process_acknowledgement(
+        self, message_id: str, response: str, error_message: str | None = None
+    ) -> None:
+        """Record the processed acknowledgement."""
+        self.acknowledgements.append((message_id, response, error_message))
+
+
+class PermissiveJobRegistry:
+    """Accepts every job number; used where filtering is orthogonal to the test."""
+
+    def is_active(self, job_number: uuid.UUID) -> bool:
+        return True
+
+    @contextmanager
+    def ingestion_guard(self):
+        yield
+
+
+def _make_orchestrator(
+    *,
+    message_source,
+    data_service,
+    job_service,
+    service_registry=None,
+    job_orchestrator=None,
+    active_job_registry=None,
+) -> Orchestrator:
+    return Orchestrator(
+        message_source=message_source,
+        data_service=data_service,
+        job_service=job_service,
+        service_registry=service_registry or ServiceRegistry(),
+        job_orchestrator=job_orchestrator or FakeJobOrchestrator(),
+        active_job_registry=active_job_registry or PermissiveJobRegistry(),
+    )
 
 
 class FakeMessageSource:
@@ -75,11 +119,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         orchestrator.update()
@@ -90,11 +133,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         workflow_id = WorkflowId(
@@ -120,11 +162,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         workflow_id1 = WorkflowId(
@@ -167,11 +208,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         workflow_id = WorkflowId(
@@ -202,11 +242,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         workflow_id = WorkflowId(
@@ -232,11 +271,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         workflow_id = WorkflowId(
@@ -261,11 +299,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         data = sc.DataArray(sc.array(dims=['x'], values=[1, 2, 3]))
@@ -280,11 +317,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         workflow_id = WorkflowId(
@@ -325,11 +361,10 @@ class TestOrchestrator:
         source = FakeMessageSource()
         data_service = DataService()
         job_service = JobService()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
         )
 
         # Track transaction calls
@@ -363,19 +398,6 @@ class TestOrchestrator:
         assert result_key in data_service
 
 
-class FakeJobOrchestrator:
-    """Fake job orchestrator that records processed acknowledgements."""
-
-    def __init__(self):
-        self.acknowledgements: list[tuple[str, str, str | None]] = []
-
-    def process_acknowledgement(
-        self, message_id: str, response: str, error_message: str | None = None
-    ) -> None:
-        """Record the processed acknowledgement."""
-        self.acknowledgements.append((message_id, response, error_message))
-
-
 class TestOrchestratorAcknowledgementProcessing:
     def test_forward_with_ack_message(self) -> None:
         """Test that acknowledgement messages are forwarded to job orchestrator."""
@@ -388,11 +410,10 @@ class TestOrchestratorAcknowledgementProcessing:
         data_service = DataService()
         job_service = JobService()
         job_orchestrator = FakeJobOrchestrator()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
             job_orchestrator=job_orchestrator,
         )
 
@@ -418,11 +439,10 @@ class TestOrchestratorAcknowledgementProcessing:
         data_service = DataService()
         job_service = JobService()
         job_orchestrator = FakeJobOrchestrator()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
             job_orchestrator=job_orchestrator,
         )
 
@@ -442,32 +462,6 @@ class TestOrchestratorAcknowledgementProcessing:
             "Workflow not found",
         )
 
-    def test_forward_with_response_message_no_orchestrator(self) -> None:
-        """Test that response messages are handled gracefully without orchestrator."""
-        from ess.livedata.config.acknowledgement import (
-            AcknowledgementResponse,
-            CommandAcknowledgement,
-        )
-
-        source = FakeMessageSource()
-        data_service = DataService()
-        job_service = JobService()
-        orchestrator = Orchestrator(
-            message_source=source,
-            data_service=data_service,
-            job_service=job_service,
-            service_registry=make_service_registry(),
-            job_orchestrator=None,
-        )
-
-        ack = CommandAcknowledgement(
-            message_id="test-uuid",
-            device="detector1",
-            response=AcknowledgementResponse.ACK,
-        )
-        # Should not raise an exception
-        orchestrator.forward(RESPONSES_STREAM_ID, ack)
-
 
 class TestOrchestratorServiceStatusRouting:
     """Test that ServiceStatus messages are routed to the ServiceRegistry."""
@@ -480,7 +474,7 @@ class TestOrchestratorServiceStatusRouting:
         data_service = DataService()
         job_service = JobService()
         service_registry = make_service_registry()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
@@ -513,7 +507,7 @@ class TestOrchestratorServiceStatusRouting:
         data_service = DataService()
         job_service = JobService()
         service_registry = make_service_registry()
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
@@ -550,11 +544,10 @@ class TestOrchestratorJobFiltering:
         registry = ActiveJobRegistry(data_service=data_service, job_service=job_service)
         for jn in active_job_numbers:
             registry.restore(jn)
-        orchestrator = Orchestrator(
+        orchestrator = _make_orchestrator(
             message_source=source,
             data_service=data_service,
             job_service=job_service,
-            service_registry=make_service_registry(),
             active_job_registry=registry,
         )
         return orchestrator, data_service, job_service
@@ -626,31 +619,6 @@ class TestOrchestratorJobFiltering:
         orchestrator.forward(STATUS_STREAM_ID, status)
 
         assert len(job_service.job_statuses) == 0
-
-    def test_no_orchestrator_accepts_all_data(self) -> None:
-        """Without a JobOrchestrator, all data is accepted (permissive mode)."""
-        source = FakeMessageSource()
-        data_service = DataService()
-        job_service = JobService()
-        orchestrator = Orchestrator(
-            message_source=source,
-            data_service=data_service,
-            job_service=job_service,
-            service_registry=make_service_registry(),
-            job_orchestrator=None,
-        )
-
-        workflow_id = WorkflowId(
-            instrument="test", namespace="ns", name="wf", version=1
-        )
-        job_id = JobId(source_name="det1", job_number=make_job_number())
-        result_key = ResultKey(
-            workflow_id=workflow_id, job_id=job_id, output_name="result"
-        )
-        data = sc.DataArray(sc.array(dims=['x'], values=[1, 2]))
-        orchestrator.forward(_data_stream_id(result_key), data)
-
-        assert result_key in data_service
 
 
 def _data_stream_id(key: ResultKey) -> StreamId:

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -353,7 +353,7 @@ class TestLinePlotter:
         resolver = TitleResolver(
             source=lambda _: 'Friendly Name', include_output_in_label=True
         )
-        line_plotter.compute({data_key: data}, title_resolver=resolver)
+        line_plotter.compute({'primary': {data_key: data}}, title_resolver=resolver)
         result = line_plotter.get_cached_state()
         assert result.label == 'Friendly Name/test_result'
 
@@ -370,7 +370,7 @@ class TestLinePlotter:
             output=lambda _: 'I(d)',
             include_output_in_label=True,
         )
-        line_plotter.compute({data_key: data}, title_resolver=resolver)
+        line_plotter.compute({'primary': {data_key: data}}, title_resolver=resolver)
         result = line_plotter.get_cached_state()
         assert result.label == 'Source/I(d)'
 
@@ -389,7 +389,7 @@ class TestLinePlotter:
             output=lambda _: 'Total counts',
             include_output_in_label=False,
         )
-        line_plotter.compute({data_key: data}, title_resolver=resolver)
+        line_plotter.compute({'primary': {data_key: data}}, title_resolver=resolver)
         result = line_plotter.get_cached_state()
         assert result.label == 'Monitor 1'
 
@@ -401,7 +401,7 @@ class TestLinePlotter:
             sc.array(dims=['x'], values=[1.0, 2.0], unit='counts'),
             coords={'x': sc.array(dims=['x'], values=[10.0, 20.0], unit='m')},
         )
-        line_plotter.compute({data_key: data})
+        line_plotter.compute({'primary': {data_key: data}})
         result = line_plotter.get_cached_state()
         assert result.label == 'test_source/test_result'
 
@@ -662,7 +662,7 @@ class TestSlicerPlotter:
     def test_compute_returns_slicer_state(self, slicer_plotter, data_3d, data_key):
         """Test that compute() returns a SlicerState with prepared data and clim."""
         data_dict = {data_key: data_3d}
-        slicer_plotter.compute(data_dict)
+        slicer_plotter.compute({'primary': data_dict})
         result = slicer_plotter.get_cached_state()
 
         assert isinstance(result, SlicerState)
@@ -679,7 +679,7 @@ class TestSlicerPlotter:
         plotter = SlicerPlotter.from_params(params)
 
         data_dict = {data_key: data_3d}
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         result = plotter.get_cached_state()
 
         # clim should span the full range of data
@@ -694,7 +694,7 @@ class TestSlicerPlotter:
         plotter = SlicerPlotter.from_params(params)
 
         data_dict = {data_key: data_3d}
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         result = plotter.get_cached_state()
 
         # data_3d starts at 0 (from arange), so min should be > 0
@@ -796,7 +796,7 @@ class TestSlicerPlotter:
         plotter = SlicerPlotter.from_params(params)
 
         data_dict = {data_key: data_3d}
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         result = plotter.get_cached_state()
 
         # First value (0) should be NaN in log scale (data_3d starts at 0 from arange)
@@ -815,7 +815,7 @@ class TestSlicerPlotter:
     ):
         """Test that SlicerPresenter creates kdims from SlicerState."""
         data_dict = {data_key: data_3d}
-        slicer_plotter.compute(data_dict)
+        slicer_plotter.compute({'primary': data_dict})
         state = slicer_plotter.get_cached_state()
 
         presenter = slicer_plotter.create_presenter()
@@ -829,7 +829,7 @@ class TestSlicerPlotter:
     def test_presenter_kdims_with_coords(self, slicer_plotter, data_3d, data_key):
         """Test that presenter kdims use coordinate values when available."""
         data_dict = {data_key: data_3d}
-        slicer_plotter.compute(data_dict)
+        slicer_plotter.compute({'primary': data_dict})
         state = slicer_plotter.get_cached_state()
 
         presenter = slicer_plotter.create_presenter()
@@ -849,7 +849,7 @@ class TestSlicerPlotter:
     ):
         """Test that presenter kdims fall back to indices without coordinates."""
         data_dict = {data_key: data_3d_no_coords}
-        slicer_plotter.compute(data_dict)
+        slicer_plotter.compute({'primary': data_dict})
         state = slicer_plotter.get_cached_state()
 
         presenter = slicer_plotter.create_presenter()
@@ -863,7 +863,7 @@ class TestSlicerPlotter:
     def test_presenter_dmap_renders_slice(self, slicer_plotter, data_3d, data_key):
         """Test that presenter's DynamicMap can render slices."""
         data_dict = {data_key: data_3d}
-        slicer_plotter.compute(data_dict)
+        slicer_plotter.compute({'primary': data_dict})
         state = slicer_plotter.get_cached_state()
 
         presenter = slicer_plotter.create_presenter()
@@ -917,7 +917,7 @@ class TestSlicerPlotter:
         )
 
         data_dict = {data_key: data}
-        slicer_plotter.compute(data_dict)
+        slicer_plotter.compute({'primary': data_dict})
         state = slicer_plotter.get_cached_state()
 
         presenter = slicer_plotter.create_presenter()
@@ -952,7 +952,7 @@ class TestSlicerPlotter:
         )
 
         data_dict = {data_key: data}
-        slicer_plotter.compute(data_dict)
+        slicer_plotter.compute({'primary': data_dict})
         state = slicer_plotter.get_cached_state()
 
         presenter = slicer_plotter.create_presenter()
@@ -993,7 +993,7 @@ class TestPlotterLabelChanges:
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         data_dict = {data_key_with_output_name: simple_data}
 
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         result = plotter.get_cached_state()
 
         # Result should have label that includes output_name
@@ -1058,7 +1058,7 @@ class TestPlotterOverlayMode:
         plotter = plots.LinePlotter.from_params(params)
         data_dict = {data_key_1: simple_data_1}
 
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         result = plotter.get_cached_state()
 
         # Should return Overlay, not raw Curve
@@ -1076,7 +1076,7 @@ class TestPlotterOverlayMode:
         plotter = plots.LinePlotter.from_params(params)
         data_dict = {data_key_1: simple_data_1, data_key_2: simple_data_2}
 
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         result = plotter.get_cached_state()
 
         # Should return Overlay
@@ -1094,7 +1094,7 @@ class TestPlotterOverlayMode:
         plotter = plots.LinePlotter.from_params(params)
         data_dict = {data_key_1: simple_data_1}
 
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         result = plotter.get_cached_state()
 
         # Should return raw Curve, not Overlay
@@ -1269,7 +1269,7 @@ class TestBarsPlotter:
             key2: sc.DataArray(sc.scalar(20.0, unit='counts')),
         }
 
-        plotter.compute(data)
+        plotter.compute({'primary': data})
         result = plotter.get_cached_state()
         # With layout mode and 2 sources, should return Layout
         assert isinstance(result, hv.Layout)
@@ -1553,7 +1553,7 @@ class TestLagIndicator:
         )
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
-        plotter.compute({data_key: data})
+        plotter.compute({'primary': {data_key: data}})
         result = plotter.get_cached_state()
 
         # Check that title contains time range and lag
@@ -1574,7 +1574,7 @@ class TestLagIndicator:
         )
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
-        plotter.compute({data_key: data})
+        plotter.compute({'primary': {data_key: data}})
         result = plotter.get_cached_state()
 
         # Check that no title is set (or title doesn't contain Lag)
@@ -1625,7 +1625,7 @@ class TestLagIndicator:
         )
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
-        plotter.compute({data_key1: data1, data_key2: data2})
+        plotter.compute({'primary': {data_key1: data1, data_key2: data2}})
         result = plotter.get_cached_state()
 
         # Check that lag is approximately 5 seconds (the older data)
@@ -1676,7 +1676,7 @@ class TestTwoStageArchitecture:
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         data_dict = {data_key: simple_data}
         # With new architecture, pipe receives pre-computed elements
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         computed = plotter.get_cached_state()
 
         presenter = plotter.create_presenter()
@@ -1704,7 +1704,7 @@ class TestTwoStageArchitecture:
         data_dict = {data_key: data_3d}
 
         # Compute returns SlicerState
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         state = plotter.get_cached_state()
         assert isinstance(state, SlicerState)
 
@@ -1726,7 +1726,7 @@ class TestTwoStageArchitecture:
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         data_dict = {data_key: simple_data}
         # With new architecture, compute() is called once and result is passed to pipe
-        plotter.compute(data_dict)
+        plotter.compute({'primary': data_dict})
         computed = plotter.get_cached_state()
 
         presenter = plotter.create_presenter()
@@ -1781,7 +1781,7 @@ class TestSaveFilenameHookOnDynamicMap:
         """Hooks on a DynamicMap with a single element work."""
         plotter = plots.ImagePlotter.from_params(PlotParams2d())
         key = self._make_key('rear')
-        plotter.compute({key: self._make_2d_data()})
+        plotter.compute({'primary': {key: self._make_2d_data()}})
 
         presenter = plotter.create_presenter()
         pipe = hv.streams.Pipe(data=plotter.get_cached_state())
@@ -1801,7 +1801,7 @@ class TestSaveFilenameHookOnDynamicMap:
             self._make_key('rear'): self._make_2d_data(),
             self._make_key('front'): self._make_2d_data(),
         }
-        plotter.compute(data)
+        plotter.compute({'primary': data})
 
         presenter = plotter.create_presenter()
         pipe = hv.streams.Pipe(data=plotter.get_cached_state())
@@ -1826,7 +1826,7 @@ class TestSaveFilenameHookOnDynamicMap:
             self._make_key('rear'): self._make_2d_data(),
             self._make_key('front'): self._make_2d_data(),
         }
-        plotter.compute(data)
+        plotter.compute({'primary': data})
 
         assert isinstance(plotter.get_cached_state(), hv.Layout)
 
@@ -2029,7 +2029,7 @@ class TestRateNormalizationIntegration:
             rate=RateNormalizationParams(normalize_to_rate=True),
         )
         plotter = plots.LinePlotter.from_params(params)
-        plotter.compute({data_key: counts_1d})
+        plotter.compute({'primary': {data_key: counts_1d}})
         result = plotter.get_cached_state()
         # Should render without error
         assert result is not None
@@ -2038,7 +2038,7 @@ class TestRateNormalizationIntegration:
         """LinePlotter with default params does not normalize."""
         params = PlotParams1d()
         plotter = plots.LinePlotter.from_params(params)
-        plotter.compute({data_key: counts_1d})
+        plotter.compute({'primary': {data_key: counts_1d}})
         result = plotter.get_cached_state()
         assert result is not None
 
@@ -2050,7 +2050,7 @@ class TestRateNormalizationIntegration:
             rate=RateNormalizationParams(normalize_to_rate=True),
         )
         plotter = plots.ImagePlotter.from_params(params)
-        plotter.compute({data_key: counts_2d})
+        plotter.compute({'primary': {data_key: counts_2d}})
         result = plotter.get_cached_state()
         assert result is not None
 
@@ -2072,7 +2072,7 @@ class TestRateNormalizationIntegration:
             rate=RateNormalizationParams(normalize_to_rate=True),
         )
         plotter = SlicerPlotter.from_params(params)
-        plotter.compute({data_key: data_3d})
+        plotter.compute({'primary': {data_key: data_3d}})
         state = plotter.get_cached_state()
         assert isinstance(state, SlicerState)
         first_da = next(iter(state.data.values()))
@@ -2094,7 +2094,7 @@ class TestRateNormalizationIntegration:
         )
         params = PlotParamsBars(rate=RateNormalizationParams(normalize_to_rate=True))
         plotter = plots.BarsPlotter.from_params(params)
-        plotter.compute({data_key: data_0d})
+        plotter.compute({'primary': {data_key: data_0d}})
         result = plotter.get_cached_state()
         # get_cached_state wraps in an Overlay even for single bars
         bars = next(iter(result.values()))

--- a/tests/dashboard/plotter_compute_benchmark.py
+++ b/tests/dashboard/plotter_compute_benchmark.py
@@ -80,16 +80,16 @@ def overlay_plotter() -> Overlay1DPlotter:
 def test_line_plotter_compute(benchmark, line_plotter):
     data_key = _make_result_key()
     da = _make_1d_curve_data()
-    benchmark(line_plotter.compute, {data_key: da})
+    benchmark(line_plotter.compute, {'primary': {data_key: da}})
 
 
 def test_image_plotter_compute(benchmark, image_plotter):
     data_key = _make_result_key()
     da = _make_2d_image_data()
-    benchmark(image_plotter.compute, {data_key: da})
+    benchmark(image_plotter.compute, {'primary': {data_key: da}})
 
 
 def test_overlay_plotter_compute(benchmark, overlay_plotter):
     data_key = _make_result_key()
     da = _make_2d_overlay_data(n_curves=5)
-    benchmark(overlay_plotter.compute, {data_key: da})
+    benchmark(overlay_plotter.compute, {'primary': {data_key: da}})

--- a/tests/dashboard/session_updater_test.py
+++ b/tests/dashboard/session_updater_test.py
@@ -11,12 +11,27 @@ from ess.livedata.dashboard.session_registry import SessionId, SessionRegistry
 from ess.livedata.dashboard.session_updater import SessionUpdater
 
 
+def _make_updater(
+    session_id: SessionId,
+    registry: SessionRegistry,
+    *,
+    notification_queue: NotificationQueue | None = None,
+    username: str | None = None,
+) -> SessionUpdater:
+    return SessionUpdater(
+        session_id=session_id,
+        session_registry=registry,
+        notification_queue=notification_queue or NotificationQueue(),
+        username=username,
+    )
+
+
 class TestSessionUpdater:
     def test_periodic_update_runs_without_error(self):
         session_id = SessionId('session-1')
         registry = SessionRegistry()
 
-        updater = SessionUpdater(session_id=session_id, session_registry=registry)
+        updater = _make_updater(session_id, registry)
 
         # Session is registered at construction time (not via heartbeat)
         # periodic_update should run without error
@@ -30,11 +45,7 @@ class TestSessionUpdater:
         registry = SessionRegistry()
         queue = NotificationQueue()
 
-        updater = SessionUpdater(
-            session_id=session_id,
-            session_registry=registry,
-            notification_queue=queue,
-        )
+        updater = _make_updater(session_id, registry, notification_queue=queue)
 
         # Push notification
         queue.push(
@@ -50,7 +61,7 @@ class TestSessionUpdater:
         session_id = SessionId('session-1')
         registry = SessionRegistry()
 
-        updater = SessionUpdater(session_id=session_id, session_registry=registry)
+        updater = _make_updater(session_id, registry)
 
         # Register custom handler
         calls = []
@@ -65,7 +76,7 @@ class TestSessionUpdater:
         session_id = SessionId('session-1')
         registry = SessionRegistry()
 
-        updater = SessionUpdater(session_id=session_id, session_registry=registry)
+        updater = _make_updater(session_id, registry)
 
         calls = []
 
@@ -87,11 +98,7 @@ class TestSessionUpdater:
         registry = SessionRegistry()
         queue = NotificationQueue()
 
-        updater = SessionUpdater(
-            session_id=session_id,
-            session_registry=registry,
-            notification_queue=queue,
-        )
+        updater = _make_updater(session_id, registry, notification_queue=queue)
 
         # Push notification
         queue.push(NotificationEvent(message='Before cleanup'))
@@ -108,7 +115,7 @@ class TestSessionUpdater:
         session_id = SessionId('test-session')
         registry = SessionRegistry()
 
-        updater = SessionUpdater(session_id=session_id, session_registry=registry)
+        updater = _make_updater(session_id, registry)
 
         assert updater.session_id == session_id
 
@@ -116,7 +123,7 @@ class TestSessionUpdater:
         session_id = SessionId('session-1')
         registry = SessionRegistry()
 
-        updater = SessionUpdater(session_id=session_id, session_registry=registry)
+        updater = _make_updater(session_id, registry)
 
         class FakeCallback:
             def __init__(self):
@@ -132,25 +139,11 @@ class TestSessionUpdater:
 
         assert callback.stopped
 
-    def test_works_without_optional_services(self):
-        session_id = SessionId('session-1')
-        registry = SessionRegistry()
-
-        # Create with no optional services
-        updater = SessionUpdater(session_id=session_id, session_registry=registry)
-
-        # Should not raise
-        updater.periodic_update()
-
     def test_username_forwarded_to_registry(self):
         session_id = SessionId('session-1')
         registry = SessionRegistry()
 
-        SessionUpdater(
-            session_id=session_id,
-            session_registry=registry,
-            username='Simon',
-        )
+        _make_updater(session_id, registry, username='Simon')
 
         info = registry.get_session_info(session_id)
         assert info is not None

--- a/tests/dashboard/stream_manager_test.py
+++ b/tests/dashboard/stream_manager_test.py
@@ -86,9 +86,9 @@ class TestStreamManager:
         # Publish data
         data_service[key] = sample_data
 
-        # Verify data received
+        # Verify data received (grouped by role)
         assert len(received_data) == 1
-        assert_dict_equal_with_scipp(received_data[0], {key: sample_data})
+        assert_dict_equal_with_scipp(received_data[0]['primary'], {key: sample_data})
 
     def test_multiple_sources_data_flow(self, data_service, sample_data, workflow_id):
         """Test data flow with multiple sources in single role."""
@@ -113,10 +113,11 @@ class TestStreamManager:
         # Should receive data for both keys
         assert len(received_data) == 2
         # First call has only key1
-        assert_dict_equal_with_scipp(received_data[0], {key1: sample_data})
+        assert_dict_equal_with_scipp(received_data[0]['primary'], {key1: sample_data})
         # Second call has both keys
         assert_dict_equal_with_scipp(
-            received_data[1], {key1: sample_data, key2: sample_data2}
+            received_data[1]['primary'],
+            {key1: sample_data, key2: sample_data2},
         )
 
     def test_partial_data_updates(self, data_service, sample_data, workflow_id):
@@ -133,11 +134,12 @@ class TestStreamManager:
         # Send data for only one key
         data_service[key1] = sample_data
 
-        # Should receive partial data
+        # Should receive partial data (grouped by role)
         assert len(received_data) == 1
-        assert key1 in received_data[0]
-        assert key2 not in received_data[0]
-        assert_identical(received_data[0][key1], sample_data)
+        primary = received_data[0]['primary']
+        assert key1 in primary
+        assert key2 not in primary
+        assert_identical(primary[key1], sample_data)
 
     def test_stream_independence(self, data_service, sample_data, workflow_id):
         """Test that multiple streams operate independently."""
@@ -190,10 +192,10 @@ class TestStreamManager:
         )
         data_service[key] = updated_data
 
-        # Should receive both updates
+        # Should receive both updates (grouped by role)
         assert len(received_data) == 2
-        assert_dict_equal_with_scipp(received_data[0], {key: sample_data})
-        assert_dict_equal_with_scipp(received_data[1], {key: updated_data})
+        assert_dict_equal_with_scipp(received_data[0]['primary'], {key: sample_data})
+        assert_dict_equal_with_scipp(received_data[1]['primary'], {key: updated_data})
 
     def test_unrelated_key_filtering(self, data_service, sample_data, workflow_id):
         """Test that unrelated keys are filtered out."""
@@ -216,9 +218,11 @@ class TestStreamManager:
         # Publish data for target key
         data_service[target_key] = sample_data
 
-        # Should receive data now
+        # Should receive data now (grouped by role)
         assert len(received_data) == 1
-        assert_dict_equal_with_scipp(received_data[0], {target_key: sample_data})
+        assert_dict_equal_with_scipp(
+            received_data[0]['primary'], {target_key: sample_data}
+        )
 
 
 class TestStreamManagerMultiRole:

--- a/tests/dashboard/time_info_test.py
+++ b/tests/dashboard/time_info_test.py
@@ -108,7 +108,7 @@ class TestTimeseriesTimeInfo:
         extracted_data = extractor.extract(buffered_data)
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
-        plotter.compute({data_key: extracted_data})
+        plotter.compute({'primary': {data_key: extracted_data}})
         result = plotter.get_cached_state()
 
         title = _extract_title(result)
@@ -148,7 +148,7 @@ class TestTimeseriesTimeInfo:
         extracted_data = extractor.extract(buffered_data)
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
-        plotter.compute({data_key: extracted_data})
+        plotter.compute({'primary': {data_key: extracted_data}})
         result = plotter.get_cached_state()
 
         title = _extract_title(result)
@@ -193,7 +193,7 @@ class TestWindowedTimeInfo:
         extracted_data = extractor.extract(buffered_data)
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
-        plotter.compute({data_key: extracted_data})
+        plotter.compute({'primary': {data_key: extracted_data}})
         result = plotter.get_cached_state()
 
         title = _extract_title(result)
@@ -223,7 +223,7 @@ class TestTimeInfoBaseline:
         )
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
-        plotter.compute({data_key: data})
+        plotter.compute({'primary': {data_key: data}})
         result = plotter.get_cached_state()
 
         title = _extract_title(result)
@@ -263,6 +263,6 @@ class TestTimeInfoEdgeCases:
         )
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
-        plotter.compute({data_key: data})  # Should not raise
+        plotter.compute({'primary': {data_key: data}})  # Should not raise
         result = plotter.get_cached_state()
         assert isinstance(_extract_title(result), str)

--- a/tests/dashboard/widgets/plot_grid_manager_test.py
+++ b/tests/dashboard/widgets/plot_grid_manager_test.py
@@ -373,8 +373,13 @@ class TestGridUpload:
         yaml_content = b"""
 title: Test Grid
 cells:
-  - config:
-      workflow_id: test
+  - layers:
+    - data_sources:
+        primary:
+          workflow_id: test
+          source_names: []
+          output_name: result
+      plot_name: image
 """  # Missing 'geometry' field
         original_title = grid_manager._title_input.value
 

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -16,6 +16,7 @@ import pytest
 from ess.livedata.config.workflow_spec import WorkflowId
 from ess.livedata.dashboard.data_service import DataService
 from ess.livedata.dashboard.job_service import JobService
+from ess.livedata.dashboard.notification_queue import NotificationQueue
 from ess.livedata.dashboard.plot_data_service import LayerId, PlotDataService
 from ess.livedata.dashboard.plot_orchestrator import (
     CellGeometry,
@@ -124,6 +125,7 @@ def plot_grid_tabs(
         session_updater=SessionUpdater(
             session_id=SessionId('test'),
             session_registry=SessionRegistry(),
+            notification_queue=NotificationQueue(),
         ),
     )
 

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from ess.livedata.dashboard.data_service import DataService
 from ess.livedata.dashboard.job_service import JobService
+from ess.livedata.dashboard.notification_queue import NotificationQueue
 from ess.livedata.dashboard.plot_data_service import PlotDataService
 from ess.livedata.dashboard.plot_orchestrator import PlotOrchestrator
 from ess.livedata.dashboard.plotting_controller import PlottingController
@@ -95,6 +96,7 @@ def session_updater():
     return SessionUpdater(
         session_id=SessionId('test-session'),
         session_registry=registry,
+        notification_queue=NotificationQueue(),
     )
 
 
@@ -226,10 +228,12 @@ class TestGridTabManagement:
         session_updater1 = SessionUpdater(
             session_id=SessionId('session-1'),
             session_registry=registry,
+            notification_queue=NotificationQueue(),
         )
         session_updater2 = SessionUpdater(
             session_id=SessionId('session-2'),
             session_registry=registry,
+            notification_queue=NotificationQueue(),
         )
 
         # Create separate workflow status widgets for each instance


### PR DESCRIPTION
Two cleanup passes over the dashboard layer, removing code paths that existed solely to support legacy formats and optional dependencies during migration.

**Drop legacy cell config and flat-dict subscriber output**

`DataSubscriber._assemble()` now always returns `dict[role, dict[ResultKey, data]]`. The single-role flat-dict shortcut (which existed for backward compatibility with standard plotters) is gone; callers extract the `primary` role explicitly. `PlotOrchestrator._parse_raw_layer` and `_parse_raw_cell` now require the current YAML format (`layers` + `data_sources` dict keyed by role); the legacy `config`, `data_sources` list, and top-level `workflow_id` branches are removed. Grid templates updated accordingly.

**Tighten dashboard APIs: remove test-only optional dependencies**

`Orchestrator`, `SessionUpdater`, and `DataService` previously accepted optional constructor arguments so tests could inject `None` and skip real dependencies. These are now required (non-optional), the `None`-guard branches are removed, and `nullcontext` fallback in `Orchestrator.ingest()` is gone. Tests updated to always supply real objects.

### Test plan

- [x] Open dashboard with existing plot configs works
- [x] Load Bifrost plot grid templates works