### PR TITLE
Fail fast on Kafka authorization errors

### DIFF
--- a/src/ess/livedata/dashboard/dashboard_services.py
+++ b/src/ess/livedata/dashboard/dashboard_services.py
@@ -2,12 +2,15 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Dashboard service composition and setup."""
 
+import os
+import signal
 import threading
 import time
 from contextlib import ExitStack
 
 import scipp as sc
 import structlog
+from confluent_kafka import KafkaException
 
 from ess.livedata.config import instrument_registry
 from ess.livedata.config.grid_template import load_raw_grid_templates
@@ -140,6 +143,14 @@ class DashboardServices:
             try:
                 self.orchestrator.update()
                 self.session_registry.cleanup_stale_sessions()
+            except KafkaException:
+                # Auth/fatal Kafka errors are not self-healing. Crash so systemd
+                # restarts the process with a fresh consumer; the in-process
+                # consumer is shared across browser sessions, so a tab reload
+                # would not recover.
+                logger.exception("dashboard_transport_failed")
+                self._on_transport_failure()
+                return
             except Exception:
                 logger.exception("orchestrator_update_error")
 
@@ -148,6 +159,16 @@ class DashboardServices:
             elapsed = time.monotonic() - start
             if elapsed < 0.01:  # < 10ms means no real work
                 self._stop_event.wait(self._update_interval)
+
+    def _on_transport_failure(self) -> None:
+        """Trigger orderly process shutdown after a fatal transport failure.
+
+        Mirrors the worker-thread → main-thread fail-fast path in
+        ``Service._run_loop``: SIGINT is delivered to the main thread, where
+        ``ServiceBase._handle_shutdown`` runs the cleanup and exits.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            os.kill(os.getpid(), signal.SIGINT)
 
     def _setup_data_infrastructure(self) -> None:
         """Set up data services, forwarder, and orchestrator."""

--- a/src/ess/livedata/kafka/errors.py
+++ b/src/ess/livedata/kafka/errors.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
+"""Shared error classification for Kafka source and sink."""
+
+from confluent_kafka import KafkaError
+
+# Auth/misconfiguration codes treated as fatal in addition to librdkafka-flagged
+# fatal errors. Crashing on these surfaces the problem to the operator instead
+# of silently spamming the broker with retries (consumer side) or dropping
+# results into a metric counter (producer side). The set is the union of codes
+# relevant to either side; codes that a given side cannot encounter are
+# harmless to include.
+FATAL_ERROR_CODES = frozenset(
+    {
+        KafkaError.TOPIC_AUTHORIZATION_FAILED,
+        KafkaError.GROUP_AUTHORIZATION_FAILED,
+        KafkaError.CLUSTER_AUTHORIZATION_FAILED,
+        KafkaError.SASL_AUTHENTICATION_FAILED,
+        KafkaError.TRANSACTIONAL_ID_AUTHORIZATION_FAILED,
+    }
+)
+
+
+def is_fatal(err: KafkaError) -> bool:
+    """Return True if the error should crash the service."""
+    return err.fatal() or err.code() in FATAL_ERROR_CODES

--- a/src/ess/livedata/kafka/sink.py
+++ b/src/ess/livedata/kafka/sink.py
@@ -12,29 +12,12 @@ import structlog
 
 from ..config.workflow_spec import ResultKey
 from ..core.message import Message, MessageSink
+from .errors import is_fatal
 
 logger = structlog.get_logger(__name__)
 
 
 T = TypeVar("T")
-
-
-# Codes treated as fatal in addition to producer-flagged fatal errors. These
-# are auth/misconfiguration failures that need operator intervention; raising
-# crashes the service so the problem surfaces, instead of silently dropping
-# results while every produce keeps failing in the background.
-_FATAL_ERROR_CODES = frozenset(
-    {
-        kafka.KafkaError.TOPIC_AUTHORIZATION_FAILED,
-        kafka.KafkaError.CLUSTER_AUTHORIZATION_FAILED,
-        kafka.KafkaError.SASL_AUTHENTICATION_FAILED,
-        kafka.KafkaError.TRANSACTIONAL_ID_AUTHORIZATION_FAILED,
-    }
-)
-
-
-def _is_fatal_error(err: kafka.KafkaError) -> bool:
-    return err.fatal() or err.code() in _FATAL_ERROR_CODES
 
 
 class SerializationError(Exception):
