### PR TITLE
Add generic cbm monitor workflow placeholder -> ESTIA beam monitor support

### DIFF
--- a/docs/user-guide/adding-new-instruments.md
+++ b/docs/user-guide/adding-new-instruments.md
@@ -163,6 +163,88 @@ def setup_factories(instrument: Instrument) -> None:
 - Workflow framework: `sciline`
 - Geometry and data loading: `scippnexus`, etc.
 
+## Monitor Workflow Registration
+
+Beam monitors get a standard time-of-arrival histogram workflow via
+`register_monitor_workflow_specs`. The function takes a list of monitor source
+names; the names must also appear in the `monitors=...` argument of the
+`Instrument` constructor and be wired up in the stream mapping (see below).
+
+```python
+from ess.livedata.handlers.monitor_workflow_specs import (
+    TOAOnlyMonitorDataParams,
+    register_monitor_workflow_specs,
+)
+
+monitor_handle = register_monitor_workflow_specs(
+    instrument, instrument.monitors, params=TOAOnlyMonitorDataParams
+)
+```
+
+Use `MonitorDataParams` instead of `TOAOnlyMonitorDataParams` if a TOF lookup
+table is available for the instrument.
+
+### Generic `cbm` Fallback
+
+For instruments coming online without confirmed monitor information, a
+standard placeholder is provided that covers source names `cbm0..cbm9`. This
+range is intentionally one wider than the documented `cbm[1-9]` convention to
+absorb upstream off-by-one configuration errors that have been observed.
+
+To use the placeholder, import `GENERIC_CBM_MONITORS` and pass it through to
+both the `Instrument` instance and the stream mapping:
+
+```python
+# specs.py
+from ess.livedata.handlers.monitor_workflow_specs import (
+    TOAOnlyMonitorDataParams,
+    register_monitor_workflow_specs,
+)
+from .._ess import GENERIC_CBM_DESCRIPTION_NOTE, GENERIC_CBM_MONITORS
+
+instrument = Instrument(
+    name='instrument_name',
+    detector_names=detector_names,
+    monitors=list(GENERIC_CBM_MONITORS),
+)
+
+instrument_registry.register(instrument)
+
+monitor_handle = register_monitor_workflow_specs(
+    instrument,
+    instrument.monitors,
+    params=TOAOnlyMonitorDataParams,
+    extra_description=GENERIC_CBM_DESCRIPTION_NOTE,
+)
+```
+
+`GENERIC_CBM_DESCRIPTION_NOTE` is appended to the workflow's standard
+description so that dashboard users see a caveat explaining that several of
+the `cbm{i}` source names likely do not correspond to real beam monitors.
+
+```python
+# streams.py
+stream_mapping = {
+    StreamingEnv.DEV: make_dev_stream_mapping(
+        'instrument_name',
+        detector_names=list(detector_fakes),
+        monitor_names=instrument.monitors,
+    ),
+    StreamingEnv.PROD: StreamMapping(
+        **make_common_stream_mapping_inputs(
+            instrument='instrument_name',
+            monitor_names=instrument.monitors,
+            cbm_start=0,
+        ),
+        detectors=_make_instrument_detectors(),
+    ),
+}
+```
+
+The internal name and Kafka source name are kept identical (both `cbm{i}`), so
+what appears on the topic is what the dashboard displays. Replace with
+explicit monitor names once the real configuration is known.
+
 ## Stream Configuration
 
 In `streams.py`, define stream mappings and optionally fake detector configuration:

--- a/src/ess/livedata/config/instruments/_ess.py
+++ b/src/ess/livedata/config/instruments/_ess.py
@@ -12,6 +12,22 @@ from ess.livedata import StreamKind
 from ess.livedata.config.streams import stream_kind_to_topic
 from ess.livedata.kafka import InputStreamKey, StreamLUT, StreamMapping
 
