### PR TITLE
Add static-flatten plotter for N-D data

### DIFF
--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-"""Plotter wrapping ImagePlotter with static (config-time) flattening of 3D data.
+"""Plotter wrapping ImagePlotter with static (config-time) flattening of N-D data.
 
-The user picks which input dim stays as one image axis; the other two are
-flattened together into the second image axis. A custom hover decomposes
-the flat-axis cell index back into outer/inner labels (with coord values
-when available) so the plot stays explorable despite the synthetic axis.
+Each image axis is built from one or more input dims, flattened together in a
+fixed order. A custom hover decomposes each axis cursor index back into
+per-dim labels (with coord values when available) so the plot stays explorable
+despite the synthetic axes.
 """
 
 from __future__ import annotations
@@ -122,58 +122,55 @@ def _coord_1d(data: sc.DataArray, dim: str) -> sc.Variable | None:
     return coord
 
 
-def _hover_part(coord: sc.Variable | None) -> tuple[str, list]:
-    """JS-side ``(template, values)`` for one flat-dim slot in the hover.
-
-    Hover tooltip rows already carry the dim name as a label, so the
-    formatter emits only the value (with unit) or — when no coord is
-    available — a bare index, avoiding ``blade: blade=...`` doubling.
-    """
-    if coord is None:
-        return '%d', []
-    values = [float(v) for v in coord.values]
-    unit = '' if coord.unit is None else f' {coord.unit}'
-    return f'%s{unit}', values
+def _joined_dim_name(names: tuple[str, ...], existing: tuple[str, ...]) -> str:
+    """Join dim names with '·', suffixing '_' until unique against ``existing``."""
+    name = '·'.join(names)
+    while name in existing:
+        name = f'{name}_'
+    return name
 
 
-def _build_flat_hover_formatter(
-    outer_coord: sc.Variable | None,
-    inner_coord: sc.Variable | None,
-    inner_size: int,
+def _c_order_strides(sizes: tuple[int, ...]) -> list[int]:
+    """C-order strides for ``sizes``: stride[k] = product of sizes[k+1:]."""
+    strides = [1] * len(sizes)
+    for k in range(len(sizes) - 2, -1, -1):
+        strides[k] = strides[k + 1] * sizes[k + 1]
+    return strides
+
+
+def _build_axis_hover_formatter(
+    names: tuple[str, ...],
+    coords: tuple[sc.Variable | None, ...],
+    sizes: tuple[int, ...],
 ) -> CustomJSHover:
-    """Hover formatter dispatching on ``format`` to outer/inner label.
+    """Hover formatter for one image axis with one or more flattened input dims.
 
-    Used as ``@<flat_field>{outer}`` and ``@<flat_field>{inner}`` so a single
-    formatter instance handles both rows of the decomposition. The flat-axis
-    cursor coord is rounded to the cell index, then split into
-    ``outer = idx // inner_size`` and ``inner = idx %% inner_size``.
+    Tooltip rows reference this formatter via ``${field}{dim_name}``; the JS
+    side splits the rounded cursor index into per-dim indices via stride math
+    and emits the coord value (or bare index) for the dim selected by
+    ``format``.
     """
-    outer_template, outer_values = _hover_part(outer_coord)
-    inner_template, inner_values = _hover_part(inner_coord)
+    strides = _c_order_strides(sizes)
+    values_by_dim = [[] if c is None else [float(v) for v in c.values] for c in coords]
     return CustomJSHover(
         args={
-            'outer_template': outer_template,
-            'outer_values': outer_values,
-            'inner_template': inner_template,
-            'inner_values': inner_values,
-            'inner_size': inner_size,
+            'names': list(names),
+            'sizes': list(sizes),
+            'strides': strides,
+            'values_by_dim': values_by_dim,
         },
         code="""
+        const k = names.indexOf(format);
+        if (k < 0) return '';
         const idx = Math.round(value);
-        if (inner_size <= 0 || idx < 0) return '';
-        let template, values, i;
-        if (format === 'outer') {
-            template = outer_template;
-            values = outer_values;
-            i = Math.floor(idx / inner_size);
-        } else {
-            template = inner_template;
-            values = inner_values;
-            i = ((idx % inner_size) + inner_size) % inner_size;
-        }
-        if (values.length === 0) return template.replace('%d', String(i));
-        if (i >= values.length) return '';
-        return template.replace('%s', String(values[i]));
+        if (idx < 0) return '';
+        const size = sizes[k];
+        const stride = strides[k];
+        const i = ((Math.floor(idx / stride) % size) + size) % size;
+        const vals = values_by_dim[k];
+        if (vals.length === 0) return String(i);
+        if (i >= vals.length) return '';
+        return String(vals[i]);
         """,
     )
 
@@ -198,28 +195,48 @@ def _make_hover_hook(hover: HoverTool):
 
 
 class FlattenPlotter(ImagePlotter):
-    """Image plotter with static flattening of 3D input to 2D.
+    """Image plotter with static flattening of N-D input to 2D.
 
-    Inherits ``compute()`` from ``Plotter``; only ``plot()`` is overridden to
-    flatten the data and attach a hover that decomposes the synthetic flat
-    axis back into outer/inner labels before delegating to ``ImagePlotter``.
+    Each image axis is built from one or more input dims via ``x_dims`` and
+    ``y_dims`` — ordered tuples of input-dim positions whose union covers all
+    dims of the input. Axes with K ≥ 2 dims are flattened together (in the
+    given order); axes with K = 1 pass through. A custom hover decomposes
+    each axis cursor back into per-dim labels.
     """
 
     def __init__(
         self,
         *,
-        keep_dim: int,
-        flatten_transposed: bool,
-        transpose: bool,
+        x_dims: tuple[int, ...],
+        y_dims: tuple[int, ...],
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._keep_dim = int(keep_dim)
-        self._flatten_transposed = flatten_transposed
-        self._transpose = transpose
+        if not x_dims or not y_dims:
+            raise ValueError("x_dims and y_dims must each contain at least one dim")
+        positions = (*x_dims, *y_dims)
+        if sorted(positions) != list(range(len(positions))):
+            raise ValueError(
+                f"x_dims/y_dims positions {positions} must be a permutation of "
+                f"range({len(positions)}); some are out of range or duplicated"
+            )
+        self._x_dims = tuple(int(p) for p in x_dims)
+        self._y_dims = tuple(int(p) for p in y_dims)
 
     @classmethod
-    def from_params(cls, params: FlattenParams) -> FlattenPlotter:
+    def from_axes(
+        cls,
+        params: PlotParams2d,
+        *,
+        x_dims: tuple[int, ...],
+        y_dims: tuple[int, ...],
+    ) -> FlattenPlotter:
+        """Construct from a partition of input dims into two ordered axes.
+
+        ``params`` supplies plot styling only; the axis spec comes from
+        ``x_dims``/``y_dims`` directly. Useful for N-D cases not yet
+        expressible through :class:`FlattenAxisConfig`.
+        """
         rate = getattr(params, 'rate', None)
         return cls(
             grow_threshold=0.1,
@@ -228,37 +245,66 @@ class FlattenPlotter(ImagePlotter):
             scale_opts=params.plot_scale,
             tick_params=params.ticks,
             normalize_to_rate=rate.normalize_to_rate if rate is not None else False,
-            keep_dim=params.flatten.keep_dim,
-            flatten_transposed=params.flatten.flatten_transposed,
-            transpose=params.flatten.transpose,
+            x_dims=x_dims,
+            y_dims=y_dims,
         )
 
-    def _resolve_axes(self, data: sc.DataArray) -> tuple[str, str, str]:
-        """Return (keep, outer, inner) actual data dim names.
+    @classmethod
+    def from_params(cls, params: FlattenParams) -> FlattenPlotter:
+        """Construct from a 3D :class:`FlattenAxisConfig`.
 
-        ``keep_dim`` is a 0-based position into ``data.dims``. The two non-kept
-        dims are taken in their natural input order as (outer, inner);
-        ``flatten_transposed`` swaps them.
+        Translates ``keep_dim`` + ``flatten_transposed`` + ``transpose`` into
+        the generic ``(x_dims, y_dims)`` partition.
         """
-        if data.ndim != 3:
-            raise ValueError(f"FlattenPlotter requires 3D input, got {data.ndim}D")
-        if not 0 <= self._keep_dim < data.ndim:
+        keep = int(params.flatten.keep_dim)
+        others = [i for i in (0, 1, 2) if i != keep]
+        if params.flatten.flatten_transposed:
+            others = others[::-1]
+        if params.flatten.transpose:
+            x_dims, y_dims = tuple(others), (keep,)
+        else:
+            x_dims, y_dims = (keep,), tuple(others)
+        return cls.from_axes(params, x_dims=x_dims, y_dims=y_dims)
+
+    @property
+    def _ndim(self) -> int:
+        return len(self._x_dims) + len(self._y_dims)
+
+    def _resolve_dim_names(
+        self, data: sc.DataArray
+    ) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        if data.ndim != self._ndim:
             raise ValueError(
-                f"keep_dim={self._keep_dim} out of range for {data.ndim}D data"
+                f"FlattenPlotter requires {self._ndim}D input, got {data.ndim}D"
             )
-        keep = data.dims[self._keep_dim]
-        others = [d for d in data.dims if d != keep]
-        outer, inner = others if not self._flatten_transposed else others[::-1]
-        return keep, outer, inner
+        x_names = tuple(data.dims[p] for p in self._x_dims)
+        y_names = tuple(data.dims[p] for p in self._y_dims)
+        return x_names, y_names
 
     def _flatten_to_2d(
-        self, data: sc.DataArray, keep: str, outer: str, inner: str
+        self,
+        data: sc.DataArray,
+        x_names: tuple[str, ...],
+        y_names: tuple[str, ...],
     ) -> sc.DataArray:
-        flat_dim = f'{outer}·{inner}'
-        if flat_dim in data.dims:
-            flat_dim = f'{flat_dim}_'
-        order = [outer, inner, keep] if not self._transpose else [keep, outer, inner]
-        return data.transpose(order).flatten(dims=[outer, inner], to=flat_dim)
+        """Flatten ``data`` to 2D with y as the slow (outer) axis.
+
+        Per scipp/HoloViews convention the last (innermost) scipp dim becomes
+        the x kdim and the first becomes y, so we transpose to ``y_names`` →
+        ``x_names`` order before flattening each group.
+        """
+        out = data.transpose([*y_names, *x_names])
+        if len(y_names) > 1:
+            out = out.flatten(
+                dims=list(y_names),
+                to=_joined_dim_name(y_names, out.dims),
+            )
+        if len(x_names) > 1:
+            out = out.flatten(
+                dims=list(x_names),
+                to=_joined_dim_name(x_names, out.dims),
+            )
+        return out
 
     def plot(
         self,
@@ -269,8 +315,8 @@ class FlattenPlotter(ImagePlotter):
         output_display_name: str = '',
         **kwargs,
     ) -> hv.Image:
-        keep, outer, inner = self._resolve_axes(data)
-        flat = self._flatten_to_2d(data, keep, outer, inner)
+        x_names, y_names = self._resolve_dim_names(data)
+        flat = self._flatten_to_2d(data, x_names, y_names)
 
         image = super().plot(
             flat,
@@ -280,33 +326,37 @@ class FlattenPlotter(ImagePlotter):
             **kwargs,
         )
 
-        # $x/$y refer to the cursor position in data space; @x/@y reference
-        # the Image glyph's anchor (a constant) and would freeze the index at 0.
-        flat_field = '$x' if self._transpose else '$y'
-        kept_field = '$y' if self._transpose else '$x'
-        hover_fmt = _build_flat_hover_formatter(
-            _coord_1d(data, outer), _coord_1d(data, inner), data.sizes[inner]
-        )
-        kept_coord = _coord_1d(data, keep)
-        kept_unit = kept_coord.unit if kept_coord is not None else None
-        keep_label = f'{keep} [{kept_unit}]' if kept_unit is not None else keep
-        # When there is no coord, $x/$y is in integer-index space [0, N-1], so
-        # rounding gives the exact bin index. We do not extend this to int coords
-        # with unit=None: there $x is in coord-value space and hovering between
-        # bins would produce values not in the coord — correct display would
-        # require a values-array nearest-neighbour lookup in JS.
-        formatters = {flat_field: hover_fmt}
-        if kept_coord is None:
-            formatters[kept_field] = CustomJSHover(
-                code='return String(Math.round(value));'
-            )
-        hover = HoverTool(
-            tooltips=[
-                (keep_label, kept_field),
-                (outer, f'{flat_field}{{outer}}'),
-                (inner, f'{flat_field}{{inner}}'),
-                ('value', '@image'),
-            ],
-            formatters=formatters,
-        )
+        tooltips, formatters = self._build_hover_spec(data, x_names, y_names)
+        hover = HoverTool(tooltips=tooltips, formatters=formatters)
         return image.opts(hooks=[_make_hover_hook(hover)])
+
+    def _build_hover_spec(
+        self,
+        data: sc.DataArray,
+        x_names: tuple[str, ...],
+        y_names: tuple[str, ...],
+    ) -> tuple[list[tuple[str, str]], dict[str, CustomJSHover]]:
+        """Tooltip rows + per-axis ``CustomJSHover`` dispatcher.
+
+        Each row references its axis formatter via ``${field}{dim_name}``;
+        the formatter looks up the dim by ``format`` and resolves the cursor
+        index → per-dim coord value (or bare index when no coord is present).
+        ``$x``/``$y`` always emit a float cursor position, so even single-dim
+        axes go through a formatter — there is no float-fallback path.
+        """
+        tooltips: list[tuple[str, str]] = []
+        formatters: dict[str, CustomJSHover] = {}
+        for field, names in (('$x', x_names), ('$y', y_names)):
+            coords = tuple(_coord_1d(data, n) for n in names)
+            sizes = tuple(data.sizes[n] for n in names)
+            formatters[field] = _build_axis_hover_formatter(names, coords, sizes)
+            for name, coord in zip(names, coords, strict=True):
+                tooltips.append((_dim_label(name, coord), f'{field}{{{name}}}'))
+        tooltips.append(('value', '@image'))
+        return tooltips, formatters
+
+
+def _dim_label(name: str, coord: sc.Variable | None) -> str:
+    if coord is not None and coord.unit is not None:
+        return f'{name} [{coord.unit}]'
+    return name

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -160,9 +160,9 @@ def _build_axis_hover_formatter(
     """Hover formatter for one image axis with one or more flattened input dims.
 
     Tooltip rows reference this formatter via ``${field}{dim_name}``; the JS
-    side splits the rounded cursor index into per-dim indices via stride math
-    and emits the coord value (or bare index) for the dim selected by
-    ``format``.
+    side either does a binary search (single non-flattened dim with physical
+    coords) or splits the flat integer cursor index via stride math (flattened
+    multi-dim axis where the image always carries integer indices).
     """
     strides = _c_order_strides(sizes)
     values_by_dim = [[] if c is None else [float(v) for v in c.values] for c in coords]
@@ -176,12 +176,28 @@ def _build_axis_hover_formatter(
         code="""
         const k = names.indexOf(format);
         if (k < 0) return '';
+        const vals = values_by_dim[k];
+        if (names.length === 1) {
+            // Single non-flattened dim: value is in image coordinate space
+            // (physical units or integer indices depending on the coord).
+            if (vals.length === 0) return String(Math.round(value));
+            // Binary search for the nearest coordinate value.
+            let lo = 0, hi = vals.length - 1;
+            while (lo < hi) {
+                const mid = lo + ((hi - lo + 1) >> 1);
+                if (vals[mid] <= value) lo = mid; else hi = mid - 1;
+            }
+            if (lo + 1 < vals.length &&
+                    Math.abs(vals[lo + 1] - value) < Math.abs(vals[lo] - value)) lo++;
+            return String(vals[lo]);
+        }
+        // Flattened multi-dim axis: the image always carries integer indices
+        // (0..N-1), so value is the flat integer position.
         const idx = Math.round(value);
         if (idx < 0) return '';
         const size = sizes[k];
         const stride = strides[k];
         const i = ((Math.floor(idx / stride) % size) + size) % size;
-        const vals = values_by_dim[k];
         if (vals.length === 0) return String(i);
         if (i >= vals.length) return '';
         return String(vals[i]);

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Plotter wrapping ImagePlotter with static (config-time) flattening of 3D data.
+
+The user picks which input dim stays as one image axis; the other two are
+flattened together into the second image axis. Tick labels on the flattened
+axis are computed dynamically (zoom-aware) from the input coords via a Bokeh
+``CustomJSTickFormatter``.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+import holoviews as hv
+import pydantic
+import scipp as sc
+from bokeh.models import CustomJSTickFormatter
+
+from ess.livedata.config.workflow_spec import ResultKey
+
+from .plot_params import PlotParams2d
+from .plots import ImagePlotter
+
+
+class FlattenAxisConfig(pydantic.BaseModel):
+    """Static-flatten axis assignment.
+
+    The placeholder ``keep_dim: str`` is narrowed by ``make_flatten_params``
+    to ``Literal[*dims]`` so the dashboard renders a dropdown of actual dim
+    names. The other two dims are flattened in their natural input order
+    (``flatten_transposed`` swaps that order).
+    """
+
+    keep_dim: str = pydantic.Field(
+        default='',
+        title='Keep dim',
+        description='Input dim that stays as one image axis. The other two dims '
+        'are flattened together into the second axis.',
+    )
+    flatten_transposed: bool = pydantic.Field(
+        default=False,
+        title='Transpose flattened axes',
+        description='Swap the order of the two flattened dims. By default '
+        'they are flattened in their natural input order.',
+    )
+    transpose: bool = pydantic.Field(
+        default=False,
+        title='Transpose',
+        description='Swap x and y axes of the result. When False the kept dim '
+        'is on x and the flattened combination on y.',
+    )
+
+
+class FlattenParams(PlotParams2d):
+    """Parameters for the static-flatten 3D-to-2D plotter."""
+
+    flatten: FlattenAxisConfig = pydantic.Field(
+        default_factory=FlattenAxisConfig,
+        description='Selection of which input dim stays as one image axis '
+        'and how the remaining two are flattened together.',
+    )
+
+
+def make_flatten_params(dims: tuple[str, ...]) -> type[FlattenParams]:
+    """Create a FlattenParams subclass narrowed to the given input dims.
+
+    Parameters
+    ----------
+    dims:
+        Dim names of the workflow output template. When exactly three are
+        provided, the returned model narrows ``keep_dim`` to
+        ``Literal[*dims]`` so the UI renders a dropdown of the actual dim
+        names. For other arities the unmodified base ``FlattenParams`` is
+        returned (the plotter rejects mismatches at plot time).
+
+    Returns
+    -------
+    :
+        A ``FlattenParams`` subclass.
+    """
+    if len(dims) != 3:
+        return FlattenParams
+
+    DimLit = Literal[*dims]  # type: ignore[valid-type]
+
+    class _AxisConfig(FlattenAxisConfig):
+        # Captured here so the plotter can fall back to positional binding
+        # when the runtime data dim names differ from the template (e.g. the
+        # detector_view abstraction declares dim_0/dim_1/... and per-instrument
+        # transforms rename to tube/pixel/... preserving order).
+        _template_dims: ClassVar[tuple[str, ...]] = dims
+
+        keep_dim: DimLit = pydantic.Field(  # type: ignore[valid-type]
+            default=dims[0],
+            title='Keep dim',
+            description='Input dim that stays as one image axis. The other '
+            'two dims are flattened together into the second axis.',
+        )
+
+    class _FlattenParams(FlattenParams):
+        flatten: _AxisConfig = pydantic.Field(  # type: ignore[valid-type]
+            default_factory=_AxisConfig,
+            description='Selection of which input dim stays as one image axis '
+            'and how the remaining two are flattened together.',
+        )
+
+    return _FlattenParams
+
+
+def _coord_for_ticks(data: sc.DataArray, dim: str) -> sc.Variable | None:
+    """1-D coord aligned with ``dim``, midpoints if bin-edged, else None."""
+    if dim not in data.coords:
+        return None
+    coord = data.coords[dim]
+    if coord.dims != (dim,):
+        return None
+    if data.coords.is_edges(dim):
+        # float64 to dodge scipp/3765 mixed-precision issues with midpoints
+        return sc.midpoints(coord.to(dtype='float64', copy=False), dim=dim)
+    return coord
+
+
+def _format_part(name: str, coord: sc.Variable | None) -> tuple[str, list]:
+    """Return JS-side (label_for_missing, values) for one flattened-dim slot."""
+    if coord is None:
+        return name + '[%d]', []
+    values = [float(v) for v in coord.values]
+    unit = '' if coord.unit is None else f' {coord.unit}'
+    return f'{name}=%s{unit}', values
+
+
+def _build_flat_axis_formatter(
+    outer_name: str,
+    inner_name: str,
+    outer_coord: sc.Variable | None,
+    inner_coord: sc.Variable | None,
+    inner_size: int,
+) -> CustomJSTickFormatter:
+    """Bokeh formatter mapping a flattened-axis position to a multi-index label.
+
+    ``Math.round(tick)`` is unraveled into ``(o_idx, i_idx)`` against
+    ``inner_size`` so labels remain accurate at any zoom level. When a coord is
+    missing for one of the input dims, the label falls back to ``name[idx]``
+    for that part.
+    """
+    outer_template, outer_values = _format_part(outer_name, outer_coord)
+    inner_template, inner_values = _format_part(inner_name, inner_coord)
+    return CustomJSTickFormatter(
+        args={
+            'outer_template': outer_template,
+            'inner_template': inner_template,
+            'outer_values': outer_values,
+            'inner_values': inner_values,
+            'inner_size': inner_size,
+        },
+        code="""
+        const idx = Math.round(tick);
+        const total = Math.max(1, inner_size);
+        if (idx < 0) return '';
+        const o_idx = Math.floor(idx / total);
+        const i_idx = idx - o_idx * total;
+        function fmt(template, values, fallback_idx) {
+            if (values.length === 0) {
+                return template.replace('%d', String(fallback_idx));
+            }
+            if (fallback_idx < 0 || fallback_idx >= values.length) return '';
+            const v = values[fallback_idx];
+            const s = (Math.abs(v) >= 1e-3 && Math.abs(v) < 1e6)
+                ? v.toPrecision(4)
+                : v.toExponential(3);
+            return template.replace('%s', s);
+        }
+        const o = fmt(outer_template, outer_values, o_idx);
+        const i = fmt(inner_template, inner_values, i_idx);
+        return o + ', ' + i;
+        """,
+    )
+
+
+class FlattenPlotter(ImagePlotter):
+    """Image plotter with static flattening of 3D input to 2D.
+
+    Inherits ``compute()`` from ``Plotter``; only ``plot()`` is overridden to
+    flatten the data and apply a zoom-aware tick formatter to the flattened
+    axis before delegating to ``ImagePlotter.plot()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        keep_dim: str,
+        flatten_transposed: bool,
+        transpose: bool,
+        template_dims: tuple[str, ...] | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._keep_dim = keep_dim
+        self._flatten_transposed = flatten_transposed
+        self._transpose = transpose
+        self._template_dims = template_dims
+
+    @classmethod
+    def from_params(cls, params: FlattenParams) -> FlattenPlotter:
+        rate = getattr(params, 'rate', None)
+        template_dims = getattr(type(params.flatten), '_template_dims', None)
+        return cls(
+            grow_threshold=0.1,
+            layout_params=params.layout,
+            aspect_params=params.plot_aspect,
+            scale_opts=params.plot_scale,
+            tick_params=params.ticks,
+            normalize_to_rate=rate.normalize_to_rate if rate is not None else False,
+            keep_dim=params.flatten.keep_dim,
+            flatten_transposed=params.flatten.flatten_transposed,
+            transpose=params.flatten.transpose,
+            template_dims=template_dims,
+        )
+
+    def _resolve_keep_dim(self, data: sc.DataArray) -> str:
+        """Map the configured ``keep_dim`` to an actual data dim.
+
+        Falls back to positional binding when the configured name doesn't
+        match data.dims directly: this handles the common case where a shared
+        template declares generic dims (``dim_0``, ``dim_1``, …) that are
+        renamed by per-instrument transforms while preserving order.
+        """
+        configured = self._keep_dim
+        if configured in data.dims:
+            return configured
+        if (
+            self._template_dims is not None
+            and configured in self._template_dims
+            and len(self._template_dims) == data.ndim
+        ):
+            return data.dims[self._template_dims.index(configured)]
+        raise ValueError(
+            f"Configured keep_dim {configured!r} matches neither the data "
+            f"dims {list(data.dims)} nor the template dims {self._template_dims}."
+        )
+
+    def _resolve_axes(self, data: sc.DataArray) -> tuple[str, str, str]:
+        """Return (keep, outer, inner) actual data dim names.
+
+        The two non-kept dims are taken in their natural input order to be
+        (outer, inner); ``flatten_transposed`` swaps them.
+        """
+        if data.ndim != 3:
+            raise ValueError(f"FlattenPlotter requires 3D input, got {data.ndim}D")
+        keep = self._resolve_keep_dim(data)
+        others = [d for d in data.dims if d != keep]
+        outer, inner = others if not self._flatten_transposed else others[::-1]
+        return keep, outer, inner
+
+    def _flatten_to_2d(
+        self, data: sc.DataArray, keep: str, outer: str, inner: str
+    ) -> sc.DataArray:
+        flat_dim = f'{outer}·{inner}'
+        if flat_dim in data.dims:
+            flat_dim = f'{flat_dim}_'
+        order = [outer, inner, keep] if not self._transpose else [keep, outer, inner]
+        return data.transpose(order).flatten(dims=[outer, inner], to=flat_dim)
+
+    def plot(
+        self,
+        data: sc.DataArray,
+        data_key: ResultKey,
+        *,
+        label: str = '',
+        output_display_name: str = '',
+        **kwargs,
+    ) -> hv.Image:
+        keep, outer, inner = self._resolve_axes(data)
+        flat = self._flatten_to_2d(data, keep, outer, inner)
+
+        image = super().plot(
+            flat,
+            data_key,
+            label=label,
+            output_display_name=output_display_name,
+            **kwargs,
+        )
+
+        formatter = _build_flat_axis_formatter(
+            outer_name=outer,
+            inner_name=inner,
+            outer_coord=_coord_for_ticks(data, outer),
+            inner_coord=_coord_for_ticks(data, inner),
+            inner_size=data.sizes[inner],
+        )
+        # When transpose=True the kept dim is on y → flat axis is x.
+        axis_kwarg = 'xformatter' if self._transpose else 'yformatter'
+        return image.opts(**{axis_kwarg: formatter})

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -19,7 +19,7 @@ from enum import IntEnum
 import holoviews as hv
 import pydantic
 import scipp as sc
-from bokeh.models import CustomJSTickFormatter, LinearAxis
+from bokeh.models import CustomJSHover, CustomJSTickFormatter, HoverTool, LinearAxis
 
 from ess.livedata.config.workflow_spec import ResultKey
 
@@ -197,24 +197,97 @@ def _outer_axis_ticks(
     ]
 
 
-def _make_inner_axis_hook(side: str, formatter: CustomJSTickFormatter):
-    """HoloViews hook adding a secondary axis carrying the inner-dim ticks.
+def _hover_part(coord: sc.Variable | None) -> tuple[str, list]:
+    """JS-side ``(template, values)`` for one flat-dim slot in the hover.
 
-    Bokeh stacks each newly added layout closer to the plot frame than the
-    primary axis, so the secondary axis ends up between the plot and the
-    primary outer-group ticks — i.e. inner-close, outer-far, the standard
-    hierarchical convention. Idempotent across re-renders.
+    Hover tooltip rows already carry the dim name as a label, so the
+    formatter emits only the value (with unit) or — when no coord is
+    available — a bare index, avoiding ``blade: blade=...`` doubling.
+    """
+    if coord is None:
+        return '%d', []
+    values = [float(v) for v in coord.values]
+    unit = '' if coord.unit is None else f' {coord.unit}'
+    return f'%s{unit}', values
+
+
+def _build_flat_hover_formatter(
+    outer_coord: sc.Variable | None,
+    inner_coord: sc.Variable | None,
+    inner_size: int,
+) -> CustomJSHover:
+    """Hover formatter dispatching on ``format`` to outer/inner label.
+
+    Used as ``@<flat_field>{outer}`` and ``@<flat_field>{inner}`` so a single
+    formatter instance handles both rows of the decomposition. The flat field
+    value at the cursor is rounded to the cell index, then split into
+    ``outer = idx // inner_size`` and ``inner = idx %% inner_size`` (mirroring
+    the inner-axis tick formatter).
+    """
+    outer_template, outer_values = _hover_part(outer_coord)
+    inner_template, inner_values = _hover_part(inner_coord)
+    return CustomJSHover(
+        args={
+            'outer_template': outer_template,
+            'outer_values': outer_values,
+            'inner_template': inner_template,
+            'inner_values': inner_values,
+            'inner_size': inner_size,
+        },
+        code="""
+        const idx = Math.round(value);
+        if (inner_size <= 0 || idx < 0) return '';
+        let template, values, i;
+        if (format === 'outer') {
+            template = outer_template;
+            values = outer_values;
+            i = Math.floor(idx / inner_size);
+        } else {
+            template = inner_template;
+            values = inner_values;
+            i = ((idx % inner_size) + inner_size) % inner_size;
+        }
+        if (values.length === 0) return template.replace('%d', String(i));
+        if (i >= values.length) return '';
+        const v = values[i];
+        const s = (Math.abs(v) >= 1e-3 && Math.abs(v) < 1e6)
+            ? v.toPrecision(4)
+            : v.toExponential(3);
+        return template.replace('%s', s);
+        """,
+    )
+
+
+def _make_flatten_hook(
+    side: str,
+    inner_formatter: CustomJSTickFormatter,
+    hover: HoverTool,
+):
+    """HoloViews hook installing the inner-dim secondary axis and hover tool.
+
+    The secondary axis carries zoom-aware inner-dim ticks; Bokeh stacks newly
+    added layouts closer to the plot frame than the primary, so the inner
+    ticks end up between the plot and the outer group labels (inner-close,
+    outer-far — standard hierarchical convention).
+
+    The default Bokeh ``HoverTool`` added by HoloViews is replaced so the
+    toolbar shows a single hover with the outer/inner decomposition. Both
+    actions are idempotent across re-renders.
     """
 
     def hook(plot, _element):
-        if plot.handles.get('flatten_inner_axis_installed'):
+        if plot.handles.get('flatten_hook_installed'):
             return
         fig = plot.handles['plot']
         fig.add_layout(
-            LinearAxis(formatter=formatter, axis_label=''),
+            LinearAxis(formatter=inner_formatter, axis_label=''),
             side,
         )
-        plot.handles['flatten_inner_axis_installed'] = True
+        fig.toolbar.tools = [
+            t for t in fig.toolbar.tools if not isinstance(t, HoverTool)
+        ]
+        fig.add_tools(hover)
+        plot.handles['flatten_hook_installed'] = True
 
     return hook
 
@@ -315,11 +388,27 @@ class FlattenPlotter(ImagePlotter):
         side = 'below' if self._transpose else 'left'
         ticks_opt = 'xticks' if self._transpose else 'yticks'
         label_opt = 'xlabel' if self._transpose else 'ylabel'
+        # $x/$y refer to the cursor position in data space; @x/@y reference
+        # the Image glyph's anchor (a constant) and would freeze the index at 0.
+        flat_field = '$x' if self._transpose else '$y'
+        kept_field = '$y' if self._transpose else '$x'
+        hover_fmt = _build_flat_hover_formatter(
+            outer_coord, inner_coord, data.sizes[inner]
+        )
+        hover = HoverTool(
+            tooltips=[
+                (keep, kept_field),
+                (outer, f'{flat_field}{{outer}}'),
+                (inner, f'{flat_field}{{inner}}'),
+                ('value', '@image'),
+            ],
+            formatters={flat_field: hover_fmt},
+        )
         # Outer goes on the primary axis (further from plot per Bokeh stacking),
         # inner on the secondary axis added via the hook (closer to plot). The
         # synthetic flat-dim name (e.g. "outer·inner") is suppressed since each
         # tick row carries its own dim name.
         return image.opts(
             **{ticks_opt: outer_ticks, label_opt: ''},
-            hooks=[_make_inner_axis_hook(side, inner_formatter)],
+            hooks=[_make_flatten_hook(side, inner_formatter, hover)],
         )

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -173,11 +173,7 @@ def _build_flat_hover_formatter(
         }
         if (values.length === 0) return template.replace('%d', String(i));
         if (i >= values.length) return '';
-        const v = values[i];
-        const s = (Math.abs(v) >= 1e-3 && Math.abs(v) < 1e6)
-            ? v.toPrecision(4)
-            : v.toExponential(3);
-        return template.replace('%s', s);
+        return template.replace('%s', String(values[i]));
         """,
     )
 

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -3,13 +3,9 @@
 """Plotter wrapping ImagePlotter with static (config-time) flattening of 3D data.
 
 The user picks which input dim stays as one image axis; the other two are
-flattened together into the second image axis. The flattened axis carries two
-stacked tick rows in the standard hierarchical convention: the inner-dim
-ticks (zoom-aware via a Bokeh ``CustomJSTickFormatter``) sit closest to the
-plot, and the outer-dim group labels at fixed group centres sit one row
-further out. Bokeh's layout stacks newly added axes closer to the plot frame
-than the primary, so the outer (fixed) ticks go on the primary axis and the
-inner (zoom-aware) ticks on a secondary axis added via a hook.
+flattened together into the second image axis. A custom hover decomposes
+the flat-axis cell index back into outer/inner labels (with coord values
+when available) so the plot stays explorable despite the synthetic axis.
 """
 
 from __future__ import annotations