@@ -104,7 +87,7 @@ class KafkaSink(MessageSink[T]):
             if err is None:
                 return
             self._publish_errors += 1
-            if _is_fatal_error(err):
+            if is_fatal(err):
                 self._fatal_error = err
                 logger.error("Fatal delivery error for topic %s: %s", msg.topic(), err)
             else:
@@ -127,7 +110,7 @@ class KafkaSink(MessageSink[T]):
                 self._producer.poll(0)
             except kafka.KafkaException as e:
                 err = e.args[0] if e.args else None
-                if isinstance(err, kafka.KafkaError) and _is_fatal_error(err):
+                if isinstance(err, kafka.KafkaError) and is_fatal(err):
                     raise
                 logger.error("Failed to publish message to %s: %s", serialized.topic, e)
 
@@ -135,7 +118,7 @@ class KafkaSink(MessageSink[T]):
             self._producer.flush(timeout=3)
         except kafka.KafkaException as e:
             err = e.args[0] if e.args else None
-            if isinstance(err, kafka.KafkaError) and _is_fatal_error(err):
+            if isinstance(err, kafka.KafkaError) and is_fatal(err):
                 raise
             logger.error("Error flushing producer: %s", e)
 

--- a/src/ess/livedata/kafka/sink.py
+++ b/src/ess/livedata/kafka/sink.py
@@ -19,6 +19,24 @@ logger = structlog.get_logger(__name__)
 T = TypeVar("T")
 
 
+# Codes treated as fatal in addition to producer-flagged fatal errors. These
+# are auth/misconfiguration failures that need operator intervention; raising
+# crashes the service so the problem surfaces, instead of silently dropping
+# results while every produce keeps failing in the background.
+_FATAL_ERROR_CODES = frozenset(
+    {
+        kafka.KafkaError.TOPIC_AUTHORIZATION_FAILED,
+        kafka.KafkaError.CLUSTER_AUTHORIZATION_FAILED,
+        kafka.KafkaError.SASL_AUTHENTICATION_FAILED,
+        kafka.KafkaError.TRANSACTIONAL_ID_AUTHORIZATION_FAILED,
+    }
+)
+
+
+def _is_fatal_error(err: kafka.KafkaError) -> bool:
+    return err.fatal() or err.code() in _FATAL_ERROR_CODES
+
+
 class SerializationError(Exception):
     """Raised when serialization of a message fails."""
 
@@ -69,6 +87,7 @@ class KafkaSink(MessageSink[T]):
         self._producer: kafka.Producer | None = None
         self._producer_factory = producer_factory
         self._serializer = serializer
+        self._fatal_error: kafka.KafkaError | None = None
         # Metrics tracking
         self._messages_published = 0
         self._publish_errors = 0
@@ -78,10 +97,17 @@ class KafkaSink(MessageSink[T]):
     def publish_messages(self, messages: list[Message[T]]) -> None:
         if self._producer is None:
             raise RuntimeError("KafkaSink must be used as a context manager")
+        if self._fatal_error is not None:
+            raise kafka.KafkaException(self._fatal_error)
 
         def delivery_callback(err, msg):
-            if err is not None:
-                self._publish_errors += 1
+            if err is None:
+                return
+            self._publish_errors += 1
+            if _is_fatal_error(err):
+                self._fatal_error = err
+                logger.error("Fatal delivery error for topic %s: %s", msg.topic(), err)
+            else:
                 logger.error("Failed to deliver message to %s: %s", msg.topic(), err)
 
         logger.debug("Publishing %d messages", len(messages))
@@ -100,12 +126,21 @@ class KafkaSink(MessageSink[T]):
                 )
                 self._producer.poll(0)
             except kafka.KafkaException as e:
+                err = e.args[0] if e.args else None
+                if isinstance(err, kafka.KafkaError) and _is_fatal_error(err):
+                    raise
                 logger.error("Failed to publish message to %s: %s", serialized.topic, e)
 
         try:
             self._producer.flush(timeout=3)
         except kafka.KafkaException as e:
