### PR TITLE
Fix Workflows tab populating one at a time on first open

### DIFF
--- a/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
@@ -216,11 +216,12 @@ class WorkflowStatusWidget:
         self._header: pn.Row | None = None
         self._body: pn.Column | None = None
 
-        # Track the orchestrator's workflow state version for change detection.
-        # refresh() compares this to detect structural changes (staging, commit, stop).
-        self._last_state_version: int | None = None
-
         self._build_widget()
+        # Initialise to the current version so the first refresh() is a no-op
+        # unless state actually changed after construction.
+        self._last_state_version = self._orchestrator.get_workflow_state_version(
+            self._workflow_id
+        )
 
     @property
     def workflow_id(self) -> WorkflowId:
@@ -1028,6 +1029,9 @@ class WorkflowStatusListWidget:
         self._is_visible: Callable[[], bool] | None = None
 
         self._widgets: dict[WorkflowId, WorkflowStatusWidget] = {}
+        # Panels pending insertion into self._panel on the first _refresh_all tick,
+        # where pn.io.hold() is effective. None after population is complete.
+        self._pending_panels: list[pn.Column] | None = None
         self._panel = self._create_panel()
 
     def _create_header_row(self) -> pn.Row:
@@ -1087,9 +1091,13 @@ class WorkflowStatusListWidget:
                 widget.set_expanded(False)
 
     def _create_panel(self) -> pn.Column:
-        """Create the main panel with all workflow widgets."""
-        workflow_widgets = []
+        """Create the main panel container with all workflow widgets pre-built.
+
+        Workflow panels are stored in _pending_panels and added to the column
+        on the first _refresh_all tick, where pn.io.hold() is effective.
+        """
         workflow_registry = self._orchestrator.get_workflow_registry()
+        panels = []
         for workflow_id, spec in sorted(
             workflow_registry.items(), key=lambda x: x[1].title
         ):
@@ -1100,13 +1108,13 @@ class WorkflowStatusListWidget:
                 job_service=self._job_service,
             )
             self._widgets[workflow_id] = widget
-            workflow_widgets.append(widget.panel())
+            panels.append(widget.panel())
 
+        self._pending_panels = panels
         header_row = self._create_header_row()
 
         return pn.Column(
             header_row,
-            *workflow_widgets,
             sizing_mode='stretch_width',
             margin=(10, 10),
         )
@@ -1135,6 +1143,23 @@ class WorkflowStatusListWidget:
         """
         self._is_visible = is_visible
         session_updater.register_custom_handler(self._refresh_all)
+        # Populate as soon as the session is connected. onload callbacks run
+        # with pn.state.curdoc set (unlike session-factory code), so
+        # pn.io.hold() is effective and all workflow panels are inserted
+        # atomically rather than one at a time.
+        pn.state.onload(self._populate_pending)
+
+    def _populate_pending(self) -> None:
+        """Insert all workflow panels into the column in one batch.
+
+        Called from pn.state.onload() where pn.io.hold() is effective.
+        Also called as a fallback from _refresh_all() in non-server contexts
+        (e.g., tests) where onload may not fire.
+        """
+        if self._pending_panels is not None:
+            with pn.io.hold():
+                self._panel.extend(self._pending_panels)
+            self._pending_panels = None
 
     def _refresh_all(self) -> None:
         """Refresh all workflow status widgets.
