### PR TITLE
Unify spectrum view into generic detector view workflow

### DIFF
--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -456,7 +456,7 @@ class Instrument:
                     transform=config.transform,
                     reduction_dim=config.reduction_dim,
                     roi_support=config.roi_support,
-                    spectrum=config.spectrum_view,
+                    spectrum_view=config.spectrum_view,
                 )
                 factory = DetectorViewFactory(
                     data_source=InstrumentDetectorSource(self),

--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from collections import UserDict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ess.livedata.handlers.detector_view_specs import SpectrumViewSpec
 
 import pydantic
 import scipp as sc
@@ -45,6 +48,7 @@ class LogicalViewConfig:
     roi_support: bool = True
     output_ndim: int | None = None
     reduction_dim: str | list[str] | None = None
+    spectrum_view: SpectrumViewSpec | None = None
 
 
 class InstrumentRegistry(UserDict[str, 'Instrument']):
@@ -258,6 +262,7 @@ class Instrument:
         roi_support: bool = True,
         output_ndim: int | None = None,
         reduction_dim: str | list[str] | None = None,
+        spectrum_view: SpectrumViewSpec | None = None,
     ) -> SpecHandle:
         """
         Register a logical detector view.
@@ -295,6 +300,10 @@ class Instrument:
             Dimension(s) to sum over after applying transform. If specified,
             enables proper ROI support by tracking which input pixels contribute
             to each output pixel.
+        spectrum_view:
+            Optional ``SpectrumViewSpec`` enabling a ``spectrum_view`` output
+            derived from the cumulative accumulated histogram via a
+            per-instrument transform.
 
         Returns
         -------
@@ -303,11 +312,14 @@ class Instrument:
         """
         from ess.livedata.handlers.detector_view_specs import (
             DetectorROIAuxSources,
-            DetectorViewParams,
             make_detector_view_outputs,
+            make_detector_view_params,
         )
 
-        outputs = make_detector_view_outputs(output_ndim, roi_support=roi_support)
+        outputs = make_detector_view_outputs(
+            output_ndim, roi_support=roi_support, spectrum=spectrum_view
+        )
+        params = make_detector_view_params(spectrum=spectrum_view)
         handle = self.register_spec(
             namespace=namespace,
             name=name,
@@ -316,7 +328,7 @@ class Instrument:
             description=description,
             source_names=list(source_names),
             aux_sources=DetectorROIAuxSources() if roi_support else None,
-            params=DetectorViewParams,
+            params=params,
             outputs=outputs,
         )
         self._logical_view_handles[name] = handle
@@ -330,6 +342,7 @@ class Instrument:
                 roi_support=roi_support,
                 output_ndim=output_ndim,
                 reduction_dim=reduction_dim,
+                spectrum_view=spectrum_view,
             )
         )
         return handle
@@ -439,13 +452,12 @@ class Instrument:
 
             for config in self._logical_views:
                 handle = self._logical_view_handles[config.name]
-                # Create view config for this logical view
                 view_config = ScilineLogicalViewConfig(
                     transform=config.transform,
                     reduction_dim=config.reduction_dim,
                     roi_support=config.roi_support,
+                    spectrum=config.spectrum_view,
                 )
-                # Create factory with InstrumentDetectorSource for dynamic lookup
                 factory = DetectorViewFactory(
                     data_source=InstrumentDetectorSource(self),
                     view_config=view_config,

--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -317,7 +317,7 @@ class Instrument:
         )
 
         outputs = make_detector_view_outputs(
-            output_ndim, roi_support=roi_support, spectrum=spectrum_view
+            output_ndim, roi_support=roi_support, spectrum_view=spectrum_view
         )
         params = make_detector_view_params(spectrum=spectrum_view)
         handle = self.register_spec(

--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -319,7 +319,7 @@ class Instrument:
         outputs = make_detector_view_outputs(
             output_ndim, roi_support=roi_support, spectrum_view=spectrum_view
         )
-        params = make_detector_view_params(spectrum=spectrum_view)
+        params = make_detector_view_params(spectrum_view=spectrum_view)
         handle = self.register_spec(
             namespace=namespace,
             name=name,

--- a/src/ess/livedata/config/instruments/bifrost/factories.py
+++ b/src/ess/livedata/config/instruments/bifrost/factories.py
@@ -16,7 +16,6 @@ from .specs import (
     BifrostCustomElasticQMapParams,
     BifrostElasticQMapParams,
     BifrostQMapParams,
-    BifrostWorkflowParams,
     DetectorRatemeterParams,
     DetectorRatemeterRegionParams,
 )
@@ -50,7 +49,6 @@ def setup_factories(instrument: Instrument) -> None:
         NeXusData,
         SampleRun,
     )
-    from ess.reduce.streaming import EternalAccumulator
     from ess.reduce.uncertainty import UncertaintyBroadcastMode
     from ess.reduce.unwrap import LookupTableFilename
     from ess.reduce.unwrap.types import LookupTableRelativeErrorThreshold
@@ -63,27 +61,12 @@ def setup_factories(instrument: Instrument) -> None:
     from scippnexus import NXdetector
 
     from ess.livedata.handlers.accumulators import LatestValue
-    from ess.livedata.handlers.detector_view import (
-        DetectorViewFactory,
-        InstrumentDetectorSource,
-        LogicalViewConfig,
-    )
     from ess.livedata.handlers.stream_processor_workflow import StreamProcessorWorkflow
 
     from .streams import detector_number
 
     # Configure detector
     instrument.configure_detector('unified_detector', detector_number=detector_number)
-
-    # Create detector view using Sciline-based factory with transform
-    _detector_view_factory = DetectorViewFactory(
-        data_source=InstrumentDetectorSource(instrument),
-        view_config=LogicalViewConfig(transform=_to_flat_detector_view),
-    )
-
-    specs.unified_detector_view_handle.attach_factory()(
-        _detector_view_factory.make_workflow
-    )
 
     # Monitor workflow factory (TOA-only)
     from ess.livedata.handlers.monitor_workflow import create_monitor_workflow
@@ -104,32 +87,8 @@ def setup_factories(instrument: Instrument) -> None:
         reduction_workflow,
         DetectorRegionCounts,
         detector_ratemeter,
-        SpectrumView,
-        SpectrumViewTimeBins,
-        SpectrumViewPixelsPerTube,
-        make_spectrum_view,
     ) = _create_base_reduction_workflow()
-
-    # Configure workflow with default parameters
-    reduction_workflow[SpectrumViewTimeBins] = 500
-    reduction_workflow[SpectrumViewPixelsPerTube] = 10
-    reduction_workflow.insert(make_spectrum_view)
     reduction_workflow.insert(detector_ratemeter)