+            err = e.args[0] if e.args else None
+            if isinstance(err, kafka.KafkaError) and _is_fatal_error(err):
+                raise
             logger.error("Error flushing producer: %s", e)
+
+        if self._fatal_error is not None:
+            raise kafka.KafkaException(self._fatal_error)
 
         self._messages_published += len(messages)
         self._maybe_log_metrics()

--- a/src/ess/livedata/kafka/source.py
+++ b/src/ess/livedata/kafka/source.py
@@ -89,7 +89,7 @@ class ConsumerHealthStatus:
     failure_reason: str | None = None
 
 
-class BackgroundMessageSource(MessageSource[KafkaMessage]):
+class BackgroundMessageSource(KafkaMessageSource):
     """
     Message source that consumes messages in a background thread.
 
@@ -128,9 +128,7 @@ class BackgroundMessageSource(MessageSource[KafkaMessage]):
         max_consecutive_errors: int = DEFAULT_MAX_CONSECUTIVE_ERRORS,
         health_timeout: float = DEFAULT_HEALTH_TIMEOUT_SECONDS,
     ):
-        self._consumer = consumer
-        self._num_messages = num_messages
-        self._timeout = timeout
+        super().__init__(consumer=consumer, num_messages=num_messages, timeout=timeout)
         self._queue: queue.Queue[list[KafkaMessage]] = queue.Queue(
             maxsize=max_queue_size
         )
@@ -204,19 +202,9 @@ class BackgroundMessageSource(MessageSource[KafkaMessage]):
         try:
             while not self._stop_event.is_set():
                 try:
-                    messages = self._consumer.consume(self._num_messages, self._timeout)
-
-                    # Filter out error messages from the consumer
-                    data_messages = []
-                    for m in messages:
-                        err = m.error()
-                        if err is not None:
-                            if err.fatal() or err.code() in _FATAL_ERROR_CODES:
-                                raise KafkaException(err)
-                            logger.warning("kafka_consumer_error", error=err)
-                            continue
-                        data_messages.append(m)
-                    messages = data_messages
+                    # Foreground consume + error filter; the public get_messages
+                    # override below dispatches from the queue instead.
+                    messages = super().get_messages()
 
                     # Reset consecutive errors on successful consume
                     self._consecutive_errors = 0

--- a/src/ess/livedata/kafka/source.py
+++ b/src/ess/livedata/kafka/source.py
@@ -8,9 +8,10 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 import structlog
-from confluent_kafka import KafkaError, KafkaException
+from confluent_kafka import KafkaException
 
 from ..core.message import MessageSource
+from .errors import is_fatal
 from .message_adapter import KafkaMessage
 
 logger = structlog.get_logger(__name__)
@@ -18,19 +19,6 @@ logger = structlog.get_logger(__name__)
 # Circuit breaker configuration
 DEFAULT_MAX_CONSECUTIVE_ERRORS = 10
 DEFAULT_HEALTH_TIMEOUT_SECONDS = 60.0
-
-# Error codes treated as fatal in addition to librdkafka-flagged fatal errors:
-# misconfiguration that requires operator intervention. Crashing surfaces the
-# problem instead of silently spamming the broker with retries.
-_FATAL_ERROR_CODES = frozenset(
-    {
-        KafkaError.TOPIC_AUTHORIZATION_FAILED,
-        KafkaError.GROUP_AUTHORIZATION_FAILED,
-        KafkaError.CLUSTER_AUTHORIZATION_FAILED,
-        KafkaError.SASL_AUTHENTICATION_FAILED,
-        KafkaError.TRANSACTIONAL_ID_AUTHORIZATION_FAILED,
-    }
-)
 
 
 class KafkaConsumer(Protocol):
@@ -67,7 +55,7 @@ class KafkaMessageSource(MessageSource[KafkaMessage]):
         for m in messages:
             err = m.error()
             if err is not None:
-                if err.fatal() or err.code() in _FATAL_ERROR_CODES:
+                if is_fatal(err):
                     raise KafkaException(err)
                 logger.warning("kafka_consumer_error", error=err)
                 continue

--- a/src/ess/livedata/kafka/source.py
+++ b/src/ess/livedata/kafka/source.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 import structlog
-from confluent_kafka import KafkaException
+from confluent_kafka import KafkaError, KafkaException
 
 from ..core.message import MessageSource
 from .message_adapter import KafkaMessage
@@ -18,6 +18,19 @@ logger = structlog.get_logger(__name__)
 # Circuit breaker configuration
 DEFAULT_MAX_CONSECUTIVE_ERRORS = 10
 DEFAULT_HEALTH_TIMEOUT_SECONDS = 60.0
+
+# Error codes treated as fatal in addition to librdkafka-flagged fatal errors:
+# misconfiguration that requires operator intervention. Crashing surfaces the
+# problem instead of silently spamming the broker with retries.
+_FATAL_ERROR_CODES = frozenset(
+    {
+        KafkaError.TOPIC_AUTHORIZATION_FAILED,
+        KafkaError.GROUP_AUTHORIZATION_FAILED,
+        KafkaError.CLUSTER_AUTHORIZATION_FAILED,
+        KafkaError.SASL_AUTHENTICATION_FAILED,
+        KafkaError.TRANSACTIONAL_ID_AUTHORIZATION_FAILED,
+    }
+)
 
 
 class KafkaConsumer(Protocol):
@@ -47,9 +60,19 @@ class KafkaMessageSource(MessageSource[KafkaMessage]):
         self._timeout = timeout
 
     def get_messages(self) -> list[KafkaMessage]:
-        return self._consumer.consume(
+        messages = self._consumer.consume(
             num_messages=self._num_messages, timeout=self._timeout
         )
+        data_messages = []
+        for m in messages:
+            err = m.error()
+            if err is not None:
+                if err.fatal() or err.code() in _FATAL_ERROR_CODES:
+                    raise KafkaException(err)
+                logger.warning("kafka_consumer_error", error=err)
+                continue
+            data_messages.append(m)
+        return data_messages
 
 
 @dataclass
@@ -186,10 +209,11 @@ class BackgroundMessageSource(MessageSource[KafkaMessage]):
                     # Filter out error messages from the consumer
                     data_messages = []
                     for m in messages:
-                        if m.error() is not None:
-                            if m.error().fatal():
-                                raise KafkaException(m.error())
-                            logger.warning("kafka_consumer_error", error=m.error())
+                        err = m.error()
+                        if err is not None:
+                            if err.fatal() or err.code() in _FATAL_ERROR_CODES:
+                                raise KafkaException(err)
+                            logger.warning("kafka_consumer_error", error=err)
                             continue
                         data_messages.append(m)
                     messages = data_messages

--- a/src/ess/livedata/kafka/source.py
+++ b/src/ess/livedata/kafka/source.py
@@ -315,7 +315,12 @@ class BackgroundMessageSource(MessageSource[KafkaMessage]):
             self._last_metrics_time = now
 
     def get_messages(self) -> list[KafkaMessage]:
-        """Get all messages consumed since the last call."""
+        """Get all messages consumed since the last call.
+
+        Raises ``RuntimeError`` once the background consume thread has died
+        for any non-clean reason and any buffered messages have been drained,
+        so the caller (typically `Service._run_loop`) can fail fast.
+        """
         if not self._started:
             self.start()
 
@@ -326,6 +331,9 @@ class BackgroundMessageSource(MessageSource[KafkaMessage]):
                 all_messages.extend(batch)
         except queue.Empty:
             pass
+
+        if not all_messages and self._failure_reason is not None:
+            raise RuntimeError(f"Background consumer stopped: {self._failure_reason}")
 
         return all_messages
 

--- a/tests/dashboard/dashboard_services_test.py
+++ b/tests/dashboard/dashboard_services_test.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for the dashboard update loop fail-fast behavior."""
+
+import threading
+
+from confluent_kafka import KafkaException
+
+from ess.livedata.dashboard.dashboard_services import DashboardServices
+
+
+class _FakeRegistry:
+    def cleanup_stale_sessions(self) -> None:
+        pass
+
+
+class _FakeOrchestrator:
+    def __init__(self, exception: BaseException | None = None) -> None:
+        self._exception = exception
+        self.update_calls = 0
+
+    def update(self) -> None:
+        self.update_calls += 1
+        if self._exception is not None:
+            raise self._exception
+
+
+def _make_loop_target(orchestrator: _FakeOrchestrator) -> DashboardServices:
+    """Build a minimal stand-in with the attributes ``_update_loop`` needs."""
+    target = DashboardServices.__new__(DashboardServices)
+    target.orchestrator = orchestrator
+    target.session_registry = _FakeRegistry()
+    target._stop_event = threading.Event()
+    target._update_interval = 0.01
+    target.transport_failure_calls = 0
+
+    def _on_transport_failure() -> None:
+        target.transport_failure_calls += 1
+
+    target._on_transport_failure = _on_transport_failure
+    return target
+
+
+def test_update_loop_exits_and_signals_failure_on_kafka_exception() -> None:
+    target = _make_loop_target(_FakeOrchestrator(KafkaException("auth denied")))
+
+    thread = threading.Thread(target=DashboardServices._update_loop, args=(target,))
+    thread.start()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    assert target.transport_failure_calls == 1
+    assert target.orchestrator.update_calls == 1
+
+
+def test_update_loop_continues_on_generic_exception() -> None:
+    """Non-Kafka exceptions stay log-and-continue, not fail-fast."""
+    raised = threading.Event()
+
+    class FlakyOrchestrator:
+        def __init__(self) -> None:
+            self.update_calls = 0
+
+        def update(self) -> None:
+            self.update_calls += 1
+            if self.update_calls == 1:
+                raised.set()
+                raise RuntimeError("transient widget bug")
+
+    orchestrator = FlakyOrchestrator()
+    target = DashboardServices.__new__(DashboardServices)
+    target.orchestrator = orchestrator
+    target.session_registry = _FakeRegistry()
+    target._stop_event = threading.Event()
+    target._update_interval = 0.01
+    target.transport_failure_calls = 0
+
+    def _on_transport_failure() -> None:
+        target.transport_failure_calls += 1
+
+    target._on_transport_failure = _on_transport_failure
+
+    thread = threading.Thread(target=DashboardServices._update_loop, args=(target,))
+    thread.start()
+    assert raised.wait(timeout=2.0)
+    # Let the loop iterate at least once more after the exception.
+    while orchestrator.update_calls < 2 and thread.is_alive():
+        target._stop_event.wait(0.01)
+    target._stop_event.set()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    assert target.transport_failure_calls == 0
+    assert orchestrator.update_calls >= 2
+
+
+def test_on_transport_failure_is_noop_on_main_thread() -> None:
+    """Guard prevents the test process from killing itself when invoked directly."""
+    target = DashboardServices.__new__(DashboardServices)
+    # Should return without raising and without sending a signal.
+    DashboardServices._on_transport_failure(target)