@@ -1144,6 +1169,9 @@ class WorkflowStatusListWidget:
         """
         if self._is_visible is not None and not self._is_visible():
             return
+        if self._pending_panels is not None:
+            # Fallback: onload didn't fire (non-server context).
+            self._populate_pending()
         for widget in self._widgets.values():
             widget.refresh()
 

--- a/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
@@ -1027,12 +1027,25 @@ class WorkflowStatusListWidget:
         self._orchestrator = orchestrator
         self._job_service = job_service
         self._is_visible: Callable[[], bool] | None = None
+        self._populated: bool = False
 
-        self._widgets: dict[WorkflowId, WorkflowStatusWidget] = {}
-        # Panels pending insertion into self._panel on the first _refresh_all tick,
-        # where pn.io.hold() is effective. None after population is complete.
-        self._pending_panels: list[pn.Column] | None = None
-        self._panel = self._create_panel()
+        workflow_registry = orchestrator.get_workflow_registry()
+        self._widgets: dict[WorkflowId, WorkflowStatusWidget] = {
+            workflow_id: WorkflowStatusWidget(
+                workflow_id=workflow_id,
+                workflow_spec=spec,
+                orchestrator=orchestrator,
+                job_service=job_service,
+            )
+            for workflow_id, spec in sorted(
+                workflow_registry.items(), key=lambda x: x[1].title
+            )
+        }
+        self._panel = pn.Column(
+            self._create_header_row(),
+            sizing_mode='stretch_width',
+            margin=(10, 10),
+        )
 
     def _create_header_row(self) -> pn.Row:
         """Create the header row with expand/collapse all buttons."""
@@ -1090,35 +1103,6 @@ class WorkflowStatusListWidget:
             for widget in self._widgets.values():
                 widget.set_expanded(False)
 
-    def _create_panel(self) -> pn.Column:
-        """Create the main panel container with all workflow widgets pre-built.
-
-        Workflow panels are stored in _pending_panels and added to the column
-        on the first _refresh_all tick, where pn.io.hold() is effective.
-        """
-        workflow_registry = self._orchestrator.get_workflow_registry()
-        panels = []
-        for workflow_id, spec in sorted(
-            workflow_registry.items(), key=lambda x: x[1].title
-        ):
-            widget = WorkflowStatusWidget(
-                workflow_id=workflow_id,
-                workflow_spec=spec,
-                orchestrator=self._orchestrator,
-                job_service=self._job_service,
-            )
-            self._widgets[workflow_id] = widget
-            panels.append(widget.panel())
-
-        self._pending_panels = panels
-        header_row = self._create_header_row()
-
-        return pn.Column(
-            header_row,
-            sizing_mode='stretch_width',
-            margin=(10, 10),
-        )
-
     def rebuild_widget(self, workflow_id: WorkflowId) -> None:
         """Rebuild a specific workflow widget after config changes."""
         widget = self._widgets.get(workflow_id)
@@ -1156,10 +1140,10 @@ class WorkflowStatusListWidget:
         Also called as a fallback from _refresh_all() in non-server contexts
         (e.g., tests) where onload may not fire.
         """
-        if self._pending_panels is not None:
+        if not self._populated:
             with pn.io.hold():
-                self._panel.extend(self._pending_panels)
-            self._pending_panels = None
+                self._panel.extend([w.panel() for w in self._widgets.values()])
+            self._populated = True
 
     def _refresh_all(self) -> None:
         """Refresh all workflow status widgets.
@@ -1169,7 +1153,7 @@ class WorkflowStatusListWidget:
         """
         if self._is_visible is not None and not self._is_visible():
             return
-        if self._pending_panels is not None:
+        if not self._populated:
             # Fallback: onload didn't fire (non-server context).
             self._populate_pending()
         for widget in self._widgets.values():


### PR DESCRIPTION
## Summary

- `pn.io.hold()` only works in session-callback contexts. The session factory (`create_layout`) runs outside that context, so rendering the dynamic tab content produced one PATCH-DOC per workflow widget, causing them to appear one at a time.
- `WorkflowStatusListWidget._create_panel()` now builds all `WorkflowStatusWidget` objects up front (pure Python, no document context needed) but stores their panels in `_pending_panels` rather than inserting them into the column immediately.
- `register_periodic_refresh()` schedules `_populate_pending()` via `pn.state.onload()`, which fires when the browser first connects. At that point `pn.state.curdoc` is set and `pn.io.hold()` is effective, so all workflow panels are extended into the column in a single batch.
- `WorkflowStatusWidget.__init__()` now initialises `_last_state_version` to the actual current version right after `_build_widget()`, eliminating an unnecessary full rebuild on the first periodic tick that caused a one-time flicker.

## Test plan

- [x] Open dashboard, verify Workflows tab populates all workflows at once (no sequential appearance)
- [x] Verify no flicker ~1 s after initial render
- [x] Stage/commit/stop a workflow and verify status updates still work correctly
- [x] Expand all / collapse all buttons work immediately on load