@@ -19,7 +15,7 @@ from enum import IntEnum
 import holoviews as hv
 import pydantic
 import scipp as sc
-from bokeh.models import CustomJSHover, CustomJSTickFormatter, HoverTool, LinearAxis
+from bokeh.models import CustomJSHover, HoverTool
 
 from ess.livedata.config.workflow_spec import ResultKey
 
@@ -113,7 +109,7 @@ def make_flatten_params(dims: tuple[str, ...]) -> type[FlattenParams]:
     return _FlattenParams
 
 
-def _coord_for_ticks(data: sc.DataArray, dim: str) -> sc.Variable | None:
+def _coord_1d(data: sc.DataArray, dim: str) -> sc.Variable | None:
     """1-D coord aligned with ``dim``, midpoints if bin-edged, else None."""
     if dim not in data.coords:
         return None
@@ -124,77 +120,6 @@ def _coord_for_ticks(data: sc.DataArray, dim: str) -> sc.Variable | None:
         # float64 to dodge scipp/3765 mixed-precision issues with midpoints
         return sc.midpoints(coord.to(dtype='float64', copy=False), dim=dim)
     return coord
-
-
-def _format_part(name: str, coord: sc.Variable | None) -> tuple[str, list]:
-    """Return JS-side (label_for_missing, values) for one flattened-dim slot."""
-    if coord is None:
-        return name + '[%d]', []
-    values = [float(v) for v in coord.values]
-    unit = '' if coord.unit is None else f' {coord.unit}'
-    return f'{name}=%s{unit}', values
-
-
-def _format_value_static(v: float) -> str:
-    """Mirror the JS formatter's per-value formatting for the outer-axis labels."""
-    if 1e-3 <= abs(v) < 1e6:
-        return f'{v:.4g}'
-    return f'{v:.3e}'
-
-
-def _label_part(name: str, idx: int, coord: sc.Variable | None) -> str:
-    """Static-side label for one dim slot, mirroring the JS formatter output."""
-    if coord is None:
-        return f'{name}[{idx}]'
-    unit = '' if coord.unit is None else f' {coord.unit}'
-    return f'{name}={_format_value_static(float(coord.values[idx]))}{unit}'
-
-
-def _build_inner_axis_formatter(
-    name: str, coord: sc.Variable | None, inner_size: int
-) -> CustomJSTickFormatter:
-    """Bokeh formatter showing only the inner-dim value at each tick.
-
-    ``Math.round(tick) % inner_size`` selects the inner index, so labels stay
-    accurate at any zoom level. Falls back to ``name[idx]`` when no coord.
-    """
-    template, values = _format_part(name, coord)
-    return CustomJSTickFormatter(
-        args={'template': template, 'values': values, 'inner_size': inner_size},
-        code="""
-        const idx = Math.round(tick);
-        if (inner_size <= 0 || idx < 0) return '';
-        const i_idx = ((idx % inner_size) + inner_size) % inner_size;
-        if (values.length === 0) {
-            return template.replace('%d', String(i_idx));
-        }
-        if (i_idx >= values.length) return '';
-        const v = values[i_idx];
-        const s = (Math.abs(v) >= 1e-3 && Math.abs(v) < 1e6)
-            ? v.toPrecision(4)
-            : v.toExponential(3);
-        return template.replace('%s', s);
-        """,
-    )
-
-
-def _outer_axis_ticks(
-    name: str, coord: sc.Variable | None, outer_size: int, inner_size: int
-) -> list[tuple[float, str]]:
-    """``(position, label)`` pairs for the outer-dim group axis.
-
-    Each outer index ``i`` gets one tick at the centre of its group on the
-    flattened axis (``i*inner_size + (inner_size-1)/2``), with a static label.
-    Returned as a list so it can be passed straight to HoloViews'
-    ``xticks``/``yticks`` opt.
-    """
-    return [
-        (
-            i * inner_size + (inner_size - 1) / 2.0,
-            _label_part(name, i, coord),
-        )
-        for i in range(outer_size)
-    ]
 
 
 def _hover_part(coord: sc.Variable | None) -> tuple[str, list]:
@@ -219,10 +144,9 @@ def _build_flat_hover_formatter(
     """Hover formatter dispatching on ``format`` to outer/inner label.
 
     Used as ``@<flat_field>{outer}`` and ``@<flat_field>{inner}`` so a single
-    formatter instance handles both rows of the decomposition. The flat field
-    value at the cursor is rounded to the cell index, then split into
-    ``outer = idx // inner_size`` and ``inner = idx %% inner_size`` (mirroring
-    the inner-axis tick formatter).
+    formatter instance handles both rows of the decomposition. The flat-axis
+    cursor coord is rounded to the cell index, then split into
+    ``outer = idx // inner_size`` and ``inner = idx %% inner_size``.
     """
     outer_template, outer_values = _hover_part(outer_coord)
     inner_template, inner_values = _hover_part(inner_coord)
@@ -258,36 +182,21 @@ def _build_flat_hover_formatter(
     )
 
 
-def _make_flatten_hook(
-    side: str,
-    inner_formatter: CustomJSTickFormatter,
-    hover: HoverTool,
-):
-    """HoloViews hook installing the inner-dim secondary axis and hover tool.
+def _make_hover_hook(hover: HoverTool):
+    """HoloViews hook replacing the default HoverTool with a custom one.
 
-    The secondary axis carries zoom-aware inner-dim ticks; Bokeh stacks newly
-    added layouts closer to the plot frame than the primary, so the inner
-    ticks end up between the plot and the outer group labels (inner-close,
-    outer-far — standard hierarchical convention).
-
-    The default Bokeh ``HoverTool`` added by HoloViews is replaced so the
-    toolbar shows a single hover with the outer/inner decomposition. Both
-    actions are idempotent across re-renders.
+    Idempotent across re-renders.
     """
 
     def hook(plot, _element):
-        if plot.handles.get('flatten_hook_installed'):
+        if plot.handles.get('flatten_hover_installed'):
             return
         fig = plot.handles['plot']
-        fig.add_layout(
-            LinearAxis(formatter=inner_formatter, axis_label=''),
-            side,
-        )
         fig.toolbar.tools = [
             t for t in fig.toolbar.tools if not isinstance(t, HoverTool)
         ]
         fig.add_tools(hover)
-        plot.handles['flatten_hook_installed'] = True
+        plot.handles['flatten_hover_installed'] = True
 
     return hook
 
@@ -296,8 +205,8 @@ class FlattenPlotter(ImagePlotter):
     """Image plotter with static flattening of 3D input to 2D.
 
     Inherits ``compute()`` from ``Plotter``; only ``plot()`` is overridden to
-    flatten the data and apply a zoom-aware tick formatter to the flattened
-    axis before delegating to ``ImagePlotter.plot()``.
+    flatten the data and attach a hover that decomposes the synthetic flat
+    axis back into outer/inner labels before delegating to ``ImagePlotter``.
     """
 
     def __init__(
@@ -375,25 +284,12 @@ class FlattenPlotter(ImagePlotter):
             **kwargs,
         )
 
-        outer_coord = _coord_for_ticks(data, outer)
-        inner_coord = _coord_for_ticks(data, inner)
-        inner_formatter = _build_inner_axis_formatter(
-            inner, inner_coord, data.sizes[inner]
-        )
-        outer_ticks = _outer_axis_ticks(
-            outer, outer_coord, data.sizes[outer], data.sizes[inner]
-        )
-        # When transpose=True the kept dim is on y → flat axis is x (side='below');
-        # otherwise flat axis is y (side='left').
-        side = 'below' if self._transpose else 'left'
-        ticks_opt = 'xticks' if self._transpose else 'yticks'
-        label_opt = 'xlabel' if self._transpose else 'ylabel'
         # $x/$y refer to the cursor position in data space; @x/@y reference
         # the Image glyph's anchor (a constant) and would freeze the index at 0.
         flat_field = '$x' if self._transpose else '$y'
         kept_field = '$y' if self._transpose else '$x'
         hover_fmt = _build_flat_hover_formatter(
-            outer_coord, inner_coord, data.sizes[inner]
+            _coord_1d(data, outer), _coord_1d(data, inner), data.sizes[inner]
         )
         hover = HoverTool(
             tooltips=[
@@ -404,11 +300,4 @@ class FlattenPlotter(ImagePlotter):
             ],
             formatters={flat_field: hover_fmt},
         )
-        # Outer goes on the primary axis (further from plot per Bokeh stacking),
-        # inner on the secondary axis added via the hook (closer to plot). The
-        # synthetic flat-dim name (e.g. "outer·inner") is suppressed since each
-        # tick row carries its own dim name.
-        return image.opts(
-            **{ticks_opt: outer_ticks, label_opt: ''},
-            hooks=[_make_flatten_hook(side, inner_formatter, hover)],
-        )
+        return image.opts(hooks=[_make_hover_hook(hover)])

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -90,17 +90,14 @@ def make_flatten_params(dims: tuple[str, ...]) -> type[FlattenParams]:
     -------
     :
         A ``FlattenParams`` subclass.
-
-    Notes
-    -----
-    Dim names must be valid Python identifiers since they become ``IntEnum``
-    member names. All ESS dim names in this codebase satisfy that.
     """
     if len(dims) < 2:
         return FlattenParams
 
     n = len(dims)
-    Dim = IntEnum('Dim', [(d, i) for i, d in enumerate(dims)])
+    Dim = IntEnum(
+        'Dim', [(d if d.isidentifier() else f'dim_{i}', i) for i, d in enumerate(dims)]
+    )
 
     class _AxisConfig(FlattenAxisConfig):
         # min_length/max_length here are not just validation — ParamWidget

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -287,9 +287,12 @@ class FlattenPlotter(ImagePlotter):
         hover_fmt = _build_flat_hover_formatter(
             _coord_1d(data, outer), _coord_1d(data, inner), data.sizes[inner]
         )
+        kept_coord = _coord_1d(data, keep)
+        kept_unit = kept_coord.unit if kept_coord is not None else None
+        keep_label = f'{keep} [{kept_unit}]' if kept_unit is not None else keep
         hover = HoverTool(
             tooltips=[
-                (keep, kept_field),
+                (keep_label, kept_field),
                 (outer, f'{flat_field}{{outer}}'),
                 (inner, f'{flat_field}{{inner}}'),
                 ('value', '@image'),

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -103,22 +103,18 @@ def make_flatten_params(dims: tuple[str, ...]) -> type[FlattenParams]:
     Dim = IntEnum('Dim', [(d, i) for i, d in enumerate(dims)])
 
     class _AxisConfig(FlattenAxisConfig):
+        # min_length/max_length here are not just validation — ParamWidget
+        # reads them off the field metadata to constrain the MultiSelect
+        # itself, so the user never lands in an empty/full state.
         axis_x_dims: set[Dim] = pydantic.Field(  # type: ignore[valid-type]
             default_factory=lambda: {Dim(0)},
+            min_length=1,
+            max_length=n - 1,
             title='Dims on X axis',
             description='Input dims that combine into the X image axis. The '
             'remaining dims form the Y axis. Each group with K ≥ 2 dims is '
             'flattened together in natural input order.',
         )
-
-        @pydantic.model_validator(mode='after')
-        def _validate_proper_subset(self) -> _AxisConfig:
-            if not 1 <= len(self.axis_x_dims) < n:
-                raise ValueError(
-                    f"axis_x_dims must be a non-empty proper subset of the "
-                    f"{n} input dims; got {len(self.axis_x_dims)} dim(s)"
-                )
-            return self
 
     class _FlattenParams(FlattenParams):
         flatten: _AxisConfig = pydantic.Field(  # type: ignore[valid-type]

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -3,19 +3,23 @@
 """Plotter wrapping ImagePlotter with static (config-time) flattening of 3D data.
 
 The user picks which input dim stays as one image axis; the other two are
-flattened together into the second image axis. Tick labels on the flattened
-axis are computed dynamically (zoom-aware) from the input coords via a Bokeh
-``CustomJSTickFormatter``.
+flattened together into the second image axis. The flattened axis carries two
+stacked tick rows in the standard hierarchical convention: the inner-dim
+ticks (zoom-aware via a Bokeh ``CustomJSTickFormatter``) sit closest to the
+plot, and the outer-dim group labels at fixed group centres sit one row
+further out. Bokeh's layout stacks newly added axes closer to the plot frame
+than the primary, so the outer (fixed) ticks go on the primary axis and the
+inner (zoom-aware) ticks on a secondary axis added via a hook.
 """
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal
+from enum import IntEnum
 
 import holoviews as hv
 import pydantic
 import scipp as sc
-from bokeh.models import CustomJSTickFormatter
+from bokeh.models import CustomJSTickFormatter, LinearAxis
 
 from ess.livedata.config.workflow_spec import ResultKey
 
@@ -26,17 +30,18 @@ from .plots import ImagePlotter
 class FlattenAxisConfig(pydantic.BaseModel):
     """Static-flatten axis assignment.
 
-    The placeholder ``keep_dim: str`` is narrowed by ``make_flatten_params``
-    to ``Literal[*dims]`` so the dashboard renders a dropdown of actual dim
-    names. The other two dims are flattened in their natural input order
-    (``flatten_transposed`` swaps that order).
+    ``keep_dim`` is the *position* (0-based index) of the input dim that stays
+    as one image axis. ``make_flatten_params`` narrows the field to an
+    ``IntEnum`` whose member names are the actual dim names so the dashboard
+    renders a dropdown of dim names while the saved value is just an integer
+    — invariant under per-instrument dim renames.
     """
 
-    keep_dim: str = pydantic.Field(
-        default='',
+    keep_dim: int = pydantic.Field(
+        default=0,
         title='Keep dim',
-        description='Input dim that stays as one image axis. The other two dims '
-        'are flattened together into the second axis.',
+        description='Input dim (by position) that stays as one image axis. '
+        'The other two dims are flattened together into the second axis.',
     )
     flatten_transposed: bool = pydantic.Field(
         default=False,
@@ -63,36 +68,36 @@ class FlattenParams(PlotParams2d):
 
 
 def make_flatten_params(dims: tuple[str, ...]) -> type[FlattenParams]:
-    """Create a FlattenParams subclass narrowed to the given input dims.
+    """Create a FlattenParams subclass with ``keep_dim`` narrowed to ``dims``.
 
     Parameters
     ----------
     dims:
         Dim names of the workflow output template. When exactly three are
-        provided, the returned model narrows ``keep_dim`` to
-        ``Literal[*dims]`` so the UI renders a dropdown of the actual dim
-        names. For other arities the unmodified base ``FlattenParams`` is
-        returned (the plotter rejects mismatches at plot time).
+        provided, ``keep_dim`` is narrowed to an ``IntEnum`` mapping each
+        dim name to its position so the UI dropdown shows dim names while
+        the stored value is the integer position. For other arities the
+        unmodified base ``FlattenParams`` is returned (the plotter rejects
+        mismatches at plot time).
 
     Returns
     -------
     :
         A ``FlattenParams`` subclass.
+
+    Notes
+    -----
+    Dim names must be valid Python identifiers since they become ``IntEnum``
+    member names. All ESS dim names in this codebase satisfy that.
     """
     if len(dims) != 3:
         return FlattenParams
 
-    DimLit = Literal[*dims]  # type: ignore[valid-type]
+    KeepDim = IntEnum('KeepDim', [(d, i) for i, d in enumerate(dims)])
 
     class _AxisConfig(FlattenAxisConfig):
-        # Captured here so the plotter can fall back to positional binding
-        # when the runtime data dim names differ from the template (e.g. the
-        # detector_view abstraction declares dim_0/dim_1/... and per-instrument
-        # transforms rename to tube/pixel/... preserving order).
-        _template_dims: ClassVar[tuple[str, ...]] = dims
-
-        keep_dim: DimLit = pydantic.Field(  # type: ignore[valid-type]
-            default=dims[0],
+        keep_dim: KeepDim = pydantic.Field(  # type: ignore[valid-type]
+            default=KeepDim(0),
             title='Keep dim',
             description='Input dim that stays as one image axis. The other '
             'two dims are flattened together into the second axis.',
@@ -130,52 +135,88 @@ def _format_part(name: str, coord: sc.Variable | None) -> tuple[str, list]:
     return f'{name}=%s{unit}', values
 
 
-def _build_flat_axis_formatter(
-    outer_name: str,
-    inner_name: str,
-    outer_coord: sc.Variable | None,
-    inner_coord: sc.Variable | None,
-    inner_size: int,
-) -> CustomJSTickFormatter:
-    """Bokeh formatter mapping a flattened-axis position to a multi-index label.
+def _format_value_static(v: float) -> str:
+    """Mirror the JS formatter's per-value formatting for the outer-axis labels."""
+    if 1e-3 <= abs(v) < 1e6:
+        return f'{v:.4g}'
+    return f'{v:.3e}'
 
-    ``Math.round(tick)`` is unraveled into ``(o_idx, i_idx)`` against
-    ``inner_size`` so labels remain accurate at any zoom level. When a coord is
-    missing for one of the input dims, the label falls back to ``name[idx]``
-    for that part.
+
+def _label_part(name: str, idx: int, coord: sc.Variable | None) -> str:
+    """Static-side label for one dim slot, mirroring the JS formatter output."""
+    if coord is None:
+        return f'{name}[{idx}]'
+    unit = '' if coord.unit is None else f' {coord.unit}'
+    return f'{name}={_format_value_static(float(coord.values[idx]))}{unit}'
+
+
+def _build_inner_axis_formatter(
+    name: str, coord: sc.Variable | None, inner_size: int
+) -> CustomJSTickFormatter:
+    """Bokeh formatter showing only the inner-dim value at each tick.
+
+    ``Math.round(tick) % inner_size`` selects the inner index, so labels stay
+    accurate at any zoom level. Falls back to ``name[idx]`` when no coord.
     """
-    outer_template, outer_values = _format_part(outer_name, outer_coord)
-    inner_template, inner_values = _format_part(inner_name, inner_coord)
+    template, values = _format_part(name, coord)
     return CustomJSTickFormatter(
-        args={
-            'outer_template': outer_template,
-            'inner_template': inner_template,
-            'outer_values': outer_values,
-            'inner_values': inner_values,
-            'inner_size': inner_size,
-        },
+        args={'template': template, 'values': values, 'inner_size': inner_size},
         code="""
         const idx = Math.round(tick);
-        const total = Math.max(1, inner_size);
-        if (idx < 0) return '';
-        const o_idx = Math.floor(idx / total);
-        const i_idx = idx - o_idx * total;
-        function fmt(template, values, fallback_idx) {
-            if (values.length === 0) {
-                return template.replace('%d', String(fallback_idx));
-            }
-            if (fallback_idx < 0 || fallback_idx >= values.length) return '';
-            const v = values[fallback_idx];
-            const s = (Math.abs(v) >= 1e-3 && Math.abs(v) < 1e6)
-                ? v.toPrecision(4)
-                : v.toExponential(3);
-            return template.replace('%s', s);
+        if (inner_size <= 0 || idx < 0) return '';
+        const i_idx = ((idx % inner_size) + inner_size) % inner_size;
+        if (values.length === 0) {
+            return template.replace('%d', String(i_idx));
         }
-        const o = fmt(outer_template, outer_values, o_idx);
-        const i = fmt(inner_template, inner_values, i_idx);
-        return o + ', ' + i;
+        if (i_idx >= values.length) return '';
+        const v = values[i_idx];
+        const s = (Math.abs(v) >= 1e-3 && Math.abs(v) < 1e6)
+            ? v.toPrecision(4)
+            : v.toExponential(3);
+        return template.replace('%s', s);
         """,
     )
+
+
+def _outer_axis_ticks(
+    name: str, coord: sc.Variable | None, outer_size: int, inner_size: int
+) -> list[tuple[float, str]]:
+    """``(position, label)`` pairs for the outer-dim group axis.
+
+    Each outer index ``i`` gets one tick at the centre of its group on the
+    flattened axis (``i*inner_size + (inner_size-1)/2``), with a static label.
+    Returned as a list so it can be passed straight to HoloViews'
+    ``xticks``/``yticks`` opt.
+    """
+    return [
+        (
+            i * inner_size + (inner_size - 1) / 2.0,
+            _label_part(name, i, coord),
+        )
+        for i in range(outer_size)
+    ]
+
+
+def _make_inner_axis_hook(side: str, formatter: CustomJSTickFormatter):
+    """HoloViews hook adding a secondary axis carrying the inner-dim ticks.
+
+    Bokeh stacks each newly added layout closer to the plot frame than the
+    primary axis, so the secondary axis ends up between the plot and the
+    primary outer-group ticks — i.e. inner-close, outer-far, the standard
+    hierarchical convention. Idempotent across re-renders.
+    """
+
+    def hook(plot, _element):
+        if plot.handles.get('flatten_inner_axis_installed'):
+            return
+        fig = plot.handles['plot']
+        fig.add_layout(
+            LinearAxis(formatter=formatter, axis_label=''),
+            side,
+        )
+        plot.handles['flatten_inner_axis_installed'] = True
+
+    return hook
 
 
 class FlattenPlotter(ImagePlotter):
@@ -189,22 +230,19 @@ class FlattenPlotter(ImagePlotter):
     def __init__(
         self,
         *,
-        keep_dim: str,
+        keep_dim: int,
         flatten_transposed: bool,
         transpose: bool,
-        template_dims: tuple[str, ...] | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self._keep_dim = keep_dim
+        self._keep_dim = int(keep_dim)
         self._flatten_transposed = flatten_transposed
         self._transpose = transpose
-        self._template_dims = template_dims
 
     @classmethod
     def from_params(cls, params: FlattenParams) -> FlattenPlotter:
         rate = getattr(params, 'rate', None)
-        template_dims = getattr(type(params.flatten), '_template_dims', None)
         return cls(
             grow_threshold=0.1,
             layout_params=params.layout,
@@ -215,40 +253,22 @@ class FlattenPlotter(ImagePlotter):
             keep_dim=params.flatten.keep_dim,
             flatten_transposed=params.flatten.flatten_transposed,
             transpose=params.flatten.transpose,
-            template_dims=template_dims,
-        )
-
-    def _resolve_keep_dim(self, data: sc.DataArray) -> str:
-        """Map the configured ``keep_dim`` to an actual data dim.
-
-        Falls back to positional binding when the configured name doesn't
-        match data.dims directly: this handles the common case where a shared
-        template declares generic dims (``dim_0``, ``dim_1``, …) that are
-        renamed by per-instrument transforms while preserving order.
-        """
-        configured = self._keep_dim
-        if configured in data.dims:
-            return configured
-        if (
-            self._template_dims is not None
-            and configured in self._template_dims
-            and len(self._template_dims) == data.ndim
-        ):
-            return data.dims[self._template_dims.index(configured)]
-        raise ValueError(
-            f"Configured keep_dim {configured!r} matches neither the data "
-            f"dims {list(data.dims)} nor the template dims {self._template_dims}."
         )
 
     def _resolve_axes(self, data: sc.DataArray) -> tuple[str, str, str]:
         """Return (keep, outer, inner) actual data dim names.
 
-        The two non-kept dims are taken in their natural input order to be
-        (outer, inner); ``flatten_transposed`` swaps them.
+        ``keep_dim`` is a 0-based position into ``data.dims``. The two non-kept
+        dims are taken in their natural input order as (outer, inner);
+        ``flatten_transposed`` swaps them.
         """
         if data.ndim != 3:
             raise ValueError(f"FlattenPlotter requires 3D input, got {data.ndim}D")
-        keep = self._resolve_keep_dim(data)
+        if not 0 <= self._keep_dim < data.ndim:
+            raise ValueError(
+                f"keep_dim={self._keep_dim} out of range for {data.ndim}D data"
+            )
+        keep = data.dims[self._keep_dim]
         others = [d for d in data.dims if d != keep]
         outer, inner = others if not self._flatten_transposed else others[::-1]
         return keep, outer, inner
@@ -282,13 +302,24 @@ class FlattenPlotter(ImagePlotter):
             **kwargs,
         )
 
-        formatter = _build_flat_axis_formatter(
-            outer_name=outer,
-            inner_name=inner,
-            outer_coord=_coord_for_ticks(data, outer),
-            inner_coord=_coord_for_ticks(data, inner),
-            inner_size=data.sizes[inner],
+        outer_coord = _coord_for_ticks(data, outer)
+        inner_coord = _coord_for_ticks(data, inner)
+        inner_formatter = _build_inner_axis_formatter(
+            inner, inner_coord, data.sizes[inner]
         )
-        # When transpose=True the kept dim is on y → flat axis is x.
-        axis_kwarg = 'xformatter' if self._transpose else 'yformatter'
-        return image.opts(**{axis_kwarg: formatter})
+        outer_ticks = _outer_axis_ticks(
+            outer, outer_coord, data.sizes[outer], data.sizes[inner]
+        )
+        # When transpose=True the kept dim is on y → flat axis is x (side='below');
+        # otherwise flat axis is y (side='left').
+        side = 'below' if self._transpose else 'left'
+        ticks_opt = 'xticks' if self._transpose else 'yticks'
+        label_opt = 'xlabel' if self._transpose else 'ylabel'
+        # Outer goes on the primary axis (further from plot per Bokeh stacking),
+        # inner on the secondary axis added via the hook (closer to plot). The
+        # synthetic flat-dim name (e.g. "outer·inner") is suppressed since each
+        # tick row carries its own dim name.
+        return image.opts(
+            **{ticks_opt: outer_ticks, label_opt: ''},
+            hooks=[_make_inner_axis_hook(side, inner_formatter)],
+        )

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -137,8 +137,11 @@ def _coord_1d(data: sc.DataArray, dim: str) -> sc.Variable | None:
 
 
 def _joined_dim_name(names: tuple[str, ...], existing: tuple[str, ...]) -> str:
-    """Join dim names with '·', suffixing '_' until unique against ``existing``."""
-    name = '·'.join(names)
+    """Tuple-notation name for a group of flattened dims.
+
+    Unique against ``existing``.
+    """
+    name = f'({",".join(names)})'
     while name in existing:
         name = f'{name}_'
     return name

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -290,6 +290,16 @@ class FlattenPlotter(ImagePlotter):
         kept_coord = _coord_1d(data, keep)
         kept_unit = kept_coord.unit if kept_coord is not None else None
         keep_label = f'{keep} [{kept_unit}]' if kept_unit is not None else keep
+        # When there is no coord, $x/$y is in integer-index space [0, N-1], so
+        # rounding gives the exact bin index. We do not extend this to int coords
+        # with unit=None: there $x is in coord-value space and hovering between
+        # bins would produce values not in the coord — correct display would
+        # require a values-array nearest-neighbour lookup in JS.
+        formatters = {flat_field: hover_fmt}
+        if kept_coord is None:
+            formatters[kept_field] = CustomJSHover(
+                code='return String(Math.round(value));'
+            )
         hover = HoverTool(
             tooltips=[
                 (keep_label, kept_field),
@@ -297,6 +307,6 @@ class FlattenPlotter(ImagePlotter):
                 (inner, f'{flat_field}{{inner}}'),
                 ('value', '@image'),
             ],
-            formatters={flat_field: hover_fmt},
+            formatters=formatters,
         )
         return image.opts(hooks=[_make_hover_hook(hover)])

--- a/src/ess/livedata/dashboard/flatten_plotter.py
+++ b/src/ess/livedata/dashboard/flatten_plotter.py
@@ -2,10 +2,11 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Plotter wrapping ImagePlotter with static (config-time) flattening of N-D data.
 
-Each image axis is built from one or more input dims, flattened together in a
-fixed order. A custom hover decomposes each axis cursor index back into
-per-dim labels (with coord values when available) so the plot stays explorable
-despite the synthetic axes.
+The user partitions the input dims into two groups via ``axis_x_dims``; the
+remaining dims form the Y group. Each group with K ≥ 2 dims is flattened
+together in natural input order, optionally reversed by per-axis
+``transpose_*_flatten`` flags. A custom hover decomposes each axis cursor
+back into per-dim labels with coord values when available.
 """
 
 from __future__ import annotations
@@ -24,57 +25,66 @@ from .plots import ImagePlotter
 
 
 class FlattenAxisConfig(pydantic.BaseModel):
-    """Static-flatten axis assignment.
+    """Static-flatten partition of input dims into X and Y groups.
 
-    ``keep_dim`` is the *position* (0-based index) of the input dim that stays
-    as one image axis. ``make_flatten_params`` narrows the field to an
-    ``IntEnum`` whose member names are the actual dim names so the dashboard
-    renders a dropdown of dim names while the saved value is just an integer
-    — invariant under per-instrument dim renames.
+    ``axis_x_dims`` holds *positions* (0-based input-dim indices) — saving
+    integers rather than dim names keeps configs invariant under
+    per-instrument dim renames. The Y group is always the complement.
+    Ordering within each group is natural input order, with the
+    ``transpose_*_flatten`` flags reversing it when the natural order is
+    wrong; arbitrary K ≥ 3 permutations are not exposed at the params layer
+    (use the plotter's direct constructor if needed).
     """
 
-    keep_dim: int = pydantic.Field(
-        default=0,
-        title='Keep dim',
-        description='Input dim (by position) that stays as one image axis. '
-        'The other two dims are flattened together into the second axis.',
+    axis_x_dims: set[int] = pydantic.Field(
+        default_factory=lambda: {0},
+        title='Dims on X axis',
+        description='Input dims (by position) that combine into the X image '
+        'axis. The remaining dims form the Y axis. Each group with K ≥ 2 '
+        'dims is flattened together in natural input order.',
     )
-    flatten_transposed: bool = pydantic.Field(
+    transpose_x_flatten: bool = pydantic.Field(
         default=False,
-        title='Transpose flattened axes',
-        description='Swap the order of the two flattened dims. By default '
-        'they are flattened in their natural input order.',
+        title='Reverse X-axis flatten order',
+        description='Reverse the order in which the X-axis dims are flattened. '
+        'Has no effect when X has a single dim.',
+    )
+    transpose_y_flatten: bool = pydantic.Field(
+        default=False,
+        title='Reverse Y-axis flatten order',
+        description='Reverse the order in which the Y-axis dims are flattened. '
+        'Has no effect when Y has a single dim.',
     )
     transpose: bool = pydantic.Field(
         default=False,
         title='Transpose',
-        description='Swap x and y axes of the result. When False the kept dim '
-        'is on x and the flattened combination on y.',
+        description='Swap x and y axes of the result.',
     )
 
 
 class FlattenParams(PlotParams2d):
-    """Parameters for the static-flatten 3D-to-2D plotter."""
+    """Parameters for the static-flatten N-D-to-2D plotter."""
 
     flatten: FlattenAxisConfig = pydantic.Field(
         default_factory=FlattenAxisConfig,
-        description='Selection of which input dim stays as one image axis '
-        'and how the remaining two are flattened together.',
+        description='Partition of input dims into X- and Y-axis groups and '
+        'their flatten ordering.',
     )
 
 
 def make_flatten_params(dims: tuple[str, ...]) -> type[FlattenParams]:
-    """Create a FlattenParams subclass with ``keep_dim`` narrowed to ``dims``.
+    """Create a FlattenParams subclass with ``axis_x_dims`` narrowed to ``dims``.
 
     Parameters
     ----------
     dims:
-        Dim names of the workflow output template. When exactly three are
-        provided, ``keep_dim`` is narrowed to an ``IntEnum`` mapping each
-        dim name to its position so the UI dropdown shows dim names while
-        the stored value is the integer position. For other arities the
-        unmodified base ``FlattenParams`` is returned (the plotter rejects
-        mismatches at plot time).
+        Dim names of the workflow output template. For ``len(dims) ≥ 2`` the
+        ``axis_x_dims`` field is narrowed to ``set[Dim]`` where ``Dim`` is an
+        ``IntEnum`` mapping each dim name to its position; the dashboard
+        renders this as a multi-select of dim names while the stored value
+        is a set of integer positions. For ``len(dims) < 2`` the unmodified
+        base ``FlattenParams`` is returned (the plotter rejects mismatches
+        at plot time).
 
     Returns
     -------
@@ -86,24 +96,35 @@ def make_flatten_params(dims: tuple[str, ...]) -> type[FlattenParams]:
     Dim names must be valid Python identifiers since they become ``IntEnum``
     member names. All ESS dim names in this codebase satisfy that.
     """
-    if len(dims) != 3:
+    if len(dims) < 2:
         return FlattenParams
 
-    KeepDim = IntEnum('KeepDim', [(d, i) for i, d in enumerate(dims)])
+    n = len(dims)
+    Dim = IntEnum('Dim', [(d, i) for i, d in enumerate(dims)])
 
     class _AxisConfig(FlattenAxisConfig):
-        keep_dim: KeepDim = pydantic.Field(  # type: ignore[valid-type]
-            default=KeepDim(0),
-            title='Keep dim',
-            description='Input dim that stays as one image axis. The other '
-            'two dims are flattened together into the second axis.',
+        axis_x_dims: set[Dim] = pydantic.Field(  # type: ignore[valid-type]
+            default_factory=lambda: {Dim(0)},
+            title='Dims on X axis',
+            description='Input dims that combine into the X image axis. The '
+            'remaining dims form the Y axis. Each group with K ≥ 2 dims is '
+            'flattened together in natural input order.',
         )
+
+        @pydantic.model_validator(mode='after')
+        def _validate_proper_subset(self) -> _AxisConfig:
+            if not 1 <= len(self.axis_x_dims) < n:
+                raise ValueError(
+                    f"axis_x_dims must be a non-empty proper subset of the "
+                    f"{n} input dims; got {len(self.axis_x_dims)} dim(s)"
+                )
+            return self
 
     class _FlattenParams(FlattenParams):
         flatten: _AxisConfig = pydantic.Field(  # type: ignore[valid-type]
             default_factory=_AxisConfig,
-            description='Selection of which input dim stays as one image axis '
-            'and how the remaining two are flattened together.',
+            description='Partition of input dims into X- and Y-axis groups '
+            'and their flatten ordering.',
         )
 
     return _FlattenParams
@@ -197,46 +218,36 @@ def _make_hover_hook(hover: HoverTool):
 class FlattenPlotter(ImagePlotter):
     """Image plotter with static flattening of N-D input to 2D.
 
-    Each image axis is built from one or more input dims via ``x_dims`` and
-    ``y_dims`` — ordered tuples of input-dim positions whose union covers all
-    dims of the input. Axes with K ≥ 2 dims are flattened together (in the
-    given order); axes with K = 1 pass through. A custom hover decomposes
-    each axis cursor back into per-dim labels.
+    The X axis takes the dims at positions in ``axis_x_dims``; Y takes the
+    complement. Within each axis dims are flattened in natural input order,
+    optionally reversed by the per-axis ``transpose_*_flatten`` flag. The
+    global ``transpose`` swaps the resulting X and Y. A custom hover
+    decomposes each axis cursor back into per-dim labels.
     """
 
     def __init__(
         self,
         *,
-        x_dims: tuple[int, ...],
-        y_dims: tuple[int, ...],
+        axis_x_dims: frozenset[int] | set[int],
+        transpose_x_flatten: bool = False,
+        transpose_y_flatten: bool = False,
+        transpose: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        if not x_dims or not y_dims:
-            raise ValueError("x_dims and y_dims must each contain at least one dim")
-        positions = (*x_dims, *y_dims)
-        if sorted(positions) != list(range(len(positions))):
-            raise ValueError(
-                f"x_dims/y_dims positions {positions} must be a permutation of "
-                f"range({len(positions)}); some are out of range or duplicated"
-            )
-        self._x_dims = tuple(int(p) for p in x_dims)
-        self._y_dims = tuple(int(p) for p in y_dims)
+        x = frozenset(int(p) for p in axis_x_dims)
+        if not x:
+            raise ValueError("axis_x_dims must contain at least one position")
+        if any(p < 0 for p in x):
+            raise ValueError(f"Negative position in axis_x_dims: {sorted(x)}")
+        self._axis_x_dims = x
+        self._transpose_x_flatten = transpose_x_flatten
+        self._transpose_y_flatten = transpose_y_flatten
+        self._transpose = transpose
 
     @classmethod
-    def from_axes(
-        cls,
-        params: PlotParams2d,
-        *,
-        x_dims: tuple[int, ...],
-        y_dims: tuple[int, ...],
-    ) -> FlattenPlotter:
-        """Construct from a partition of input dims into two ordered axes.
-
-        ``params`` supplies plot styling only; the axis spec comes from
-        ``x_dims``/``y_dims`` directly. Useful for N-D cases not yet
-        expressible through :class:`FlattenAxisConfig`.
-        """
+    def from_params(cls, params: FlattenParams) -> FlattenPlotter:
+        cfg = params.flatten
         rate = getattr(params, 'rate', None)
         return cls(
             grow_threshold=0.1,
@@ -245,40 +256,33 @@ class FlattenPlotter(ImagePlotter):
             scale_opts=params.plot_scale,
             tick_params=params.ticks,
             normalize_to_rate=rate.normalize_to_rate if rate is not None else False,
-            x_dims=x_dims,
-            y_dims=y_dims,
+            axis_x_dims=frozenset(int(p) for p in cfg.axis_x_dims),
+            transpose_x_flatten=cfg.transpose_x_flatten,
+            transpose_y_flatten=cfg.transpose_y_flatten,
+            transpose=cfg.transpose,
         )
-
-    @classmethod
-    def from_params(cls, params: FlattenParams) -> FlattenPlotter:
-        """Construct from a 3D :class:`FlattenAxisConfig`.
-
-        Translates ``keep_dim`` + ``flatten_transposed`` + ``transpose`` into
-        the generic ``(x_dims, y_dims)`` partition.
-        """
-        keep = int(params.flatten.keep_dim)
-        others = [i for i in (0, 1, 2) if i != keep]
-        if params.flatten.flatten_transposed:
-            others = others[::-1]
-        if params.flatten.transpose:
-            x_dims, y_dims = tuple(others), (keep,)
-        else:
-            x_dims, y_dims = (keep,), tuple(others)
-        return cls.from_axes(params, x_dims=x_dims, y_dims=y_dims)
-
-    @property
-    def _ndim(self) -> int:
-        return len(self._x_dims) + len(self._y_dims)
 
     def _resolve_dim_names(
         self, data: sc.DataArray
     ) -> tuple[tuple[str, ...], tuple[str, ...]]:
-        if data.ndim != self._ndim:
+        n = data.ndim
+        if any(p >= n for p in self._axis_x_dims):
             raise ValueError(
-                f"FlattenPlotter requires {self._ndim}D input, got {data.ndim}D"
+                f"axis_x_dims {sorted(self._axis_x_dims)} contains positions "
+                f"out of range for {n}D data"
             )
-        x_names = tuple(data.dims[p] for p in self._x_dims)
-        y_names = tuple(data.dims[p] for p in self._y_dims)
+        x_positions = sorted(self._axis_x_dims)
+        y_positions = [p for p in range(n) if p not in self._axis_x_dims]
+        if not y_positions:
+            raise ValueError(f"All {n} dims assigned to X axis; Y axis would be empty")
+        if self._transpose_x_flatten:
+            x_positions = x_positions[::-1]
+        if self._transpose_y_flatten:
+            y_positions = y_positions[::-1]
+        if self._transpose:
+            x_positions, y_positions = y_positions, x_positions
+        x_names = tuple(data.dims[p] for p in x_positions)
+        y_names = tuple(data.dims[p] for p in y_positions)
         return x_names, y_names
 
     def _flatten_to_2d(

--- a/src/ess/livedata/dashboard/plot_configuration_adapter.py
+++ b/src/ess/livedata/dashboard/plot_configuration_adapter.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import pydantic
@@ -38,6 +39,8 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
         instrument_config: Instrument | None = None,
         hidden_fields: frozenset[str] = frozenset(),
         output_template_dims: tuple[str, ...] | None = None,
+        params_factory: Callable[[tuple[str, ...]], type[pydantic.BaseModel]]
+        | None = None,
     ):
         """
         Initialize plot configuration adapter.
@@ -59,9 +62,14 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
         hidden_fields:
             Field names to hide in the parameter configuration UI.
         output_template_dims:
-            Dim names of the workflow output template. Passed to the plotter
-            spec's ``params_factory`` (when set) to build a parameters model
+            Dim names of the workflow output template. Passed to
+            ``params_factory`` (when set) to build a parameters model
             specialized for these dims.
+        params_factory:
+            Optional factory returning a parameters model specialized for the
+            output template dims. When both this and ``output_template_dims``
+            are provided, the factory's result is used in place of
+            ``plot_spec.params``.
         """
         super().__init__(
             config_state=config_state, initial_source_names=initial_source_names
@@ -72,6 +80,7 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
         self._instrument_config = instrument_config
         self._hidden_fields = hidden_fields
         self._output_template_dims = output_template_dims
+        self._params_factory = params_factory
 
     @property
     def hidden_fields(self) -> frozenset[str]:
@@ -91,13 +100,12 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
     def model_class(self) -> type[pydantic.BaseModel] | None:
         """Get the pydantic model class for plotter parameters.
 
-        When the plotter spec defines a ``params_factory`` and we have the
-        output template dims, returns a model specialized for those dims.
-        Falls back to the static ``params`` class otherwise.
+        When a ``params_factory`` and output template dims are both available,
+        returns a model specialized for those dims. Falls back to the static
+        ``plot_spec.params`` class otherwise.
         """
-        factory = self._plot_spec.params_factory
-        if factory is not None and self._output_template_dims is not None:
-            return factory(self._output_template_dims)
+        if self._params_factory is not None and self._output_template_dims is not None:
+            return self._params_factory(self._output_template_dims)
         return self._plot_spec.params
 
     @property

--- a/src/ess/livedata/dashboard/plot_configuration_adapter.py
+++ b/src/ess/livedata/dashboard/plot_configuration_adapter.py
@@ -37,6 +37,7 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
         initial_source_names: list[str] | None = None,
         instrument_config: Instrument | None = None,
         hidden_fields: frozenset[str] = frozenset(),
+        output_template_dims: tuple[str, ...] | None = None,
     ):
         """
         Initialize plot configuration adapter.
@@ -57,6 +58,10 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
             Optional instrument configuration for source metadata lookup.
         hidden_fields:
             Field names to hide in the parameter configuration UI.
+        output_template_dims:
+            Dim names of the workflow output template. Passed to the plotter
+            spec's ``params_factory`` (when set) to build a parameters model
+            specialized for these dims.
         """
         super().__init__(
             config_state=config_state, initial_source_names=initial_source_names
@@ -66,6 +71,7 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
         self._success_callback = success_callback
         self._instrument_config = instrument_config
         self._hidden_fields = hidden_fields
+        self._output_template_dims = output_template_dims
 
     @property
     def hidden_fields(self) -> frozenset[str]:
@@ -83,7 +89,15 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
         return self._plot_spec.description
 
     def model_class(self) -> type[pydantic.BaseModel] | None:
-        """Get the pydantic model class for plotter parameters."""
+        """Get the pydantic model class for plotter parameters.
+
+        When the plotter spec defines a ``params_factory`` and we have the
+        output template dims, returns a model specialized for those dims.
+        Falls back to the static ``params`` class otherwise.
+        """
+        factory = self._plot_spec.params_factory
+        if factory is not None and self._output_template_dims is not None:
+            return factory(self._output_template_dims)
         return self._plot_spec.params
 
     @property

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -408,14 +408,14 @@ def _register_all_plotters() -> None:
         name='flatten',
         title='Flatten to 2D',
         description=(
-            'Flatten N-D data (N ≥ 2) to a 2D image with a static '
+            'Flatten N-D data (N ≥ 3) to a 2D image with a static '
             '(config-time) partition of input dims into X- and Y-axis '
             'groups. Each group with two or more dims is flattened together; '
             'hovering decomposes each axis back into per-dim labels with '
             'their coord values.'
         ),
         data_requirements=DataRequirements(
-            min_dims=2,
+            min_dims=3,
             max_dims=6,
             multiple_datasets=False,
         ),

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -128,8 +128,6 @@ class PlotterSpec(pydantic.BaseModel):
     dynamic creation of user interfaces for configuring plots.
     """
 
-    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
-
     name: str = pydantic.Field(description="Name of the plot type. Used internally.")
     title: str = pydantic.Field(
         description="Title of the plot type. For display in the UI."
@@ -137,17 +135,6 @@ class PlotterSpec(pydantic.BaseModel):
     description: str = pydantic.Field(description="Description of the plot type.")
     params: type[pydantic.BaseModel] = pydantic.Field(
         description="Pydantic model defining the parameters for the plot."
-    )
-    params_factory: Callable[[tuple[str, ...]], type[pydantic.BaseModel]] | None = (
-        pydantic.Field(
-            default=None,
-            description=(
-                "Optional factory that returns a parameters model specialized for "
-                "the dims of the chosen workflow output. When set, the plot config "
-                "modal calls it with the output template's dim names instead of "
-                "using the static `params` class."
-            ),
-        )
     )
     data_requirements: DataRequirements = pydantic.Field(
         description="Requirements the data to be plotted must fulfill."
@@ -172,10 +159,19 @@ class PlotterFactory(Protocol, Generic[P]):
 
 @dataclass
 class PlotterEntry:
-    """Entry combining a plotter specification with its factory."""
+    """Entry combining a plotter specification with its factory.
+
+    ``params_factory`` is an optional callable that returns a parameters model
+    specialized for the dims of the chosen workflow output. When set, the
+    plot config modal calls it with the output template's dim names instead of
+    using the static ``spec.params`` class. It lives here (alongside
+    ``factory``) rather than on ``spec`` so ``PlotterSpec`` stays a pure
+    pydantic-validated metadata record.
+    """
 
     spec: PlotterSpec
     factory: PlotterFactory[Any]  # Use Any since we store different param types
+    params_factory: Callable[[tuple[str, ...]], type[pydantic.BaseModel]] | None = None
 
 
 class PlotterRegistry(UserDict[str, PlotterEntry]):
@@ -200,12 +196,13 @@ class PlotterRegistry(UserDict[str, PlotterEntry]):
             title=title,
             description=description,
             params=type_hints['params'],
-            params_factory=params_factory,
             data_requirements=data_requirements,
             spec_requirements=spec_requirements or SpecRequirements(),
             category=category,
         )
-        self[name] = PlotterEntry(spec=spec, factory=factory)
+        self[name] = PlotterEntry(
+            spec=spec, factory=factory, params_factory=params_factory
+        )
 
     def get_compatible_plotters(
         self, data: dict[Any, sc.DataArray]
@@ -271,6 +268,12 @@ class PlotterRegistry(UserDict[str, PlotterEntry]):
     def get_spec(self, name: str) -> PlotterSpec:
         """Get specification for a specific plotter."""
         return self[name].spec
+
+    def get_params_factory(
+        self, name: str
+    ) -> Callable[[tuple[str, ...]], type[pydantic.BaseModel]] | None:
+        """Get the dim-specialized params factory for a plotter, if any."""
+        return self[name].params_factory
 
     def create_plotter(self, name: str, params: pydantic.BaseModel) -> Plotter:
         """Create a plotter instance with the given parameters."""

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -406,16 +406,16 @@ def _register_all_plotters() -> None:
 
     plotter_registry.register_plotter(
         name='flatten',
-        title='3D Flatten',
+        title='Flatten to 2D',
         description=(
-            'Flatten 3D data to a 2D image with a static (config-time) choice '
-            'of which dim stays as one image axis. The other two dims are '
-            'flattened together; hovering decomposes the synthetic axis back '
-            'into outer/inner labels with their coord values.'
+            'Flatten N-D data (N ≥ 2) to a 2D image with a static '
+            '(config-time) partition of input dims into X- and Y-axis '
+            'groups. Each group with two or more dims is flattened together; '
+            'hovering decomposes each axis back into per-dim labels with '
+            'their coord values.'
         ),
         data_requirements=DataRequirements(
-            min_dims=3,
-            max_dims=3,
+            min_dims=2,
             multiple_datasets=False,
         ),
         factory=FlattenPlotter.from_params,

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -128,6 +128,8 @@ class PlotterSpec(pydantic.BaseModel):
     dynamic creation of user interfaces for configuring plots.
     """
 
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+
     name: str = pydantic.Field(description="Name of the plot type. Used internally.")
     title: str = pydantic.Field(
         description="Title of the plot type. For display in the UI."
@@ -135,6 +137,17 @@ class PlotterSpec(pydantic.BaseModel):
     description: str = pydantic.Field(description="Description of the plot type.")
     params: type[pydantic.BaseModel] = pydantic.Field(
         description="Pydantic model defining the parameters for the plot."
+    )
+    params_factory: Callable[[tuple[str, ...]], type[pydantic.BaseModel]] | None = (
+        pydantic.Field(
+            default=None,
+            description=(
+                "Optional factory that returns a parameters model specialized for "
+                "the dims of the chosen workflow output. When set, the plot config "
+                "modal calls it with the output template's dim names instead of "
+                "using the static `params` class."
+            ),
+        )
     )
     data_requirements: DataRequirements = pydantic.Field(
         description="Requirements the data to be plotted must fulfill."
@@ -175,6 +188,8 @@ class PlotterRegistry(UserDict[str, PlotterEntry]):
         factory: PlotterFactory[P],
         spec_requirements: SpecRequirements | None = None,
         category: PlotterCategory = PlotterCategory.DATA,
+        params_factory: Callable[[tuple[str, ...]], type[pydantic.BaseModel]]
+        | None = None,
     ) -> None:
         # Try to get the type hint of the 'params' argument if it exists
         # Use get_type_hints to resolve forward references, in case we used
@@ -185,6 +200,7 @@ class PlotterRegistry(UserDict[str, PlotterEntry]):
             title=title,
             description=description,
             params=type_hints['params'],
+            params_factory=params_factory,
             data_requirements=data_requirements,
             spec_requirements=spec_requirements or SpecRequirements(),
             category=category,
@@ -301,6 +317,7 @@ def _register_all_plotters() -> None:
         CorrelationHistogram2dPlotter,
     )
     from .extractors import FullHistoryExtractor
+    from .flatten_plotter import FlattenPlotter, make_flatten_params
     from .plots import (
         BarsPlotter,
         ImagePlotter,
@@ -382,6 +399,24 @@ def _register_all_plotters() -> None:
             custom_validators=[_all_coords_evenly_spaced],
         ),
         factory=SlicerPlotter.from_params,
+    )
+
+    plotter_registry.register_plotter(
+        name='flatten',
+        title='3D Flatten',
+        description=(
+            'Flatten 3D data to a 2D image with a static (config-time) choice '
+            'of which dim stays as one image axis. The other two dims are '
+            'flattened together; tick labels on the flattened axis are '
+            'derived from the input coords (zoom-aware).'
+        ),
+        data_requirements=DataRequirements(
+            min_dims=3,
+            max_dims=3,
+            multiple_datasets=False,
+        ),
+        factory=FlattenPlotter.from_params,
+        params_factory=make_flatten_params,
     )
 
     plotter_registry.register_plotter(

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -416,6 +416,7 @@ def _register_all_plotters() -> None:
         ),
         data_requirements=DataRequirements(
             min_dims=2,
+            max_dims=6,
             multiple_datasets=False,
         ),
         factory=FlattenPlotter.from_params,

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -407,8 +407,8 @@ def _register_all_plotters() -> None:
         description=(
             'Flatten 3D data to a 2D image with a static (config-time) choice '
             'of which dim stays as one image axis. The other two dims are '
-            'flattened together; tick labels on the flattened axis are '
-            'derived from the input coords (zoom-aware).'
+            'flattened together; hovering decomposes the synthetic axis back '
+            'into outer/inner labels with their coord values.'
         ),
         data_requirements=DataRequirements(
             min_dims=3,

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -112,6 +112,12 @@ class PlottingController:
         """
         return plotter_registry.get_spec(plot_name)
 
+    def get_params_factory(
+        self, plot_name: str
+    ) -> Callable[[tuple[str, ...]], type[pydantic.BaseModel]] | None:
+        """Get the dim-specialized params factory for a plotter, if any."""
+        return plotter_registry.get_params_factory(plot_name)
+
     def get_static_plotters(self) -> dict[str, PlotterSpec]:
         """
         Get available static plotters (for overlays without data sources).

--- a/src/ess/livedata/dashboard/widgets/param_widget.py
+++ b/src/ess/livedata/dashboard/widgets/param_widget.py
@@ -118,8 +118,9 @@ class ParamWidget:
                     # (e.g., PlotAspectType.aspect = 'Fixed plot aspect ratio').
                     display_key = enum_val.value
                 else:
-                    # `.name`, not `str(enum_val)` — IntEnum inherits __str__
-                    # from int, so str() returns the integer, not the name.
+                    # `.name` is the member name regardless of __str__.
+                    # IntEnum/IntFlag inherit __str__ from int (returning the
+                    # integer), and plain Enum subclasses may override __str__.
                     display_key = enum_val.name
                 options[display_key] = enum_val
 

--- a/src/ess/livedata/dashboard/widgets/param_widget.py
+++ b/src/ess/livedata/dashboard/widgets/param_widget.py
@@ -4,6 +4,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Literal, get_args, get_origin
 
+import annotated_types
 import panel as pn
 import pydantic
 from pydantic_core import PydanticUndefined
@@ -43,6 +44,43 @@ def _is_set_of_enum(field_type) -> bool:
         return False
     inner = args[0]
     return isinstance(inner, type) and issubclass(inner, Enum)
+
+
+def _length_bounds(
+    field_info: pydantic.fields.FieldInfo,
+) -> tuple[int | None, int | None]:
+    """Extract ``(min_length, max_length)`` from a field's annotated metadata."""
+    min_len = max_len = None
+    for m in field_info.metadata:
+        if isinstance(m, annotated_types.MinLen):
+            min_len = m.min_length
+        elif isinstance(m, annotated_types.MaxLen):
+            max_len = m.max_length
+    return min_len, max_len
+
+
+def _enforce_length_bounds(
+    widget: pn.widgets.MultiSelect,
+    min_len: int | None,
+    max_len: int | None,
+) -> None:
+    """Veto value changes that would violate the configured length bounds.
+
+    Reverts to the previous value when the user adds beyond ``max_len`` or
+    removes below ``min_len``. Cheaper than tracking selection-add events
+    and matches the constraint already enforced by pydantic on submit.
+    """
+    if min_len is None and max_len is None:
+        return
+
+    def _on_change(event):
+        n = len(event.new)
+        if (max_len is not None and n > max_len) or (
+            min_len is not None and n < min_len
+        ):
+            widget.value = event.old
+
+    widget.param.watch(_on_change, 'value')
 
 
 class ParamWidget:
@@ -154,12 +192,15 @@ class ParamWidget:
             (enum_type,) = get_args(field_type)
             options = _enum_options(enum_type)
             default_widget_value = list(default_value) if default_value else []
-            return pn.widgets.MultiSelect(
+            multi_select = pn.widgets.MultiSelect(
                 options=options,
                 value=default_widget_value,
                 size=min(len(options), 10),
                 **shared_options,
             )
+            min_len, max_len = _length_bounds(field_info)
+            _enforce_length_bounds(multi_select, min_len, max_len)
+            return multi_select
         elif get_origin(field_type) is Literal:
             # Handle Literal types (e.g., Literal['a', 'b', 'c'])
             literal_values = get_args(field_type)

--- a/src/ess/livedata/dashboard/widgets/param_widget.py
+++ b/src/ess/livedata/dashboard/widgets/param_widget.py
@@ -114,11 +114,13 @@ class ParamWidget:
             options = {}
             for enum_val in field_type:
                 if isinstance(enum_val.value, str):
-                    # Use the value for string enums
+                    # String enums use the value as the user-facing label
+                    # (e.g., PlotAspectType.aspect = 'Fixed plot aspect ratio').
                     display_key = enum_val.value
                 else:
-                    # Use string repr without enum class name for other enums
-                    display_key = str(enum_val).split('.')[-1]
+                    # `.name`, not `str(enum_val)` — IntEnum inherits __str__
+                    # from int, so str() returns the integer, not the name.
+                    display_key = enum_val.name
                 options[display_key] = enum_val
 
             # Set the actual enum instance as the default value

--- a/src/ess/livedata/dashboard/widgets/param_widget.py
+++ b/src/ess/livedata/dashboard/widgets/param_widget.py
@@ -17,6 +17,34 @@ def snake_to_camel(snake_str: str) -> str:
     return ''.join(word.capitalize() for word in components)
 
 
+def _enum_options(enum_type: type[Enum]) -> dict[str, Enum]:
+    """Build a Panel ``options`` dict mapping display label → enum member.
+
+    String enums use the value as the label (e.g. an enum with member values
+    that are user-readable strings); other enums use the member name —
+    ``.name`` is robust to ``__str__`` overrides on plain ``Enum``s and to
+    ``IntEnum``/``IntFlag`` inheriting their integer ``__str__``.
+    """
+    options: dict[str, Enum] = {}
+    for enum_val in enum_type:
+        if isinstance(enum_val.value, str):
+            options[enum_val.value] = enum_val
+        else:
+            options[enum_val.name] = enum_val
+    return options
+
+
+def _is_set_of_enum(field_type) -> bool:
+    """True for ``set[E]`` / ``frozenset[E]`` where ``E`` is an ``Enum``."""
+    if get_origin(field_type) not in (set, frozenset):
+        return False
+    args = get_args(field_type)
+    if len(args) != 1:
+        return False
+    inner = args[0]
+    return isinstance(inner, type) and issubclass(inner, Enum)
+
+
 class ParamWidget:
     """Widget for creating and validating Pydantic model instances."""
 
@@ -45,9 +73,12 @@ class ParamWidget:
     ):
         """Create appropriate widget based on field type."""
         field_type = field_info.annotation
-        default_value = (
-            field_info.default if field_info.default is not PydanticUndefined else None
-        )
+        if field_info.default is not PydanticUndefined:
+            default_value = field_info.default
+        elif field_info.default_factory is not None:
+            default_value = field_info.default_factory()
+        else:
+            default_value = None
         description = field_info.description or field_name
         display_name = field_info.title or snake_to_camel(field_name)
 
@@ -111,25 +142,23 @@ class ParamWidget:
                 **shared_options,
             )
         elif isinstance(field_type, type) and issubclass(field_type, Enum):
-            options = {}
-            for enum_val in field_type:
-                if isinstance(enum_val.value, str):
-                    # String enums use the value as the user-facing label
-                    # (e.g., PlotAspectType.aspect = 'Fixed plot aspect ratio').
-                    display_key = enum_val.value
-                else:
-                    # `.name` is the member name regardless of __str__.
-                    # IntEnum/IntFlag inherit __str__ from int (returning the
-                    # integer), and plain Enum subclasses may override __str__.
-                    display_key = enum_val.name
-                options[display_key] = enum_val
-
+            options = _enum_options(field_type)
             # Set the actual enum instance as the default value
             default_widget_value = (
                 default_value if default_value else next(iter(options.values()))
             )
             return pn.widgets.Select(
                 options=options, value=default_widget_value, **shared_options
+            )
+        elif _is_set_of_enum(field_type):
+            (enum_type,) = get_args(field_type)
+            options = _enum_options(enum_type)
+            default_widget_value = list(default_value) if default_value else []
+            return pn.widgets.MultiSelect(
+                options=options,
+                value=default_widget_value,
+                size=min(len(options), 10),
+                **shared_options,
             )
         elif get_origin(field_type) is Literal:
             # Handle Literal types (e.g., Literal['a', 'b', 'c'])
@@ -159,6 +188,10 @@ class ParamWidget:
             # Convert Path strings back to Path objects
             if field_type == Path and isinstance(value, str):
                 value = Path(value) if value else None
+            elif _is_set_of_enum(field_type):
+                # MultiSelect emits a list of enum members; pydantic accepts
+                # any iterable for set/frozenset, so just pass the list through.
+                pass
             # Handle enum values - widget.value will be the enum instance for Select
             # widgets with enum options
             elif isinstance(field_type, type) and issubclass(field_type, Enum):
@@ -178,6 +211,9 @@ class ParamWidget:
                     # Checkbox widget is wrapped in a Row
                     self.widgets[field_name][0].value = value
                     continue
+                elif _is_set_of_enum(field_type):
+                    (enum_type,) = get_args(field_type)
+                    value = [enum_type(v) for v in value]
                 elif isinstance(field_type, type) and issubclass(field_type, Enum):
                     value = field_type(value)
                 self.widgets[field_name].value = value

--- a/src/ess/livedata/dashboard/widgets/param_widget.py
+++ b/src/ess/livedata/dashboard/widgets/param_widget.py
@@ -4,7 +4,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Literal, get_args, get_origin
 
-import annotated_types
 import panel as pn
 import pydantic
 from pydantic_core import PydanticUndefined
@@ -44,43 +43,6 @@ def _is_set_of_enum(field_type) -> bool:
         return False
     inner = args[0]
     return isinstance(inner, type) and issubclass(inner, Enum)
-
-
-def _length_bounds(
-    field_info: pydantic.fields.FieldInfo,
-) -> tuple[int | None, int | None]:
-    """Extract ``(min_length, max_length)`` from a field's annotated metadata."""
-    min_len = max_len = None
-    for m in field_info.metadata:
-        if isinstance(m, annotated_types.MinLen):
-            min_len = m.min_length
-        elif isinstance(m, annotated_types.MaxLen):
-            max_len = m.max_length
-    return min_len, max_len
-
-
-def _enforce_length_bounds(
-    widget: pn.widgets.MultiSelect,
-    min_len: int | None,
-    max_len: int | None,
-) -> None:
-    """Veto value changes that would violate the configured length bounds.
-
-    Reverts to the previous value when the user adds beyond ``max_len`` or
-    removes below ``min_len``. Cheaper than tracking selection-add events
-    and matches the constraint already enforced by pydantic on submit.
-    """
-    if min_len is None and max_len is None:
-        return
-
-    def _on_change(event):
-        n = len(event.new)
-        if (max_len is not None and n > max_len) or (
-            min_len is not None and n < min_len
-        ):
-            widget.value = event.old
-
-    widget.param.watch(_on_change, 'value')
 
 
 class ParamWidget:
@@ -192,15 +154,12 @@ class ParamWidget:
             (enum_type,) = get_args(field_type)
             options = _enum_options(enum_type)
             default_widget_value = list(default_value) if default_value else []
-            multi_select = pn.widgets.MultiSelect(
+            return pn.widgets.MultiSelect(
                 options=options,
                 value=default_widget_value,
                 size=min(len(options), 10),
                 **shared_options,
             )
-            min_len, max_len = _length_bounds(field_info)
-            _enforce_length_bounds(multi_select, min_len, max_len)
-            return multi_select
         elif get_origin(field_type) is Literal:
             # Handle Literal types (e.g., Literal['a', 'b', 'c'])
             literal_values = get_args(field_type)

--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -1200,6 +1200,14 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
         if initial_source_names is None and not hints.preselect_all_sources:
             initial_source_names = []
 
+        output_template_dims: tuple[str, ...] | None = None
+        if not is_static:
+            template = workflow_spec.get_output_template(
+                self._plotter_selection.output_name
+            )
+            if template is not None:
+                output_template_dims = tuple(template.dims)
+
         config_adapter = PlotConfigurationAdapter(
             plot_spec=plot_spec,
             source_names=source_names,
@@ -1208,6 +1216,7 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
             initial_source_names=initial_source_names,
             instrument_config=self._instrument_config,
             hidden_fields=hints.hidden_fields,
+            output_template_dims=output_template_dims,
         )
 
         self._config_panel = ConfigurationPanel(config=config_adapter)

--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -1217,6 +1217,9 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
             instrument_config=self._instrument_config,
             hidden_fields=hints.hidden_fields,
             output_template_dims=output_template_dims,
+            params_factory=self._plotting_controller.get_params_factory(
+                self._plotter_selection.plot_name
+            ),
         )
 
         self._config_panel = ConfigurationPanel(config=config_adapter)

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -290,7 +290,7 @@ class DetectorViewOutputs(DetectorViewOutputsBase):
 def _make_spectrum_template(output_dims: list[str]) -> sc.DataArray:
     # Append a placeholder spectral dim so the template has the right ndim for
     # plotter selection. The actual dim name is determined at runtime by the transform.
-    dims = [*output_dims, 'spectrum']
+    dims = [*output_dims, '<spectral_coord>']
     return sc.DataArray(sc.zeros(dims=dims, shape=[0] * len(dims), unit='counts'))
 
 

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -5,12 +5,13 @@
 from __future__ import annotations
 
 import uuid
-from typing import Literal
+from enum import IntEnum
 
 import holoviews as hv
 import pydantic
 import pytest
 import scipp as sc
+from bokeh.models import CustomJSTickFormatter, LinearAxis
 
 from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
 from ess.livedata.dashboard.flatten_plotter import (
@@ -20,6 +21,34 @@ from ess.livedata.dashboard.flatten_plotter import (
     make_flatten_params,
 )
 from ess.livedata.dashboard.plot_params import PlotScale
+
+
+class _FakeFigure:
+    def __init__(self) -> None:
+        self.layouts: list[tuple[LinearAxis, str]] = []
+
+    def add_layout(self, axis: LinearAxis, side: str) -> None:
+        self.layouts.append((axis, side))
+
+
+class _FakePlot:
+    def __init__(self) -> None:
+        self.handles: dict = {'plot': _FakeFigure()}
+
+
+def _run_inner_axis_hook(img: hv.Image) -> _FakeFigure:
+    """Invoke the secondary-axis hook against a fake bokeh figure and return it."""
+    [hook] = img.opts.get('plot').kwargs['hooks']
+    plot = _FakePlot()
+    hook(plot, None)
+    return plot.handles['plot']
+
+
+def _outer_ticks_opt(img: hv.Image, transpose: bool) -> list[tuple[float, str]]:
+    """Outer-axis ticks set on the primary (HoloViews xticks/yticks opt)."""
+    key = 'xticks' if transpose else 'yticks'
+    return img.opts.get('plot').kwargs[key]
+
 
 hv.extension('bokeh')
 
@@ -53,14 +82,16 @@ def data_abc() -> sc.DataArray:
 def _make_params(
     dims: tuple[str, ...],
     *,
-    keep_dim: str,
+    keep_dim: str | int,
     flatten_transposed: bool = False,
     transpose: bool = False,
 ) -> FlattenParams:
+    """Build params, accepting ``keep_dim`` as a name (resolved to position) or int."""
     Cls = make_flatten_params(dims)
+    keep_dim_index = dims.index(keep_dim) if isinstance(keep_dim, str) else keep_dim
     p = Cls(
         flatten={
-            'keep_dim': keep_dim,
+            'keep_dim': keep_dim_index,
             'flatten_transposed': flatten_transposed,
             'transpose': transpose,
         }
@@ -74,10 +105,12 @@ def _axis_cls(params_cls: type[FlattenParams]) -> type[FlattenAxisConfig]:
 
 
 class TestMakeFlattenParams:
-    def test_narrows_keep_dim_to_literal(self) -> None:
+    def test_narrows_keep_dim_to_intenum_with_dim_names_as_members(self) -> None:
         Cls = make_flatten_params(('a', 'b', 'c'))
         annotation = _axis_cls(Cls).model_fields['keep_dim'].annotation
-        assert annotation == Literal['a', 'b', 'c']
+        assert issubclass(annotation, IntEnum)
+        # Member names render as dropdown labels; values are positions.
+        assert {m.name: m.value for m in annotation} == {'a': 0, 'b': 1, 'c': 2}
 
     def test_does_not_expose_outer_dim_choice(self) -> None:
         # The flatten ordering is controlled by a single boolean checkbox so
@@ -88,10 +121,22 @@ class TestMakeFlattenParams:
         assert 'flatten_outer' not in fields
         assert fields['flatten_transposed'].annotation is bool
 
-    def test_rejects_invalid_dim_name(self) -> None:
+    def test_rejects_keep_dim_out_of_range(self) -> None:
         Cls = make_flatten_params(('a', 'b', 'c'))
         with pytest.raises(pydantic.ValidationError):
-            Cls(flatten={'keep_dim': 'nope'})
+            Cls(flatten={'keep_dim': 99})
+
+    def test_saved_keep_dim_round_trips_as_integer(self) -> None:
+        # Integer storage is the whole point: the saved value is invariant
+        # under per-instrument dim renames, and validates against the base
+        # class on restore without needing template_dims.
+        Cls = make_flatten_params(('a', 'b', 'c'))
+        narrowed = Cls(flatten={'keep_dim': 1})
+        dumped = narrowed.model_dump()
+        assert dumped['flatten']['keep_dim'] == 1
+        # Restore path: validate the dumped dict against the base class.
+        restored = FlattenParams(**dumped)
+        assert restored.flatten.keep_dim == 1
 
     def test_non_3d_returns_base_class_unmodified(self) -> None:
         # 2D / 4D etc. fall back to the unparameterized base; the plotter then
@@ -152,44 +197,109 @@ class TestFlattenPlotterPlot:
         b_dim = next(d for d in img.kdims if d.name == 'b')
         assert b_dim.unit == 's'
 
-    def test_natural_order_sets_inner_size_in_formatter(
+    def test_outer_ticks_at_group_centres_on_primary_axis(
         self, data_abc, data_key
     ) -> None:
-        # keep_dim='b' → outer='a' (size 3), inner='c' (size 5) → inner_size=5
+        # outer='a' size 3, inner='c' size 5 → centres at i*5 + 2 = 2, 7, 12.
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
-        formatter = img.opts.get('plot').kwargs['yformatter']
-        assert formatter.args['inner_size'] == 5
-        assert len(formatter.args['outer_values']) == 3
-        assert len(formatter.args['inner_values']) == 5
+        ticks = _outer_ticks_opt(img, transpose=False)
+        assert [pos for pos, _ in ticks] == [2.0, 7.0, 12.0]
+        assert all(label.startswith('a=') for _, label in ticks)
+
+    def test_inner_axis_hook_installs_secondary_with_inner_formatter(
+        self, data_abc, data_key
+    ) -> None:
+        # keep_dim='b' → inner='c' size 5 → inner_size=5; secondary axis must
+        # carry the zoom-aware inner formatter for the y axis (side='left').
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        fig = _run_inner_axis_hook(img)
+        [(axis, side)] = fig.layouts
+        assert side == 'left'
+        assert isinstance(axis, LinearAxis)
+        assert isinstance(axis.formatter, CustomJSTickFormatter)
+        assert axis.formatter.args['inner_size'] == 5
+        assert len(axis.formatter.args['values']) == 5
+        # No axis_label on the secondary — it would float between the rows.
+        assert axis.axis_label == ''
+
+    def test_primary_axis_label_is_cleared(self, data_abc, data_key) -> None:
+        # The synthetic flat-dim name (e.g. "a·c") is suppressed since each
+        # tick row carries its own dim name.
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        assert img.opts.get('plot').kwargs['ylabel'] == ''
+
+    def test_inner_axis_hook_is_idempotent(self, data_abc, data_key) -> None:
+        # HoloViews may invoke hooks on every re-render; the secondary axis
+        # must not accumulate.
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        [hook] = img.opts.get('plot').kwargs['hooks']
+        plot = _FakePlot()
+        hook(plot, None)
+        hook(plot, None)
+        assert len(plot.handles['plot'].layouts) == 1
+
+    def test_transposed_uses_x_axis_and_below_side(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b', transpose=True)
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        # Outer ticks on the primary x axis.
+        assert _outer_ticks_opt(img, transpose=True)
+        assert img.opts.get('plot').kwargs['xlabel'] == ''
+        # Secondary axis attached to 'below'.
+        fig = _run_inner_axis_hook(img)
+        [(_axis, side)] = fig.layouts
+        assert side == 'below'
 
     def test_flatten_transposed_changes_inner_size(self, data_abc, data_key) -> None:
         # outer='c' (size 5), inner='a' (size 3) → inner_size=3
         params = _make_params(('a', 'b', 'c'), keep_dim='b', flatten_transposed=True)
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
-        formatter = img.opts.get('plot').kwargs['yformatter']
-        assert formatter.args['inner_size'] == 3
+        fig = _run_inner_axis_hook(img)
+        [(axis, _side)] = fig.layouts
+        assert axis.formatter.args['inner_size'] == 3
 
-    def test_missing_coord_falls_back_to_index_template(
+    def test_missing_inner_coord_falls_back_to_index_template(
         self, data_abc, data_key
     ) -> None:
-        # Drop coord on the inner dim ('c' under natural order with keep='b')
+        # Drop coord on the inner dim ('c' under natural order with keep='b').
         data = data_abc.copy(deep=False)
         del data.coords['c']
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
-        formatter = img.opts.get('plot').kwargs['yformatter']
-        # outer (a) has values, inner (c) falls back to "c[%d]"
-        assert formatter.args['outer_values'] != []
-        assert formatter.args['inner_values'] == []
-        assert '%d' in formatter.args['inner_template']
+        fig = _run_inner_axis_hook(img)
+        [(axis, _side)] = fig.layouts
+        # Inner formatter falls back to "c[%d]".
+        assert axis.formatter.args['values'] == []
+        assert '%d' in axis.formatter.args['template']
+        # Outer ('a') still has its real-coord labels on the primary axis.
+        ticks = _outer_ticks_opt(img, transpose=False)
+        assert all(label.startswith('a=') for _, label in ticks)
+
+    def test_missing_outer_coord_falls_back_to_index_label(
+        self, data_abc, data_key
+    ) -> None:
+        # Drop coord on the outer dim ('a' under natural order with keep='b').
+        data = data_abc.copy(deep=False)
+        del data.coords['a']
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data, data_key)
+        ticks = _outer_ticks_opt(img, transpose=False)
+        assert {label for _, label in ticks} == {f'a[{i}]' for i in range(3)}
 
     def test_bin_edge_coord_uses_midpoints(self, data_key) -> None:
         # 'a' (the outer under natural order with keep='b') has bin edges
-        # (size 4 for dim size 3) → midpoints = 3 values
+        # (size 4 for dim size 3) → 3 outer-axis ticks for the 3 midpoints.
         data = sc.DataArray(
             sc.arange('z', 0, 60, dtype='float64').fold(
                 dim='z', sizes={'a': 3, 'b': 4, 'c': 5}
@@ -204,8 +314,8 @@ class TestFlattenPlotterPlot:
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
-        formatter = img.opts.get('plot').kwargs['yformatter']
-        assert len(formatter.args['outer_values']) == 3  # midpoints of 4 edges
+        ticks = _outer_ticks_opt(img, transpose=False)
+        assert len(ticks) == 3
 
     def test_raises_for_non_3d_input(self, data_key) -> None:
         data = sc.DataArray(sc.zeros(dims=['x', 'y'], shape=[2, 2]))
@@ -214,32 +324,26 @@ class TestFlattenPlotterPlot:
         with pytest.raises(ValueError, match='3D input'):
             plotter.plot(data, data_key)
 
-    def test_falls_back_to_positional_when_data_renamed(
-        self, data_abc, data_key
-    ) -> None:
-        # Template dims (a, b, c) configured with keep_dim='b'; runtime data
-        # is renamed to (a, d, c). Order preserved → 'b' resolves to position
-        # 1 → 'd'. This is the common case when shared templates declare
-        # generic dim names that per-instrument transforms rename.
+    def test_runtime_dim_rename_is_transparent(self, data_abc, data_key) -> None:
+        # Template dims (a, b, c) configured with keep_dim='b' (position 1);
+        # runtime data is renamed to (a, d, c). Position 1 → 'd'. The
+        # plotter never references the dim name, so renames are transparent.
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
         data = data_abc.rename_dims({'b': 'd'})
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
-        assert img.kdims[0].name == 'd'  # x = kept, resolved positionally
+        assert img.kdims[0].name == 'd'  # x = kept (position 1)
         assert img.kdims[1].name == 'a·c'
 
-    def test_raises_when_neither_name_nor_position_resolves(
-        self, data_abc, data_key
-    ) -> None:
-        # Configured 'b' is not in data.dims and template_dims is unavailable
-        # → cannot resolve.
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+    def test_raises_for_keep_dim_out_of_range(self, data_abc, data_key) -> None:
+        # Out-of-range positions are caught at plot time. Pydantic prevents
+        # the narrowed model from constructing one, but the base model
+        # accepts any int — and that's the path saved configs go through on
+        # restore.
+        params = FlattenParams(flatten={'keep_dim': 5})
         plotter = FlattenPlotter.from_params(params)
-        # Manually disable the positional fallback to simulate "no template"
-        plotter._template_dims = None
-        data = data_abc.rename_dims({'b': 'd'})
-        with pytest.raises(ValueError, match='matches neither'):
-            plotter.plot(data, data_key)
+        with pytest.raises(ValueError, match='out of range'):
+            plotter.plot(data_abc, data_key)
 
 
 class TestFlattenPlotterCompute:

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -81,20 +81,42 @@ def data_abc() -> sc.DataArray:
     return da
 
 
+@pytest.fixture
+def data_abcd() -> sc.DataArray:
+    """4D data with dims (a, b, c, d) and 1-D coords on each."""
+    da = sc.DataArray(
+        sc.arange('z', 0, 120, dtype='float64').fold(
+            dim='z', sizes={'a': 2, 'b': 3, 'c': 4, 'd': 5}
+        ),
+        coords={
+            'a': sc.linspace('a', 0.0, 1.0, num=2, unit='m'),
+            'b': sc.linspace('b', 0.0, 1.0, num=3, unit='s'),
+            'c': sc.linspace('c', 0.0, 1.0, num=4, unit='K'),
+            'd': sc.linspace('d', 0.0, 1.0, num=5, unit='J'),
+        },
+    )
+    da.data.unit = 'counts'
+    return da
+
+
 def _make_params(
     dims: tuple[str, ...],
     *,
-    keep_dim: str | int,
-    flatten_transposed: bool = False,
+    axis_x: tuple[str | int, ...] | str | int,
+    transpose_x_flatten: bool = False,
+    transpose_y_flatten: bool = False,
     transpose: bool = False,
 ) -> FlattenParams:
-    """Build params, accepting ``keep_dim`` as a name (resolved to position) or int."""
+    """Build params, accepting ``axis_x`` as dim name(s) or position(s)."""
     Cls = make_flatten_params(dims)
-    keep_dim_index = dims.index(keep_dim) if isinstance(keep_dim, str) else keep_dim
+    if isinstance(axis_x, (str, int)):
+        axis_x = (axis_x,)
+    positions = {dims.index(d) if isinstance(d, str) else d for d in axis_x}
     p = Cls(
         flatten={
-            'keep_dim': keep_dim_index,
-            'flatten_transposed': flatten_transposed,
+            'axis_x_dims': positions,
+            'transpose_x_flatten': transpose_x_flatten,
+            'transpose_y_flatten': transpose_y_flatten,
             'transpose': transpose,
         }
     )
@@ -107,44 +129,59 @@ def _axis_cls(params_cls: type[FlattenParams]) -> type[FlattenAxisConfig]:
 
 
 class TestMakeFlattenParams:
-    def test_narrows_keep_dim_to_intenum_with_dim_names_as_members(self) -> None:
+    def test_narrows_axis_x_dims_to_set_of_intenum_with_dim_names(self) -> None:
         Cls = make_flatten_params(('a', 'b', 'c'))
-        annotation = _axis_cls(Cls).model_fields['keep_dim'].annotation
-        assert issubclass(annotation, IntEnum)
-        # Member names render as dropdown labels; values are positions.
-        assert {m.name: m.value for m in annotation} == {'a': 0, 'b': 1, 'c': 2}
+        annotation = _axis_cls(Cls).model_fields['axis_x_dims'].annotation
+        # set[Dim] — extract the inner Enum and verify member mapping.
+        from typing import get_args
 
-    def test_does_not_expose_outer_dim_choice(self) -> None:
-        # The flatten ordering is controlled by a single boolean checkbox so
-        # the user is exposed to (potentially placeholder) dim names only via
-        # the keep_dim dropdown.
+        (inner,) = get_args(annotation)
+        assert issubclass(inner, IntEnum)
+        assert {m.name: m.value for m in inner} == {'a': 0, 'b': 1, 'c': 2}
+
+    def test_axis_config_exposes_partition_and_per_axis_flags(self) -> None:
         Cls = make_flatten_params(('a', 'b', 'c'))
         fields = _axis_cls(Cls).model_fields
-        assert 'flatten_outer' not in fields
-        assert fields['flatten_transposed'].annotation is bool
+        assert 'axis_x_dims' in fields
+        assert fields['transpose_x_flatten'].annotation is bool
+        assert fields['transpose_y_flatten'].annotation is bool
+        assert fields['transpose'].annotation is bool
 
-    def test_rejects_keep_dim_out_of_range(self) -> None:
+    def test_rejects_empty_axis_x_dims(self) -> None:
         Cls = make_flatten_params(('a', 'b', 'c'))
         with pytest.raises(pydantic.ValidationError):
-            Cls(flatten={'keep_dim': 99})
+            Cls(flatten={'axis_x_dims': set()})
 
-    def test_saved_keep_dim_round_trips_as_integer(self) -> None:
-        # Integer storage is the whole point: the saved value is invariant
-        # under per-instrument dim renames, and validates against the base
-        # class on restore without needing template_dims.
+    def test_rejects_axis_x_dims_covering_all_dims(self) -> None:
         Cls = make_flatten_params(('a', 'b', 'c'))
-        narrowed = Cls(flatten={'keep_dim': 1})
-        dumped = narrowed.model_dump()
-        assert dumped['flatten']['keep_dim'] == 1
-        # Restore path: validate the dumped dict against the base class.
-        restored = FlattenParams(**dumped)
-        assert restored.flatten.keep_dim == 1
+        with pytest.raises(pydantic.ValidationError):
+            Cls(flatten={'axis_x_dims': {0, 1, 2}})
 
-    def test_non_3d_returns_base_class_unmodified(self) -> None:
-        # 2D / 4D etc. fall back to the unparameterized base; the plotter then
-        # rejects mismatches at plot-time rather than at config-time.
-        assert make_flatten_params(('x', 'y')) is FlattenParams
-        assert make_flatten_params(('a', 'b', 'c', 'd')) is FlattenParams
+    def test_rejects_axis_x_dims_with_unknown_position(self) -> None:
+        Cls = make_flatten_params(('a', 'b', 'c'))
+        with pytest.raises(pydantic.ValidationError):
+            Cls(flatten={'axis_x_dims': {99}})
+
+    def test_saved_axis_x_dims_round_trips_as_integers(self) -> None:
+        # Integer storage is the whole point: invariant under per-instrument
+        # dim renames, and validates against the base class on restore
+        # without needing template_dims.
+        Cls = make_flatten_params(('a', 'b', 'c'))
+        narrowed = Cls(flatten={'axis_x_dims': {1}})
+        dumped = narrowed.model_dump()
+        assert dumped['flatten']['axis_x_dims'] == {1}
+        restored = FlattenParams(**dumped)
+        assert restored.flatten.axis_x_dims == {1}
+
+    def test_returns_base_class_for_arity_below_two(self) -> None:
+        # 0D / 1D have no meaningful partition; fall back to the un-narrowed
+        # base. The plotter rejects mismatches at plot time.
+        assert make_flatten_params(()) is FlattenParams
+        assert make_flatten_params(('x',)) is FlattenParams
+
+    def test_narrows_for_arity_two_or_more(self) -> None:
+        for dims in [('x', 'y'), ('a', 'b', 'c'), ('a', 'b', 'c', 'd')]:
+            assert make_flatten_params(dims) is not FlattenParams
 
     def test_renders_in_model_widget(self) -> None:
         """Every top-level field must itself be a BaseModel (one tab each).
@@ -162,67 +199,117 @@ class TestMakeFlattenParams:
 
 
 class TestFlattenPlotterPlot:
-    # data_abc has dims ('a', 'b', 'c'); for keep_dim='b' the natural-order
-    # flatten pair is (outer='a', inner='c'). flatten_transposed swaps that.
+    # data_abc has dims ('a', 'b', 'c'); for axis_x='b' the natural-order
+    # complement on Y is (a, c). transpose_y_flatten swaps that.
 
     def test_returns_2d_image(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         assert isinstance(img, hv.Image)
 
-    def test_kept_dim_is_x_when_not_transposed(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+    def test_x_axis_holds_axis_x_dim_when_not_transposed(
+        self, data_abc, data_key
+    ) -> None:
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         # HoloViews Image: kdims[0] is x, kdims[1] is y
         assert img.kdims[0].name == 'b'
         assert img.kdims[1].name == 'a·c'
 
-    def test_kept_dim_is_y_when_transposed(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b', transpose=True)
+    def test_global_transpose_swaps_x_and_y(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), axis_x='b', transpose=True)
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         assert img.kdims[1].name == 'b'
         assert img.kdims[0].name == 'a·c'
 
-    def test_flatten_transposed_swaps_outer_and_inner(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b', flatten_transposed=True)
+    def test_transpose_y_flatten_reverses_y_flat_order(
+        self, data_abc, data_key
+    ) -> None:
+        params = _make_params(('a', 'b', 'c'), axis_x='b', transpose_y_flatten=True)
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         assert img.kdims[1].name == 'c·a'
 
-    def test_kept_dim_unit_is_preserved(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+    def test_transpose_x_flatten_reverses_x_flat_order(
+        self, data_abc, data_key
+    ) -> None:
+        # X holds (a, c); reversing → (c, a).
+        params = _make_params(
+            ('a', 'b', 'c'), axis_x=('a', 'c'), transpose_x_flatten=True
+        )
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        assert img.kdims[0].name == 'c·a'
+        assert img.kdims[1].name == 'b'
+
+    def test_axis_x_dim_unit_is_preserved(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         b_dim = next(d for d in img.kdims if d.name == 'b')
         assert b_dim.unit == 's'
 
-    def test_raises_for_non_3d_input(self, data_key) -> None:
-        data = sc.DataArray(sc.zeros(dims=['x', 'y'], shape=[2, 2]))
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
-        plotter = FlattenPlotter.from_params(params)
-        with pytest.raises(ValueError, match='3D input'):
-            plotter.plot(data, data_key)
-
     def test_runtime_dim_rename_is_transparent(self, data_abc, data_key) -> None:
-        # Template dims (a, b, c) configured with keep_dim='b' (position 1);
-        # runtime data is renamed to (a, d, c). Position 1 → 'd'. The
-        # plotter never references the dim name, so renames are transparent.
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        # Template dims (a, b, c) configured with axis_x='b' (position 1);
+        # runtime data renamed to (a, d, c). Position 1 → 'd'. The plotter
+        # never references the dim name, so renames are transparent.
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         data = data_abc.rename_dims({'b': 'd'})
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
-        assert img.kdims[0].name == 'd'  # x = kept (position 1)
+        assert img.kdims[0].name == 'd'
         assert img.kdims[1].name == 'a·c'
 
-    def test_raises_for_keep_dim_out_of_range(self) -> None:
-        # Saved configs go through the un-narrowed FlattenParams which accepts
-        # any int. The plotter rejects out-of-range positions at construction.
-        params = FlattenParams(flatten={'keep_dim': 5})
+    def test_raises_when_axis_x_position_out_of_range_for_data(self, data_key) -> None:
+        # Configured for 3D (axis_x position 2), data is 2D → position 2
+        # is out of range. Out-of-range positions are caught at plot time;
+        # the un-narrowed base FlattenParams accepts any int set, which is
+        # the path saved configs go through on restore.
+        data_2d = sc.DataArray(sc.zeros(dims=['x', 'y'], shape=[2, 2]))
+        params = FlattenParams(flatten={'axis_x_dims': {2}})
+        plotter = FlattenPlotter.from_params(params)
         with pytest.raises(ValueError, match='out of range'):
-            FlattenPlotter.from_params(params)
+            plotter.plot(data_2d, data_key)
+
+    def test_raises_when_axis_x_covers_all_dims_at_plot_time(
+        self, data_abc, data_key
+    ) -> None:
+        # The narrowed model rejects this at config time; the base model
+        # doesn't, so restore-then-plot must catch it.
+        params = FlattenParams(flatten={'axis_x_dims': {0, 1, 2}})
+        plotter = FlattenPlotter.from_params(params)
+        with pytest.raises(ValueError, match='Y axis would be empty'):
+            plotter.plot(data_abc, data_key)
+
+
+class TestFlattenPlotterDirectConstruction:
+    """`__init__`-level validation independent of params."""
+
+    def _kwargs(self, **flatten_kwargs):
+        # ImagePlotter requires several styling kwargs; lift them off a
+        # default FlattenParams so each test only states the flatten kwargs
+        # that matter to it.
+        base = FlattenParams()
+        return dict(
+            grow_threshold=0.1,
+            layout_params=base.layout,
+            aspect_params=base.plot_aspect,
+            scale_opts=base.plot_scale,
+            tick_params=base.ticks,
+            normalize_to_rate=False,
+            **flatten_kwargs,
+        )
+
+    def test_rejects_empty_axis_x_dims(self) -> None:
+        with pytest.raises(ValueError, match='at least one'):
+            FlattenPlotter(**self._kwargs(axis_x_dims=frozenset()))
+
+    def test_rejects_negative_position(self) -> None:
+        with pytest.raises(ValueError, match='Negative position'):
+            FlattenPlotter(**self._kwargs(axis_x_dims={-1}))
 
 
 class TestFlattenPlotterHover:
@@ -231,7 +318,7 @@ class TestFlattenPlotterHover:
     def test_hook_replaces_default_hover_with_custom_one(
         self, data_abc, data_key
     ) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
@@ -243,7 +330,7 @@ class TestFlattenPlotterHover:
     def test_hover_tooltips_one_row_per_dim_then_value(
         self, data_abc, data_key
     ) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
@@ -261,12 +348,12 @@ class TestFlattenPlotterHover:
         assert '$x' in hover.formatters
         assert '$y' in hover.formatters
 
-    def test_hover_kept_dim_label_omits_unit_when_coord_missing(
+    def test_hover_dim_label_omits_unit_when_coord_missing(
         self, data_abc, data_key
     ) -> None:
         data = data_abc.copy(deep=False)
         del data.coords['b']
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
         fig = _run_hook(img)
@@ -275,12 +362,11 @@ class TestFlattenPlotterHover:
         assert labels[0] == 'b'
 
     def test_hover_swaps_axes_when_transposed(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b', transpose=True)
+        params = _make_params(('a', 'b', 'c'), axis_x='b', transpose=True)
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
-        # Transposed: flat (a, c) on x, kept (b) on y.
         labels = [name for name, _ in hover.tooltips]
         assert labels == ['a [m]', 'c [K]', 'b [s]', 'value']
         templates = dict(hover.tooltips)
@@ -291,7 +377,7 @@ class TestFlattenPlotterHover:
     def test_hover_formatter_args_describe_axis_levels(
         self, data_abc, data_key
     ) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
@@ -340,7 +426,7 @@ class TestFlattenPlotterHover:
             },
         )
         da.data.unit = 'counts'
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(da, data_key)
         fig = _run_hook(img)
@@ -354,7 +440,7 @@ class TestFlattenPlotterHover:
     ) -> None:
         data = data_abc.copy(deep=False)
         del data.coords['c']
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
         fig = _run_hook(img)
@@ -373,7 +459,7 @@ class TestFlattenPlotterHover:
         # integer indices.
         data = data_abc.copy(deep=False)
         del data.coords['b']
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
         fig = _run_hook(img)
@@ -384,7 +470,7 @@ class TestFlattenPlotterHover:
     def test_hover_single_dim_axis_with_coord_uses_values_lookup(
         self, data_abc, data_key
     ) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
@@ -396,7 +482,7 @@ class TestFlattenPlotterHover:
     def test_hook_is_idempotent(self, data_abc, data_key) -> None:
         # HoloViews may invoke hooks on every re-render; the hover must not
         # be installed multiple times.
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         [hook] = img.opts.get('plot').kwargs['hooks']
@@ -409,7 +495,7 @@ class TestFlattenPlotterHover:
     def test_flat_axis_label_is_not_suppressed(self, data_abc, data_key) -> None:
         # The synthetic flat-dim name (e.g. "a·c") flows through as the default
         # HoloViews axis label — no xlabel/ylabel opt overriding it.
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
         plot_kwargs = img.opts.get('plot').kwargs
@@ -418,44 +504,20 @@ class TestFlattenPlotterHover:
 
 
 class TestFlattenPlotterNDimGeneralization:
-    """Direct-construction tests demonstrating the internals are not 3D-bound.
-
-    Input params (FlattenAxisConfig) only express the 3D case today;
-    ``from_axes`` exposes the underlying ``(x_dims, y_dims)`` partition for
-    arbitrary arity.
-    """
-
-    @pytest.fixture
-    def data_abcd(self) -> sc.DataArray:
-        da = sc.DataArray(
-            sc.arange('z', 0, 120, dtype='float64').fold(
-                dim='z', sizes={'a': 2, 'b': 3, 'c': 4, 'd': 5}
-            ),
-            coords={
-                'a': sc.linspace('a', 0.0, 1.0, num=2, unit='m'),
-                'b': sc.linspace('b', 0.0, 1.0, num=3, unit='s'),
-                'c': sc.linspace('c', 0.0, 1.0, num=4, unit='K'),
-                'd': sc.linspace('d', 0.0, 1.0, num=5, unit='J'),
-            },
-        )
-        da.data.unit = 'counts'
-        return da
+    """Param model and plotter handle 4D+ inputs uniformly."""
 
     def test_4d_input_with_two_dims_per_axis(self, data_abcd, data_key) -> None:
-        plotter = FlattenPlotter.from_axes(
-            FlattenParams(),
-            x_dims=(0, 1),  # (a, b) → 'a·b' size 6
-            y_dims=(2, 3),  # (c, d) → 'c·d' size 20
-        )
+        # X = (a, b), Y = (c, d). Flat axes: 'a·b' size 6 and 'c·d' size 20.
+        params = _make_params(('a', 'b', 'c', 'd'), axis_x=('a', 'b'))
+        plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abcd, data_key)
         # HoloViews kdims: x = innermost scipp dim, y = outermost.
         assert img.kdims[0].name == 'a·b'
         assert img.kdims[1].name == 'c·d'
 
     def test_4d_hover_has_one_row_per_input_dim(self, data_abcd, data_key) -> None:
-        plotter = FlattenPlotter.from_axes(
-            FlattenParams(), x_dims=(0, 1), y_dims=(2, 3)
-        )
+        params = _make_params(('a', 'b', 'c', 'd'), axis_x=('a', 'b'))
+        plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abcd, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
@@ -473,10 +535,9 @@ class TestFlattenPlotterNDimGeneralization:
     def test_3_to_1_partition_keeps_one_dim_unflattened(
         self, data_abcd, data_key
     ) -> None:
-        # x = (a, b, c) flattened, y = (d) single-dim.
-        plotter = FlattenPlotter.from_axes(
-            FlattenParams(), x_dims=(0, 1, 2), y_dims=(3,)
-        )
+        # X = (a, b, c) flattened, Y = (d) single-dim.
+        params = _make_params(('a', 'b', 'c', 'd'), axis_x=('a', 'b', 'c'))
+        plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abcd, data_key)
         assert img.kdims[0].name == 'a·b·c'
         assert img.kdims[1].name == 'd'
@@ -486,30 +547,21 @@ class TestFlattenPlotterNDimGeneralization:
         assert x_fmt.args['names'] == ['a', 'b', 'c']
         assert x_fmt.args['strides'] == [12, 4, 1]
 
-    def test_init_rejects_position_out_of_range(self) -> None:
-        with pytest.raises(ValueError, match='out of range'):
-            FlattenPlotter.from_axes(FlattenParams(), x_dims=(0,), y_dims=(5,))
-
-    def test_init_rejects_duplicate_position(self) -> None:
-        with pytest.raises(ValueError, match='duplicated'):
-            FlattenPlotter.from_axes(FlattenParams(), x_dims=(0, 1), y_dims=(1, 2))
-
-    def test_init_rejects_empty_axis(self) -> None:
-        with pytest.raises(ValueError, match='at least one'):
-            FlattenPlotter.from_axes(FlattenParams(), x_dims=(), y_dims=(0,))
-
 
 class TestFlattenPlotterCompute:
     def test_compute_caches_state(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)
         plotter.compute({'primary': {data_key: data_abc}})
         assert plotter.has_cached_state()
 
-    def test_compute_renders_error_text_on_ndim_mismatch(self, data_key) -> None:
-        # 2D data → ndim mismatch → base Plotter.compute() wraps the
-        # ValueError in a Text element rather than crashing.
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+    def test_compute_renders_error_text_on_position_out_of_range(
+        self, data_key
+    ) -> None:
+        # 2D data with axis_x position 2 → out-of-range error → base
+        # Plotter.compute() wraps the ValueError in a Text element rather
+        # than crashing.
+        params = FlattenParams(flatten={'axis_x_dims': {2}})
         plotter = FlattenPlotter.from_params(params)
         data_2d = sc.DataArray(sc.zeros(dims=['x', 'y'], shape=[2, 2]))
         plotter.compute({'primary': {data_key: data_2d}})

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -501,9 +501,8 @@ class TestFlattenPlotterHover:
     def test_hover_single_dim_axis_without_coord_emits_index(
         self, data_abc, data_key
     ) -> None:
-        # The single-dim axis goes through the same formatter; with no coord,
-        # the JS emits ``Math.round(value)`` so cursor floats display as clean
-        # integer indices.
+        # With no coord, the JS returns String(Math.round(value)) — the image
+        # axis uses integer indices so the cursor is already in index space.
         data = data_abc.copy(deep=False)
         del data.coords['b']
         params = _make_params(('a', 'b', 'c'), axis_x='b')

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -64,39 +64,46 @@ def data_key() -> ResultKey:
     )
 
 
-@pytest.fixture
-def data_abc() -> sc.DataArray:
-    """3D data with dims (a, b, c) and 1-D coords on each."""
+def _make_data(sizes: dict[str, int], units: dict[str, str]) -> sc.DataArray:
+    """Build a DataArray with C-order range data and 1-D coords on each dim."""
+    n = 1
+    for s in sizes.values():
+        n *= s
     da = sc.DataArray(
-        sc.arange('z', 0, 60, dtype='float64').fold(
-            dim='z', sizes={'a': 3, 'b': 4, 'c': 5}
-        ),
+        sc.arange('z', 0, n, dtype='float64').fold(dim='z', sizes=sizes),
         coords={
-            'a': sc.linspace('a', 0.0, 1.0, num=3, unit='m'),
-            'b': sc.linspace('b', 0.0, 1.0, num=4, unit='s'),
-            'c': sc.linspace('c', 0.0, 1.0, num=5, unit='K'),
+            d: sc.linspace(d, 0.0, 1.0, num=size, unit=units[d])
+            for d, size in sizes.items()
         },
     )
     da.data.unit = 'counts'
     return da
+
+
+@pytest.fixture
+def data_ab() -> sc.DataArray:
+    return _make_data({'a': 3, 'b': 4}, {'a': 'm', 'b': 's'})
+
+
+@pytest.fixture
+def data_abc() -> sc.DataArray:
+    return _make_data({'a': 3, 'b': 4, 'c': 5}, {'a': 'm', 'b': 's', 'c': 'K'})
 
 
 @pytest.fixture
 def data_abcd() -> sc.DataArray:
-    """4D data with dims (a, b, c, d) and 1-D coords on each."""
-    da = sc.DataArray(
-        sc.arange('z', 0, 120, dtype='float64').fold(
-            dim='z', sizes={'a': 2, 'b': 3, 'c': 4, 'd': 5}
-        ),
-        coords={
-            'a': sc.linspace('a', 0.0, 1.0, num=2, unit='m'),
-            'b': sc.linspace('b', 0.0, 1.0, num=3, unit='s'),
-            'c': sc.linspace('c', 0.0, 1.0, num=4, unit='K'),
-            'd': sc.linspace('d', 0.0, 1.0, num=5, unit='J'),
-        },
+    return _make_data(
+        {'a': 2, 'b': 3, 'c': 4, 'd': 5},
+        {'a': 'm', 'b': 's', 'c': 'K', 'd': 'J'},
     )
-    da.data.unit = 'counts'
-    return da
+
+
+@pytest.fixture
+def data_abcde() -> sc.DataArray:
+    return _make_data(
+        {'a': 2, 'b': 3, 'c': 4, 'd': 5, 'e': 6},
+        {'a': 'm', 'b': 's', 'c': 'K', 'd': 'J', 'e': 'A'},
+    )
 
 
 def _make_params(
@@ -128,6 +135,18 @@ def _axis_cls(params_cls: type[FlattenParams]) -> type[FlattenAxisConfig]:
     return params_cls.model_fields['flatten'].annotation
 
 
+_ARITY_PARAMS = pytest.mark.parametrize(
+    'dims',
+    [
+        ('a', 'b'),
+        ('a', 'b', 'c'),
+        ('a', 'b', 'c', 'd'),
+        ('a', 'b', 'c', 'd', 'e'),
+    ],
+    ids=['2d', '3d', '4d', '5d'],
+)
+
+
 class TestMakeFlattenParams:
     def test_narrows_axis_x_dims_to_set_of_intenum_with_dim_names(self) -> None:
         Cls = make_flatten_params(('a', 'b', 'c'))
@@ -147,18 +166,21 @@ class TestMakeFlattenParams:
         assert fields['transpose_y_flatten'].annotation is bool
         assert fields['transpose'].annotation is bool
 
-    def test_rejects_empty_axis_x_dims(self) -> None:
-        Cls = make_flatten_params(('a', 'b', 'c'))
+    @_ARITY_PARAMS
+    def test_rejects_empty_axis_x_dims(self, dims) -> None:
+        Cls = make_flatten_params(dims)
         with pytest.raises(pydantic.ValidationError):
             Cls(flatten={'axis_x_dims': set()})
 
-    def test_rejects_axis_x_dims_covering_all_dims(self) -> None:
-        Cls = make_flatten_params(('a', 'b', 'c'))
+    @_ARITY_PARAMS
+    def test_rejects_axis_x_dims_covering_all_dims(self, dims) -> None:
+        Cls = make_flatten_params(dims)
         with pytest.raises(pydantic.ValidationError):
-            Cls(flatten={'axis_x_dims': {0, 1, 2}})
+            Cls(flatten={'axis_x_dims': set(range(len(dims)))})
 
-    def test_rejects_axis_x_dims_with_unknown_position(self) -> None:
-        Cls = make_flatten_params(('a', 'b', 'c'))
+    @_ARITY_PARAMS
+    def test_rejects_axis_x_dims_with_unknown_position(self, dims) -> None:
+        Cls = make_flatten_params(dims)
         with pytest.raises(pydantic.ValidationError):
             Cls(flatten={'axis_x_dims': {99}})
 
@@ -183,7 +205,8 @@ class TestMakeFlattenParams:
         for dims in [('x', 'y'), ('a', 'b', 'c'), ('a', 'b', 'c', 'd')]:
             assert make_flatten_params(dims) is not FlattenParams
 
-    def test_renders_in_model_widget(self) -> None:
+    @_ARITY_PARAMS
+    def test_renders_in_model_widget(self, dims) -> None:
         """Every top-level field must itself be a BaseModel (one tab each).
 
         Regression test: the dashboard's ModelWidget builds tabs by calling
@@ -192,7 +215,7 @@ class TestMakeFlattenParams:
         """
         from ess.livedata.dashboard.widgets.model_widget import ModelWidget
 
-        Cls = make_flatten_params(('a', 'b', 'c'))
+        Cls = make_flatten_params(dims)
         widget = ModelWidget(Cls)
         tab_names = {entry[0] for entry in widget.param_group_tabs}
         assert 'flatten' in tab_names
@@ -208,42 +231,66 @@ class TestFlattenPlotterPlot:
         img = plotter.plot(data_abc, data_key)
         assert isinstance(img, hv.Image)
 
-    def test_x_axis_holds_axis_x_dim_when_not_transposed(
-        self, data_abc, data_key
+    # HoloViews Image: kdims[0] is x, kdims[1] is y. The flat axis name is the
+    # input dim names joined with '·' in the order the dims feed the flatten;
+    # the global ``transpose`` swaps the resulting X and Y wholesale.
+    @pytest.mark.parametrize(
+        ('data_fixture', 'axis_x', 'flags', 'expected_x', 'expected_y'),
+        [
+            # 2D: degenerate, no flatten on either side.
+            ('data_ab', 'b', {}, 'b', 'a'),
+            # 3D: basic, transpose, per-axis flatten reversal.
+            ('data_abc', 'b', {}, 'b', 'a·c'),
+            ('data_abc', 'b', {'transpose': True}, 'a·c', 'b'),
+            ('data_abc', 'b', {'transpose_y_flatten': True}, 'b', 'c·a'),
+            ('data_abc', ('a', 'c'), {'transpose_x_flatten': True}, 'c·a', 'b'),
+            # 4D: 2-2, 3-1, 1-3 partitions; K=3 reversal on each side; transpose.
+            ('data_abcd', ('a', 'b'), {}, 'a·b', 'c·d'),
+            ('data_abcd', ('a', 'b', 'c'), {}, 'a·b·c', 'd'),
+            ('data_abcd', 'a', {}, 'a', 'b·c·d'),
+            (
+                'data_abcd',
+                ('a', 'b', 'c'),
+                {'transpose_x_flatten': True},
+                'c·b·a',
+                'd',
+            ),
+            ('data_abcd', 'a', {'transpose_y_flatten': True}, 'a', 'd·c·b'),
+            ('data_abcd', ('a', 'b'), {'transpose': True}, 'c·d', 'a·b'),
+            # 5D: smoke for scaling beyond 4D.
+            ('data_abcde', ('a', 'b'), {}, 'a·b', 'c·d·e'),
+        ],
+        ids=[
+            '2d',
+            '3d_basic',
+            '3d_transpose',
+            '3d_y_reversed',
+            '3d_x_reversed',
+            '4d_2_2',
+            '4d_3_1',
+            '4d_1_3',
+            '4d_x_k3_reversed',
+            '4d_y_k3_reversed',
+            '4d_transpose',
+            '5d_2_3',
+        ],
+    )
+    def test_kdims_match_partition_and_flags(
+        self,
+        request,
+        data_key,
+        data_fixture,
+        axis_x,
+        flags,
+        expected_x,
+        expected_y,
     ) -> None:
-        params = _make_params(('a', 'b', 'c'), axis_x='b')
+        data = request.getfixturevalue(data_fixture)
+        params = _make_params(data.dims, axis_x=axis_x, **flags)
         plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        # HoloViews Image: kdims[0] is x, kdims[1] is y
-        assert img.kdims[0].name == 'b'
-        assert img.kdims[1].name == 'a·c'
-
-    def test_global_transpose_swaps_x_and_y(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), axis_x='b', transpose=True)
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        assert img.kdims[1].name == 'b'
-        assert img.kdims[0].name == 'a·c'
-
-    def test_transpose_y_flatten_reverses_y_flat_order(
-        self, data_abc, data_key
-    ) -> None:
-        params = _make_params(('a', 'b', 'c'), axis_x='b', transpose_y_flatten=True)
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        assert img.kdims[1].name == 'c·a'
-
-    def test_transpose_x_flatten_reverses_x_flat_order(
-        self, data_abc, data_key
-    ) -> None:
-        # X holds (a, c); reversing → (c, a).
-        params = _make_params(
-            ('a', 'b', 'c'), axis_x=('a', 'c'), transpose_x_flatten=True
-        )
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        assert img.kdims[0].name == 'c·a'
-        assert img.kdims[1].name == 'b'
+        img = plotter.plot(data, data_key)
+        assert img.kdims[0].name == expected_x
+        assert img.kdims[1].name == expected_y
 
     def test_axis_x_dim_unit_is_preserved(self, data_abc, data_key) -> None:
         params = _make_params(('a', 'b', 'c'), axis_x='b')
@@ -504,18 +551,12 @@ class TestFlattenPlotterHover:
 
 
 class TestFlattenPlotterNDimGeneralization:
-    """Param model and plotter handle 4D+ inputs uniformly."""
-
-    def test_4d_input_with_two_dims_per_axis(self, data_abcd, data_key) -> None:
-        # X = (a, b), Y = (c, d). Flat axes: 'a·b' size 6 and 'c·d' size 20.
-        params = _make_params(('a', 'b', 'c', 'd'), axis_x=('a', 'b'))
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abcd, data_key)
-        # HoloViews kdims: x = innermost scipp dim, y = outermost.
-        assert img.kdims[0].name == 'a·b'
-        assert img.kdims[1].name == 'c·d'
+    """Hover formatter args at higher arities (kdim names live in the
+    parametrized ``test_kdims_match_partition_and_flags``)."""
 
     def test_4d_hover_has_one_row_per_input_dim(self, data_abcd, data_key) -> None:
+        # 2-2 partition: tooltip rows span all four input dims and each axis
+        # carries a per-dim formatter.
         params = _make_params(('a', 'b', 'c', 'd'), axis_x=('a', 'b'))
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abcd, data_key)
@@ -532,20 +573,45 @@ class TestFlattenPlotterNDimGeneralization:
         assert y_fmt.args['sizes'] == [4, 5]
         assert y_fmt.args['strides'] == [5, 1]
 
-    def test_3_to_1_partition_keeps_one_dim_unflattened(
-        self, data_abcd, data_key
+    @pytest.mark.parametrize(
+        ('axis_x', 'flags', 'fmt_key', 'names', 'sizes', 'strides'),
+        [
+            # K=3 flatten on X (3-1 partition).
+            (('a', 'b', 'c'), {}, '$x', ['a', 'b', 'c'], [2, 3, 4], [12, 4, 1]),
+            # K=3 flatten on Y (1-3 partition) — Y-side stride math.
+            ('a', {}, '$y', ['b', 'c', 'd'], [3, 4, 5], [20, 5, 1]),
+            # K=3 reversal: (a, b, c) → (c, b, a); strides reflect new order.
+            (
+                ('a', 'b', 'c'),
+                {'transpose_x_flatten': True},
+                '$x',
+                ['c', 'b', 'a'],
+                [4, 3, 2],
+                [6, 2, 1],
+            ),
+        ],
+        ids=['k3_x', 'k3_y', 'k3_x_reversed'],
+    )
+    def test_4d_k3_flatten_strides(
+        self,
+        data_abcd,
+        data_key,
+        axis_x,
+        flags,
+        fmt_key,
+        names,
+        sizes,
+        strides,
     ) -> None:
-        # X = (a, b, c) flattened, Y = (d) single-dim.
-        params = _make_params(('a', 'b', 'c', 'd'), axis_x=('a', 'b', 'c'))
+        params = _make_params(('a', 'b', 'c', 'd'), axis_x=axis_x, **flags)
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abcd, data_key)
-        assert img.kdims[0].name == 'a·b·c'
-        assert img.kdims[1].name == 'd'
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
-        x_fmt = hover.formatters['$x']
-        assert x_fmt.args['names'] == ['a', 'b', 'c']
-        assert x_fmt.args['strides'] == [12, 4, 1]
+        fmt = hover.formatters[fmt_key]
+        assert fmt.args['names'] == names
+        assert fmt.args['sizes'] == sizes
+        assert fmt.args['strides'] == strides
 
 
 class TestFlattenPlotterCompute:

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -231,8 +231,8 @@ class TestFlattenPlotterPlot:
         img = plotter.plot(data_abc, data_key)
         assert isinstance(img, hv.Image)
 
-    # HoloViews Image: kdims[0] is x, kdims[1] is y. The flat axis name is the
-    # input dim names joined with '·' in the order the dims feed the flatten;
+    # HoloViews Image: kdims[0] is x, kdims[1] is y. The flat axis name uses
+    # tuple notation for the dims that feed the flatten;
     # the global ``transpose`` swaps the resulting X and Y wholesale.
     @pytest.mark.parametrize(
         ('data_fixture', 'axis_x', 'flags', 'expected_x', 'expected_y'),
@@ -240,25 +240,25 @@ class TestFlattenPlotterPlot:
             # 2D: degenerate, no flatten on either side.
             ('data_ab', 'b', {}, 'b', 'a'),
             # 3D: basic, transpose, per-axis flatten reversal.
-            ('data_abc', 'b', {}, 'b', 'a·c'),
-            ('data_abc', 'b', {'transpose': True}, 'a·c', 'b'),
-            ('data_abc', 'b', {'transpose_y_flatten': True}, 'b', 'c·a'),
-            ('data_abc', ('a', 'c'), {'transpose_x_flatten': True}, 'c·a', 'b'),
+            ('data_abc', 'b', {}, 'b', '(a,c)'),
+            ('data_abc', 'b', {'transpose': True}, '(a,c)', 'b'),
+            ('data_abc', 'b', {'transpose_y_flatten': True}, 'b', '(c,a)'),
+            ('data_abc', ('a', 'c'), {'transpose_x_flatten': True}, '(c,a)', 'b'),
             # 4D: 2-2, 3-1, 1-3 partitions; K=3 reversal on each side; transpose.
-            ('data_abcd', ('a', 'b'), {}, 'a·b', 'c·d'),
-            ('data_abcd', ('a', 'b', 'c'), {}, 'a·b·c', 'd'),
-            ('data_abcd', 'a', {}, 'a', 'b·c·d'),
+            ('data_abcd', ('a', 'b'), {}, '(a,b)', '(c,d)'),
+            ('data_abcd', ('a', 'b', 'c'), {}, '(a,b,c)', 'd'),
+            ('data_abcd', 'a', {}, 'a', '(b,c,d)'),
             (
                 'data_abcd',
                 ('a', 'b', 'c'),
                 {'transpose_x_flatten': True},
-                'c·b·a',
+                '(c,b,a)',
                 'd',
             ),
-            ('data_abcd', 'a', {'transpose_y_flatten': True}, 'a', 'd·c·b'),
-            ('data_abcd', ('a', 'b'), {'transpose': True}, 'c·d', 'a·b'),
+            ('data_abcd', 'a', {'transpose_y_flatten': True}, 'a', '(d,c,b)'),
+            ('data_abcd', ('a', 'b'), {'transpose': True}, '(c,d)', '(a,b)'),
             # 5D: smoke for scaling beyond 4D.
-            ('data_abcde', ('a', 'b'), {}, 'a·b', 'c·d·e'),
+            ('data_abcde', ('a', 'b'), {}, '(a,b)', '(c,d,e)'),
         ],
         ids=[
             '2d',
@@ -308,7 +308,7 @@ class TestFlattenPlotterPlot:
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
         assert img.kdims[0].name == 'd'
-        assert img.kdims[1].name == 'a·c'
+        assert img.kdims[1].name == '(a,c)'
 
     def test_raises_when_axis_x_position_out_of_range_for_data(self, data_key) -> None:
         # Configured for 3D (axis_x position 2), data is 2D → position 2
@@ -539,7 +539,7 @@ class TestFlattenPlotterHover:
         assert len(fig.added_tools) == 1
 
     def test_flat_axis_label_is_not_suppressed(self, data_abc, data_key) -> None:
-        # The synthetic flat-dim name (e.g. "a·c") flows through as the default
+        # The synthetic flat-dim name (e.g. "(a,c)") flows through as the default
         # HoloViews axis label — no xlabel/ylabel opt overriding it.
         params = _make_params(('a', 'b', 'c'), axis_x='b')
         plotter = FlattenPlotter.from_params(params)

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -358,6 +358,33 @@ class TestFlattenPlotterHover:
         # Outer ('a') still carries real coord values.
         assert len(fmt.args['outer_values']) == 3
 
+    def test_hover_kept_dim_rounds_to_index_when_no_coord(
+        self, data_abc, data_key
+    ) -> None:
+        data = data_abc.copy(deep=False)
+        del data.coords['b']
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data, data_key)
+        fig = _run_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        # No coord on kept dim → rounding formatter on $x so cursor floats
+        # display as clean integer indices.
+        assert '$x' in hover.formatters
+        assert '$y' in hover.formatters  # flat-axis formatter still present
+
+    def test_hover_kept_dim_has_no_rounding_formatter_when_coord_present(
+        self, data_abc, data_key
+    ) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        fig = _run_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        # Coord present → raw $x float (physical value); no extra formatter.
+        assert '$x' not in hover.formatters
+        assert '$y' in hover.formatters
+
     def test_hook_is_idempotent(self, data_abc, data_key) -> None:
         # HoloViews may invoke hooks on every re-render; the hover must not
         # be installed multiple times.

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -11,7 +11,7 @@ import holoviews as hv
 import pydantic
 import pytest
 import scipp as sc
-from bokeh.models import CustomJSTickFormatter, LinearAxis
+from bokeh.models import CustomJSTickFormatter, HoverTool, LinearAxis
 
 from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
 from ess.livedata.dashboard.flatten_plotter import (
@@ -23,12 +23,24 @@ from ess.livedata.dashboard.flatten_plotter import (
 from ess.livedata.dashboard.plot_params import PlotScale
 
 
+class _FakeToolbar:
+    def __init__(self) -> None:
+        # Mimic the default HoloViews-added HoverTool that the hook should drop.
+        self.tools: list = [HoverTool()]
+
+
 class _FakeFigure:
     def __init__(self) -> None:
         self.layouts: list[tuple[LinearAxis, str]] = []
+        self.toolbar = _FakeToolbar()
+        self.added_tools: list = []
 
     def add_layout(self, axis: LinearAxis, side: str) -> None:
         self.layouts.append((axis, side))
+
+    def add_tools(self, tool) -> None:
+        self.added_tools.append(tool)
+        self.toolbar.tools.append(tool)
 
 
 class _FakePlot:
@@ -344,6 +356,87 @@ class TestFlattenPlotterPlot:
         plotter = FlattenPlotter.from_params(params)
         with pytest.raises(ValueError, match='out of range'):
             plotter.plot(data_abc, data_key)
+
+
+class TestFlattenPlotterHover:
+    """Hover decomposes the flat axis into outer/inner labels."""
+
+    def test_hook_replaces_default_hover_with_custom_one(
+        self, data_abc, data_key
+    ) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        fig = _run_inner_axis_hook(img)
+        hovers = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        # Exactly one hover survives — the custom flatten one.
+        assert len(hovers) == 1
+        assert hovers[0] in fig.added_tools
+
+    def test_hover_tooltips_label_keep_outer_inner_and_value(
+        self, data_abc, data_key
+    ) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        fig = _run_inner_axis_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        labels = [name for name, _ in hover.tooltips]
+        # Keep dim is 'b'; natural-order outer='a', inner='c'.
+        assert labels == ['b', 'a', 'c', 'value']
+        # Flat axis is y when not transposed; outer/inner both reference it.
+        templates = dict(hover.tooltips)
+        assert templates['b'] == '$x'
+        assert templates['a'] == '$y{outer}'
+        assert templates['c'] == '$y{inner}'
+        assert templates['value'] == '@image'
+        assert '$y' in hover.formatters
+
+    def test_hover_swaps_axes_when_transposed(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b', transpose=True)
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        fig = _run_inner_axis_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        templates = dict(hover.tooltips)
+        # Transposed: kept on y, flat on x.
+        assert templates['b'] == '$y'
+        assert templates['a'] == '$x{outer}'
+        assert templates['c'] == '$x{inner}'
+        assert '$x' in hover.formatters
+
+    def test_hover_formatter_carries_outer_and_inner_coord_values(
+        self, data_abc, data_key
+    ) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        fig = _run_inner_axis_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        fmt = hover.formatters['$y']
+        assert fmt.args['inner_size'] == 5
+        assert len(fmt.args['outer_values']) == 3  # a
+        assert len(fmt.args['inner_values']) == 5  # c
+        # No dim-name prefix in templates: tooltip row already shows the name.
+        assert fmt.args['outer_template'] == '%s m'
+        assert fmt.args['inner_template'] == '%s K'
+
+    def test_hover_falls_back_to_index_when_coord_missing(
+        self, data_abc, data_key
+    ) -> None:
+        data = data_abc.copy(deep=False)
+        del data.coords['c']
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data, data_key)
+        fig = _run_inner_axis_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        fmt = hover.formatters['$y']
+        # Inner ('c') has no coord → empty values, bare-index template.
+        assert fmt.args['inner_values'] == []
+        assert fmt.args['inner_template'] == '%d'
+        # Outer ('a') still carries real coord values.
+        assert len(fmt.args['outer_values']) == 3
 
 
 class TestFlattenPlotterCompute:

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -252,15 +252,28 @@ class TestFlattenPlotterHover:
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
         labels = [name for name, _ in hover.tooltips]
-        # Keep dim is 'b'; natural-order outer='a', inner='c'.
-        assert labels == ['b', 'a', 'c', 'value']
+        # Keep dim is 'b' (unit 's'); natural-order outer='a', inner='c'.
+        assert labels == ['b [s]', 'a', 'c', 'value']
         # Flat axis is y when not transposed; outer/inner both reference it.
         templates = dict(hover.tooltips)
-        assert templates['b'] == '$x'
+        assert templates['b [s]'] == '$x'
         assert templates['a'] == '$y{outer}'
         assert templates['c'] == '$y{inner}'
         assert templates['value'] == '@image'
         assert '$y' in hover.formatters
+
+    def test_hover_kept_dim_label_omits_unit_when_coord_missing(
+        self, data_abc, data_key
+    ) -> None:
+        data = data_abc.copy(deep=False)
+        del data.coords['b']
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data, data_key)
+        fig = _run_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        labels = [name for name, _ in hover.tooltips]
+        assert labels[0] == 'b'
 
     def test_hover_swaps_axes_when_transposed(self, data_abc, data_key) -> None:
         params = _make_params(('a', 'b', 'c'), keep_dim='b', transpose=True)
@@ -269,8 +282,8 @@ class TestFlattenPlotterHover:
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
         templates = dict(hover.tooltips)
-        # Transposed: kept on y, flat on x.
-        assert templates['b'] == '$y'
+        # Transposed: kept on y, flat on x. 'b' has unit 's'.
+        assert templates['b [s]'] == '$y'
         assert templates['a'] == '$x{outer}'
         assert templates['c'] == '$x{inner}'
         assert '$x' in hover.formatters
@@ -287,9 +300,46 @@ class TestFlattenPlotterHover:
         assert fmt.args['inner_size'] == 5
         assert len(fmt.args['outer_values']) == 3  # a
         assert len(fmt.args['inner_values']) == 5  # c
-        # No dim-name prefix in templates: tooltip row already shows the name.
-        assert fmt.args['outer_template'] == '%s m'
-        assert fmt.args['inner_template'] == '%s K'
+
+    @pytest.mark.parametrize(
+        ('outer_unit', 'inner_unit', 'expected_outer', 'expected_inner'),
+        [
+            ('m', 'K', '%s m', '%s K'),
+            ('m', None, '%s m', '%s'),
+            (None, 'K', '%s', '%s K'),
+            (None, None, '%s', '%s'),
+        ],
+        ids=['both_units', 'outer_only', 'inner_only', 'no_units'],
+    )
+    def test_hover_formatter_template_reflects_coord_unit(
+        self,
+        data_key,
+        outer_unit: str | None,
+        inner_unit: str | None,
+        expected_outer: str,
+        expected_inner: str,
+    ) -> None:
+        da = sc.DataArray(
+            sc.arange('z', 0, 60, dtype='float64').fold(
+                dim='z', sizes={'a': 3, 'b': 4, 'c': 5}
+            ),
+            coords={
+                'a': sc.array(dims=['a'], values=[0.0, 0.5, 1.0], unit=outer_unit),
+                'b': sc.linspace('b', 0.0, 1.0, num=4, unit='s'),
+                'c': sc.array(
+                    dims=['c'], values=[0.0, 0.25, 0.5, 0.75, 1.0], unit=inner_unit
+                ),
+            },
+        )
+        da.data.unit = 'counts'
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(da, data_key)
+        fig = _run_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        fmt = hover.formatters['$y']
+        assert fmt.args['outer_template'] == expected_outer
+        assert fmt.args['inner_template'] == expected_inner
 
     def test_hover_falls_back_to_index_when_coord_missing(
         self, data_abc, data_key

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -11,7 +11,7 @@ import holoviews as hv
 import pydantic
 import pytest
 import scipp as sc
-from bokeh.models import CustomJSTickFormatter, HoverTool, LinearAxis
+from bokeh.models import HoverTool
 
 from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
 from ess.livedata.dashboard.flatten_plotter import (
@@ -31,12 +31,8 @@ class _FakeToolbar:
 
 class _FakeFigure:
     def __init__(self) -> None:
-        self.layouts: list[tuple[LinearAxis, str]] = []
         self.toolbar = _FakeToolbar()
         self.added_tools: list = []
-
-    def add_layout(self, axis: LinearAxis, side: str) -> None:
-        self.layouts.append((axis, side))
 
     def add_tools(self, tool) -> None:
         self.added_tools.append(tool)
@@ -48,18 +44,12 @@ class _FakePlot:
         self.handles: dict = {'plot': _FakeFigure()}
 
 
-def _run_inner_axis_hook(img: hv.Image) -> _FakeFigure:
-    """Invoke the secondary-axis hook against a fake bokeh figure and return it."""
+def _run_hook(img: hv.Image) -> _FakeFigure:
+    """Invoke the plotter's hook against a fake bokeh figure and return it."""
     [hook] = img.opts.get('plot').kwargs['hooks']
     plot = _FakePlot()
     hook(plot, None)
     return plot.handles['plot']
-
-
-def _outer_ticks_opt(img: hv.Image, transpose: bool) -> list[tuple[float, str]]:
-    """Outer-axis ticks set on the primary (HoloViews xticks/yticks opt)."""
-    key = 'xticks' if transpose else 'yticks'
-    return img.opts.get('plot').kwargs[key]
 
 
 hv.extension('bokeh')
@@ -209,126 +199,6 @@ class TestFlattenPlotterPlot:
         b_dim = next(d for d in img.kdims if d.name == 'b')
         assert b_dim.unit == 's'
 
-    def test_outer_ticks_at_group_centres_on_primary_axis(
-        self, data_abc, data_key
-    ) -> None:
-        # outer='a' size 3, inner='c' size 5 → centres at i*5 + 2 = 2, 7, 12.
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        ticks = _outer_ticks_opt(img, transpose=False)
-        assert [pos for pos, _ in ticks] == [2.0, 7.0, 12.0]
-        assert all(label.startswith('a=') for _, label in ticks)
-
-    def test_inner_axis_hook_installs_secondary_with_inner_formatter(
-        self, data_abc, data_key
-    ) -> None:
-        # keep_dim='b' → inner='c' size 5 → inner_size=5; secondary axis must
-        # carry the zoom-aware inner formatter for the y axis (side='left').
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        fig = _run_inner_axis_hook(img)
-        [(axis, side)] = fig.layouts
-        assert side == 'left'
-        assert isinstance(axis, LinearAxis)
-        assert isinstance(axis.formatter, CustomJSTickFormatter)
-        assert axis.formatter.args['inner_size'] == 5
-        assert len(axis.formatter.args['values']) == 5
-        # No axis_label on the secondary — it would float between the rows.
-        assert axis.axis_label == ''
-
-    def test_primary_axis_label_is_cleared(self, data_abc, data_key) -> None:
-        # The synthetic flat-dim name (e.g. "a·c") is suppressed since each
-        # tick row carries its own dim name.
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        assert img.opts.get('plot').kwargs['ylabel'] == ''
-
-    def test_inner_axis_hook_is_idempotent(self, data_abc, data_key) -> None:
-        # HoloViews may invoke hooks on every re-render; the secondary axis
-        # must not accumulate.
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        [hook] = img.opts.get('plot').kwargs['hooks']
-        plot = _FakePlot()
-        hook(plot, None)
-        hook(plot, None)
-        assert len(plot.handles['plot'].layouts) == 1
-
-    def test_transposed_uses_x_axis_and_below_side(self, data_abc, data_key) -> None:
-        params = _make_params(('a', 'b', 'c'), keep_dim='b', transpose=True)
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        # Outer ticks on the primary x axis.
-        assert _outer_ticks_opt(img, transpose=True)
-        assert img.opts.get('plot').kwargs['xlabel'] == ''
-        # Secondary axis attached to 'below'.
-        fig = _run_inner_axis_hook(img)
-        [(_axis, side)] = fig.layouts
-        assert side == 'below'
-
-    def test_flatten_transposed_changes_inner_size(self, data_abc, data_key) -> None:
-        # outer='c' (size 5), inner='a' (size 3) → inner_size=3
-        params = _make_params(('a', 'b', 'c'), keep_dim='b', flatten_transposed=True)
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data_abc, data_key)
-        fig = _run_inner_axis_hook(img)
-        [(axis, _side)] = fig.layouts
-        assert axis.formatter.args['inner_size'] == 3
-
-    def test_missing_inner_coord_falls_back_to_index_template(
-        self, data_abc, data_key
-    ) -> None:
-        # Drop coord on the inner dim ('c' under natural order with keep='b').
-        data = data_abc.copy(deep=False)
-        del data.coords['c']
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data, data_key)
-        fig = _run_inner_axis_hook(img)
-        [(axis, _side)] = fig.layouts
-        # Inner formatter falls back to "c[%d]".
-        assert axis.formatter.args['values'] == []
-        assert '%d' in axis.formatter.args['template']
-        # Outer ('a') still has its real-coord labels on the primary axis.
-        ticks = _outer_ticks_opt(img, transpose=False)
-        assert all(label.startswith('a=') for _, label in ticks)
-
-    def test_missing_outer_coord_falls_back_to_index_label(
-        self, data_abc, data_key
-    ) -> None:
-        # Drop coord on the outer dim ('a' under natural order with keep='b').
-        data = data_abc.copy(deep=False)
-        del data.coords['a']
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data, data_key)
-        ticks = _outer_ticks_opt(img, transpose=False)
-        assert {label for _, label in ticks} == {f'a[{i}]' for i in range(3)}
-
-    def test_bin_edge_coord_uses_midpoints(self, data_key) -> None:
-        # 'a' (the outer under natural order with keep='b') has bin edges
-        # (size 4 for dim size 3) → 3 outer-axis ticks for the 3 midpoints.
-        data = sc.DataArray(
-            sc.arange('z', 0, 60, dtype='float64').fold(
-                dim='z', sizes={'a': 3, 'b': 4, 'c': 5}
-            ),
-            coords={
-                'a': sc.linspace('a', 0.0, 1.0, num=4, unit='m'),
-                'b': sc.linspace('b', 0.0, 1.0, num=4, unit='s'),
-                'c': sc.linspace('c', 0.0, 1.0, num=5, unit='K'),
-            },
-        )
-        data.data.unit = 'counts'
-        params = _make_params(('a', 'b', 'c'), keep_dim='b')
-        plotter = FlattenPlotter.from_params(params)
-        img = plotter.plot(data, data_key)
-        ticks = _outer_ticks_opt(img, transpose=False)
-        assert len(ticks) == 3
-
     def test_raises_for_non_3d_input(self, data_key) -> None:
         data = sc.DataArray(sc.zeros(dims=['x', 'y'], shape=[2, 2]))
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
@@ -367,7 +237,7 @@ class TestFlattenPlotterHover:
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
-        fig = _run_inner_axis_hook(img)
+        fig = _run_hook(img)
         hovers = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
         # Exactly one hover survives — the custom flatten one.
         assert len(hovers) == 1
@@ -379,7 +249,7 @@ class TestFlattenPlotterHover:
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
-        fig = _run_inner_axis_hook(img)
+        fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
         labels = [name for name, _ in hover.tooltips]
         # Keep dim is 'b'; natural-order outer='a', inner='c'.
@@ -396,7 +266,7 @@ class TestFlattenPlotterHover:
         params = _make_params(('a', 'b', 'c'), keep_dim='b', transpose=True)
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
-        fig = _run_inner_axis_hook(img)
+        fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
         templates = dict(hover.tooltips)
         # Transposed: kept on y, flat on x.
@@ -411,7 +281,7 @@ class TestFlattenPlotterHover:
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data_abc, data_key)
-        fig = _run_inner_axis_hook(img)
+        fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
         fmt = hover.formatters['$y']
         assert fmt.args['inner_size'] == 5
@@ -429,7 +299,7 @@ class TestFlattenPlotterHover:
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
         plotter = FlattenPlotter.from_params(params)
         img = plotter.plot(data, data_key)
-        fig = _run_inner_axis_hook(img)
+        fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
         fmt = hover.formatters['$y']
         # Inner ('c') has no coord → empty values, bare-index template.
@@ -437,6 +307,29 @@ class TestFlattenPlotterHover:
         assert fmt.args['inner_template'] == '%d'
         # Outer ('a') still carries real coord values.
         assert len(fmt.args['outer_values']) == 3
+
+    def test_hook_is_idempotent(self, data_abc, data_key) -> None:
+        # HoloViews may invoke hooks on every re-render; the hover must not
+        # be installed multiple times.
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        [hook] = img.opts.get('plot').kwargs['hooks']
+        plot = _FakePlot()
+        hook(plot, None)
+        hook(plot, None)
+        fig = plot.handles['plot']
+        assert len(fig.added_tools) == 1
+
+    def test_flat_axis_label_is_not_suppressed(self, data_abc, data_key) -> None:
+        # The synthetic flat-dim name (e.g. "a·c") flows through as the default
+        # HoloViews axis label — no xlabel/ylabel opt overriding it.
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        plot_kwargs = img.opts.get('plot').kwargs
+        assert 'xlabel' not in plot_kwargs
+        assert 'ylabel' not in plot_kwargs
 
 
 class TestFlattenPlotterCompute:

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -217,19 +217,16 @@ class TestFlattenPlotterPlot:
         assert img.kdims[0].name == 'd'  # x = kept (position 1)
         assert img.kdims[1].name == 'a·c'
 
-    def test_raises_for_keep_dim_out_of_range(self, data_abc, data_key) -> None:
-        # Out-of-range positions are caught at plot time. Pydantic prevents
-        # the narrowed model from constructing one, but the base model
-        # accepts any int — and that's the path saved configs go through on
-        # restore.
+    def test_raises_for_keep_dim_out_of_range(self) -> None:
+        # Saved configs go through the un-narrowed FlattenParams which accepts
+        # any int. The plotter rejects out-of-range positions at construction.
         params = FlattenParams(flatten={'keep_dim': 5})
-        plotter = FlattenPlotter.from_params(params)
         with pytest.raises(ValueError, match='out of range'):
-            plotter.plot(data_abc, data_key)
+            FlattenPlotter.from_params(params)
 
 
 class TestFlattenPlotterHover:
-    """Hover decomposes the flat axis into outer/inner labels."""
+    """Hover decomposes each image axis into per-dim labels."""
 
     def test_hook_replaces_default_hover_with_custom_one(
         self, data_abc, data_key
@@ -243,7 +240,7 @@ class TestFlattenPlotterHover:
         assert len(hovers) == 1
         assert hovers[0] in fig.added_tools
 
-    def test_hover_tooltips_label_keep_outer_inner_and_value(
+    def test_hover_tooltips_one_row_per_dim_then_value(
         self, data_abc, data_key
     ) -> None:
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
@@ -251,15 +248,17 @@ class TestFlattenPlotterHover:
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        # x first, y next, value last. Per-dim format directive = dim name.
+        # Each dim's row label carries its unit; values come back unit-less.
         labels = [name for name, _ in hover.tooltips]
-        # Keep dim is 'b' (unit 's'); natural-order outer='a', inner='c'.
-        assert labels == ['b [s]', 'a', 'c', 'value']
-        # Flat axis is y when not transposed; outer/inner both reference it.
+        assert labels == ['b [s]', 'a [m]', 'c [K]', 'value']
         templates = dict(hover.tooltips)
-        assert templates['b [s]'] == '$x'
-        assert templates['a'] == '$y{outer}'
-        assert templates['c'] == '$y{inner}'
+        assert templates['b [s]'] == '$x{b}'
+        assert templates['a [m]'] == '$y{a}'
+        assert templates['c [K]'] == '$y{c}'
         assert templates['value'] == '@image'
+        # Both axes always have a formatter — single-dim axes too.
+        assert '$x' in hover.formatters
         assert '$y' in hover.formatters
 
     def test_hover_kept_dim_label_omits_unit_when_coord_missing(
@@ -281,14 +280,15 @@ class TestFlattenPlotterHover:
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        # Transposed: flat (a, c) on x, kept (b) on y.
+        labels = [name for name, _ in hover.tooltips]
+        assert labels == ['a [m]', 'c [K]', 'b [s]', 'value']
         templates = dict(hover.tooltips)
-        # Transposed: kept on y, flat on x. 'b' has unit 's'.
-        assert templates['b [s]'] == '$y'
-        assert templates['a'] == '$x{outer}'
-        assert templates['c'] == '$x{inner}'
-        assert '$x' in hover.formatters
+        assert templates['a [m]'] == '$x{a}'
+        assert templates['c [K]'] == '$x{c}'
+        assert templates['b [s]'] == '$y{b}'
 
-    def test_hover_formatter_carries_outer_and_inner_coord_values(
+    def test_hover_formatter_args_describe_axis_levels(
         self, data_abc, data_key
     ) -> None:
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
@@ -296,28 +296,36 @@ class TestFlattenPlotterHover:
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
-        fmt = hover.formatters['$y']
-        assert fmt.args['inner_size'] == 5
-        assert len(fmt.args['outer_values']) == 3  # a
-        assert len(fmt.args['inner_values']) == 5  # c
+        # Y axis flattens (a outer, c inner); strides are C-order.
+        y_fmt = hover.formatters['$y']
+        assert y_fmt.args['names'] == ['a', 'c']
+        assert y_fmt.args['sizes'] == [3, 5]
+        assert y_fmt.args['strides'] == [5, 1]
+        assert len(y_fmt.args['values_by_dim'][0]) == 3
+        assert len(y_fmt.args['values_by_dim'][1]) == 5
+        # X axis is single-dim ('b') — one level, stride 1.
+        x_fmt = hover.formatters['$x']
+        assert x_fmt.args['names'] == ['b']
+        assert x_fmt.args['sizes'] == [4]
+        assert x_fmt.args['strides'] == [1]
 
     @pytest.mark.parametrize(
-        ('outer_unit', 'inner_unit', 'expected_outer', 'expected_inner'),
+        ('outer_unit', 'inner_unit', 'expected_a', 'expected_c'),
         [
-            ('m', 'K', '%s m', '%s K'),
-            ('m', None, '%s m', '%s'),
-            (None, 'K', '%s', '%s K'),
-            (None, None, '%s', '%s'),
+            ('m', 'K', 'a [m]', 'c [K]'),
+            ('m', None, 'a [m]', 'c'),
+            (None, 'K', 'a', 'c [K]'),
+            (None, None, 'a', 'c'),
         ],
         ids=['both_units', 'outer_only', 'inner_only', 'no_units'],
     )
-    def test_hover_formatter_template_reflects_coord_unit(
+    def test_hover_row_label_reflects_coord_unit(
         self,
         data_key,
         outer_unit: str | None,
         inner_unit: str | None,
-        expected_outer: str,
-        expected_inner: str,
+        expected_a: str,
+        expected_c: str,
     ) -> None:
         da = sc.DataArray(
             sc.arange('z', 0, 60, dtype='float64').fold(
@@ -337,11 +345,11 @@ class TestFlattenPlotterHover:
         img = plotter.plot(da, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
-        fmt = hover.formatters['$y']
-        assert fmt.args['outer_template'] == expected_outer
-        assert fmt.args['inner_template'] == expected_inner
+        labels = [name for name, _ in hover.tooltips]
+        assert expected_a in labels
+        assert expected_c in labels
 
-    def test_hover_falls_back_to_index_when_coord_missing(
+    def test_hover_falls_back_to_bare_index_when_coord_missing(
         self, data_abc, data_key
     ) -> None:
         data = data_abc.copy(deep=False)
@@ -351,16 +359,18 @@ class TestFlattenPlotterHover:
         img = plotter.plot(data, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
-        fmt = hover.formatters['$y']
-        # Inner ('c') has no coord → empty values, bare-index template.
-        assert fmt.args['inner_values'] == []
-        assert fmt.args['inner_template'] == '%d'
-        # Outer ('a') still carries real coord values.
-        assert len(fmt.args['outer_values']) == 3
+        y_fmt = hover.formatters['$y']
+        # 'c' has no coord → empty values list → JS emits the bare index.
+        assert y_fmt.args['values_by_dim'][1] == []
+        # 'a' still carries real coord values.
+        assert len(y_fmt.args['values_by_dim'][0]) == 3
 
-    def test_hover_kept_dim_rounds_to_index_when_no_coord(
+    def test_hover_single_dim_axis_without_coord_emits_index(
         self, data_abc, data_key
     ) -> None:
+        # The single-dim axis goes through the same formatter; with no coord,
+        # the JS emits ``Math.round(value)`` so cursor floats display as clean
+        # integer indices.
         data = data_abc.copy(deep=False)
         del data.coords['b']
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
@@ -368,12 +378,10 @@ class TestFlattenPlotterHover:
         img = plotter.plot(data, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
-        # No coord on kept dim → rounding formatter on $x so cursor floats
-        # display as clean integer indices.
-        assert '$x' in hover.formatters
-        assert '$y' in hover.formatters  # flat-axis formatter still present
+        x_fmt = hover.formatters['$x']
+        assert x_fmt.args['values_by_dim'] == [[]]
 
-    def test_hover_kept_dim_has_no_rounding_formatter_when_coord_present(
+    def test_hover_single_dim_axis_with_coord_uses_values_lookup(
         self, data_abc, data_key
     ) -> None:
         params = _make_params(('a', 'b', 'c'), keep_dim='b')
@@ -381,9 +389,9 @@ class TestFlattenPlotterHover:
         img = plotter.plot(data_abc, data_key)
         fig = _run_hook(img)
         [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
-        # Coord present → raw $x float (physical value); no extra formatter.
-        assert '$x' not in hover.formatters
-        assert '$y' in hover.formatters
+        x_fmt = hover.formatters['$x']
+        # 'b' coord is present → values lookup; the row label carries the unit.
+        assert len(x_fmt.args['values_by_dim'][0]) == 4
 
     def test_hook_is_idempotent(self, data_abc, data_key) -> None:
         # HoloViews may invoke hooks on every re-render; the hover must not
@@ -407,6 +415,88 @@ class TestFlattenPlotterHover:
         plot_kwargs = img.opts.get('plot').kwargs
         assert 'xlabel' not in plot_kwargs
         assert 'ylabel' not in plot_kwargs
+
+
+class TestFlattenPlotterNDimGeneralization:
+    """Direct-construction tests demonstrating the internals are not 3D-bound.
+
+    Input params (FlattenAxisConfig) only express the 3D case today;
+    ``from_axes`` exposes the underlying ``(x_dims, y_dims)`` partition for
+    arbitrary arity.
+    """
+
+    @pytest.fixture
+    def data_abcd(self) -> sc.DataArray:
+        da = sc.DataArray(
+            sc.arange('z', 0, 120, dtype='float64').fold(
+                dim='z', sizes={'a': 2, 'b': 3, 'c': 4, 'd': 5}
+            ),
+            coords={
+                'a': sc.linspace('a', 0.0, 1.0, num=2, unit='m'),
+                'b': sc.linspace('b', 0.0, 1.0, num=3, unit='s'),
+                'c': sc.linspace('c', 0.0, 1.0, num=4, unit='K'),
+                'd': sc.linspace('d', 0.0, 1.0, num=5, unit='J'),
+            },
+        )
+        da.data.unit = 'counts'
+        return da
+
+    def test_4d_input_with_two_dims_per_axis(self, data_abcd, data_key) -> None:
+        plotter = FlattenPlotter.from_axes(
+            FlattenParams(),
+            x_dims=(0, 1),  # (a, b) → 'a·b' size 6
+            y_dims=(2, 3),  # (c, d) → 'c·d' size 20
+        )
+        img = plotter.plot(data_abcd, data_key)
+        # HoloViews kdims: x = innermost scipp dim, y = outermost.
+        assert img.kdims[0].name == 'a·b'
+        assert img.kdims[1].name == 'c·d'
+
+    def test_4d_hover_has_one_row_per_input_dim(self, data_abcd, data_key) -> None:
+        plotter = FlattenPlotter.from_axes(
+            FlattenParams(), x_dims=(0, 1), y_dims=(2, 3)
+        )
+        img = plotter.plot(data_abcd, data_key)
+        fig = _run_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        labels = [name for name, _ in hover.tooltips]
+        assert labels == ['a [m]', 'b [s]', 'c [K]', 'd [J]', 'value']
+        x_fmt = hover.formatters['$x']
+        y_fmt = hover.formatters['$y']
+        assert x_fmt.args['names'] == ['a', 'b']
+        assert x_fmt.args['sizes'] == [2, 3]
+        assert x_fmt.args['strides'] == [3, 1]
+        assert y_fmt.args['names'] == ['c', 'd']
+        assert y_fmt.args['sizes'] == [4, 5]
+        assert y_fmt.args['strides'] == [5, 1]
+
+    def test_3_to_1_partition_keeps_one_dim_unflattened(
+        self, data_abcd, data_key
+    ) -> None:
+        # x = (a, b, c) flattened, y = (d) single-dim.
+        plotter = FlattenPlotter.from_axes(
+            FlattenParams(), x_dims=(0, 1, 2), y_dims=(3,)
+        )
+        img = plotter.plot(data_abcd, data_key)
+        assert img.kdims[0].name == 'a·b·c'
+        assert img.kdims[1].name == 'd'
+        fig = _run_hook(img)
+        [hover] = [t for t in fig.toolbar.tools if isinstance(t, HoverTool)]
+        x_fmt = hover.formatters['$x']
+        assert x_fmt.args['names'] == ['a', 'b', 'c']
+        assert x_fmt.args['strides'] == [12, 4, 1]
+
+    def test_init_rejects_position_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match='out of range'):
+            FlattenPlotter.from_axes(FlattenParams(), x_dims=(0,), y_dims=(5,))
+
+    def test_init_rejects_duplicate_position(self) -> None:
+        with pytest.raises(ValueError, match='duplicated'):
+            FlattenPlotter.from_axes(FlattenParams(), x_dims=(0, 1), y_dims=(1, 2))
+
+    def test_init_rejects_empty_axis(self) -> None:
+        with pytest.raises(ValueError, match='at least one'):
+            FlattenPlotter.from_axes(FlattenParams(), x_dims=(), y_dims=(0,))
 
 
 class TestFlattenPlotterCompute:

--- a/tests/dashboard/flatten_plotter_test.py
+++ b/tests/dashboard/flatten_plotter_test.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for FlattenPlotter and the dynamic param model."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+import holoviews as hv
+import pydantic
+import pytest
+import scipp as sc
+
+from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
+from ess.livedata.dashboard.flatten_plotter import (
+    FlattenAxisConfig,
+    FlattenParams,
+    FlattenPlotter,
+    make_flatten_params,
+)
+from ess.livedata.dashboard.plot_params import PlotScale
+
+hv.extension('bokeh')
+
+
+@pytest.fixture
+def data_key() -> ResultKey:
+    return ResultKey(
+        workflow_id=WorkflowId(instrument='inst', namespace='ns', name='wf', version=1),
+        job_id=JobId(source_name='src', job_number=uuid.uuid4()),
+        output_name='out',
+    )
+
+
+@pytest.fixture
+def data_abc() -> sc.DataArray:
+    """3D data with dims (a, b, c) and 1-D coords on each."""
+    da = sc.DataArray(
+        sc.arange('z', 0, 60, dtype='float64').fold(
+            dim='z', sizes={'a': 3, 'b': 4, 'c': 5}
+        ),
+        coords={
+            'a': sc.linspace('a', 0.0, 1.0, num=3, unit='m'),
+            'b': sc.linspace('b', 0.0, 1.0, num=4, unit='s'),
+            'c': sc.linspace('c', 0.0, 1.0, num=5, unit='K'),
+        },
+    )
+    da.data.unit = 'counts'
+    return da
+
+
+def _make_params(
+    dims: tuple[str, ...],
+    *,
+    keep_dim: str,
+    flatten_transposed: bool = False,
+    transpose: bool = False,
+) -> FlattenParams:
+    Cls = make_flatten_params(dims)
+    p = Cls(
+        flatten={
+            'keep_dim': keep_dim,
+            'flatten_transposed': flatten_transposed,
+            'transpose': transpose,
+        }
+    )
+    p.plot_scale.color_scale = PlotScale.linear
+    return p
+
+
+def _axis_cls(params_cls: type[FlattenParams]) -> type[FlattenAxisConfig]:
+    return params_cls.model_fields['flatten'].annotation
+
+
+class TestMakeFlattenParams:
+    def test_narrows_keep_dim_to_literal(self) -> None:
+        Cls = make_flatten_params(('a', 'b', 'c'))
+        annotation = _axis_cls(Cls).model_fields['keep_dim'].annotation
+        assert annotation == Literal['a', 'b', 'c']
+
+    def test_does_not_expose_outer_dim_choice(self) -> None:
+        # The flatten ordering is controlled by a single boolean checkbox so
+        # the user is exposed to (potentially placeholder) dim names only via
+        # the keep_dim dropdown.
+        Cls = make_flatten_params(('a', 'b', 'c'))
+        fields = _axis_cls(Cls).model_fields
+        assert 'flatten_outer' not in fields
+        assert fields['flatten_transposed'].annotation is bool
+
+    def test_rejects_invalid_dim_name(self) -> None:
+        Cls = make_flatten_params(('a', 'b', 'c'))
+        with pytest.raises(pydantic.ValidationError):
+            Cls(flatten={'keep_dim': 'nope'})
+
+    def test_non_3d_returns_base_class_unmodified(self) -> None:
+        # 2D / 4D etc. fall back to the unparameterized base; the plotter then
+        # rejects mismatches at plot-time rather than at config-time.
+        assert make_flatten_params(('x', 'y')) is FlattenParams
+        assert make_flatten_params(('a', 'b', 'c', 'd')) is FlattenParams
+
+    def test_renders_in_model_widget(self) -> None:
+        """Every top-level field must itself be a BaseModel (one tab each).
+
+        Regression test: the dashboard's ModelWidget builds tabs by calling
+        ``model_fields`` on each field annotation. Plain Literal/bool fields
+        crash this.
+        """
+        from ess.livedata.dashboard.widgets.model_widget import ModelWidget
+
+        Cls = make_flatten_params(('a', 'b', 'c'))
+        widget = ModelWidget(Cls)
+        tab_names = {entry[0] for entry in widget.param_group_tabs}
+        assert 'flatten' in tab_names
+
+
+class TestFlattenPlotterPlot:
+    # data_abc has dims ('a', 'b', 'c'); for keep_dim='b' the natural-order
+    # flatten pair is (outer='a', inner='c'). flatten_transposed swaps that.
+
+    def test_returns_2d_image(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        assert isinstance(img, hv.Image)
+
+    def test_kept_dim_is_x_when_not_transposed(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        # HoloViews Image: kdims[0] is x, kdims[1] is y
+        assert img.kdims[0].name == 'b'
+        assert img.kdims[1].name == 'a·c'
+
+    def test_kept_dim_is_y_when_transposed(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b', transpose=True)
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        assert img.kdims[1].name == 'b'
+        assert img.kdims[0].name == 'a·c'
+
+    def test_flatten_transposed_swaps_outer_and_inner(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b', flatten_transposed=True)
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        assert img.kdims[1].name == 'c·a'
+
+    def test_kept_dim_unit_is_preserved(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        b_dim = next(d for d in img.kdims if d.name == 'b')
+        assert b_dim.unit == 's'
+
+    def test_natural_order_sets_inner_size_in_formatter(
+        self, data_abc, data_key
+    ) -> None:
+        # keep_dim='b' → outer='a' (size 3), inner='c' (size 5) → inner_size=5
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        formatter = img.opts.get('plot').kwargs['yformatter']
+        assert formatter.args['inner_size'] == 5
+        assert len(formatter.args['outer_values']) == 3
+        assert len(formatter.args['inner_values']) == 5
+
+    def test_flatten_transposed_changes_inner_size(self, data_abc, data_key) -> None:
+        # outer='c' (size 5), inner='a' (size 3) → inner_size=3
+        params = _make_params(('a', 'b', 'c'), keep_dim='b', flatten_transposed=True)
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data_abc, data_key)
+        formatter = img.opts.get('plot').kwargs['yformatter']
+        assert formatter.args['inner_size'] == 3
+
+    def test_missing_coord_falls_back_to_index_template(
+        self, data_abc, data_key
+    ) -> None:
+        # Drop coord on the inner dim ('c' under natural order with keep='b')
+        data = data_abc.copy(deep=False)
+        del data.coords['c']
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data, data_key)
+        formatter = img.opts.get('plot').kwargs['yformatter']
+        # outer (a) has values, inner (c) falls back to "c[%d]"
+        assert formatter.args['outer_values'] != []
+        assert formatter.args['inner_values'] == []
+        assert '%d' in formatter.args['inner_template']
+
+    def test_bin_edge_coord_uses_midpoints(self, data_key) -> None:
+        # 'a' (the outer under natural order with keep='b') has bin edges
+        # (size 4 for dim size 3) → midpoints = 3 values
+        data = sc.DataArray(
+            sc.arange('z', 0, 60, dtype='float64').fold(
+                dim='z', sizes={'a': 3, 'b': 4, 'c': 5}
+            ),
+            coords={
+                'a': sc.linspace('a', 0.0, 1.0, num=4, unit='m'),
+                'b': sc.linspace('b', 0.0, 1.0, num=4, unit='s'),
+                'c': sc.linspace('c', 0.0, 1.0, num=5, unit='K'),
+            },
+        )
+        data.data.unit = 'counts'
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data, data_key)
+        formatter = img.opts.get('plot').kwargs['yformatter']
+        assert len(formatter.args['outer_values']) == 3  # midpoints of 4 edges
+
+    def test_raises_for_non_3d_input(self, data_key) -> None:
+        data = sc.DataArray(sc.zeros(dims=['x', 'y'], shape=[2, 2]))
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        with pytest.raises(ValueError, match='3D input'):
+            plotter.plot(data, data_key)
+
+    def test_falls_back_to_positional_when_data_renamed(
+        self, data_abc, data_key
+    ) -> None:
+        # Template dims (a, b, c) configured with keep_dim='b'; runtime data
+        # is renamed to (a, d, c). Order preserved → 'b' resolves to position
+        # 1 → 'd'. This is the common case when shared templates declare
+        # generic dim names that per-instrument transforms rename.
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        data = data_abc.rename_dims({'b': 'd'})
+        plotter = FlattenPlotter.from_params(params)
+        img = plotter.plot(data, data_key)
+        assert img.kdims[0].name == 'd'  # x = kept, resolved positionally
+        assert img.kdims[1].name == 'a·c'
+
+    def test_raises_when_neither_name_nor_position_resolves(
+        self, data_abc, data_key
+    ) -> None:
+        # Configured 'b' is not in data.dims and template_dims is unavailable
+        # → cannot resolve.
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        # Manually disable the positional fallback to simulate "no template"
+        plotter._template_dims = None
+        data = data_abc.rename_dims({'b': 'd'})
+        with pytest.raises(ValueError, match='matches neither'):
+            plotter.plot(data, data_key)
+
+
+class TestFlattenPlotterCompute:
+    def test_compute_caches_state(self, data_abc, data_key) -> None:
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        plotter.compute({'primary': {data_key: data_abc}})
+        assert plotter.has_cached_state()
+
+    def test_compute_renders_error_text_on_ndim_mismatch(self, data_key) -> None:
+        # 2D data → ndim mismatch → base Plotter.compute() wraps the
+        # ValueError in a Text element rather than crashing.
+        params = _make_params(('a', 'b', 'c'), keep_dim='b')
+        plotter = FlattenPlotter.from_params(params)
+        data_2d = sc.DataArray(sc.zeros(dims=['x', 'y'], shape=[2, 2]))
+        plotter.compute({'primary': {data_key: data_2d}})
+        assert plotter.get_cached_state() is not None

--- a/tests/dashboard/plot_configuration_adapter_test.py
+++ b/tests/dashboard/plot_configuration_adapter_test.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for PlotConfigurationAdapter — focused on params_factory wiring."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pydantic
+
+from ess.livedata.dashboard.plot_configuration_adapter import (
+    PlotConfigurationAdapter,
+)
+from ess.livedata.dashboard.plotter_registry import (
+    DataRequirements,
+    PlotterSpec,
+)
+
+
+class _StaticParams(pydantic.BaseModel):
+    pass
+
+
+def _make_spec(params_factory=None) -> PlotterSpec:
+    return PlotterSpec(
+        name='dummy',
+        title='Dummy',
+        description='',
+        params=_StaticParams,
+        params_factory=params_factory,
+        data_requirements=DataRequirements(min_dims=0, max_dims=10),
+    )
+
+
+def _adapter(spec, *, output_template_dims=None) -> PlotConfigurationAdapter:
+    return PlotConfigurationAdapter(
+        plot_spec=spec,
+        source_names=['s'],
+        success_callback=lambda *_: None,
+        output_template_dims=output_template_dims,
+    )
+
+
+def test_returns_static_params_when_no_factory() -> None:
+    adapter = _adapter(_make_spec(), output_template_dims=('a', 'b'))
+    assert adapter.model_class() is _StaticParams
+
+
+def test_returns_static_params_when_factory_set_but_no_dims() -> None:
+    def factory(dims):  # would raise if called with None
+        raise AssertionError('factory should not be called without dims')
+
+    adapter = _adapter(_make_spec(factory), output_template_dims=None)
+    assert adapter.model_class() is _StaticParams
+
+
+def test_calls_factory_with_dims_when_both_provided() -> None:
+    captured: list[tuple[str, ...]] = []
+
+    def factory(dims):
+        captured.append(dims)
+
+        class _Dyn(_StaticParams):
+            pick: Literal[*dims] = dims[0]  # type: ignore[valid-type]
+
+        return _Dyn
+
+    adapter = _adapter(_make_spec(factory), output_template_dims=('x', 'y', 'z'))
+    Dyn = adapter.model_class()
+    assert captured == [('x', 'y', 'z')]
+    assert Dyn is not _StaticParams
+    assert issubclass(Dyn, _StaticParams)
+    assert Dyn.model_fields['pick'].annotation == Literal['x', 'y', 'z']

--- a/tests/dashboard/plot_configuration_adapter_test.py
+++ b/tests/dashboard/plot_configuration_adapter_test.py
@@ -21,28 +21,30 @@ class _StaticParams(pydantic.BaseModel):
     pass
 
 
-def _make_spec(params_factory=None) -> PlotterSpec:
+def _make_spec() -> PlotterSpec:
     return PlotterSpec(
         name='dummy',
         title='Dummy',
         description='',
         params=_StaticParams,
-        params_factory=params_factory,
         data_requirements=DataRequirements(min_dims=0, max_dims=10),
     )
 
 
-def _adapter(spec, *, output_template_dims=None) -> PlotConfigurationAdapter:
+def _adapter(
+    *, params_factory=None, output_template_dims=None
+) -> PlotConfigurationAdapter:
     return PlotConfigurationAdapter(
-        plot_spec=spec,
+        plot_spec=_make_spec(),
         source_names=['s'],
         success_callback=lambda *_: None,
         output_template_dims=output_template_dims,
+        params_factory=params_factory,
     )
 
 
 def test_returns_static_params_when_no_factory() -> None:
-    adapter = _adapter(_make_spec(), output_template_dims=('a', 'b'))
+    adapter = _adapter(output_template_dims=('a', 'b'))
     assert adapter.model_class() is _StaticParams
 
 
@@ -50,7 +52,7 @@ def test_returns_static_params_when_factory_set_but_no_dims() -> None:
     def factory(dims):  # would raise if called with None
         raise AssertionError('factory should not be called without dims')
 
-    adapter = _adapter(_make_spec(factory), output_template_dims=None)
+    adapter = _adapter(params_factory=factory, output_template_dims=None)
     assert adapter.model_class() is _StaticParams
 
 
@@ -65,7 +67,7 @@ def test_calls_factory_with_dims_when_both_provided() -> None:
 
         return _Dyn
 
-    adapter = _adapter(_make_spec(factory), output_template_dims=('x', 'y', 'z'))
+    adapter = _adapter(params_factory=factory, output_template_dims=('x', 'y', 'z'))
     Dyn = adapter.model_class()
     assert captured == [('x', 'y', 'z')]
     assert Dyn is not _StaticParams

--- a/tests/dashboard/widgets/param_widget_test.py
+++ b/tests/dashboard/widgets/param_widget_test.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-from enum import Enum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 from pathlib import Path
 from typing import Literal
 
@@ -318,6 +318,23 @@ class TestEnumHandling:
         assert "LOW" in select.options
         assert "MEDIUM" in select.options
         assert "HIGH" in select.options
+
+    def test_int_enum_subclass_uses_member_names_not_values(self):
+        # IntEnum inherits __str__ from int, so str(member) returns the integer
+        # value rather than 'ClassName.member'. The dropdown must label by
+        # member name (e.g., dim names), not by the integer.
+        class Dims(IntEnum):
+            x = 0
+            y = 1
+            z = 2
+
+        class TestModel(pydantic.BaseModel):
+            dim: Dims = Dims.x
+
+        widget = ParamWidget(TestModel)
+
+        options = widget.widgets["dim"].options
+        assert set(options) == {"x", "y", "z"}
 
 
 class TestLiteralHandling:

--- a/tests/dashboard/widgets/param_widget_test.py
+++ b/tests/dashboard/widgets/param_widget_test.py
@@ -370,43 +370,6 @@ class TestSetOfEnumHandling:
         model = widget.create_model()
         assert model.selected == {Dims.x, Dims.y}
 
-    def test_multiselect_max_length_reverts_oversize_selections(self):
-        # max_length=2 on a set[Dim] field: the MultiSelect must veto a
-        # value change that would push selection count above 2.
-        class Dims(IntEnum):
-            x = 0
-            y = 1
-            z = 2
-
-        class TestModel(pydantic.BaseModel):
-            selected: set[Dims] = pydantic.Field(
-                default_factory=lambda: {Dims.x},
-                max_length=2,
-            )
-
-        widget = ParamWidget(TestModel)
-        ms = widget.widgets["selected"]
-        ms.value = [Dims.x, Dims.y]
-        assert ms.value == [Dims.x, Dims.y]
-        ms.value = [Dims.x, Dims.y, Dims.z]
-        assert ms.value == [Dims.x, Dims.y]
-
-    def test_multiselect_min_length_reverts_undersize_selections(self):
-        class Dims(IntEnum):
-            x = 0
-            y = 1
-
-        class TestModel(pydantic.BaseModel):
-            selected: set[Dims] = pydantic.Field(
-                default_factory=lambda: {Dims.x},
-                min_length=1,
-            )
-
-        widget = ParamWidget(TestModel)
-        ms = widget.widgets["selected"]
-        ms.value = []
-        assert ms.value == [Dims.x]
-
     def test_set_of_enum_set_values_accepts_raw_ints(self):
         # Restoring a saved config goes through int values, not enum members.
         class Dims(IntEnum):

--- a/tests/dashboard/widgets/param_widget_test.py
+++ b/tests/dashboard/widgets/param_widget_test.py
@@ -337,6 +337,55 @@ class TestEnumHandling:
         assert set(options) == {"x", "y", "z"}
 
 
+class TestSetOfEnumHandling:
+    """Tests for set-of-enum field handling (rendered as MultiSelect)."""
+
+    def test_set_of_enum_creates_multiselect(self):
+        class Dims(IntEnum):
+            x = 0
+            y = 1
+            z = 2
+
+        class TestModel(pydantic.BaseModel):
+            selected: set[Dims] = pydantic.Field(default_factory=lambda: {Dims.x})
+
+        widget = ParamWidget(TestModel)
+
+        ms = widget.widgets["selected"]
+        assert isinstance(ms, pn.widgets.MultiSelect)
+        assert set(ms.options) == {"x", "y", "z"}
+        assert ms.value == [Dims.x]
+
+    def test_set_of_enum_default_round_trips(self):
+        class Dims(IntEnum):
+            x = 0
+            y = 1
+
+        class TestModel(pydantic.BaseModel):
+            selected: set[Dims] = pydantic.Field(default_factory=lambda: {Dims.y})
+
+        widget = ParamWidget(TestModel)
+        ms = widget.widgets["selected"]
+        ms.value = [Dims.x, Dims.y]
+        model = widget.create_model()
+        assert model.selected == {Dims.x, Dims.y}
+
+    def test_set_of_enum_set_values_accepts_raw_ints(self):
+        # Restoring a saved config goes through int values, not enum members.
+        class Dims(IntEnum):
+            x = 0
+            y = 1
+            z = 2
+
+        class TestModel(pydantic.BaseModel):
+            selected: set[Dims] = pydantic.Field(default_factory=set)
+
+        widget = ParamWidget(TestModel)
+        widget.set_values({"selected": {0, 2}})
+        ms = widget.widgets["selected"]
+        assert set(ms.value) == {Dims.x, Dims.z}
+
+
 class TestLiteralHandling:
     """Tests for Literal type handling."""
 

--- a/tests/dashboard/widgets/param_widget_test.py
+++ b/tests/dashboard/widgets/param_widget_test.py
@@ -370,6 +370,43 @@ class TestSetOfEnumHandling:
         model = widget.create_model()
         assert model.selected == {Dims.x, Dims.y}
 
+    def test_multiselect_max_length_reverts_oversize_selections(self):
+        # max_length=2 on a set[Dim] field: the MultiSelect must veto a
+        # value change that would push selection count above 2.
+        class Dims(IntEnum):
+            x = 0
+            y = 1
+            z = 2
+
+        class TestModel(pydantic.BaseModel):
+            selected: set[Dims] = pydantic.Field(
+                default_factory=lambda: {Dims.x},
+                max_length=2,
+            )
+
+        widget = ParamWidget(TestModel)
+        ms = widget.widgets["selected"]
+        ms.value = [Dims.x, Dims.y]
+        assert ms.value == [Dims.x, Dims.y]
+        ms.value = [Dims.x, Dims.y, Dims.z]
+        assert ms.value == [Dims.x, Dims.y]
+
+    def test_multiselect_min_length_reverts_undersize_selections(self):
+        class Dims(IntEnum):
+            x = 0
+            y = 1
+
+        class TestModel(pydantic.BaseModel):
+            selected: set[Dims] = pydantic.Field(
+                default_factory=lambda: {Dims.x},
+                min_length=1,
+            )
+
+        widget = ParamWidget(TestModel)
+        ms = widget.widgets["selected"]
+        ms.value = []
+        assert ms.value == [Dims.x]
+
     def test_set_of_enum_set_values_accepts_raw_ints(self):
         # Restoring a saved config goes through int values, not enum members.
         class Dims(IntEnum):


### PR DESCRIPTION
## Summary

New \"static-flatten\" plotter: reduces N-D data (3–6 dims) to a 2D image by partitioning the input dims into an X-axis group and a Y-axis group at config time. Groups with two or more dims are flattened together; the partition is stored as a set of dim positions (not names), so saved configs survive per-instrument dim renames.

Key design points:
- Custom hover decomposes each flattened axis back into per-dim labels with coord values and units (integer position fallback when no coord is present), so the plot remains explorable despite the joined axes.
- `params_factory` hook on `PlotterEntry` (moved off `PlotterSpec`) lets the plotter narrow the `axis_x_dims` MultiSelect to the actual workflow output dim names.
- MultiSelect enforces partition validity on submit rather than disabling options dynamically, avoiding tricky interaction states.
- `DataRequirements.max_dims` is now optional (default `None` is uncapped); the flatten plotter uses `min_dims=3, max_dims=6` (2D is degenerate — no flattening would occur; 6 is scipp's dim-count ceiling).
- The `<spectral_coord>` placeholder dim in the SpectrumView output template was renamed from `spectrum` to make clear it is a runtime placeholder, not a spectrum-number axis.

*Not included*:
- Decided against doing anything particular to the flat axis - just showing array indices, no reference to any of the coords.

## Examples

<img width="1628" height="1199" alt="screenshot-2026-04-28T12:51:18" src="https://github.com/user-attachments/assets/af8795d6-8bd8-4b70-bef0-fc3efecf8e57" />
<img width="991" height="1080" alt="screenshot-2026-04-28T12:52:07" src="https://github.com/user-attachments/assets/05404c23-8c0a-4e8a-b742-dca765ebdd04" />


## Test plan

- [x] Created a flatten plot on a 3D ; verified the X-axis dims MultiSelect shows real dim names and the resulting image axes are correct..
- [x] Hover over flattened axes; verify outer/inner labels with coord values, units, and integer-index fallback when no coord is present.
- [x] Submit an invalid partition in the MultiSelect (e.g., all dims in X); verify validation error is shown and the plot is not updated.
- [x] Open the plot config widget for a SpectrumView output; verify the placeholder dim shows as `<spectral_coord>` rather than `spectrum`.