### PR TITLE
Convert workflow/plot config modal to vertical tabs layout

### DIFF
--- a/scripts/generate_widget_screenshots.py
+++ b/scripts/generate_widget_screenshots.py
@@ -92,7 +92,7 @@ def create_widget_app(
     # Create adapter (dummy start callback)
     adapter = WorkflowConfigurationAdapter(
         spec=spec,
-        persistent_config=None,
+        config_state=None,
         start_callback=lambda *args, **kwargs: None,
     )
 

--- a/src/ess/livedata/dashboard/widgets/configuration_widget.py
+++ b/src/ess/livedata/dashboard/widgets/configuration_widget.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
+import html
 from collections.abc import Callable
 from typing import Any
 
@@ -13,7 +14,7 @@ from ess.livedata.config.workflow_spec import AuxSources
 from ess.livedata.dashboard.configuration_adapter import ConfigurationAdapter
 
 from .model_widget import ModelWidget
-from .styles import Colors, ErrorBox, StatusColors
+from .styles import Colors, ErrorBox, ModalSizing, StatusColors
 
 _VTABS_STYLESHEET = f"""
 .bk-tab {{
@@ -45,14 +46,10 @@ class ConfigurationWidget:
         self._aux_sources_widget = self._create_aux_sources_widget()
         self._source_error_pane = pn.pane.HTML("", sizing_mode='stretch_width')
         self._model_widget = self._create_model_widget()
-        self._tabs = self._build_tabs()
-        self._tab_field_order: list[str | None] = self._compute_tab_field_order()
-        self._title_pane = pn.pane.HTML(
-            f"<h2 style='margin:0 0 4px 0;'>{self._config.title}</h2>"
-            f"<p style='margin:0; color:#666;'>{self._config.description}</p>",
-            sizing_mode='stretch_width',
-        )
-        self._widget = self._create_widget()
+        self._tabs: pn.Tabs | None = None
+        self._tab_field_order: list[str | None] = []
+        self._title_pane = self._create_title_pane()
+        self._widget = pn.Column(self._build_body(), sizing_mode='stretch_both')
 
     def _create_source_selector(self) -> pn.widgets.MultiChoice | None:
         """Create source selection widget, or None if no sources available."""
@@ -116,18 +113,27 @@ class ConfigurationWidget:
         except Exception as e:
             return ErrorWidget(str(e))
 
-        if model_class is None:
+        if model_class is None or not model_class.model_fields:
             return NoParamsWidget()
-        else:
-            return ModelWidget(
-                model_class=model_class,
-                initial_values=self._config.initial_parameter_values,
-                show_descriptions=True,
-                hidden_fields=self._config.hidden_fields,
-            )
+        return ModelWidget(
+            model_class=model_class,
+            initial_values=self._config.initial_parameter_values,
+            show_descriptions=True,
+            hidden_fields=self._config.hidden_fields,
+        )
 
-    def _build_general_tab(self) -> pn.Column:
-        """Build the 'General' tab content: sources + aux dropdowns."""
+    def _create_title_pane(self) -> pn.pane.HTML:
+        """Build the title/description pane with HTML-escaped text."""
+        title = html.escape(self._config.title)
+        description = html.escape(self._config.description)
+        return pn.pane.HTML(
+            f"<h2 style='margin:0 0 4px 0;'>{title}</h2>"
+            f"<p style='margin:0; color:{Colors.TEXT_MUTED};'>{description}</p>",
+            sizing_mode='stretch_width',
+        )
+
+    def _general_tab_items(self) -> list[Any]:
+        """Collect items that belong in the 'General' tab (sources/aux/errors)."""
         items: list[Any] = []
         if self._source_selector is not None:
             items.append(self._source_selector)
@@ -136,65 +142,63 @@ class ConfigurationWidget:
             items.append(self._aux_sources_widget.panel)
         if isinstance(self._model_widget, ErrorWidget):
             items.append(self._model_widget.widget)
-        if not items:
-            items.append(
-                pn.pane.HTML(
-                    "<p style='color: #666; font-style: italic;'>"
-                    "No general settings.</p>"
+        return items
+
+    def _build_body(self) -> pn.Tabs | pn.Column | pn.pane.HTML:
+        """Build the body: vertical tabs when multiple sections exist, else the
+        model widget directly."""
+        general_items = self._general_tab_items()
+        param_tabs = self._model_widget.param_group_tabs
+        if not general_items and not param_tabs:
+            # Nothing tabbable (typically NoParamsWidget with no sources).
+            self._tabs = None
+            self._tab_field_order = []
+            return self._model_widget.widget
+
+        tab_entries: list[tuple[str, pn.Column]] = []
+        field_order: list[str | None] = []
+        if general_items:
+            tab_entries.append(
+                (
+                    'General',
+                    pn.Column(
+                        *general_items, sizing_mode='stretch_width', margin=(10, 10)
+                    ),
                 )
             )
-        return pn.Column(*items, sizing_mode='stretch_width', margin=(10, 10))
+            field_order.append(None)
+        for field_name, title, content in param_tabs:
+            tab_entries.append((title, content))
+            field_order.append(field_name)
 
-    def _build_tabs(self) -> pn.Tabs:
-        """Build the vertical tabs: General first, then one per param group."""
-        tabs: list[tuple[str, pn.Column]] = [('General', self._build_general_tab())]
-        for _, title, content in self._model_widget.param_group_tabs:
-            tabs.append((title, content))
-        return pn.Tabs(
-            *tabs,
+        self._tabs = pn.Tabs(
+            *tab_entries,
             tabs_location='left',
             dynamic=True,
             sizing_mode='stretch_width',
             min_height=350,
             stylesheets=[_VTABS_STYLESHEET],
         )
-
-    def _compute_tab_field_order(self) -> list[str | None]:
-        """Return the field name (or None for 'General') of each tab index."""
-        order: list[str | None] = [None]
-        for field_name, _, _ in self._model_widget.param_group_tabs:
-            order.append(field_name)
-        return order
+        self._tab_field_order = field_order
+        return self._tabs
 
     def _on_aux_source_changed(self, event) -> None:
         """Handle auxiliary source selection change."""
         self._model_widget = self._create_model_widget()
         with pn.io.hold():
-            new_tabs = self._build_tabs()
-            new_order = self._compute_tab_field_order()
-            for i, item in enumerate(self._widget.objects):
-                if item is self._tabs:
-                    self._widget.objects = [
-                        *self._widget.objects[:i],
-                        new_tabs,
-                        *self._widget.objects[i + 1 :],
-                    ]
-                    break
-            self._tabs = new_tabs
-            self._tab_field_order = new_order
-
-    def _create_widget(self) -> pn.Column:
-        """Create the main configuration widget body (tabs only; title is separate)."""
-        return pn.Column(self._tabs, sizing_mode='stretch_both')
+            self._widget.objects = [self._build_body()]
 
     @property
     def widget(self) -> pn.Column:
-        """Get the Panel widget body (tabs, no title)."""
+        """Configuration body (tabs or fallback widget); does not include title."""
         return self._widget
 
     @property
     def title_pane(self) -> pn.pane.HTML:
-        """Get the title/description pane so callers can place it where appropriate."""
+        """Title/description pane.
+
+        Separate so callers can pin it above a scroll area.
+        """
         return self._title_pane
 
     @property
@@ -263,13 +267,23 @@ class ConfigurationWidget:
         """Switch to the first tab containing a validation error.
 
         Source errors and whole-model errors resolve to the 'General' tab.
-        Per-field errors resolve to the tab owning that field.
+        Per-field errors resolve to the tab owning that field. No-op when the
+        body falls back to a non-tabbed widget.
         """
-        if self._source_selector is not None and len(self.selected_sources) == 0:
-            self._tabs.active = 0
+        if self._tabs is None:
             return
-        if isinstance(self._model_widget, ErrorWidget):
-            self._tabs.active = 0
+        general_index = (
+            self._tab_field_order.index(None) if None in self._tab_field_order else -1
+        )
+        if (
+            self._source_selector is not None
+            and len(self.selected_sources) == 0
+            and general_index >= 0
+        ):
+            self._tabs.active = general_index
+            return
+        if isinstance(self._model_widget, ErrorWidget) and general_index >= 0:
+            self._tabs.active = general_index
             return
         failing = self._model_widget.get_failing_field_names()
         if not failing:
@@ -300,20 +314,17 @@ class ConfigurationPanel:
         self._config_widget = ConfigurationWidget(config)
         self._error_pane = pn.pane.HTML("", sizing_mode='stretch_width')
         self._logger = structlog.get_logger()
-        self._panel = self._create_panel()
-
-    def _create_panel(self) -> pn.Column:
-        """Create the configuration panel body (tabs + error pane)."""
-        return pn.Column(
+        self._body = pn.Column(
             self._config_widget.widget,
             self._error_pane,
             sizing_mode='stretch_both',
         )
+        self._combined_panel: pn.Column | None = None
 
-    @property
-    def title_pane(self) -> pn.pane.HTML:
-        """Title/description pane for the underlying configuration widget."""
-        return self._config_widget.title_pane
+    def split_for_sticky_header(self) -> tuple[pn.pane.HTML, pn.Column]:
+        """Return (title pane, body) separately for modal layouts that pin the
+        title above an independently scrolling body."""
+        return self._config_widget.title_pane, self._body
 
     def validate(self) -> tuple[bool, list[str]]:
         """
@@ -408,8 +419,18 @@ class ConfigurationPanel:
 
     @property
     def panel(self) -> pn.Column:
-        """Get the panel widget."""
-        return self._panel
+        """Combined panel: title + body (for inline/non-modal placement).
+
+        Mutually exclusive with :meth:`split_for_sticky_header`; do not use both
+        for the same ``ConfigurationPanel`` instance.
+        """
+        if self._combined_panel is None:
+            self._combined_panel = pn.Column(
+                self._config_widget.title_pane,
+                self._body,
+                sizing_mode='stretch_both',
+            )
+        return self._combined_panel
 
 
 class ConfigurationModal:
@@ -460,14 +481,15 @@ class ConfigurationModal:
             margin=(10, 0),
             sizing_mode='stretch_width',
         )