--- a/tests/kafka/kafka_sink_test.py
+++ b/tests/kafka/kafka_sink_test.py
@@ -13,10 +13,11 @@ failure injection for the :class:`SerializationError` handling tests.
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 import scipp as sc
-from confluent_kafka import KafkaException
+from confluent_kafka import KafkaError, KafkaException
 from pydantic import BaseModel
 from streaming_data_types import dataarray_da00
 
@@ -40,14 +41,23 @@ from ess.livedata.kafka.sink_serializers import CommandSerializer, Da00Serialize
 INSTRUMENT = 'dummy'
 
 
+class _FakeMsg:
+    def __init__(self, topic: str) -> None:
+        self._topic = topic
+
+    def topic(self) -> str:
+        return self._topic
+
+
 class _FakeProducer:
     """
     Minimal stand-in for ``confluent_kafka.Producer``.
 
     Faking the broker is unavoidable — a real producer would need a running
     Kafka cluster. Records ``produce`` calls for assertion. ``raise_on_produce``
-    / ``raise_on_flush`` inject broker errors so the sink's error handling can
-    be verified without a real broker.
+    / ``raise_on_flush`` inject broker errors. ``delivery_error`` simulates
+    the broker reporting a delivery failure asynchronously: pending callbacks
+    fire with the given error on the next ``poll``/``flush``.
     """
 
     def __init__(self, config: dict) -> None:
@@ -56,6 +66,8 @@ class _FakeProducer:
         self.flushed = 0
         self.raise_on_produce: BaseException | None = None
         self.raise_on_flush: BaseException | None = None
+        self.delivery_error: KafkaError | None = None
+        self._pending: list[tuple[Any, _FakeMsg]] = []
 
     def produce(
         self,
@@ -70,13 +82,21 @@ class _FakeProducer:
         self.produced.append(
             {'topic': topic, 'key': key, 'value': value, 'callback': callback}
         )
+        if callback is not None:
+            self._pending.append((callback, _FakeMsg(topic)))
+
+    def _drain_callbacks(self) -> None:
+        for cb, msg in self._pending:
+            cb(self.delivery_error, msg)
+        self._pending = []
 
     def poll(self, timeout: float) -> None:
-        pass
+        self._drain_callbacks()
 
     def flush(self, timeout: float | None = None) -> None:
         if self.raise_on_flush is not None:
             raise self.raise_on_flush
+        self._drain_callbacks()
         self.flushed += 1
 
 
@@ -264,5 +284,72 @@ class TestErrorHandling:
     ) -> None:
         with sink_factory(Da00Serializer(instrument=INSTRUMENT)) as sink:
             producer.raise_on_flush = KafkaException('flush failed')
