### PR TITLE
Add ESTIA detector rotation f144 stream

### DIFF
--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -6,7 +6,7 @@ ESTIA instrument spec registration.
 
 import scipp as sc
 
-from ess.livedata.config import Instrument, instrument_registry
+from ess.livedata.config import Instrument, SourceMetadata, instrument_registry
 from ess.livedata.handlers.detector_view_specs import SpectrumViewSpec
 from ess.livedata.handlers.monitor_workflow_specs import (
     TOAOnlyMonitorDataParams,
@@ -18,11 +18,35 @@ from .views import get_multiblade_view
 
 detector_names = ['multiblade_detector']
 
+# f144 log streams for ESTIA. The detector rotation is the only time-dependent
+# transformation in the multiblade detector's depends_on chain; sample-detector
+# distance is invariant under this rotation, so the value is currently exposed
+# only for plotting, not for geometry. The PV channel ``.RBV`` (readback) is
+# taken from ``coda_estia_999999_00027641.hdf`` under
+# ``/entry/instrument/detector_arm/detector_rotation/value`` (NXpositioner).
+# The same positioner also publishes ``.VAL`` (setpoint) and ``.DMOV``
+# (done-moving) on the same topic; not exposed here.
+f144_log_streams = {
+    'detector_rotation': {
+        'source': 'ESTIA-DtRot:MC-RotZ01:Mtr.RBV',
+        'topic': 'estia_motion',
+        'units': 'deg',
+    },
+}
+
 instrument = Instrument(
     name='estia',
     detector_names=detector_names,
     monitors=list(GENERIC_CBM_MONITORS),
-    f144_attribute_registry={},
+    f144_attribute_registry={
+        name: {'units': info['units']} for name, info in f144_log_streams.items()
+    },
+    source_metadata={
+        'detector_rotation': SourceMetadata(
+            title='Detector Rotation',
+            description='Multiblade detector bank rotation angle.',
+        ),
+    },
 )
 
 instrument_registry.register(instrument)

--- a/src/ess/livedata/config/instruments/estia/streams.py
+++ b/src/ess/livedata/config/instruments/estia/streams.py
@@ -6,7 +6,7 @@ from ess.livedata.config.env import StreamingEnv
 from ess.livedata.kafka import InputStreamKey, StreamLUT, StreamMapping
 
 from .._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
-from .specs import instrument
+from .specs import f144_log_streams, instrument
 
 # Fake detector configuration: detector_name -> (first_id, last_id)
 # ESTIA multiblade detector has 98,304 pixels with IDs 98305-196608
@@ -19,6 +19,14 @@ def _make_estia_detectors() -> StreamLUT:
         InputStreamKey(
             topic='estia_detector', source_name='multiblade'
         ): 'multiblade_detector',
+    }
+
+
+def _make_estia_logs() -> StreamLUT:
+    """ESTIA log data mapping (f144 streams)."""
+    return {
+        InputStreamKey(topic=info['topic'], source_name=info['source']): internal_name
+        for internal_name, info in f144_log_streams.items()
     }
 
 
@@ -36,5 +44,6 @@ stream_mapping = {
             cbm_start=0,
         ),
         detectors=_make_estia_detectors(),
+        logs=_make_estia_logs(),
     ),
 }


### PR DESCRIPTION
## Summary

Expose the multiblade detector bank rotation (`ESTIA-DtRot:MC-RotZ01:Mtr.RBV` on topic `estia_motion`) as a timeseries so users can plot it in the dashboard. The timeseries workflow spec is auto-registered from `f144_attribute_registry` by `Instrument.__post_init__`.

Scope is intentionally narrow: log stream + timeseries plotting only. Sample-detector distance is invariant under this rotation, so the value is not (yet) needed for wavelength reconstruction or motion-aware geometry.

## Notes

PV channel and topic taken from the f144 writer attributes on the NXpositioner NXlog `/entry/instrument/detector_arm/detector_rotation/value` in `coda_estia_999999_00027641.hdf`. The same positioner also publishes `.VAL` (setpoint) and `.DMOV` (done-moving) on the same topic; not exposed here.

A separate file-writer issue was flagged upstream: the chain entry at `multiblade_detector/transformations/detector_rotation` is a duplicate NXlog whose `@source` lacks the `.RBV` suffix and would never be populated. Doesn't affect this change (we ingest from Kafka directly), but it would block a LOKI-style motion-aware geometry wiring later.