+        title, body = self._panel.split_for_sticky_header()
         scroll_body = pn.Column(
-            self._panel.panel,
+            body,
             sizing_mode='stretch_width',
-            max_height=650,
+            max_height=ModalSizing.SCROLL_BODY_MAX_HEIGHT,
             scroll=True,
         )
         content = pn.Column(
-            self._panel.title_pane,
+            title,
             scroll_body,
             footer,
             sizing_mode='stretch_width',
@@ -476,7 +498,7 @@ class ConfigurationModal:
             content,
             name=f"Configure {self._config.title}",
             margin=20,
-            width=800,
+            width=ModalSizing.WIDTH,
         )
 
         modal.param.watch(self._on_modal_closed, 'open')

--- a/src/ess/livedata/dashboard/widgets/configuration_widget.py
+++ b/src/ess/livedata/dashboard/widgets/configuration_widget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
 
 import panel as pn
 import pydantic
@@ -12,7 +13,19 @@ from ess.livedata.config.workflow_spec import AuxSources
 from ess.livedata.dashboard.configuration_adapter import ConfigurationAdapter
 
 from .model_widget import ModelWidget
-from .styles import ErrorBox, StatusColors
+from .styles import Colors, ErrorBox, StatusColors
+
+_VTABS_STYLESHEET = f"""
+.bk-tab {{
+    border-right: 1px solid {Colors.TAB_BORDER} !important;
+    text-align: left !important;
+}}
+.bk-tab.bk-active {{
+    background-color: {Colors.TAB_ACTIVE_BG} !important;
+    border: 1px solid {Colors.TAB_BORDER} !important;
+    border-right: none !important;
+}}
+"""
 
 
 class ConfigurationWidget:
@@ -30,8 +43,15 @@ class ConfigurationWidget:
         self._config = config
         self._source_selector = self._create_source_selector()
         self._aux_sources_widget = self._create_aux_sources_widget()
-        self._model_widget = self._create_model_widget()
         self._source_error_pane = pn.pane.HTML("", sizing_mode='stretch_width')
+        self._model_widget = self._create_model_widget()
+        self._tabs = self._build_tabs()
+        self._tab_field_order: list[str | None] = self._compute_tab_field_order()
+        self._title_pane = pn.pane.HTML(
+            f"<h2 style='margin:0 0 4px 0;'>{self._config.title}</h2>"
+            f"<p style='margin:0; color:#666;'>{self._config.description}</p>",
+            sizing_mode='stretch_width',
+        )
         self._widget = self._create_widget()
 
     def _create_source_selector(self) -> pn.widgets.MultiChoice | None:
@@ -62,7 +82,6 @@ class ConfigurationWidget:
             value=sorted(initial_source_names),
             placeholder="Select source names to apply workflow to",
             sizing_mode='stretch_width',
-            margin=(0, 0, 0, 0),
         )
 
     def _create_aux_sources_widget(self) -> AuxSourcesWidget | None:
@@ -104,57 +123,79 @@ class ConfigurationWidget:
                 model_class=model_class,
                 initial_values=self._config.initial_parameter_values,
                 show_descriptions=True,
-                cards_collapsed=False,
                 hidden_fields=self._config.hidden_fields,
             )
 
+    def _build_general_tab(self) -> pn.Column:
+        """Build the 'General' tab content: sources + aux dropdowns."""
+        items: list[Any] = []
+        if self._source_selector is not None:
+            items.append(self._source_selector)
+            items.append(self._source_error_pane)
+        if self._aux_sources_widget is not None:
+            items.append(self._aux_sources_widget.panel)
+        if isinstance(self._model_widget, ErrorWidget):
+            items.append(self._model_widget.widget)
+        if not items:
+            items.append(
+                pn.pane.HTML(
+                    "<p style='color: #666; font-style: italic;'>"
+                    "No general settings.</p>"
+                )
+            )
+        return pn.Column(*items, sizing_mode='stretch_width', margin=(10, 10))
+
+    def _build_tabs(self) -> pn.Tabs:
+        """Build the vertical tabs: General first, then one per param group."""
+        tabs: list[tuple[str, pn.Column]] = [('General', self._build_general_tab())]
+        for _, title, content in self._model_widget.param_group_tabs:
+            tabs.append((title, content))
+        return pn.Tabs(
+            *tabs,
+            tabs_location='left',
+            dynamic=True,
+            sizing_mode='stretch_width',
+            min_height=350,
+            stylesheets=[_VTABS_STYLESHEET],
+        )
+
+    def _compute_tab_field_order(self) -> list[str | None]:
+        """Return the field name (or None for 'General') of each tab index."""
+        order: list[str | None] = [None]
+        for field_name, _, _ in self._model_widget.param_group_tabs:
+            order.append(field_name)
+        return order
+
     def _on_aux_source_changed(self, event) -> None:
         """Handle auxiliary source selection change."""
-        # Recreate model widget with new model class
-        old_widget = self._model_widget
         self._model_widget = self._create_model_widget()
-
-        # Replace widget in the column
-        # Batch the widget replacement to avoid multiple render cycles
         with pn.io.hold():
-            widget_index = None
+            new_tabs = self._build_tabs()
+            new_order = self._compute_tab_field_order()
             for i, item in enumerate(self._widget.objects):
-                if item is old_widget.widget:
-                    widget_index = i
+                if item is self._tabs:
+                    self._widget.objects = [
+                        *self._widget.objects[:i],
+                        new_tabs,
+                        *self._widget.objects[i + 1 :],
+                    ]
                     break
-
-            if widget_index is not None:
-                self._widget.objects = [
-                    *self._widget.objects[:widget_index],
-                    self._model_widget.widget,
-                    *self._widget.objects[widget_index + 1 :],
-                ]
+            self._tabs = new_tabs
+            self._tab_field_order = new_order
 
     def _create_widget(self) -> pn.Column:
-        """Create the main configuration widget."""
-        components = [
-            pn.pane.HTML(
-                f"<h1>{self._config.title}</h1><p>{self._config.description}</p>"
-            ),
-        ]
-
-        # Add source selector only if there are sources to select
-        if self._source_selector is not None:
-            components.append(self._source_selector)
-            components.append(self._source_error_pane)
-
-        # Add auxiliary sources widget if it exists
-        if self._aux_sources_widget is not None:
-            components.append(self._aux_sources_widget.panel)
-
-        components.append(self._model_widget.widget)
-
-        return pn.Column(*components)
+        """Create the main configuration widget body (tabs only; title is separate)."""
+        return pn.Column(self._tabs, sizing_mode='stretch_both')
 
     @property
     def widget(self) -> pn.Column:
-        """Get the Panel widget."""
+        """Get the Panel widget body (tabs, no title)."""
         return self._widget
+
+    @property
+    def title_pane(self) -> pn.pane.HTML:
+        """Get the title/description pane so callers can place it where appropriate."""
+        return self._title_pane
 
     @property
     def selected_sources(self) -> list[str]:
@@ -218,6 +259,27 @@ class ConfigurationWidget:
         self._highlight_source_error(False)
         self._model_widget.clear_validation_errors()
 
+    def activate_first_error_tab(self) -> None:
+        """Switch to the first tab containing a validation error.
+
+        Source errors and whole-model errors resolve to the 'General' tab.
+        Per-field errors resolve to the tab owning that field.
+        """
+        if self._source_selector is not None and len(self.selected_sources) == 0:
+            self._tabs.active = 0
+            return
+        if isinstance(self._model_widget, ErrorWidget):
+            self._tabs.active = 0
+            return
+        failing = self._model_widget.get_failing_field_names()
+        if not failing:
+            return
+        first = failing[0]
+        for i, field_name in enumerate(self._tab_field_order):
+            if field_name == first:
+                self._tabs.active = i
+                return
+
 
 class ConfigurationPanel:
     """Reusable configuration panel with validation and action execution."""
@@ -241,11 +303,17 @@ class ConfigurationPanel:
         self._panel = self._create_panel()
 
     def _create_panel(self) -> pn.Column:
-        """Create the configuration panel."""
+        """Create the configuration panel body (tabs + error pane)."""
         return pn.Column(
             self._config_widget.widget,
             self._error_pane,
+            sizing_mode='stretch_both',
         )
+
+    @property
+    def title_pane(self) -> pn.pane.HTML:
+        """Title/description pane for the underlying configuration widget."""
+        return self._config_widget.title_pane
 
     def validate(self) -> tuple[bool, list[str]]:
         """
@@ -263,6 +331,7 @@ class ConfigurationPanel:
 
         if not is_valid:
             self._show_validation_errors(errors)
+            self._config_widget.activate_first_error_tab()
 
         return is_valid, errors
 
@@ -383,29 +452,34 @@ class ConfigurationModal:
         self._modal = self._create_modal()
 
     def _create_modal(self) -> pn.Modal:
-        """Create the modal dialog."""
-        # Combine panel with buttons
-        content = pn.Column(
-            self._panel.panel,
-            pn.Row(
-                pn.Spacer(),
-                self._cancel_button,
-                self._start_button,
-                margin=(10, 0),
-            ),
+        """Create the modal dialog with sticky header + footer."""
+        footer = pn.Row(
+            pn.Spacer(),
+            self._cancel_button,
+            self._start_button,
+            margin=(10, 0),
+            sizing_mode='stretch_width',
         )
-
+        scroll_body = pn.Column(
+            self._panel.panel,
+            sizing_mode='stretch_width',
+            max_height=650,
+            scroll=True,
+        )
+        content = pn.Column(
+            self._panel.title_pane,
+            scroll_body,
+            footer,
+            sizing_mode='stretch_width',
+        )
         modal = pn.Modal(
             content,
             name=f"Configure {self._config.title}",
             margin=20,
             width=800,
-            height=800,
         )
 
-        # Watch for modal close events to clean up
         modal.param.watch(self._on_modal_closed, 'open')
-
         return modal
 
     def _on_start_clicked(self, event) -> None:
@@ -503,6 +577,11 @@ class NoParamsWidget:
         )
 
     @property
+    def param_group_tabs(self) -> list[tuple[str, str, pn.Column]]:
+        """No parameter groups when the model has no fields."""
+        return []
+
+    @property
     def parameter_values(self) -> pydantic.BaseModel:
         """Return empty model serializing to empty dict."""
         return self.EmptyModel()
@@ -510,6 +589,10 @@ class NoParamsWidget:
     def validate_parameters(self) -> tuple[bool, list[str]]:
         """Always valid when no parameters."""
         return True, []
+
+    def get_failing_field_names(self) -> list[str]:
+        """No fields to fail."""
+        return []
 
     def clear_validation_errors(self) -> None:
         """No-op for no parameters."""
@@ -532,6 +615,11 @@ class ErrorWidget:
         )
 
     @property
+    def param_group_tabs(self) -> list[tuple[str, str, pn.Column]]:
+        """No tabs when the model failed to build."""
+        return []
+
+    @property
     def parameter_values(self) -> None:
         """Return None when in error state."""
         return None
@@ -541,6 +629,10 @@ class ErrorWidget:
         return False, [
             "Configuration error - please check auxiliary source selections."
         ]
+
+    def get_failing_field_names(self) -> list[str]:
+        """The error is a whole-model error, not a per-field error."""
+        return []
 
     def clear_validation_errors(self) -> None:
         """No-op for error widget."""

--- a/src/ess/livedata/dashboard/widgets/model_widget.py
+++ b/src/ess/livedata/dashboard/widgets/model_widget.py
@@ -65,6 +65,7 @@ class ModelWidget:
         self._hidden_fields = hidden_fields
         self._parameter_widgets: dict[str, ParamWidget] = {}
         self._tab_entries: list[tuple[str, str, pn.Column]] = []
+        self._failing_field_names: list[str] = []
         try:
             self._build_tabs()
         except Exception as e:
@@ -151,25 +152,24 @@ class ModelWidget:
             (is_valid, list_of_error_messages)
         """
         errors = []
+        self._failing_field_names = []
         for field_name, widget in self._parameter_widgets.items():
             is_valid, error_msg = widget.validate()
             if not is_valid:
                 errors.append(f"{field_name}: {error_msg}")
+                self._failing_field_names.append(field_name)
                 widget.set_error_state(True, error_msg)
             else:
                 widget.set_error_state(False, "")
         return len(errors) == 0, errors
 
     def get_failing_field_names(self) -> list[str]:
-        """Return field names whose widget currently fails validation."""
-        return [
-            name
-            for name, widget in self._parameter_widgets.items()
-            if not widget.validate()[0]
-        ]
+        """Return field names that failed the most recent validate_parameters call."""
+        return list(self._failing_field_names)
 
     def clear_validation_errors(self) -> None:
         """Clear all validation error states."""
+        self._failing_field_names = []
         for widget in self._parameter_widgets.values():
             widget.set_error_state(False, "")
 

--- a/src/ess/livedata/dashboard/widgets/model_widget.py
+++ b/src/ess/livedata/dashboard/widgets/model_widget.py
@@ -7,6 +7,7 @@ import pydantic
 from pydantic_core import PydanticUndefined
 
 from .param_widget import ParamWidget
+from .styles import Colors
 
 
 def get_defaults(model: type[pydantic.BaseModel]) -> dict[str, Any]:
@@ -33,14 +34,14 @@ def get_defaults(model: type[pydantic.BaseModel]) -> dict[str, Any]:
 
 
 class ModelWidget:
-    """Generic widget for configuring Pydantic models with nested model fields."""
+    """Builds per-field tab content for configuring a Pydantic model with nested
+    model fields."""
 
     def __init__(
         self,
         model_class: type[pydantic.BaseModel],
         initial_values: dict[str, Any] | None = None,
         show_descriptions: bool = True,
-        cards_collapsed: bool = False,
         hidden_fields: frozenset[str] = frozenset(),
     ) -> None:
         """
@@ -54,8 +55,6 @@ class ModelWidget:
             Initial values to populate the widgets with
         show_descriptions
             Whether to show field descriptions
-        cards_collapsed
-            Whether parameter cards should be initially collapsed
         hidden_fields
             Field names to exclude from the UI. Hidden fields use their
             model defaults in ``parameter_values``.
@@ -63,49 +62,45 @@ class ModelWidget:
         self._model_class = model_class
         self._initial_values = initial_values or {}
         self._show_descriptions = show_descriptions
-        self._cards_collapsed = cards_collapsed
         self._hidden_fields = hidden_fields
         self._parameter_widgets: dict[str, ParamWidget] = {}
+        self._tab_entries: list[tuple[str, str, pn.Column]] = []
         try:
-            self._widget = self._create_widget()
+            self._build_tabs()
         except Exception as e:
             raise ValueError(
                 f"Failed to create ModelWidget for {model_class}: {e}"
             ) from e
 
-    def _create_widget(self) -> pn.Column:
-        """Create the main model configuration widget."""
-        widget_data = self._get_parameter_widget_data()
-
-        parameter_cards = []
-        for field_name, data in widget_data.items():
+    def _build_tabs(self) -> None:
+        """Build one (field_name, title, content) entry per parameter group."""
+        for field_name, data in self._get_parameter_widget_data().items():
             param_widget = ParamWidget(data['field_type'])
             param_widget.set_values(data['values'])
             self._parameter_widgets[field_name] = param_widget
 
-            # Create card content
-            card_content = [param_widget.panel()]
-
-            # Add description if available and enabled
+            content: list[Any] = [param_widget.panel()]
             if self._show_descriptions and data['description']:
-                description_pane = pn.pane.HTML(
-                    "<p style='margin: 0 0 0 0; color: #666; font-size: 0.9em;'>"
-                    f"{data['description']}</p>",
-                    margin=(5, 5),
+                content.insert(
+                    0,
+                    pn.pane.HTML(
+                        "<p style='margin: 0 0 10px 0; "
+                        f"color: {Colors.TEXT_MUTED}; font-size: 0.9em;'>"
+                        f"{data['description']}</p>",
+                        margin=(5, 5),
+                    ),
                 )
-                card_content.insert(0, description_pane)
-
-            card = pn.Card(
-                *card_content,
-                title=data['title'],
-                margin=(3, 0),
-                collapsed=self._cards_collapsed,
-                width_policy='max',
-                sizing_mode='stretch_width',
+            self._tab_entries.append(
+                (
+                    field_name,
+                    data['title'],
+                    pn.Column(
+                        *content,
+                        sizing_mode='stretch_width',
+                        margin=(10, 10),
+                    ),
+                )
             )
-            parameter_cards.append(card)
-
-        return pn.Column(*parameter_cards, sizing_mode='stretch_width')
 
     def _get_parameter_widget_data(self) -> dict[str, dict[str, Any]]:
         """Get parameter widget data for the model."""
@@ -133,9 +128,9 @@ class ModelWidget:
         return widget_data
 
     @property
-    def widget(self) -> pn.Column:
-        """Get the Panel widget."""
-        return self._widget
+    def param_group_tabs(self) -> list[tuple[str, str, pn.Column]]:
+        """Return (field_name, title, content) for each parameter group."""
+        return list(self._tab_entries)
 
     @property
     def parameter_values(self) -> pydantic.BaseModel:
@@ -156,8 +151,6 @@ class ModelWidget:
             (is_valid, list_of_error_messages)
         """
         errors = []
-
-        # Validate parameter widgets
         for field_name, widget in self._parameter_widgets.items():
             is_valid, error_msg = widget.validate()
             if not is_valid:
@@ -165,8 +158,15 @@ class ModelWidget:
                 widget.set_error_state(True, error_msg)
             else:
                 widget.set_error_state(False, "")
-
         return len(errors) == 0, errors
+
+    def get_failing_field_names(self) -> list[str]:
+        """Return field names whose widget currently fails validation."""
+        return [
+            name
+            for name, widget in self._parameter_widgets.items()
+            if not widget.validate()[0]
+        ]
 
     def clear_validation_errors(self) -> None:
         """Clear all validation error states."""