+            # Must not raise.
+            sink.publish_messages([_data_message()])
+
+
+class TestFailFast:
+    """
+    Authorization/auth-misconfiguration errors must crash the sink instead of
+    being silently logged. confluent_kafka does not flag these as fatal, so
+    the sink applies its own auth-code list (see ``_FATAL_ERROR_CODES``).
+    """
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            KafkaError.TOPIC_AUTHORIZATION_FAILED,
+            KafkaError.CLUSTER_AUTHORIZATION_FAILED,
+            KafkaError.SASL_AUTHENTICATION_FAILED,
+            KafkaError.TRANSACTIONAL_ID_AUTHORIZATION_FAILED,
+        ],
+    )
+    def test_fatal_delivery_callback_raises_after_publish(
+        self, sink_factory, producer: _FakeProducer, code: int
+    ) -> None:
+        producer.delivery_error = KafkaError(code)
+        with sink_factory(Da00Serializer(instrument=INSTRUMENT)) as sink:
+            with pytest.raises(KafkaException):
+                sink.publish_messages([_data_message()])
+
+    def test_subsequent_publish_raises_after_fatal(
+        self, sink_factory, producer: _FakeProducer
+    ) -> None:
+        producer.delivery_error = KafkaError(KafkaError.TOPIC_AUTHORIZATION_FAILED)
+        with sink_factory(Da00Serializer(instrument=INSTRUMENT)) as sink:
+            with pytest.raises(KafkaException):
+                sink.publish_messages([_data_message('a')])
+            # Even after clearing the broker-side fault, the sink stays poisoned:
+            # operator must restart the service.
+            producer.delivery_error = None
+            with pytest.raises(KafkaException):
+                sink.publish_messages([_data_message('b')])
+
+    def test_fatal_kafka_exception_from_produce_propagates(
+        self, sink_factory, producer: _FakeProducer
+    ) -> None:
+        producer.raise_on_produce = KafkaException(
+            KafkaError(KafkaError.SASL_AUTHENTICATION_FAILED)
+        )
+        with sink_factory(Da00Serializer(instrument=INSTRUMENT)) as sink:
+            with pytest.raises(KafkaException):
+                sink.publish_messages([_data_message()])
+
+    def test_fatal_kafka_exception_from_flush_propagates(
+        self, sink_factory, producer: _FakeProducer
+    ) -> None:
+        producer.raise_on_flush = KafkaException(
+            KafkaError(KafkaError.CLUSTER_AUTHORIZATION_FAILED)
+        )
+        with sink_factory(Da00Serializer(instrument=INSTRUMENT)) as sink:
+            with pytest.raises(KafkaException):
+                sink.publish_messages([_data_message()])
+
+    def test_nonfatal_delivery_error_does_not_raise(
+        self, sink_factory, producer: _FakeProducer
+    ) -> None:
+        # NETWORK_EXCEPTION is a transient delivery failure, not auth/misconfig.
+        producer.delivery_error = KafkaError(KafkaError.NETWORK_EXCEPTION)
+        with sink_factory(Da00Serializer(instrument=INSTRUMENT)) as sink:
             # Must not raise.
             sink.publish_messages([_data_message()])