-
-    @specs.spectrum_view_handle.attach_factory()
-    def _spectrum_view_workflow(
-        params: BifrostWorkflowParams,
-    ) -> StreamProcessorWorkflow:
-        wf = reduction_workflow.copy()
-        view_params = params.spectrum_view
-        wf[SpectrumViewTimeBins] = view_params.time_bins
-        wf[SpectrumViewPixelsPerTube] = view_params.pixels_per_tube
-        return StreamProcessorWorkflow(
-            wf,
-            dynamic_keys={'unified_detector': NeXusData[NXdetector, SampleRun]},
-            target_keys={'spectrum_view': SpectrumView},
-            accumulators={SpectrumView: EternalAccumulator},
-        )
 
     @specs.detector_ratemeter_handle.attach_factory()
     def _detector_ratemeter_workflow(
@@ -301,16 +260,6 @@ def _combine_banks(*bank: sc.DataArray) -> sc.DataArray:
     return _transpose_with_coords(combined, ('arc', 'tube', 'channel', 'pixel')).copy()
 
 
-def _to_flat_detector_view(
-    obj: sc.Variable | sc.DataArray, source_name: str
-) -> sc.DataArray:
-    da = sc.DataArray(obj) if isinstance(obj, sc.Variable) else obj
-    da = da.to(dtype='float32')
-    return da.flatten(dims=('arc', 'tube'), to='arc/tube').flatten(
-        dims=('channel', 'pixel'), to='channel/pixel'
-    )
-
-
 def _create_base_reduction_workflow():
     """
     Create the base Bifrost reduction workflow with all helper types and functions.
@@ -329,14 +278,6 @@ def _create_base_reduction_workflow():
         NewType for detector region counts.
     detector_ratemeter:
         Function that computes detector region counts.
-    SpectrumView:
-        NewType for spectrum view data.
-    SpectrumViewTimeBins:
-        NewType for spectrum view time bins parameter.
-    SpectrumViewPixelsPerTube:
-        NewType for spectrum view pixels per tube parameter.
-    make_spectrum_view:
-        Function that creates spectrum view from detector data.
     """
     # Lazy imports
     from typing import NewType
@@ -384,35 +325,6 @@ def _create_base_reduction_workflow():
         counts.variances = counts.values
         return DetectorRegionCounts(counts)
 
-    SpectrumView = NewType('SpectrumView', sc.DataArray)
-    SpectrumViewTimeBins = NewType('SpectrumViewTimeBins', int)
-    SpectrumViewPixelsPerTube = NewType('SpectrumViewPixelsPerTube', int)
-
-    def _make_spectrum_view(
-        data: RawDetector[SampleRun],
-        time_bins: SpectrumViewTimeBins,
-        pixels_per_tube: SpectrumViewPixelsPerTube,
-    ) -> SpectrumView:
-        edges = sc.linspace(
-            'event_time_offset', 0, 71_000_000, num=time_bins + 1, unit='ns'
-        )
-        per_arc = 3 * 900
-        detector_number_step = 100 // pixels_per_tube
-        detector_number = sc.arange(
-            'detector_number', 0, 5 * per_arc, step=detector_number_step, unit=None
-        ).fold(dim='detector_number', sizes={'arc': 5, 'detector_number': -1})
-        return SpectrumView(
-            data.fold('pixel', sizes={'pixel': pixels_per_tube, 'subpixel': -1})
-            .drop_coords(tuple(data.coords))
-            .bins.concat('subpixel')
-            .flatten(dims=('tube', 'channel', 'pixel'), to='detector_number')
-            .hist(event_time_offset=edges)
-            .assign_coords(
-                event_time_offset=edges.to(unit='ms'),
-                detector_number=detector_number,
-            )
-        )
-
     reduction_workflow = TofWorkflow(run_types=(SampleRun,), monitor_types=())
     reduction_workflow[Filename[SampleRun]] = get_nexus_geometry_filename('bifrost')
     reduction_workflow[EmptyDetector[SampleRun]] = (
@@ -421,12 +333,4 @@ def _create_base_reduction_workflow():
         .reduce(func=_combine_banks)
     )
 
-    return (
-        reduction_workflow,
-        DetectorRegionCounts,
-        _detector_ratemeter,
-        SpectrumView,
-        SpectrumViewTimeBins,
-        SpectrumViewPixelsPerTube,
-        _make_spectrum_view,
-    )
+    return reduction_workflow, DetectorRegionCounts, _detector_ratemeter

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/spectrum_view.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/spectrum_view.yaml
@@ -12,7 +12,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/data_reduction/spectrum_view/1
+        workflow_id: bifrost/detector_data/unified_detector_view/1
         output_name: spectrum_view
         source_names:
         - unified_detector

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -12,6 +12,7 @@ for full instrument details.
 """
 
 from enum import StrEnum
+from typing import Literal
 
 import pydantic
 import scipp as sc
@@ -380,18 +381,11 @@ def _logical_view(obj: sc.Variable | sc.DataArray, source_name: str) -> sc.DataA
 class BifrostSpectrumParams(pydantic.BaseModel):
     """Runtime parameters for the Bifrost spectrum-view transform."""
 
-    pixels_per_tube: int = pydantic.Field(
+    pixels_per_tube: Literal[1, 2, 4, 5, 10, 20, 25, 50, 100] = pydantic.Field(
         default=10,
         title='Pixels per tube',
-        description='Number of output pixels per tube. Must be a divisor of 100.',
+        description='Number of output pixels per tube.',
     )
-
-    @pydantic.field_validator('pixels_per_tube')
-    @classmethod
-    def _pixels_per_tube_must_be_divisor_of_100(cls, v: int) -> int:
-        if v <= 0 or 100 % v != 0:
-            raise ValueError('pixels_per_tube must be a positive divisor of 100')
-        return v
 
 
 def _bifrost_spectrum_transform(

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -18,10 +18,7 @@ import scipp as sc
 
 from ess.livedata.config import Instrument, instrument_registry
 from ess.livedata.config.workflow_spec import AuxInput, AuxSources, WorkflowOutputsBase
-from ess.livedata.handlers.detector_view_specs import (
-    DetectorViewOutputs,
-    DetectorViewParams,
-)
+from ess.livedata.handlers.detector_view_specs import SpectrumViewSpec
 from ess.livedata.handlers.monitor_workflow_specs import (
     TOAOnlyMonitorDataParams,
     register_monitor_workflow_specs,
@@ -70,51 +67,10 @@ class DetectorRatemeterRegionParams(pydantic.BaseModel):
         return self
 
 
-class SpectrumViewParams(pydantic.BaseModel):
-    time_bins: int = pydantic.Field(
-        title='Time bins',
-        description='Number of time bins for the spectrum view.',
-        default=500,
-        ge=1,
-        le=10000,
-    )
-    pixels_per_tube: int = pydantic.Field(
-        title='Pixels per tube',
-        description='Number of pixels per tube for the spectrum view.',
-        default=10,
-    )
-
-    @pydantic.field_validator('pixels_per_tube')
-    @classmethod
-    def pixels_per_tube_must_be_divisor_of_100(cls, v):
-        if 100 % v != 0:
-            raise ValueError('pixels_per_tube must be a divisor of 100')
-        return v
-
-
-class BifrostWorkflowParams(pydantic.BaseModel):
-    spectrum_view: SpectrumViewParams = pydantic.Field(
-        title='Spectrum view parameters', default_factory=SpectrumViewParams
-    )
-
-
-def _make_2d_template() -> sc.DataArray:
-    """Create an empty 2D template for 2D output data."""
-    return sc.DataArray(sc.zeros(dims=['dim_0', 'dim_1'], shape=[0, 0], unit='counts'))
-
-
 def _make_3d_template() -> sc.DataArray:
     """Create an empty 3D template for 3D output data."""
     return sc.DataArray(
         sc.zeros(dims=['dim_0', 'dim_1', 'dim_2'], shape=[0, 0, 0], unit='counts')
-    )
-
-
-class SpectrumViewOutputs(WorkflowOutputsBase):
-    spectrum_view: sc.DataArray = pydantic.Field(
-        default_factory=_make_3d_template,
-        title='Spectrum View',
-        description='Spectrum view showing time-of-flight vs. detector position.',
     )
 
 
@@ -407,27 +363,52 @@ monitor_handle = register_monitor_workflow_specs(
     instrument, monitors, params=TOAOnlyMonitorDataParams
 )
 
-# Register detector view spec.
-unified_detector_view_handle = instrument.register_spec(
-    namespace='detector_data',
+
+def _logical_view(obj: sc.Variable | sc.DataArray, source_name: str) -> sc.DataArray:
+    """Reshape raw detector data into ``(arc, detector_number_full)``.
+
+    ``arc`` is preserved so the spectrum transform can operate per-arc; the
+    remaining (tube, channel, pixel) axes are flattened into a single
+    ``detector_number_full`` dim of size 2700.
+    """
+    da = sc.DataArray(obj) if isinstance(obj, sc.Variable) else obj
+    return da.to(dtype='float32').flatten(
+        dims=('tube', 'channel', 'pixel'), to='detector_number_full'
+    )
+
+
+def _bifrost_spectrum_transform(histogram: sc.DataArray, rebin: int) -> sc.DataArray:
+    """Reshape the cumulative histogram into ``(arc, detector_number, toa)``.
+
+    ``detector_number_full`` is folded back into an outer detector_number
+    axis and an inner ``subpixel`` axis of size ``rebin``; summing over
+    ``subpixel`` yields ``100 // rebin`` pixels per tube.
+    """
+    folded = histogram.fold(
+        'detector_number_full',
+        sizes={'detector_number': -1, 'subpixel': rebin},
+    )
+    return folded.sum('subpixel')
+
+
+# Register unified detector view with embedded spectrum output.
+unified_detector_view_handle = instrument.add_logical_view(
     name='unified_detector_view',
-    version=1,
     title='Unified detector view',
     description='All banks merged into a single detector view.',
     source_names=['unified_detector'],
-    params=DetectorViewParams,
-    outputs=DetectorViewOutputs,
-)
-
-# Register spectroscopy workflow specs
-spectrum_view_handle = instrument.register_spec(
-    name='spectrum_view',
-    version=1,
-    title='Spectrum view',
-    description='Spectrum view with configurable time bins and pixels per tube.',
-    source_names=['unified_detector'],
-    params=BifrostWorkflowParams,
-    outputs=SpectrumViewOutputs,
+    transform=_logical_view,
+    output_ndim=2,
+    spectrum_view=SpectrumViewSpec(
+        transform=_bifrost_spectrum_transform,
+        output_dims=['arc', 'detector_number', 'time_of_arrival'],
+        output_title='Spectrum view',
+        output_description=(
+            'Per-arc, per-pixel spectrum over time-of-arrival, with adjacent '
+            'pixels within a tube grouped by the rebin factor.'
+        ),
+        default_rebin_factor=10,
+    ),
 )
 
 detector_ratemeter_handle = instrument.register_spec(

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -377,16 +377,36 @@ def _logical_view(obj: sc.Variable | sc.DataArray, source_name: str) -> sc.DataA
     )
 
 
-def _bifrost_spectrum_transform(histogram: sc.DataArray, rebin: int) -> sc.DataArray:
+class BifrostSpectrumParams(pydantic.BaseModel):
+    """Runtime parameters for the Bifrost spectrum-view transform."""
+
+    pixels_per_tube: int = pydantic.Field(
+        default=10,
+        title='Pixels per tube',
+        description='Number of output pixels per tube. Must be a divisor of 100.',
+    )
+
+    @pydantic.field_validator('pixels_per_tube')
+    @classmethod
+    def _pixels_per_tube_must_be_divisor_of_100(cls, v: int) -> int:
+        if v <= 0 or 100 % v != 0:
+            raise ValueError('pixels_per_tube must be a positive divisor of 100')
+        return v
+
+
+def _bifrost_spectrum_transform(
+    histogram: sc.DataArray, params: BifrostSpectrumParams
+) -> sc.DataArray:
     """Reshape the cumulative histogram into ``(arc, detector_number, toa)``.
 
-    ``detector_number_full`` is folded back into an outer detector_number
-    axis and an inner ``subpixel`` axis of size ``rebin``; summing over
-    ``subpixel`` yields ``100 // rebin`` pixels per tube.
+    ``detector_number_full`` is folded back into an outer ``detector_number``
+    axis of size ``pixels_per_tube`` and an inner ``subpixel`` axis;
+    summing over ``subpixel`` yields ``pixels_per_tube`` pixels per tube.
     """
+    subpixel = 100 // params.pixels_per_tube
     folded = histogram.fold(
         'detector_number_full',
-        sizes={'detector_number': -1, 'subpixel': rebin},
+        sizes={'detector_number': -1, 'subpixel': subpixel},
     )
     return folded.sum('subpixel')
 
@@ -403,10 +423,11 @@ unified_detector_view_handle = instrument.add_logical_view(
         transform=_bifrost_spectrum_transform,
         output_dims=['arc', 'detector_number'],
         extra_description=(
-            'Per-arc, per-pixel spectrum with adjacent pixels within a tube '
-            'grouped by the rebin factor.'
+            'Per-arc, per-pixel spectrum. Adjacent pixels within a tube are '
+            'grouped so each tube yields ``pixels_per_tube`` output pixels.'
         ),
-        default_rebin_factor=10,
+        params_model=BifrostSpectrumParams,
+        params_title='Spectrum view parameters',
     ),
 )
 

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -427,7 +427,6 @@ unified_detector_view_handle = instrument.add_logical_view(
             'grouped so each tube yields ``pixels_per_tube`` output pixels.'
         ),
         params_model=BifrostSpectrumParams,
-        params_title='Spectrum view parameters',
     ),
 )
 

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -401,11 +401,10 @@ unified_detector_view_handle = instrument.add_logical_view(
     output_ndim=2,
     spectrum_view=SpectrumViewSpec(
         transform=_bifrost_spectrum_transform,
-        output_dims=['arc', 'detector_number', 'time_of_arrival'],
-        output_title='Spectrum view',
-        output_description=(
-            'Per-arc, per-pixel spectrum over time-of-arrival, with adjacent '
-            'pixels within a tube grouped by the rebin factor.'
+        output_dims=['arc', 'detector_number'],
+        extra_description=(
+            'Per-arc, per-pixel spectrum with adjacent pixels within a tube '
+            'grouped by the rebin factor.'
         ),
         default_rebin_factor=10,
     ),

--- a/src/ess/livedata/config/instruments/estia/factories.py
+++ b/src/ess/livedata/config/instruments/estia/factories.py
@@ -4,59 +4,13 @@
 ESTIA instrument factory implementations.
 """
 
-from typing import NewType
-
-import scipp as sc
-
 from ess.livedata.config import Instrument
-
-from . import specs
-
-SpectrumView = NewType('SpectrumView', sc.DataArray)
-SpectrumViewTOAEdges = NewType('SpectrumViewTOAEdges', sc.Variable)
 
 
 def setup_factories(instrument: Instrument) -> None:
-    """Initialize ESTIA-specific factories and workflows."""
-    from ess.estia import EstiaWorkflow
-    from ess.reduce.nexus.types import NeXusData, RawDetector, SampleRun
-    from ess.reduce.streaming import EternalAccumulator
-    from scippnexus import NXdetector
+    """Initialize ESTIA-specific factories and workflows.
 
-    from ess.livedata.handlers.stream_processor_workflow import StreamProcessorWorkflow
-
-    def _make_spectrum_view(
-        data: RawDetector[SampleRun],
-        toa_edges: SpectrumViewTOAEdges,
-    ) -> SpectrumView:
-        """Create spectrum view with over strip, which has constant scattering angle."""
-        edges_ns = toa_edges.to(unit='ns')
-        return SpectrumView(
-            data.bins.concat('strip')
-            .hist(event_time_offset=edges_ns)
-            .assign_coords(event_time_offset=toa_edges)
-        )
-
-    from ess.reduce.nexus.types import Filename
-
-    from ess.livedata.handlers.detector_data_handler import get_nexus_geometry_filename
-
-    reduction_workflow = EstiaWorkflow()
-    reduction_workflow[Filename[SampleRun]] = get_nexus_geometry_filename('estia')
-    reduction_workflow.insert(_make_spectrum_view)
-
-    @specs.spectrum_view_handle.attach_factory()
-    def _spectrum_view_workflow(
-        params: specs.EstiaSpectrumViewParams,
-    ) -> StreamProcessorWorkflow:
-        wf = reduction_workflow.copy()
-        edges = params.toa_edges.get_edges().rename_dims(
-            time_of_arrival='event_time_offset'
-        )
-        wf[SpectrumViewTOAEdges] = edges
-        return StreamProcessorWorkflow(
-            wf,
-            dynamic_keys={'multiblade_detector': NeXusData[NXdetector, SampleRun]},
-            target_keys={'spectrum_view': SpectrumView},
-            accumulators={SpectrumView: EternalAccumulator},
-        )
+    ESTIA currently has no bespoke workflows: the multiblade detector view
+    (with its spectrum output) is wired entirely via ``add_logical_view`` in
+    ``specs.py``.
+    """

--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -23,7 +23,7 @@ instrument = Instrument(
 instrument_registry.register(instrument)
 
 
-def _estia_spectrum_transform(histogram: sc.DataArray, rebin: int) -> sc.DataArray:
+def _estia_spectrum_transform(histogram: sc.DataArray) -> sc.DataArray:
     """Sum over the ``strip`` axis (constant scattering angle)."""
     return histogram.sum('strip')
 

--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -38,11 +38,7 @@ instrument.add_logical_view(
     output_ndim=3,
     spectrum_view=SpectrumViewSpec(
         transform=_estia_spectrum_transform,
-        output_dims=['blade', 'wire', 'time_of_arrival'],
-        output_title='Spectrum view',
-        output_description=(
-            'Spectrum view over time-of-arrival vs. blade and wire, '
-            'summed across strips.'
-        ),
+        output_dims=['blade', 'wire'],
+        extra_description='Summed across strips, yielding per-blade, per-wire spectra.',
     ),
 )

--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -4,12 +4,10 @@
 ESTIA instrument spec registration.
 """
 
-import pydantic
 import scipp as sc
 
 from ess.livedata.config import Instrument, instrument_registry
-from ess.livedata.config.workflow_spec import WorkflowOutputsBase
-from ess.livedata.parameter_models import TOAEdges
+from ess.livedata.handlers.detector_view_specs import SpectrumViewSpec
 
 from .views import get_multiblade_view
 
@@ -24,6 +22,12 @@ instrument = Instrument(
 
 instrument_registry.register(instrument)
 
+
+def _estia_spectrum_transform(histogram: sc.DataArray, rebin: int) -> sc.DataArray:
+    """Sum over the ``strip`` axis (constant scattering angle)."""
+    return histogram.sum('strip')
+
+
 instrument.add_logical_view(
     name='estia_multiblade_detector_view',
     title='Multiblade Detector',
@@ -32,44 +36,13 @@ instrument.add_logical_view(
     transform=get_multiblade_view,
     roi_support=False,
     output_ndim=3,
-)
-
-
-class EstiaSpectrumViewParams(pydantic.BaseModel):
-    """Parameters for ESTIA spectrum view."""
-
-    toa_edges: TOAEdges = pydantic.Field(
-        title='Time of arrival edges',
-        description='Histogram bin edges for the time-of-arrival axis.',
-        default_factory=lambda: TOAEdges(start=0.0, stop=1000.0 / 14, num_bins=100),
-    )
-
-
-class SpectrumViewOutputs(WorkflowOutputsBase):
-    """Outputs for ESTIA spectrum view workflow."""
-
-    spectrum_view: sc.DataArray = pydantic.Field(
-        default_factory=lambda: sc.DataArray(
-            sc.zeros(
-                dims=['blade', 'wire', 'event_time_offset'],
-                shape=[0, 0, 0],
-                unit='counts',
-            ),
-            coords={'event_time_offset': sc.arange('event_time_offset', 0, unit='ms')},
+    spectrum_view=SpectrumViewSpec(
+        transform=_estia_spectrum_transform,
+        output_dims=['blade', 'wire', 'time_of_arrival'],
+        output_title='Spectrum view',
+        output_description=(
+            'Spectrum view over time-of-arrival vs. blade and wire, '
+            'summed across strips.'
         ),
-        title='Spectrum View',
-        description='Spectrum view showing accumulated counts in time-of-arrival vs. '
-        'blade and wire.',
-    )
-
-
-spectrum_view_handle = instrument.register_spec(
-    name='spectrum_view',
-    version=1,
-    title='Spectrum view',
-    description='Spectrum view with configurable time-of-arrival bins. Counts within '
-    'the same strip are summed.',
-    source_names=['multiblade_detector'],
-    params=EstiaSpectrumViewParams,
-    outputs=SpectrumViewOutputs,
+    ),
 )

--- a/src/ess/livedata/handlers/detector_view/__init__.py
+++ b/src/ess/livedata/handlers/detector_view/__init__.py
@@ -21,6 +21,7 @@ from .types import (
     CoordinateMode,
     GeometricViewConfig,
     LogicalViewConfig,
+    SpectrumView,
     TransformValueStream,
 )
 
@@ -31,5 +32,6 @@ __all__ = [
     'InstrumentDetectorSource',
     'LogicalViewConfig',
     'NeXusDetectorSource',
+    'SpectrumView',
     'TransformValueStream',
 ]

--- a/src/ess/livedata/handlers/detector_view/factory.py
+++ b/src/ess/livedata/handlers/detector_view/factory.py
@@ -19,7 +19,7 @@ from ..accumulators import make_no_copy_accumulator_pair
 
 # Import types unconditionally for runtime type hint resolution
 # (used by workflow_factory.attach_factory to inspect parameter types)
-from ..detector_view_specs import DetectorViewParams, SpectrumViewRebin
+from ..detector_view_specs import DetectorViewParams
 from ..stream_processor_workflow import StreamProcessorWorkflow
 from .data_source import DetectorDataSource, DetectorNumberSource
 from .providers import spectrum_view
@@ -212,8 +212,20 @@ class DetectorViewFactory:
 
         if config.spectrum_view is not None:
             workflow.insert(spectrum_view)
-            workflow[SpectrumViewTransform] = config.spectrum_view.transform
-            workflow[SpectrumViewRebin] = params.spectrum_rebin
+            raw_transform = config.spectrum_view.transform
+            if config.spectrum_view.params_model is not None:
+                spectrum_params = params.spectrum_params  # type: ignore[attr-defined]
+
+                def bound_spectrum_transform(
+                    histogram: sc.DataArray,
+                    _transform=raw_transform,
+                    _params=spectrum_params,
+                ) -> sc.DataArray:
+                    return _transform(histogram, _params)
+
+                workflow[SpectrumViewTransform] = bound_spectrum_transform
+            else:
+                workflow[SpectrumViewTransform] = raw_transform
             target_keys['spectrum_view'] = SpectrumView
         context_keys: dict[str, type] = {}
         window_outputs = (

--- a/src/ess/livedata/handlers/detector_view/factory.py
+++ b/src/ess/livedata/handlers/detector_view/factory.py
@@ -19,7 +19,7 @@ from ..accumulators import make_no_copy_accumulator_pair
 
 # Import types unconditionally for runtime type hint resolution
 # (used by workflow_factory.attach_factory to inspect parameter types)
-from ..detector_view_specs import DetectorViewParams
+from ..detector_view_specs import DetectorViewParams, SpectrumViewRebin
 from ..stream_processor_workflow import StreamProcessorWorkflow
 from .data_source import DetectorDataSource, DetectorNumberSource
 from .providers import spectrum_view
@@ -38,7 +38,6 @@ from .types import (
     ROIRectangleRequest,
     ROISpectra,
     SpectrumView,
-    SpectrumViewSpatialRebin,
     SpectrumViewTransform,
     TransformValueLog,
     TransformValueStream,
@@ -214,7 +213,7 @@ class DetectorViewFactory:
         if config.spectrum_view is not None:
             workflow.insert(spectrum_view)
             workflow[SpectrumViewTransform] = config.spectrum_view.transform
-            workflow[SpectrumViewSpatialRebin] = params.spectrum_rebin.factor
+            workflow[SpectrumViewRebin] = params.spectrum_rebin
             target_keys['spectrum_view'] = SpectrumView
         context_keys: dict[str, type] = {}
         window_outputs = (

--- a/src/ess/livedata/handlers/detector_view/factory.py
+++ b/src/ess/livedata/handlers/detector_view/factory.py
@@ -22,6 +22,7 @@ from ..accumulators import make_no_copy_accumulator_pair
 from ..detector_view_specs import DetectorViewParams
 from ..stream_processor_workflow import StreamProcessorWorkflow
 from .data_source import DetectorDataSource, DetectorNumberSource
+from .providers import spectrum_view
 from .types import (
     AccumulatedHistogram,
     CountsInRange,
@@ -36,6 +37,9 @@ from .types import (
     ROIRectangleReadback,
     ROIRectangleRequest,
     ROISpectra,
+    SpectrumView,
+    SpectrumViewSpatialRebin,
+    SpectrumViewTransform,
     TransformValueLog,
     TransformValueStream,
     UsePixelWeighting,
@@ -206,6 +210,12 @@ class DetectorViewFactory:
             'counts_total_cumulative': CountsTotal[Cumulative],
             'counts_in_toa_range_cumulative': CountsInRange[Cumulative],
         }
+
+        if config.spectrum_view is not None:
+            workflow.insert(spectrum_view)
+            workflow[SpectrumViewTransform] = config.spectrum_view.transform
+            workflow[SpectrumViewSpatialRebin] = params.spectrum_rebin.factor
+            target_keys['spectrum_view'] = SpectrumView
         context_keys: dict[str, type] = {}
         window_outputs = (
             'current',

--- a/src/ess/livedata/handlers/detector_view/providers.py
+++ b/src/ess/livedata/handlers/detector_view/providers.py
@@ -19,6 +19,7 @@ from .types import (
     AccumulationMode,
     CountsInRange,
     CountsTotal,
+    Cumulative,
     DetectorHistogram,
     DetectorImage,
     EventCoordName,
@@ -27,6 +28,9 @@ from .types import (
     PixelWeights,
     ScreenBinnedEvents,
     ScreenMetadata,
+    SpectrumView,
+    SpectrumViewSpatialRebin,
+    SpectrumViewTransform,
     UsePixelWeighting,
 )
 
@@ -261,6 +265,34 @@ def counts_total(
         Total counts as 0D scalar.
     """
     return CountsTotal[AccumulationMode](histogram.sum())
+
+
+def spectrum_view(
+    histogram: AccumulatedHistogram[Cumulative],
+    transform: SpectrumViewTransform,
+    rebin: SpectrumViewSpatialRebin,
+) -> SpectrumView:
+    """
+    Apply the per-instrument spectrum transform to the cumulative histogram.
+
+    The transform typically sums over unwanted spatial dims and/or rebins
+    kept spatial dims, preserving the event coordinate axis.
+
+    Parameters
+    ----------
+    histogram:
+        Cumulative accumulated histogram (spatial dims + event coordinate).
+    transform:
+        Callable ``(histogram, rebin) -> spectrum`` bound at spec time.
+    rebin:
+        Runtime rebin factor; ignored by transforms that do not need it.
+
+    Returns
+    -------
+    :
+        Spectrum view as a reshaped/partially-summed histogram.
+    """
+    return SpectrumView(transform(histogram, rebin))
 
 
 def counts_in_range(

--- a/src/ess/livedata/handlers/detector_view/providers.py
+++ b/src/ess/livedata/handlers/detector_view/providers.py
@@ -13,6 +13,7 @@ import scipp as sc
 from ess.reduce.nexus.types import EmptyDetector, RawDetector, SampleRun
 from ess.reduce.unwrap.types import WavelengthDetector
 
+from ..detector_view_specs import SpectrumViewRebin
 from .projectors import GeometricProjector, LogicalProjector, Projector
 from .types import (
     AccumulatedHistogram,
@@ -29,7 +30,6 @@ from .types import (
     ScreenBinnedEvents,
     ScreenMetadata,
     SpectrumView,
-    SpectrumViewSpatialRebin,
     SpectrumViewTransform,
     UsePixelWeighting,
 )
@@ -270,7 +270,7 @@ def counts_total(
 def spectrum_view(
     histogram: AccumulatedHistogram[Cumulative],
     transform: SpectrumViewTransform,
-    rebin: SpectrumViewSpatialRebin,
+    rebin: SpectrumViewRebin,
 ) -> SpectrumView:
     """
     Apply the per-instrument spectrum transform to the cumulative histogram.
@@ -292,7 +292,7 @@ def spectrum_view(
     :
         Spectrum view as a reshaped/partially-summed histogram.
     """
-    return SpectrumView(transform(histogram, rebin))
+    return SpectrumView(transform(histogram, rebin.factor))
 
 
 def counts_in_range(

--- a/src/ess/livedata/handlers/detector_view/providers.py
+++ b/src/ess/livedata/handlers/detector_view/providers.py
@@ -13,7 +13,6 @@ import scipp as sc
 from ess.reduce.nexus.types import EmptyDetector, RawDetector, SampleRun
 from ess.reduce.unwrap.types import WavelengthDetector
 
-from ..detector_view_specs import SpectrumViewRebin
 from .projectors import GeometricProjector, LogicalProjector, Projector
 from .types import (
     AccumulatedHistogram,
@@ -270,29 +269,29 @@ def counts_total(
 def spectrum_view(
     histogram: AccumulatedHistogram[Cumulative],
     transform: SpectrumViewTransform,
-    rebin: SpectrumViewRebin,
 ) -> SpectrumView:
     """
     Apply the per-instrument spectrum transform to the cumulative histogram.
 
     The transform typically sums over unwanted spatial dims and/or rebins
-    kept spatial dims, preserving the event coordinate axis.
+    kept spatial dims, preserving the event coordinate axis. When the
+    ``SpectrumViewSpec`` declares a ``params_model``, the factory binds the
+    runtime parameter instance into the callable before inserting it here.
 
     Parameters
     ----------
     histogram:
         Cumulative accumulated histogram (spatial dims + event coordinate).
     transform:
-        Callable ``(histogram, rebin) -> spectrum`` bound at spec time.
-    rebin:
-        Runtime rebin factor; ignored by transforms that do not need it.
+        Callable ``(histogram,) -> spectrum`` bound at workflow-construction
+        time.
 
     Returns
     -------
     :
         Spectrum view as a reshaped/partially-summed histogram.
     """
-    return SpectrumView(transform(histogram, rebin.factor))
+    return SpectrumView(transform(histogram))
 
 
 def counts_in_range(

--- a/src/ess/livedata/handlers/detector_view/types.py
+++ b/src/ess/livedata/handlers/detector_view/types.py
@@ -207,9 +207,6 @@ Signature: ``(histogram, rebin_factor) -> spectrum``. Instruments that do not
 need a rebin factor simply ignore the second argument.
 """
 
-SpectrumViewSpatialRebin = NewType('SpectrumViewSpatialRebin', int)
-"""Runtime rebin factor consumed by the spectrum transform."""
-
 
 # Generic accumulated data types - parametrized by accumulation mode
 class AccumulatedHistogram(

--- a/src/ess/livedata/handlers/detector_view/types.py
+++ b/src/ess/livedata/handlers/detector_view/types.py
@@ -199,12 +199,13 @@ SpectrumView = NewType('SpectrumView', sc.DataArray)
 
 SpectrumViewTransform = NewType(
     'SpectrumViewTransform',
-    Callable[[sc.DataArray, int], sc.DataArray],
+    Callable[[sc.DataArray], sc.DataArray],
 )
 """Callable applied to AccumulatedHistogram[Cumulative] to produce SpectrumView.
 
-Signature: ``(histogram, rebin_factor) -> spectrum``. Instruments that do not
-need a rebin factor simply ignore the second argument.
+Signature: ``(histogram,) -> spectrum``. Runtime parameters declared via
+``SpectrumViewSpec.params_model`` are bound into this callable by the
+detector-view factory before insertion into the workflow.
 """
 
 

--- a/src/ess/livedata/handlers/detector_view/types.py
+++ b/src/ess/livedata/handlers/detector_view/types.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal, NewType, TypeVar
+from typing import TYPE_CHECKING, Literal, NewType, TypeVar
 
 import sciline
 import scipp as sc
+
+if TYPE_CHECKING:
+    from ..detector_view_specs import SpectrumViewSpec
 
 # Coordinate mode for detector view workflow
 CoordinateMode = Literal['toa', 'tof', 'wavelength']
@@ -88,12 +91,18 @@ class GeometricViewConfig:
         detectors face the same direction as the observer and typically
         do not need flipping. The preferred orientation may also depend on
         instrument scientist conventions.
+    spectrum_view:
+        Optional ``SpectrumViewSpec`` enabling a ``spectrum_view`` output
+        derived from the cumulative accumulated histogram. Geometric
+        projections do not preserve detector-pixel identity, so the spectrum
+        is per-screen-pixel; document this caveat at registration.
     """
 
     projection_type: Literal['xy_plane', 'cylinder_mantle_z']
     resolution: dict[str, int]
     pixel_noise: Literal['cylindrical'] | sc.Variable | None = None
     flip_x: bool = False
+    spectrum_view: SpectrumViewSpec | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,11 +123,16 @@ class LogicalViewConfig:
     roi_support:
         Whether ROI selection is supported. If False, ROI-related outputs are
         excluded from the workflow. Typically False for 1D views.
+    spectrum_view:
+        Optional ``SpectrumViewSpec`` enabling a ``spectrum_view`` output
+        derived from the cumulative accumulated histogram via a
+        per-instrument transform.
     """
 
     transform: Callable[[sc.DataArray, str], sc.DataArray] | None = None
     reduction_dim: str | list[str] | None = None
     roi_support: bool = True
+    spectrum_view: SpectrumViewSpec | None = None
 
 
 ViewConfig = GeometricViewConfig | LogicalViewConfig
@@ -175,6 +189,26 @@ coordinate preserved."""
 DetectorHistogram = NewType('DetectorHistogram', sc.DataArray)
 """Histogram with screen dims + event coordinate - computed once, shared by
 accumulators."""
+
+
+# Spectrum view types: derived from AccumulatedHistogram[Cumulative] via a
+# per-instrument transform. The transform reshapes or partially sums the
+# accumulated histogram into a spectrum (spatial dims + event coordinate).
+SpectrumView = NewType('SpectrumView', sc.DataArray)
+"""Spectrum view derived from AccumulatedHistogram[Cumulative]."""
+
+SpectrumViewTransform = NewType(
+    'SpectrumViewTransform',
+    Callable[[sc.DataArray, int], sc.DataArray],
+)
+"""Callable applied to AccumulatedHistogram[Cumulative] to produce SpectrumView.
+
+Signature: ``(histogram, rebin_factor) -> spectrum``. Instruments that do not
+need a rebin factor simply ignore the second argument.
+"""
+
+SpectrumViewSpatialRebin = NewType('SpectrumViewSpatialRebin', int)
+"""Runtime rebin factor consumed by the spectrum transform."""
 
 
 # Generic accumulated data types - parametrized by accumulation mode

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -137,9 +137,6 @@ class SpectrumViewSpec:
         the generated ``DetectorViewParams`` subclass and passed to the
         transform. When ``None`` (default), the transform takes only the
         histogram and no parameter widget is shown in the UI.
-    params_title:
-        Title for the ``spectrum_params`` field (only used when ``params_model``
-        is set).
     params_description:
         Description for the ``spectrum_params`` field (only used when
         ``params_model`` is set).
@@ -147,11 +144,10 @@ class SpectrumViewSpec:
 
     transform: Callable[..., sc.DataArray]
     output_dims: list[str]
-    output_title: str = 'Spectrum view'
+    output_title: str = 'Spectrum View'
     extra_description: str = ''
     params_model: type[pydantic.BaseModel] | None = None
-    params_title: str = 'Spectrum parameters'
-    params_description: str = 'Runtime parameters for the spectrum-view transform.'
+    params_description: str = 'Runtime parameters for the spectrum-view.'
 
     @property
     def output_description(self) -> str:
@@ -395,7 +391,7 @@ def make_detector_view_params(
         return DetectorViewParams
 
     params_model = spectrum_view.params_model
-    title = spectrum_view.params_title
+    title = spectrum_view.output_title
     description = spectrum_view.params_description
 
     class DetectorViewWithSpectrumParams(DetectorViewParams):

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -132,12 +132,15 @@ class SpectrumViewSpec:
         cumulative accumulated histogram. Transforms that do not need a
         rebin factor simply ignore the second argument.
     output_dims:
-        Output dimension names, used for the template of the ``spectrum_view``
-        field in the workflow outputs.
+        Spatial output dimension names, used for the initial empty template of
+        the ``spectrum_view`` field. The transform preserves the spectral axis
+        of the input histogram (time-of-arrival or wavelength depending on mode),
+        so it is not listed here.
     output_title:
         Human-readable title for the output field.
-    output_description:
-        Description for the output field.
+    extra_description:
+        Instrument-specific description appended as a second paragraph to the
+        base description.
     default_rebin_factor:
         Default value for the runtime ``spectrum_rebin.factor`` parameter.
         Transforms that ignore the rebin factor can leave the default at 1.
@@ -146,10 +149,19 @@ class SpectrumViewSpec:
     transform: Callable[[sc.DataArray, int], sc.DataArray]
     output_dims: list[str]
     output_title: str = 'Spectrum view'
-    output_description: str = (
-        'Accumulated histogram reshaped into a per-spatial-group spectrum.'
-    )
+    extra_description: str = ''
     default_rebin_factor: int = 1
+
+    @property
+    def output_description(self) -> str:
+        base = (
+            'Accumulated histogram reshaped into a per-spatial-group spectrum. '
+            'The last axis is the spectral coordinate of the input histogram '
+            '(time-of-arrival or wavelength, depending on the workflow mode).'
+        )
+        if self.extra_description:
+            return f'{base}\n\n{self.extra_description}'
+        return base
 
 
 def _make_nd_template(ndim: int, *, with_time_coord: bool = False) -> sc.DataArray:

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -301,7 +301,7 @@ def make_detector_view_outputs(
     output_ndim: int | None = None,
     *,
     roi_support: bool = True,
-    spectrum: SpectrumViewSpec | None = None,
+    spectrum_view: SpectrumViewSpec | None = None,
 ) -> type[DetectorViewOutputsBase]:
     """
     Create a DetectorViewOutputs subclass with the appropriate configuration.
@@ -316,10 +316,10 @@ def make_detector_view_outputs(
         Whether to include ROI-related outputs. If False, the returned class
         will not include roi_spectra_current, roi_spectra_cumulative,
         roi_rectangle, or roi_polygon fields.
-    spectrum:
+    spectrum_view:
         Optional spectrum view configuration. When provided, the returned
         class includes an additional ``spectrum_view`` field with a template
-        matching ``spectrum.output_dims``.
+        matching ``spectrum_view.output_dims``.
 
     Returns
     -------
@@ -330,7 +330,7 @@ def make_detector_view_outputs(
         DetectorViewOutputs if roi_support else DetectorViewOutputsBase
     )
 
-    if output_ndim is None and spectrum is None:
+    if output_ndim is None and spectrum_view is None:
         return base_class
 
     if output_ndim is not None:
@@ -358,14 +358,14 @@ def make_detector_view_outputs(
 
         base_class = _WithNdim
 
-    if spectrum is not None:
-        output_dims = list(spectrum.output_dims)
+    if spectrum_view is not None:
+        output_dims = list(spectrum_view.output_dims)
 
         def make_spectrum_template() -> sc.DataArray:
             return _make_spectrum_template(output_dims)
 
-        title = spectrum.output_title
-        description = spectrum.output_description
+        title = spectrum_view.output_title
+        description = spectrum_view.output_description
 
         class _WithSpectrum(base_class):  # type: ignore[valid-type,misc]
             spectrum_view: sc.DataArray = pydantic.Field(
@@ -577,5 +577,5 @@ def register_detector_view_spec(
         source_names=source_names,
         aux_sources=aux_sources if aux_sources is not None else DetectorROIAuxSources(),
         params=make_detector_view_params(spectrum=spectrum),
-        outputs=make_detector_view_outputs(roi_support=True, spectrum=spectrum),
+        outputs=make_detector_view_outputs(roi_support=True, spectrum_view=spectrum),
     )

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -13,6 +13,8 @@ and should only be imported by backend services.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -106,6 +108,48 @@ class DetectorViewParams(pydantic.BaseModel):
                     if self.wavelength_range.enabled
                     else None
                 )
+
+
+class SpectrumViewRebin(pydantic.BaseModel):
+    """Runtime spatial rebin configuration for a spectrum view."""
+
+    factor: int = pydantic.Field(
+        default=1,
+        ge=1,
+        title='Rebin factor',
+        description='Group this many adjacent bins along the rebinned spatial dim.',
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SpectrumViewSpec:
+    """Per-instrument configuration enabling a spectrum-view output.
+
+    Parameters
+    ----------
+    transform:
+        Callable ``(histogram, rebin_factor) -> spectrum`` applied to the
+        cumulative accumulated histogram. Transforms that do not need a
+        rebin factor simply ignore the second argument.
+    output_dims:
+        Output dimension names, used for the template of the ``spectrum_view``
+        field in the workflow outputs.
+    output_title:
+        Human-readable title for the output field.
+    output_description:
+        Description for the output field.
+    default_rebin_factor:
+        Default value for the runtime ``spectrum_rebin.factor`` parameter.
+        Transforms that ignore the rebin factor can leave the default at 1.
+    """
+
+    transform: Callable[[sc.DataArray, int], sc.DataArray]
+    output_dims: list[str]
+    output_title: str = 'Spectrum view'
+    output_description: str = (
+        'Accumulated histogram reshaped into a per-spatial-group spectrum.'
+    )
+    default_rebin_factor: int = 1
 
 
 def _make_nd_template(ndim: int, *, with_time_coord: bool = False) -> sc.DataArray:
@@ -234,10 +278,18 @@ class DetectorViewOutputs(DetectorViewOutputsBase):
     )
 
 
+def _make_spectrum_template(output_dims: list[str]) -> sc.DataArray:
+    ndim = len(output_dims)
+    return sc.DataArray(
+        sc.zeros(dims=output_dims, shape=[0] * ndim, unit='counts'),
+    )
+
+
 def make_detector_view_outputs(
     output_ndim: int | None = None,
     *,
     roi_support: bool = True,
+    spectrum: SpectrumViewSpec | None = None,
 ) -> type[DetectorViewOutputsBase]:
     """
     Create a DetectorViewOutputs subclass with the appropriate configuration.
@@ -252,39 +304,94 @@ def make_detector_view_outputs(
         Whether to include ROI-related outputs. If False, the returned class
         will not include roi_spectra_current, roi_spectra_cumulative,
         roi_rectangle, or roi_polygon fields.
+    spectrum:
+        Optional spectrum view configuration. When provided, the returned
+        class includes an additional ``spectrum_view`` field with a template
+        matching ``spectrum.output_dims``.
 
     Returns
     -------
     :
         A subclass of DetectorViewOutputsBase with appropriate configuration.
     """
-    base_class = DetectorViewOutputs if roi_support else DetectorViewOutputsBase
+    base_class: type[DetectorViewOutputsBase] = (
+        DetectorViewOutputs if roi_support else DetectorViewOutputsBase
+    )
 
-    if output_ndim is None:
+    if output_ndim is None and spectrum is None:
         return base_class
 
-    def make_cumulative_template() -> sc.DataArray:
-        return _make_nd_template(output_ndim)
+    if output_ndim is not None:
 
-    def make_current_template() -> sc.DataArray:
-        return _make_nd_template(output_ndim, with_time_coord=True)
+        def make_cumulative_template() -> sc.DataArray:
+            return _make_nd_template(output_ndim)
 
-    class CustomDetectorViewOutputs(base_class):  # type: ignore[valid-type]
-        cumulative: sc.DataArray = pydantic.Field(
-            title='Image (cumulative)',
-            description='Detector image accumulated since the start of the run.',
-            default_factory=make_cumulative_template,
+        def make_current_template() -> sc.DataArray:
+            return _make_nd_template(output_ndim, with_time_coord=True)
+
+        class _WithNdim(base_class):  # type: ignore[valid-type,misc]
+            cumulative: sc.DataArray = pydantic.Field(
+                title='Image (cumulative)',
+                description='Detector image accumulated since the start of the run.',
+                default_factory=make_cumulative_template,
+            )
+            current: sc.DataArray = pydantic.Field(
+                title='Image (current)',
+                description=(
+                    'Detector image for the latest update interval only. '
+                    'Resets each update interval.'
+                ),
+                default_factory=make_current_template,
+            )
+
+        base_class = _WithNdim
+
+    if spectrum is not None:
+        output_dims = list(spectrum.output_dims)
+
+        def make_spectrum_template() -> sc.DataArray:
+            return _make_spectrum_template(output_dims)
+
+        title = spectrum.output_title
+        description = spectrum.output_description
+
+        class _WithSpectrum(base_class):  # type: ignore[valid-type,misc]
+            spectrum_view: sc.DataArray = pydantic.Field(
+                title=title,
+                description=description,
+                default_factory=make_spectrum_template,
+            )
+
+        base_class = _WithSpectrum
+
+    return base_class
+
+
+def make_detector_view_params(
+    spectrum: SpectrumViewSpec | None = None,
+) -> type[DetectorViewParams]:
+    """Return a ``DetectorViewParams`` subclass, adding spectrum-specific fields.
+
+    When ``spectrum`` is provided, the subclass adds a ``spectrum_rebin``
+    field so the runtime rebin factor can be exposed in the UI. Workflows
+    without spectrum keep the base ``DetectorViewParams`` unchanged.
+    """
+    if spectrum is None:
+        return DetectorViewParams
+
+    default_factor = spectrum.default_rebin_factor
+
+    def make_default_rebin() -> SpectrumViewRebin:
+        return SpectrumViewRebin(factor=default_factor)
+
+    class DetectorViewWithSpectrumParams(DetectorViewParams):
+        spectrum_rebin: SpectrumViewRebin = pydantic.Field(
+            title='Spectrum rebin',
+            description='Spatial rebin applied by the spectrum-view transform.',
+            default_factory=make_default_rebin,
         )
-        current: sc.DataArray = pydantic.Field(
-            title='Image (current)',
-            description=(
-                'Detector image for the latest update interval only. '
-                'Resets each update interval.'
-            ),
-            default_factory=make_current_template,
-        )
 
-    return CustomDetectorViewOutputs
+    return DetectorViewWithSpectrumParams
 
 
 class DetectorROIAuxSources(AuxSources):
@@ -360,6 +467,7 @@ def register_detector_view_spec(
     projection: ProjectionType | dict[str, ProjectionType],
     source_names: list[str] | None = None,
     aux_sources: AuxSources | None = None,
+    spectrum: SpectrumViewSpec | None = None,
 ) -> SpecHandle:
     """
     Register detector view specs for a given projection.
@@ -383,6 +491,13 @@ def register_detector_view_spec(
         Optional auxiliary source specification. If None (default), uses
         DetectorROIAuxSources for ROI geometry streams. Instruments that need
         both ROI and position streams can subclass DetectorROIAuxSources.
+    spectrum:
+        Optional spectrum-view configuration. When provided, the registered
+        params/outputs include the spectrum-specific rebin param and the
+        ``spectrum_view`` output field. The factory is still responsible for
+        wiring the transform into the Sciline workflow (pass ``spectrum`` on
+        the Sciline ``GeometricViewConfig`` / ``LogicalViewConfig`` when
+        constructing ``DetectorViewFactory``).
 
     Returns
     -------
@@ -449,6 +564,6 @@ def register_detector_view_spec(
         description=description,
         source_names=source_names,
         aux_sources=aux_sources if aux_sources is not None else DetectorROIAuxSources(),
-        params=DetectorViewParams,
-        outputs=DetectorViewOutputs,
+        params=make_detector_view_params(spectrum=spectrum),
+        outputs=make_detector_view_outputs(roi_support=True, spectrum=spectrum),
     )

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -291,10 +291,10 @@ class DetectorViewOutputs(DetectorViewOutputsBase):
 
 
 def _make_spectrum_template(output_dims: list[str]) -> sc.DataArray:
-    ndim = len(output_dims)
-    return sc.DataArray(
-        sc.zeros(dims=output_dims, shape=[0] * ndim, unit='counts'),
-    )
+    # Append a placeholder spectral dim so the template has the right ndim for
+    # plotter selection. The actual dim name is determined at runtime by the transform.
+    dims = [*output_dims, 'spectrum']
+    return sc.DataArray(sc.zeros(dims=dims, shape=[0] * len(dims), unit='counts'))
 
 
 def make_detector_view_outputs(

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -128,7 +128,7 @@ class SpectrumViewSpec:
     Parameters
     ----------
     transform:
-        Callable ``(histogram, rebin_factor) -> spectrum`` applied to the
+        Callable ``(histogram, rebin_factor) -> spectrum_view`` applied to the
         cumulative accumulated histogram. Transforms that do not need a
         rebin factor simply ignore the second argument.
     output_dims:
@@ -380,18 +380,18 @@ def make_detector_view_outputs(
 
 
 def make_detector_view_params(
-    spectrum: SpectrumViewSpec | None = None,
+    spectrum_view: SpectrumViewSpec | None = None,
 ) -> type[DetectorViewParams]:
     """Return a ``DetectorViewParams`` subclass, adding spectrum-specific fields.
 
-    When ``spectrum`` is provided, the subclass adds a ``spectrum_rebin``
+    When ``spectrum_view`` is provided, the subclass adds a ``spectrum_rebin``
     field so the runtime rebin factor can be exposed in the UI. Workflows
-    without spectrum keep the base ``DetectorViewParams`` unchanged.
+    without spectrum-view keep the base ``DetectorViewParams`` unchanged.
     """
-    if spectrum is None:
+    if spectrum_view is None:
         return DetectorViewParams
 
-    default_factor = spectrum.default_rebin_factor
+    default_factor = spectrum_view.default_rebin_factor
 
     def make_default_rebin() -> SpectrumViewRebin:
         return SpectrumViewRebin(factor=default_factor)
@@ -479,7 +479,7 @@ def register_detector_view_spec(
     projection: ProjectionType | dict[str, ProjectionType],
     source_names: list[str] | None = None,
     aux_sources: AuxSources | None = None,
-    spectrum: SpectrumViewSpec | None = None,
+    spectrum_view: SpectrumViewSpec | None = None,
 ) -> SpecHandle:
     """
     Register detector view specs for a given projection.
@@ -503,11 +503,11 @@ def register_detector_view_spec(
         Optional auxiliary source specification. If None (default), uses
         DetectorROIAuxSources for ROI geometry streams. Instruments that need
         both ROI and position streams can subclass DetectorROIAuxSources.
-    spectrum:
+    spectrum_view:
         Optional spectrum-view configuration. When provided, the registered
         params/outputs include the spectrum-specific rebin param and the
         ``spectrum_view`` output field. The factory is still responsible for
-        wiring the transform into the Sciline workflow (pass ``spectrum`` on
+        wiring the transform into the Sciline workflow (pass ``spectrum_view`` on
         the Sciline ``GeometricViewConfig`` / ``LogicalViewConfig`` when
         constructing ``DetectorViewFactory``).
 
@@ -576,6 +576,8 @@ def register_detector_view_spec(
         description=description,
         source_names=source_names,
         aux_sources=aux_sources if aux_sources is not None else DetectorROIAuxSources(),
-        params=make_detector_view_params(spectrum=spectrum),
-        outputs=make_detector_view_outputs(roi_support=True, spectrum_view=spectrum),
+        params=make_detector_view_params(spectrum_view=spectrum_view),
+        outputs=make_detector_view_outputs(
+            roi_support=True, spectrum_view=spectrum_view
+        ),
     )

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -110,17 +110,6 @@ class DetectorViewParams(pydantic.BaseModel):
                 )
 
 
-class SpectrumViewRebin(pydantic.BaseModel):
-    """Runtime spatial rebin configuration for a spectrum view."""
-
-    factor: int = pydantic.Field(
-        default=1,
-        ge=1,
-        title='Rebin factor',
-        description='Group this many adjacent bins along the rebinned spatial dim.',
-    )
-
-
 @dataclass(frozen=True, slots=True)
 class SpectrumViewSpec:
     """Per-instrument configuration enabling a spectrum-view output.
@@ -128,9 +117,10 @@ class SpectrumViewSpec:
     Parameters
     ----------
     transform:
-        Callable ``(histogram, rebin_factor) -> spectrum_view`` applied to the
-        cumulative accumulated histogram. Transforms that do not need a
-        rebin factor simply ignore the second argument.
+        Callable applied to the cumulative accumulated histogram to produce
+        the spectrum view. Signature is ``(histogram,) -> spectrum_view`` when
+        ``params_model`` is ``None``, else ``(histogram, params) -> spectrum_view``
+        where ``params`` is an instance of ``params_model``.
     output_dims:
         Spatial output dimension names, used for the initial empty template of
         the ``spectrum_view`` field. The transform preserves the spectral axis
@@ -141,16 +131,27 @@ class SpectrumViewSpec:
     extra_description:
         Instrument-specific description appended as a second paragraph to the
         base description.
-    default_rebin_factor:
-        Default value for the runtime ``spectrum_rebin.factor`` parameter.
-        Transforms that ignore the rebin factor can leave the default at 1.
+    params_model:
+        Optional pydantic model carrying runtime parameters for the transform.
+        When provided, a ``spectrum_params`` field of this type is injected into
+        the generated ``DetectorViewParams`` subclass and passed to the
+        transform. When ``None`` (default), the transform takes only the
+        histogram and no parameter widget is shown in the UI.
+    params_title:
+        Title for the ``spectrum_params`` field (only used when ``params_model``
+        is set).
+    params_description:
+        Description for the ``spectrum_params`` field (only used when
+        ``params_model`` is set).
     """
 
-    transform: Callable[[sc.DataArray, int], sc.DataArray]
+    transform: Callable[..., sc.DataArray]
     output_dims: list[str]
     output_title: str = 'Spectrum view'
     extra_description: str = ''
-    default_rebin_factor: int = 1
+    params_model: type[pydantic.BaseModel] | None = None
+    params_title: str = 'Spectrum parameters'
+    params_description: str = 'Runtime parameters for the spectrum-view transform.'
 
     @property
     def output_description(self) -> str:
@@ -384,23 +385,24 @@ def make_detector_view_params(
 ) -> type[DetectorViewParams]:
     """Return a ``DetectorViewParams`` subclass, adding spectrum-specific fields.
 
-    When ``spectrum_view`` is provided, the subclass adds a ``spectrum_rebin``
-    field so the runtime rebin factor can be exposed in the UI. Workflows
-    without spectrum-view keep the base ``DetectorViewParams`` unchanged.
+    When ``spectrum_view.params_model`` is set, the subclass adds a
+    ``spectrum_params`` field of that model type so the runtime parameters can
+    be exposed in the UI. Workflows without spectrum-view (or whose spectrum
+    transform needs no runtime parameters) keep the base ``DetectorViewParams``
+    unchanged.
     """
-    if spectrum_view is None:
+    if spectrum_view is None or spectrum_view.params_model is None:
         return DetectorViewParams
 
-    default_factor = spectrum_view.default_rebin_factor
-
-    def make_default_rebin() -> SpectrumViewRebin:
-        return SpectrumViewRebin(factor=default_factor)
+    params_model = spectrum_view.params_model
+    title = spectrum_view.params_title
+    description = spectrum_view.params_description
 
     class DetectorViewWithSpectrumParams(DetectorViewParams):
-        spectrum_rebin: SpectrumViewRebin = pydantic.Field(
-            title='Spectrum rebin',
-            description='Spatial rebin applied by the spectrum-view transform.',
-            default_factory=make_default_rebin,
+        spectrum_params: params_model = pydantic.Field(  # type: ignore[valid-type]
+            title=title,
+            description=description,
+            default_factory=params_model,
         )
 
     return DetectorViewWithSpectrumParams

--- a/src/ess/livedata/handlers/workflow_factory.py
+++ b/src/ess/livedata/handlers/workflow_factory.py
@@ -116,7 +116,9 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
             inferred_params = type_hints.get('params', None)
 
             if spec.params is not None and inferred_params is not None:
-                if spec.params is not inferred_params:  # Use `is not`
+                # Spec params may be a subclass of the factory's declared type
+                # (e.g. dynamic subclasses produced by ``make_detector_view_params``).
+                if not issubclass(spec.params, inferred_params):
                     raise TypeError(f"Params type mismatch for {workflow_id}")
             elif spec.params is None and inferred_params is not None:
                 raise TypeError(

--- a/tests/bifrost_test.py
+++ b/tests/bifrost_test.py
@@ -26,15 +26,9 @@ def bifrost_workflow():
     Returns a tuple of (workflow, DetectorRegionCounts) where the workflow
     has the detector_ratemeter function already inserted.
     """
-    (
-        workflow,
-        DetectorRegionCounts,
-        detector_ratemeter,
-        _SpectrumView,
-        _SpectrumViewTimeBins,
-        _SpectrumViewPixelsPerTube,
-        _make_spectrum_view,
-    ) = _create_base_reduction_workflow()
+    workflow, DetectorRegionCounts, detector_ratemeter = (
+        _create_base_reduction_workflow()
+    )
     workflow.insert(detector_ratemeter)
     return workflow, DetectorRegionCounts
 

--- a/tests/handlers/detector_view/spectrum_view_test.py
+++ b/tests/handlers/detector_view/spectrum_view_test.py
@@ -49,7 +49,7 @@ class TestSpectrumViewIntegration:
             output_dims=['x', 'time_of_arrival'],
         )
         factory = _make_factory_with_spectrum(spec)
-        params = make_detector_view_params(spectrum=spec)()
+        params = make_detector_view_params(spectrum_view=spec)()
         workflow = factory.make_workflow('detector', params=params)
 
         events = make_fake_nexus_detector_data(y_size=4, x_size=4, n_events_per_pixel=5)
@@ -73,7 +73,7 @@ class TestSpectrumViewIntegration:
             output_dims=['y', 'x', 'time_of_arrival'],
         )
         factory = _make_factory_with_spectrum(spec, y_size=4, x_size=4)
-        Params = make_detector_view_params(spectrum=spec)
+        Params = make_detector_view_params(spectrum_view=spec)
         params = Params(spectrum_rebin=SpectrumViewRebin(factor=2))
         workflow = factory.make_workflow('detector', params=params)
 

--- a/tests/handlers/detector_view/spectrum_view_test.py
+++ b/tests/handlers/detector_view/spectrum_view_test.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Integration tests for the unified spectrum-view output."""
 
+import pydantic
 import scipp as sc
 from ess.reduce.nexus.types import RawDetector, SampleRun
 
@@ -10,7 +11,6 @@ from ess.livedata.handlers.detector_view.data_source import DetectorNumberSource
 from ess.livedata.handlers.detector_view.factory import DetectorViewFactory
 from ess.livedata.handlers.detector_view.types import LogicalViewConfig
 from ess.livedata.handlers.detector_view_specs import (
-    SpectrumViewRebin,
     SpectrumViewSpec,
     make_detector_view_params,
 )
@@ -18,14 +18,20 @@ from ess.livedata.handlers.detector_view_specs import (
 from .utils import make_fake_detector_number, make_fake_nexus_detector_data
 
 
-def _sum_y_transform(histogram: sc.DataArray, rebin: int) -> sc.DataArray:
-    """Sum the ``y`` dim; the ``rebin`` argument is intentionally ignored."""
+class _RebinParams(pydantic.BaseModel):
+    factor: int = pydantic.Field(default=1, ge=1)
+
+
+def _sum_y_transform(histogram: sc.DataArray) -> sc.DataArray:
+    """Sum the ``y`` dim; takes no runtime parameters."""
     return histogram.sum('y')
 
 
-def _rebin_x_transform(histogram: sc.DataArray, rebin: int) -> sc.DataArray:
-    """Group ``rebin`` adjacent bins along ``x`` (reshape + sum)."""
-    return histogram.fold('x', sizes={'x': -1, 'subpixel': rebin}).sum('subpixel')
+def _rebin_x_transform(histogram: sc.DataArray, params: _RebinParams) -> sc.DataArray:
+    """Group ``params.factor`` adjacent bins along ``x`` (reshape + sum)."""
+    return histogram.fold('x', sizes={'x': -1, 'subpixel': params.factor}).sum(
+        'subpixel'
+    )
 
 
 def _make_factory_with_spectrum(
@@ -71,10 +77,11 @@ class TestSpectrumViewIntegration:
         spec = SpectrumViewSpec(
             transform=_rebin_x_transform,
             output_dims=['y', 'x', 'time_of_arrival'],
+            params_model=_RebinParams,
         )
         factory = _make_factory_with_spectrum(spec, y_size=4, x_size=4)
         Params = make_detector_view_params(spectrum_view=spec)
-        params = Params(spectrum_rebin=SpectrumViewRebin(factor=2))
+        params = Params(spectrum_params=_RebinParams(factor=2))
         workflow = factory.make_workflow('detector', params=params)
 
         events = make_fake_nexus_detector_data(y_size=4, x_size=4, n_events_per_pixel=5)

--- a/tests/handlers/detector_view/spectrum_view_test.py
+++ b/tests/handlers/detector_view/spectrum_view_test.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration tests for the unified spectrum-view output."""
+
+import scipp as sc
+from ess.reduce.nexus.types import RawDetector, SampleRun
+
+from ess.livedata.core.timestamp import Timestamp
+from ess.livedata.handlers.detector_view.data_source import DetectorNumberSource
+from ess.livedata.handlers.detector_view.factory import DetectorViewFactory
+from ess.livedata.handlers.detector_view.types import LogicalViewConfig
+from ess.livedata.handlers.detector_view_specs import (
+    SpectrumViewRebin,
+    SpectrumViewSpec,
+    make_detector_view_params,
+)
+
+from .utils import make_fake_detector_number, make_fake_nexus_detector_data
+
+
+def _sum_y_transform(histogram: sc.DataArray, rebin: int) -> sc.DataArray:
+    """Sum the ``y`` dim; the ``rebin`` argument is intentionally ignored."""
+    return histogram.sum('y')
+
+
+def _rebin_x_transform(histogram: sc.DataArray, rebin: int) -> sc.DataArray:
+    """Group ``rebin`` adjacent bins along ``x`` (reshape + sum)."""
+    return histogram.fold('x', sizes={'x': -1, 'subpixel': rebin}).sum('subpixel')
+
+
+def _make_factory_with_spectrum(
+    spec: SpectrumViewSpec, *, y_size: int = 4, x_size: int = 4
+) -> DetectorViewFactory:
+    detector_number = make_fake_detector_number(y_size, x_size)
+
+    def logical_transform(da: sc.DataArray, source_name: str) -> sc.DataArray:
+        return da.fold(dim='detector_number', sizes={'y': y_size, 'x': x_size})
+
+    return DetectorViewFactory(
+        data_source=DetectorNumberSource(detector_number),
+        view_config=LogicalViewConfig(transform=logical_transform, spectrum_view=spec),
+    )
+
+
+class TestSpectrumViewIntegration:
+    def test_spectrum_view_sums_over_declared_dim(self):
+        spec = SpectrumViewSpec(
+            transform=_sum_y_transform,
+            output_dims=['x', 'time_of_arrival'],
+        )
+        factory = _make_factory_with_spectrum(spec)
+        params = make_detector_view_params(spectrum=spec)()
+        workflow = factory.make_workflow('detector', params=params)
+
+        events = make_fake_nexus_detector_data(y_size=4, x_size=4, n_events_per_pixel=5)
+        workflow.accumulate(
+            {'detector': RawDetector[SampleRun](events)},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+        result = workflow.finalize()
+
+        assert 'spectrum_view' in result
+        spectrum = result['spectrum_view']
+        assert spectrum.dims == ('x', 'time_of_arrival')
+        cumulative = result['cumulative']
+        # Cumulative is summed over time_of_arrival => total counts match total events.
+        assert sc.isclose(spectrum.sum().data, cumulative.sum().data).value
+
+    def test_spectrum_view_rebin_factor_applied(self):
+        spec = SpectrumViewSpec(
+            transform=_rebin_x_transform,
+            output_dims=['y', 'x', 'time_of_arrival'],
+        )
+        factory = _make_factory_with_spectrum(spec, y_size=4, x_size=4)
+        Params = make_detector_view_params(spectrum=spec)
+        params = Params(spectrum_rebin=SpectrumViewRebin(factor=2))
+        workflow = factory.make_workflow('detector', params=params)
+
+        events = make_fake_nexus_detector_data(y_size=4, x_size=4, n_events_per_pixel=5)
+        workflow.accumulate(
+            {'detector': RawDetector[SampleRun](events)},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+        result = workflow.finalize()
+
+        spectrum = result['spectrum_view']
+        assert spectrum.dims == ('y', 'x', 'time_of_arrival')
+        # With factor=2 grouping along x (size 4), output x size is 2.
+        assert spectrum.sizes['x'] == 2
+        assert spectrum.sizes['y'] == 4
+
+    def test_no_spectrum_view_when_spec_absent(self):
+        """Without a SpectrumViewSpec, spectrum_view is not in the outputs."""
+        detector_number = make_fake_detector_number(4, 4)
+
+        def logical_transform(da: sc.DataArray, source_name: str) -> sc.DataArray:
+            return da.fold(dim='detector_number', sizes={'y': 4, 'x': 4})
+
+        factory = DetectorViewFactory(
+            data_source=DetectorNumberSource(detector_number),
+            view_config=LogicalViewConfig(transform=logical_transform),
+        )
+        params = make_detector_view_params()()
+        workflow = factory.make_workflow('detector', params=params)
+
+        events = make_fake_nexus_detector_data(y_size=4, x_size=4, n_events_per_pixel=2)
+        workflow.accumulate(
+            {'detector': RawDetector[SampleRun](events)},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+        result = workflow.finalize()
+        assert 'spectrum_view' not in result

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -36,19 +36,11 @@ def make_reduction_app(instrument: str) -> LivedataApp:
 first_source_name = {
     'dummy': 'panel_0',
     'dream': 'mantle_detector',
-    'bifrost': 'unified_detector',
     'loki': 'loki_detector_0',
 }
 
 
-@pytest.mark.parametrize(
-    "instrument",
-    [
-        pytest.param('bifrost', marks=pytest.mark.slow),
-        'dummy',
-        'dream',
-    ],
-)
+@pytest.mark.parametrize("instrument", ['dummy', 'dream'])
 def test_can_configure_and_stop_workflow_with_detector(
     instrument: str, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -57,11 +49,10 @@ def test_can_configure_and_stop_workflow_with_detector(
     sink = app.sink
     service = app.service
     workflow_name = {
-        'bifrost': 'spectrum_view',
         'dummy': 'total_counts',
         'dream': 'powder_reduction',
     }[instrument]
-    n_target = {'bifrost': 1, 'dummy': 1, 'dream': 3}[instrument]
+    n_target = {'dummy': 1, 'dream': 3}[instrument]
     check_counts = instrument != 'dream'
     # WorkflowSpec (second arg) unused here since the workflow does not take params.
     workflow_id, _ = _get_workflow_from_registry(instrument, workflow_name)

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -68,33 +68,35 @@ def test_can_configure_and_stop_detector_workflow(
         # LOKI rear bank consumes the f144 detector_carriage position;
         # the workflow refuses to produce output until a value is seen.
         app.publish_log_message(source_name='detector_carriage', time=1, value=5000.0)
+    # Each workflow call returns 10 results by default: cumulative, current,
+    # counts_total, counts_in_toa, counts_total_cumulative,
+    # counts_in_toa_range_cumulative, roi_spectra_cumulative,
+    # roi_spectra_current, roi_rectangle, roi_polygon. Instruments that enable
+    # a unified spectrum output add one additional spectrum_view message.
+    n_out = 11 if instrument == 'bifrost' else 10
     app.publish_events(size=2000, time=2)
     service.step()
-    # Each workflow call returns 10 results: cumulative, current,
-    # roi_spectra_current, roi_spectra_cumulative, counts_total, counts_in_toa,
-    # counts_total_cumulative, counts_in_toa_range_cumulative,
-    # roi_rectangle, roi_polygon
-    assert len(sink.messages) == 10
+    assert len(sink.messages) == n_out
     assert sink.messages[0].value.nansum().value == 2000  # cumulative
     assert sink.messages[1].value.nansum().value == 2000  # current
     # No data -> no data published
     service.step()
-    assert len(sink.messages) == 10
+    assert len(sink.messages) == n_out
 
     app.publish_events(size=3000, time=4)
     service.step()
-    assert len(sink.messages) == 20  # 10 + 10
-    assert sink.messages[10].value.nansum().value == 5000  # cumulative
-    assert sink.messages[11].value.nansum().value == 3000  # current
+    assert len(sink.messages) == 2 * n_out
+    assert sink.messages[n_out].value.nansum().value == 5000  # cumulative
+    assert sink.messages[n_out + 1].value.nansum().value == 3000  # current
 
     # More events but the same time
     app.publish_events(size=1000, time=4)
     # Later time
     app.publish_events(size=1000, time=5)
     service.step()
-    assert len(sink.messages) == 30  # 20 + 10
-    assert sink.messages[20].value.nansum().value == 7000  # cumulative
-    assert sink.messages[21].value.nansum().value == 2000  # current
+    assert len(sink.messages) == 3 * n_out
+    assert sink.messages[2 * n_out].value.nansum().value == 7000  # cumulative
+    assert sink.messages[2 * n_out + 1].value.nansum().value == 2000  # current
 
     # Stop workflow
     command = JobCommand(action=JobAction.stop)
@@ -105,7 +107,7 @@ def test_can_configure_and_stop_detector_workflow(
     service.step()
     app.publish_events(size=1000, time=20)
     service.step()
-    assert len(sink.messages) == 30
+    assert len(sink.messages) == 3 * n_out
 
 
 def test_service_can_recover_after_bad_workflow_id_was_set(


### PR DESCRIPTION
Closes #884.

Removes the bespoke `spectrum_view` workflows previously defined separately in Bifrost and ESTIA. Instruments now opt into a `spectrum_view` output on the generic detector view by passing a `SpectrumViewSpec` to `instrument.add_logical_view(..., spectrum=...)`.

The new workflow graph is:
<img width="1529" height="875" alt="implementation-detail-not-for-user-facing-reports" src="https://github.com/user-attachments/assets/0e1ba223-d40f-4983-8c99-37e8251093ae" />