--- a/src/ess/livedata/dashboard/widgets/param_widget.py
+++ b/src/ess/livedata/dashboard/widgets/param_widget.py
@@ -35,9 +35,9 @@ class ParamWidget:
 
     def _create_layout(self):
         """Create the layout with widgets and error pane."""
-        widget_row = pn.Row(*self.widgets.values(), sizing_mode='stretch_width')
+        widget_column = pn.Column(*self.widgets.values(), sizing_mode='stretch_width')
         self.layout = pn.Column(
-            widget_row, self._error_pane, sizing_mode='stretch_width'
+            widget_column, self._error_pane, sizing_mode='stretch_width'
         )
 
     def _create_widget_for_field(
@@ -66,7 +66,7 @@ class ParamWidget:
             'name': display_name,
             'description': description,
             'sizing_mode': 'stretch_width',
-            'margin': (0, 5),
+            'margin': (5, 5),
             'disabled': field_info.frozen or False,
         }
 

--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -40,7 +40,7 @@ from ess.livedata.dashboard.plot_orchestrator import (
 from ess.livedata.dashboard.plotter_registry import PlotterSpec
 
 from .configuration_widget import ConfigurationPanel
-from .styles import Colors
+from .styles import Colors, ModalSizing
 from .wizard import Wizard, WizardStep
 
 logger = structlog.get_logger(__name__)
@@ -1213,7 +1213,6 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
         self._config_panel = ConfigurationPanel(config=config_adapter)
 
         self._panel_container.clear()
-        self._panel_container.append(self._config_panel.title_pane)
         self._panel_container.append(self._config_panel.panel)
 
     def _on_config_collected(
@@ -1338,8 +1337,8 @@ class PlotConfigModal:
             self._wizard.render(),
             name=modal_title,
             margin=20,
-            width=800,
-            max_height=800,
+            width=ModalSizing.WIDTH,
+            max_height=ModalSizing.MAX_HEIGHT,
         )
 
         # Watch for modal close events

--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -1213,6 +1213,7 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
         self._config_panel = ConfigurationPanel(config=config_adapter)
 
         self._panel_container.clear()
+        self._panel_container.append(self._config_panel.title_pane)
         self._panel_container.append(self._config_panel.panel)
 
     def _on_config_collected(
@@ -1338,7 +1339,7 @@ class PlotConfigModal:
             name=modal_title,
             margin=20,
             width=800,
-            height=800,
+            max_height=800,
         )
 
         # Watch for modal close events

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -171,11 +171,11 @@ class PlotGridTabs:
                     font-weight: bold;
                 }}
                 .bk-tab {{
-                    border-bottom: 1px solid #2c5aa0 !important;
+                    border-bottom: 1px solid {Colors.TAB_BORDER} !important;
                 }}
                 .bk-tab.bk-active {{
-                    background-color: #e8f4f8 !important;
-                    border: 1px solid #2c5aa0 !important;
+                    background-color: {Colors.TAB_ACTIVE_BG} !important;
+                    border: 1px solid {Colors.TAB_BORDER} !important;
                     border-bottom: none !important;
                 }}
                 """

--- a/src/ess/livedata/dashboard/widgets/styles.py
+++ b/src/ess/livedata/dashboard/widgets/styles.py
@@ -38,6 +38,8 @@ class Colors:
     TEXT_DARK = "#212529"
     TEXT = "#495057"
     TEXT_MUTED = "#6c757d"
+    TAB_BORDER = "#2c5aa0"
+    TAB_ACTIVE_BG = "#e8f4f8"
 
 
 class ErrorBox:

--- a/src/ess/livedata/dashboard/widgets/styles.py
+++ b/src/ess/livedata/dashboard/widgets/styles.py
@@ -56,3 +56,11 @@ class WarningBox:
     BG = "#fff3cd"
     BORDER = "#ffc107"
     TEXT = "#856404"
+
+
+class ModalSizing:
+    """Shared sizing constants for modal dialogs with sticky header/footer."""
+
+    WIDTH = 800
+    MAX_HEIGHT = 800
+    SCROLL_BODY_MAX_HEIGHT = 650

--- a/src/ess/livedata/dashboard/widgets/wizard.py
+++ b/src/ess/livedata/dashboard/widgets/wizard.py
@@ -10,6 +10,8 @@ from typing import Any, Generic, TypeVar
 
 import panel as pn
 
+from .styles import ModalSizing
+
 TInput = TypeVar('TInput')
 TOutput = TypeVar('TOutput')
 
@@ -308,7 +310,7 @@ class Wizard:
         scrollable_content = pn.Column(
             self._current_step.render_content(),
             sizing_mode='stretch_width',
-            max_height=650,
+            max_height=ModalSizing.SCROLL_BODY_MAX_HEIGHT,
             scroll=True,
         )
 

--- a/src/ess/livedata/dashboard/widgets/wizard.py
+++ b/src/ess/livedata/dashboard/widgets/wizard.py
@@ -52,32 +52,13 @@ class WizardStep(ABC, Generic[TInput, TOutput]):
         """Optional description text shown below the step header."""
         return None
 
-    def render(self, step_number: int) -> pn.Column:
-        """
-        Render the step's UI with automatic header generation.
-
-        Parameters
-        ----------
-        step_number:
-            The 1-based step number to display in the header
-
-        Returns
-        -------
-        :
-            Column containing header and step content
-        """
+    def render_header(self, step_number: int) -> pn.pane.HTML:
+        """Render the sticky header (step number, name, description)."""
         self._step_number = step_number
-
-        # Build header
-        header_parts = [f"<h3>Step {step_number}: {self.name}</h3>"]
+        parts = [f"<h3>Step {step_number}: {self.name}</h3>"]
         if self.description:
-            header_parts.append(f"<p>{self.description}</p>")
-
-        return pn.Column(
-            pn.pane.HTML("".join(header_parts)),
-            self.render_content(),
-            sizing_mode='stretch_width',
-        )
+            parts.append(f"<p>{self.description}</p>")
+        return pn.pane.HTML("".join(parts), sizing_mode='stretch_width')
 
     @abstractmethod
     def render_content(self) -> pn.Column | pn.viewable.Viewable:
@@ -177,8 +158,7 @@ class Wizard:
         )
         self._cancel_button.on_click(self._on_cancel_clicked)
 
-        # Content container - stretch both to fill modal and allow proper scrolling
-        self._content = pn.Column(sizing_mode='stretch_both')
+        self._content = pn.Column(sizing_mode='stretch_width')
 
     def advance(self) -> None:
         """Move to next step if current step is valid."""
@@ -323,15 +303,16 @@ class Wizard:
         # Create navigation button row (fixed at bottom)
         nav_row = pn.Row(*nav_buttons, sizing_mode='stretch_width', margin=(10, 0))
 
-        # Create scrollable content area
-        # Use scroll=True to enable scrolling when content exceeds available space
+        # Sticky header + scrollable body + sticky nav row
+        sticky_header = self._current_step.render_header(self._current_step_index + 1)
         scrollable_content = pn.Column(
-            self._current_step.render(self._current_step_index + 1),
-            sizing_mode='stretch_both',
+            self._current_step.render_content(),
+            sizing_mode='stretch_width',
+            max_height=650,
             scroll=True,
         )
 
-        # Layout: scrollable content above fixed buttons
+        self._content.append(sticky_header)
         self._content.append(scrollable_content)
         self._content.append(nav_row)
 

--- a/tests/dashboard/widgets/configuration_widget_test.py
+++ b/tests/dashboard/widgets/configuration_widget_test.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for ConfigurationWidget / ConfigurationPanel tab routing and rendering."""
+
+from __future__ import annotations
+
+import panel as pn
+import pydantic
+import pytest
+
+from ess.livedata.dashboard.configuration_adapter import ConfigurationAdapter
+from ess.livedata.dashboard.widgets.configuration_widget import (
+    ConfigurationPanel,
+    ConfigurationWidget,
+    NoParamsWidget,
+)
+from ess.livedata.dashboard.widgets.model_widget import ModelWidget
+
+
+class _Params1(pydantic.BaseModel):
+    a: int = 1
+
+
+class _Params2(pydantic.BaseModel):
+    b: int = pydantic.Field(default=0, ge=0, le=10)
+
+
+class _MultiGroupModel(pydantic.BaseModel):
+    group_one: _Params1 = pydantic.Field(default_factory=_Params1, title='Group One')
+    group_two: _Params2 = pydantic.Field(default_factory=_Params2, title='Group Two')
+
+
+class _EmptyModel(pydantic.BaseModel):
+    pass
+
+
+class _Adapter(ConfigurationAdapter):
+    """Minimal ConfigurationAdapter for driving the widget in tests."""
+
+    def __init__(
+        self,
+        *,
+        title: str = 'Test',
+        description: str = 'desc',
+        model: type[pydantic.BaseModel] | None = _MultiGroupModel,
+        source_names: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._description = description
+        self._model = model
+        self._source_names = source_names if source_names is not None else ['s1', 's2']
+        self.started_with: tuple[list[str], pydantic.BaseModel | None] | None = None
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    def model_class(self) -> type[pydantic.BaseModel] | None:
+        return self._model
+
+    @property
+    def source_names(self) -> list[str]:
+        return self._source_names
+
+    def start_action(
+        self, selected_sources: list[str], parameter_values: pydantic.BaseModel
+    ) -> None:
+        self.started_with = (selected_sources, parameter_values)
+
+
+def _param_tab_index(widget: ConfigurationWidget, field_name: str) -> int:
+    return widget._tab_field_order.index(field_name)
+
+
+class TestTitlePaneEscaping:
+    def test_title_and_description_are_html_escaped(self) -> None:
+        adapter = _Adapter(
+            title='Evil <script>alert(1)</script>',
+            description='Also "quoted" & stuff',
+        )
+        widget = ConfigurationWidget(adapter)
+        html_text = widget.title_pane.object
+        assert '<script>' not in html_text
+        assert '&lt;script&gt;' in html_text
+        assert '&amp;' in html_text
+
+
+class TestBodyShape:
+    def test_tabs_created_when_multiple_groups(self) -> None:
+        widget = ConfigurationWidget(_Adapter())
+        body = widget.widget.objects[0]
+        assert isinstance(body, pn.Tabs)
+        assert list(body._names) == ['General', 'Group One', 'Group Two']
+
+    def test_no_tabs_when_nothing_to_configure(self) -> None:
+        """No sources + no params → body falls back to NoParamsWidget directly."""
+        adapter = _Adapter(model=_EmptyModel, source_names=[])
+        widget = ConfigurationWidget(adapter)
+        body = widget.widget.objects[0]
+        assert not isinstance(body, pn.Tabs)
+        assert widget._tabs is None
+
+    def test_activate_first_error_tab_is_noop_when_no_tabs(self) -> None:
+        adapter = _Adapter(model=_EmptyModel, source_names=[])
+        widget = ConfigurationWidget(adapter)
+        widget.activate_first_error_tab()  # must not raise
+
+
+class TestErrorTabRouting:
+    def test_source_error_activates_general_tab(self) -> None:
+        widget = ConfigurationWidget(_Adapter())
+        # Clear source selection, switch to a non-General tab, then validate.
+        widget._source_selector.value = []
+        body = widget.widget.objects[0]
+        assert isinstance(body, pn.Tabs)
+        body.active = _param_tab_index(widget, 'group_two')
+        valid, _ = widget.validate_configuration()
+        assert not valid
+        widget.activate_first_error_tab()
+        assert body.active == _param_tab_index(widget, None)  # General
+
+    def test_param_error_activates_owning_tab(self) -> None:
+        widget = ConfigurationWidget(_Adapter())
+        # Inject out-of-range value into group_two.b (must be 0..10).
+        param_widget = widget._model_widget.get_parameter_widget('group_two')
+        assert param_widget is not None
+        param_widget.set_values({'b': 999})
+        body = widget.widget.objects[0]
+        assert isinstance(body, pn.Tabs)
+        body.active = _param_tab_index(widget, None)  # General
+        valid, _ = widget.validate_configuration()
+        assert not valid
+        widget.activate_first_error_tab()
+        assert body.active == _param_tab_index(widget, 'group_two')
+
+
+class TestFailingFieldTracking:
+    def test_failing_names_populated_by_validate(self) -> None:
+        mw = ModelWidget(_MultiGroupModel)
+        mw.get_parameter_widget('group_two').set_values({'b': 999})
+        valid, _ = mw.validate_parameters()
+        assert not valid
+        assert mw.get_failing_field_names() == ['group_two']
+
+    def test_failing_names_cleared_on_success(self) -> None:
+        mw = ModelWidget(_MultiGroupModel)
+        mw.get_parameter_widget('group_two').set_values({'b': 999})
+        mw.validate_parameters()
+        mw.get_parameter_widget('group_two').set_values({'b': 1})
+        valid, _ = mw.validate_parameters()
+        assert valid
+        assert mw.get_failing_field_names() == []
+
+    def test_failing_names_cleared_by_clear_validation_errors(self) -> None:
+        mw = ModelWidget(_MultiGroupModel)
+        mw.get_parameter_widget('group_two').set_values({'b': 999})
+        mw.validate_parameters()
+        mw.clear_validation_errors()
+        assert mw.get_failing_field_names() == []
+
+
+class TestConfigurationPanelShape:
+    def test_panel_includes_title_then_body(self) -> None:
+        panel = ConfigurationPanel(_Adapter())
+        combined = panel.panel
+        assert combined.objects[0] is panel._config_widget.title_pane
+        # The second child is the body column holding the widget + error pane.
+        assert combined.objects[1] is panel._body
+
+    def test_panel_property_is_cached(self) -> None:
+        panel = ConfigurationPanel(_Adapter())
+        assert panel.panel is panel.panel
+
+    def test_split_for_sticky_header_returns_same_slots(self) -> None:
+        panel = ConfigurationPanel(_Adapter())
+        title, body = panel.split_for_sticky_header()
+        assert title is panel._config_widget.title_pane
+        assert body is panel._body
+
+
+class TestNoParamsWidget:
+    def test_no_params_widget_exposes_empty_tab_list(self) -> None:
+        widget = NoParamsWidget()
+        assert widget.param_group_tabs == []
+        assert widget.get_failing_field_names() == []
+
+
+@pytest.fixture(autouse=True)
+def _panel_extensions_loaded():
+    """Ensure Panel extensions required by pn.Tabs etc. are loaded."""
+    pn.extension()


### PR DESCRIPTION
## Summary

- Convert the workflow/plot configuration modal from stacked `pn.Card`s to a vertical tabs layout, with the modal title/description sticky above the tabbed body and the navigation row sticky at the bottom.
- Route error focus to the offending tab: source-selection errors activate the General tab; parameter errors activate the owning parameter tab.
- Extract shared modal sizing to `ModalSizing` in `styles.py` and HTML-escape user-visible title/description.

## Why

Stacked cards forced the user to scroll through every parameter group to reach a specific section, and validation errors deep in a card were easy to miss. Vertical tabs keep every group one click away, keep the header/footer visible, and let us focus the failing tab on validation.

### Before

<img width="1637" height="1632" alt="screenshot-2026-04-20T13:30:30" src="https://github.com/user-attachments/assets/fbbb24a9-eec2-453b-b2c9-8e5fd05323ca" />

### After

<img width="1620" height="1046" alt="screenshot-2026-04-20T13:29:08" src="https://github.com/user-attachments/assets/793ecf31-9508-45fc-9dc7-d47b3ec737f6" />
<img width="1622" height="1044" alt="screenshot-2026-04-20T13:28:58" src="https://github.com/user-attachments/assets/bc1784d8-7334-4c05-9754-8177834f93e4" />
<img width="1624" height="1163" alt="screenshot-2026-04-20T13:28:08" src="https://github.com/user-attachments/assets/df9e6d5c-f1e7-4254-96db-d7ee63869a2f" />
<img width="1627" height="1269" alt="screenshot-2026-04-20T13:27:41" src="https://github.com/user-attachments/assets/a19ae119-dbab-4ba7-8f82-fd3dfa3528be" />


## Notes

- `ConfigurationPanel.panel` now returns the combined title + body. `split_for_sticky_header()` exposes the two slots for the modal's sticky-header layout.
- `ModelWidget` no longer owns the outer container; it exposes `param_group_tabs` so the configuration widget can compose them with source selection into a single `pn.Tabs`. Failing field names are cached from the last `validate_parameters()` to avoid a second validation pass.
- When there are no sources and no params, the body falls back to a `NoParamsWidget` directly (no empty tabs).

## Test plan

- [x] Open a workflow config modal with multiple parameter groups — tabs on the left, title/footer stay pinned while scrolling.
- [x] Clear the source selection and click the action button — General tab activates, error visible.
- [x] Enter an out-of-range value in a parameter tab, switch to General, click the action button — the offending parameter tab activates.
- [x] Open a workflow with no params  — modal shows only the general tab.
- [x] Plot-config wizard still renders correctly across all steps (back/next navigation, sticky header, scrollable body).