--- a/tests/kafka/source_test.py
+++ b/tests/kafka/source_test.py
@@ -4,6 +4,7 @@ import time
 from queue import Queue
 
 import pytest
+from confluent_kafka import KafkaError, KafkaException
 
 from ess.livedata.kafka.message_adapter import FakeKafkaMessage
 from ess.livedata.kafka.source import (
@@ -87,6 +88,43 @@ def test_limit_number_of_consumed_messages() -> None:
     messages2 = source.get_messages()
     # The FakeKafkaConsumer returns the same messages every time
     assert messages1 == messages2
+
+
+def test_kafka_message_source_filters_nonfatal_errors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    consumer = ControllableKafkaConsumer()
+    consumer.add_messages(
+        [
+            FakeErrorMessage(FakeKafkaError(is_fatal=False)),
+            FakeKafkaMessage(value=b'good', topic="topic1"),
+        ]
+    )
+    source = KafkaMessageSource(consumer=consumer, num_messages=10)
+
+    messages = source.get_messages()
+
+    assert len(messages) == 1
+    assert messages[0].value() == b'good'
+    assert "kafka_consumer_error" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        KafkaError.TOPIC_AUTHORIZATION_FAILED,
+        KafkaError.GROUP_AUTHORIZATION_FAILED,
+        KafkaError.CLUSTER_AUTHORIZATION_FAILED,
+        KafkaError.SASL_AUTHENTICATION_FAILED,
+    ],
+)
+def test_kafka_message_source_raises_on_auth_error(code: int) -> None:
+    consumer = ControllableKafkaConsumer()
+    consumer.add_messages([FakeErrorMessage(FakeKafkaError(code=code))])
+    source = KafkaMessageSource(consumer=consumer, num_messages=10)
+
+    with pytest.raises(KafkaException):
+        source.get_messages()
 
 
 class TestBackgroundMessageSource:
@@ -602,16 +640,47 @@ class TestBackgroundMessageSource:
             assert not source.is_healthy()
             assert source.get_health_status().failure_reason is not None
 
+    def test_auth_error_messages_stop_consume_loop(self) -> None:
+        consumer = ControllableKafkaConsumer()
+        consumer.add_messages(
+            [
+                FakeErrorMessage(
+                    FakeKafkaError(code=KafkaError.TOPIC_AUTHORIZATION_FAILED)
+                )
+            ]
+        )
+
+        with BackgroundMessageSource(
+            consumer, timeout=0.01, max_consecutive_errors=10
+        ) as source:
+            for _ in range(50):
+                if not source.get_health_status().thread_alive:
+                    break
+                time.sleep(0.05)
+
+            assert not source.is_healthy()
+            assert source.get_health_status().failure_reason is not None
+
 
 class FakeKafkaError:
     """Fake KafkaError for testing error message filtering."""
 
-    def __init__(self, *, is_fatal: bool = False, message: str = "test error"):
+    def __init__(
+        self,
+        *,
+        is_fatal: bool = False,
+        code: int = 0,
+        message: str = "test error",
+    ):
         self._fatal = is_fatal
+        self._code = code
         self._message = message
 
     def fatal(self) -> bool:
         return self._fatal
+
+    def code(self) -> int:
+        return self._code
 
     def __str__(self) -> str:
         return self._message

--- a/tests/kafka/source_test.py
+++ b/tests/kafka/source_test.py
@@ -653,13 +653,45 @@ class TestBackgroundMessageSource:
         with BackgroundMessageSource(
             consumer, timeout=0.01, max_consecutive_errors=10
         ) as source:
-            for _ in range(50):
-                if not source.get_health_status().thread_alive:
-                    break
-                time.sleep(0.05)
+            source._thread.join(timeout=2.0)
 
             assert not source.is_healthy()
             assert source.get_health_status().failure_reason is not None