+#: Generic monitor source names ``cbm0..cbm9`` for instruments without specific
+#: monitor information. The range starts at zero to absorb both 0- and 1-based
+#: upstream indexing conventions, since the actual convention has been observed
+#: to vary.
+GENERIC_CBM_MONITORS: tuple[str, ...] = tuple(f'cbm{i}' for i in range(10))
+
+#: Caveat appended to the workflow description when the generic ``cbm`` monitor
+#: placeholder is in use. Pass to ``register_monitor_workflow_specs`` via the
+#: ``extra_description`` argument.
+GENERIC_CBM_DESCRIPTION_NOTE: str = (
+    "This instrument uses a generic placeholder covering cbm0..cbm9. cbm0 most "
+    "likely does not exist on the real instrument, and few instruments have a "
+    "monitor as far as cbm9. The wide range absorbs upstream off-by-one "
+    "indexing until the actual monitor configuration is known."
+)
+
 
 def _make_cbm_monitors(
     instrument: str,

--- a/src/ess/livedata/config/instruments/estia/factories.py
+++ b/src/ess/livedata/config/instruments/estia/factories.py
@@ -6,11 +6,24 @@ ESTIA instrument factory implementations.
 
 from ess.livedata.config import Instrument
 
+from . import specs
+
 
 def setup_factories(instrument: Instrument) -> None:
     """Initialize ESTIA-specific factories and workflows.
 
-    ESTIA currently has no bespoke workflows: the multiblade detector view
-    (with its spectrum output) is wired entirely via ``add_logical_view`` in
-    ``specs.py``.
+    The multiblade detector view (with its spectrum output) is wired via
+    ``add_logical_view`` in ``specs.py``. The generic ``cbm`` monitor workflow
+    factory is attached here.
     """
+    from ess.livedata.handlers.monitor_workflow import create_monitor_workflow
+    from ess.livedata.handlers.monitor_workflow_specs import TOAOnlyMonitorDataParams
+
+    @specs.monitor_handle.attach_factory()
+    def _monitor_workflow_factory(source_name: str, params: TOAOnlyMonitorDataParams):
+        return create_monitor_workflow(
+            source_name=source_name,
+            edges=params.get_active_edges(),
+            range_filter=params.get_active_range(),
+            coordinate_mode='toa',
+        )

--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -8,7 +8,12 @@ import scipp as sc
 
 from ess.livedata.config import Instrument, instrument_registry
 from ess.livedata.handlers.detector_view_specs import SpectrumViewSpec
+from ess.livedata.handlers.monitor_workflow_specs import (
+    TOAOnlyMonitorDataParams,
+    register_monitor_workflow_specs,
+)
 
+from .._ess import GENERIC_CBM_DESCRIPTION_NOTE, GENERIC_CBM_MONITORS
 from .views import get_multiblade_view
 
 detector_names = ['multiblade_detector']
@@ -16,11 +21,18 @@ detector_names = ['multiblade_detector']
 instrument = Instrument(
     name='estia',
     detector_names=detector_names,
-    monitors=[],
+    monitors=list(GENERIC_CBM_MONITORS),
     f144_attribute_registry={},
 )
 
 instrument_registry.register(instrument)
+
+monitor_handle = register_monitor_workflow_specs(
+    instrument,
+    instrument.monitors,
+    params=TOAOnlyMonitorDataParams,
+    extra_description=GENERIC_CBM_DESCRIPTION_NOTE,
+)
 
 
 def _estia_spectrum_transform(histogram: sc.DataArray) -> sc.DataArray:

--- a/src/ess/livedata/config/instruments/estia/streams.py
+++ b/src/ess/livedata/config/instruments/estia/streams.py
@@ -26,10 +26,15 @@ stream_mapping = {
     StreamingEnv.DEV: make_dev_stream_mapping(
         'estia',
         detector_names=list(detector_fakes),
+        monitor_names=instrument.monitors,
         log_names=list(instrument.f144_attribute_registry.keys()),
     ),
     StreamingEnv.PROD: StreamMapping(
-        **make_common_stream_mapping_inputs(instrument='estia'),
+        **make_common_stream_mapping_inputs(
+            instrument='estia',
+            monitor_names=instrument.monitors,
+            cbm_start=0,
+        ),
         detectors=_make_estia_detectors(),
     ),
 }

--- a/src/ess/livedata/handlers/monitor_workflow_specs.py
+++ b/src/ess/livedata/handlers/monitor_workflow_specs.py
@@ -232,7 +232,7 @@ def register_monitor_workflow_specs(
         "is histogrammed or rebinned into specified time-of-arrival (TOA) bins."
     )
     if extra_description:
-        description = f"{description} {extra_description}"
+        description = f"{description}\n\n{extra_description}"
 
     return instrument.register_spec(
         namespace='monitor_data',

--- a/src/ess/livedata/handlers/monitor_workflow_specs.py
+++ b/src/ess/livedata/handlers/monitor_workflow_specs.py
@@ -195,6 +195,7 @@ def register_monitor_workflow_specs(
     source_names: list[str],
     params: type[MonitorDataParams] = MonitorDataParams,
     aux_sources: AuxSources | None = None,
+    extra_description: str | None = None,
 ) -> SpecHandle | None:
     """
     Register monitor workflow specs (lightweight, no heavy dependencies).
@@ -214,6 +215,10 @@ def register_monitor_workflow_specs(
         Optional auxiliary source specification for position or other dynamic data
         streams. Instruments with movable monitors can provide an AuxSources spec
         that maps logical names to f144 position streams.
+    extra_description
+        Optional text appended to the standard workflow description. Use this to
+        document instrument-specific caveats (e.g. that a generic placeholder is
+        in use until the real monitor configuration is known).
 
     Returns
     -------
@@ -222,13 +227,19 @@ def register_monitor_workflow_specs(
     if not source_names:
         return None
 
+    description = (
+        "Histogrammed and time-integrated beam monitor. The monitor "
+        "is histogrammed or rebinned into specified time-of-arrival (TOA) bins."
+    )
+    if extra_description:
+        description = f"{description} {extra_description}"
+
     return instrument.register_spec(
         namespace='monitor_data',
         name='monitor_histogram',
         version=1,
         title="Beam monitor",
-        description="Histogrammed and time-integrated beam monitor. The monitor "
-        "is histogrammed or rebinned into specified time-of-arrival (TOA) bins.",
+        description=description,
         source_names=source_names,
         aux_sources=aux_sources,
         params=params,

--- a/src/ess/livedata/handlers/monitor_workflow_specs.py
+++ b/src/ess/livedata/handlers/monitor_workflow_specs.py
@@ -232,7 +232,7 @@ def register_monitor_workflow_specs(
         "is histogrammed or rebinned into specified time-of-arrival (TOA) bins."
     )
     if extra_description:
-        description = f"{description}\n\n{extra_description}"
+        description = f"{description}<br><br>{extra_description}"
 
     return instrument.register_spec(
         namespace='monitor_data',

--- a/tests/config/monitor_source_names_test.py
+++ b/tests/config/monitor_source_names_test.py
@@ -13,6 +13,7 @@ import pytest
 
 from ess.livedata.config import streams
 from ess.livedata.config.instruments import available_instruments
+from ess.livedata.config.instruments._ess import GENERIC_CBM_MONITORS
 
 
 @pytest.mark.parametrize(
@@ -20,13 +21,20 @@ from ess.livedata.config.instruments import available_instruments
     available_instruments(),
 )
 def test_production_monitors_do_not_use_cbm0(instrument: str) -> None:
-    """All instruments use 1-based cbm source names (cbm1, cbm2, ...)."""
+    """Instruments with bespoke monitor configs use 1-based cbm source names.
+
+    Instruments still using the generic ``cbm0..cbm9`` placeholder are exempt:
+    the wider range is intentional to absorb upstream off-by-one errors until
+    the real configuration is known.
+    """
     stream_mapping = streams.get_stream_mapping(instrument=instrument, dev=False)
-    cbm_source_names = [
+    cbm_source_names = {
         key.source_name
         for key in stream_mapping.monitors
         if key.source_name.startswith('cbm')
-    ]
+    }
+    if cbm_source_names == set(GENERIC_CBM_MONITORS):
+        pytest.skip(f"{instrument} uses the generic cbm[0-9] placeholder")
     assert 'cbm0' not in cbm_source_names, (
         f"Monitor mapping for {instrument} includes cbm0, but this instrument "
         "is expected to use 1-indexed cbm source names (cbm1, cbm2, ...)"


### PR DESCRIPTION
## Summary

- Adds a reusable `cbm0..cbm9` monitor placeholder for instruments coming online without confirmed monitor information, so a standard TOA histogram workflow can be enabled with minimal boilerplate.
- Range starts at zero deliberately to absorb upstream off-by-one indexing observed in real configurations.
- `register_monitor_workflow_specs` gains an `extra_description` argument; a generic caveat (`GENERIC_CBM_DESCRIPTION_NOTE`) warns dashboard users that cbm0 and cbm9 likely do not correspond to real monitors.
- ESTIA is wired up as the first user. The `cbm0` production-mapping test skips instruments using the generic placeholder.

## Test plan

- [x] Verify the dashboard renders the monitor workflow description (with appended caveat) correctly for ESTIA.
- [x] Sanity-check fake_monitors + monitor_data services for ESTIA (`--dev --num-monitors 10`) populate cbm0..cbm9 in the dashboard.