+
+    def test_get_messages_raises_after_consume_thread_dies(self) -> None:
+        consumer = ControllableKafkaConsumer()
+        consumer.should_raise = True
+        consumer.exception_to_raise = RuntimeError("boom")
+
+        with BackgroundMessageSource(
+            consumer, timeout=0.01, max_consecutive_errors=2
+        ) as source:
+            source._thread.join(timeout=2.0)
+            assert source.get_health_status().failure_reason is not None
+
+            with pytest.raises(RuntimeError, match="Background consumer stopped"):
+                source.get_messages()
+
+    def test_get_messages_drains_queue_before_raising(self) -> None:
+        consumer = ControllableKafkaConsumer()
+        good_msg = FakeKafkaMessage(value=b'good', topic="topic1")
+        consumer.add_messages(
+            [
+                good_msg,
+                FakeErrorMessage(FakeKafkaError(is_fatal=True)),
+            ]
+        )
+
+        with BackgroundMessageSource(consumer, num_messages=1, timeout=0.01) as source:
+            source._thread.join(timeout=2.0)
+            assert source.get_health_status().failure_reason is not None
+
+            messages = source.get_messages()
+            assert len(messages) == 1
+            assert messages[0].value() == b'good'
+
+            with pytest.raises(RuntimeError, match="Background consumer stopped"):
+                source.get_messages()
 
 
 class FakeKafkaError:


### PR DESCRIPTION
## Summary

Motivation: PR #891 disabled the filewriter topic subscription because lacking authorization for it caused services to hammer Kafka with failed auth requests. Investigating the loop revealed two gaps:

1. `TOPIC_AUTHORIZATION_FAILED` (and the other `*_AUTHORIZATION_FAILED` / `SASL_AUTHENTICATION_FAILED` codes) are not flagged fatal by librdkafka. They were being logged at every poll and otherwise ignored by app code while librdkafka kept retrying in the background. The circuit breaker never tripped because `consume()` doesn't raise for these — it returns error messages.
2. When the `BackgroundMessageSource` consume thread dies (auth, circuit breaker, or any fatal exception), the worker thread polls `get_messages()` forever on an empty queue. The service appears alive while doing nothing.

This PR closes both gaps so a missing-auth topic crashes the service hard, surfacing the misconfiguration via the orchestrator's restart loop / alerting:

- `KafkaMessageSource.get_messages()` and `BackgroundMessageSource._consume_loop` raise `KafkaException` on librdkafka-fatal errors **and** auth-failure codes.
- `BackgroundMessageSource.get_messages()` raises `RuntimeError` once the consume thread has exited with `_failure_reason` set and the queue is drained. The exception propagates through `processor.process()` → `Service._run_loop`'s existing `except Exception` → `_worker_error` set + SIGINT to main thread → orderly resource cleanup via `Service.__exit__` / `ExitStack`.

Buffered messages are drained before raising, so no data is lost on the way down.

The filewriter run-control case from #891 is treated as a one-off workaround (already merged); no generic "optional topic" mechanism is introduced here.

## Test plan

- [x] Unit tests cover: `KafkaMessageSource` raising on each auth code, filtering non-fatal non-auth errors; `BackgroundMessageSource` thread exiting on auth code; `get_messages()` raising once the thread has died; `get_messages()` draining buffered messages before raising.
- [x] Test orderly dashboard shutdown by injecting error:
```2026-04-27T07:21:55.173320Z [info     ] 101 GET /ws (127.0.0.1) 0.55ms [tornado.access]
INFO:bokeh.server.views.ws:WebSocket connection opened
INFO:bokeh.server.views.ws:ServerConnection created
2026-04-27T07:22:06.971817Z [error    ] dashboard_transport_failed     [ess.livedata.dashboard.dashboard_services]
Traceback (most recent call last):
  File "/home/simon/claude/esslivedata/src/ess/livedata/dashboard/dashboard_services.py", line 154, in _update_loop
    raise KafkaException("TEMP: simulated transport failure")
cimpl.KafkaException: TEMP: simulated transport failure
2026-04-27T07:22:06.973650Z [info     ] Stopping service...            [ess.livedata.core.service]
2026-04-27T07:22:06.974027Z [info     ] orchestrator_update_thread_stopped [ess.livedata.dashboard.dashboard_services]
2026-04-27T07:22:06.977530Z [info     ] dashboard_kafka_transport_cleaned_up [ess.livedata.dashboard.kafka_transport]
2026-04-27T07:22:06.977858Z [info     ] Service stopped                [ess.livedata.core.service]```