### PR TITLE
Add one-shot job mechanism for zero-physical-stream sources

### DIFF
--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -12,6 +12,7 @@ import scipp as sc
 from ess.livedata.handlers.workflow_factory import Workflow
 
 from ..config.workflow_spec import JobId, ResultKey, WorkflowId
+from .message import STATUS_STREAM_ID, Message, StreamId, StreamKind
 from .timestamp import Timestamp
 
 
@@ -54,6 +55,14 @@ class JobResult:
             job_id=self.job_id,
         ).model_dump_json()
 
+    def to_message(self) -> Message:
+        """Convert this result to a publishable data-stream message."""
+        return Message(
+            timestamp=self.start_time or Timestamp.from_ns(0),
+            stream=StreamId(kind=StreamKind.LIVEDATA_DATA, name=self.stream_name),
+            value=self.data,
+        )
+
 
 @dataclass
 class JobStatus:
@@ -76,6 +85,14 @@ class JobStatus:
     def has_warning(self) -> bool:
         """Check if the job status indicates a warning."""
         return self.state == JobState.warning or self.warning_message is not None
+
+    def to_message(self, timestamp: Timestamp | None = None) -> Message:
+        """Convert this status to a publishable status-stream message."""
+        return Message(
+            timestamp=timestamp or Timestamp.now(),
+            stream=STATUS_STREAM_ID,
+            value=self,
+        )
 
 
 @dataclass
@@ -208,6 +225,7 @@ class Job:
         source_names: list[str],
         aux_source_names: dict[str, str] | None = None,
         reset_on_run_transition: bool = True,
+        is_one_shot: bool = False,
     ) -> None:
         """
         Initialize a Job with the given parameters.
@@ -227,6 +245,11 @@ class Job:
             None if no auxiliary sources are needed.
         reset_on_run_transition:
             Whether this job should be reset when a run transition occurs.
+        is_one_shot:
+            Set when the job's primary sources resolve to zero physical streams,
+            i.e. the job will never receive data. JobManager runs such jobs
+            synchronously on schedule (single finalize, no scheduled/active
+            state) instead of waiting for message-driven activation.
         """
         self._job_id = job_id
         self._workflow_id = workflow_id
@@ -235,6 +258,7 @@ class Job:
         self._end_time: Timestamp | None = None
         self._source_names = source_names
         self._reset_on_run_transition = reset_on_run_transition
+        self._is_one_shot = is_one_shot
         self._aux_source_mapping: dict[str, str] = aux_source_names or {}
 
         # Create reverse mapping: stream_name -> list of field_names
@@ -281,6 +305,10 @@ class Job:
     @property
     def reset_on_run_transition(self) -> bool:
         return self._reset_on_run_transition
+
+    @property
+    def is_one_shot(self) -> bool:
+        return self._is_one_shot
 
     def add(self, data: JobData) -> JobReply:
         try:

--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -15,6 +15,7 @@ import scipp as sc
 import structlog
 
 from ess.livedata.config.instrument import Instrument
+from ess.livedata.config.route_derivation import resolve_stream_names
 from ess.livedata.config.workflow_spec import (
     JobId,
     JobSchedule,
@@ -22,9 +23,10 @@ from ess.livedata.config.workflow_spec import (
     WorkflowId,
     WorkflowSpec,
 )
+from ess.livedata.kafka.stream_mapping import StreamMapping
 
 from .job import Job, JobData, JobReply, JobResult, JobState, JobStatus
-from .message import RunStart, RunStop, StreamId
+from .message import Message, RunStart, RunStop, StreamId
 from .timestamp import Timestamp
 
 logger = structlog.get_logger(__name__)
@@ -83,8 +85,24 @@ class JobCommand(pydantic.BaseModel):
 
 
 class JobFactory:
-    def __init__(self, instrument: Instrument) -> None:
+    def __init__(
+        self,
+        instrument: Instrument,
+        stream_mapping: StreamMapping | None = None,
+    ) -> None:
+        """Initialize the factory.
+
+        Parameters
+        ----------
+        instrument:
+            The instrument owning the workflow specs.
+        stream_mapping:
+            Stream mapping used to detect jobs whose primary sources resolve to
+            zero physical streams (one-shot jobs). When ``None``, one-shot
+            detection is disabled and all jobs follow the normal lifecycle.
+        """
         self._instrument = instrument
+        self._stream_mapping = stream_mapping
 
     def get_workflow_spec(self, workflow_id: WorkflowId) -> WorkflowSpec | None:
         """Get the workflow specification for a given workflow ID."""
@@ -162,7 +180,17 @@ class JobFactory:
             # Job will use values for routing and remap keys for workflow
             aux_source_names=rendered_aux_names,
             reset_on_run_transition=workflow_spec.reset_on_run_transition,
+            is_one_shot=self._is_one_shot(job_id.source_name),
         )
+
+    def _is_one_shot(self, source_name: str) -> bool:
+        """A job is one-shot if its primary source has no physical streams routed."""
+        if self._stream_mapping is None:
+            return False
+        resolved = resolve_stream_names(
+            {source_name}, self._instrument, self._stream_mapping
+        )
+        return not resolved
 
 
 class JobManager:
@@ -182,6 +210,11 @@ class JobManager:
         self._jobs_with_primary_data: set[JobId] = set()
         # Pending reset times, kept sorted via bisect.insort
         self._pending_reset_times: list[Timestamp] = []
+        # Messages produced by one-shot jobs that ran inline during schedule_job:
+        # the data result followed by a JobStatus(stopped) so the dashboard can
+        # deactivate the workflow. The caller (typically JobManagerAdapter)
+        # drains them on the same call.
+        self._pending_messages: list[Message] = []
         self._executor: ThreadPoolExecutor | None = (
             ThreadPoolExecutor(max_workers=job_threads) if job_threads > 1 else None
         )
@@ -237,11 +270,20 @@ class JobManager:
     def schedule_job(self, source_name: str, config: WorkflowConfig) -> JobId:
         """
         Schedule a new job based on the provided configuration.
+
+        One-shot jobs (whose primary source resolves to zero physical streams)
+        are finalized inline: they never enter ``_scheduled_jobs`` or
+        ``_active_jobs`` and their result is stashed for the caller to retrieve
+        via :meth:`drain_pending_results`. Such jobs cannot be data-driven, so
+        gating them on message-time advancement would never fire.
         """
         job_id = JobId(
             job_number=config.job_number or uuid.uuid4(), source_name=source_name
         )
         job = self._job_factory.create(job_id=job_id, config=config)
+        if job.is_one_shot:
+            self._run_one_shot(job)
+            return job_id
         self._job_schedules[job_id] = config.schedule
         self._job_states[job_id] = JobState.scheduled
         self._scheduled_jobs[job_id] = job
@@ -253,6 +295,43 @@ class JobManager:
             schedule=str(config.schedule),
         )
         return job_id
+
+    def _run_one_shot(self, job: Job) -> None:
+        """Finalize a one-shot job inline and stash messages for draining.
+
+        Produces a result message followed by a ``JobStatus(stopped)`` message
+        so dashboard consumers can deactivate the workflow — without these,
+        the job would never appear or disappear in the regular status stream
+        because it never enters ``_active_jobs``/``_scheduled_jobs``.
+        """
+        result = self._job_factory.enrich_result(job.get())
+        # Use ``stopped`` regardless of error state: the workflow ran exactly
+        # once and is no longer present, ``error_message`` carries the failure
+        # if any. This matches how ``OrchestratingProcessor.finalize`` reports
+        # remaining jobs at service shutdown.
+        status = JobStatus(
+            job_id=job.job_id,
+            workflow_id=job.workflow_id,
+            state=JobState.stopped,
+            error_message=result.error_message,
+            warning_message=result.warning_message,
+            start_time=result.start_time,
+            end_time=result.end_time,
+        )
+        self._pending_messages.append(result.to_message())
+        self._pending_messages.append(status.to_message())
+        logger.info(
+            "one_shot_job_finalized",
+            job_id=str(job.job_id),
+            workflow_id=str(job.workflow_id),
+            has_error=result.error_message is not None,
+        )
+
+    def drain_pending_messages(self) -> list[Message]:
+        """Return and clear messages stashed by inline one-shot jobs."""
+        drained = self._pending_messages
+        self._pending_messages = []
+        return drained
 
     def stop_job(self, job_id: JobId) -> None:
         """Stop a job and remove it from the system."""

--- a/src/ess/livedata/core/job_manager_adapter.py
+++ b/src/ess/livedata/core/job_manager_adapter.py
@@ -7,6 +7,7 @@ import structlog
 from ..config.acknowledgement import AcknowledgementResponse, CommandAcknowledgement
 from ..config.workflow_spec import WorkflowConfig
 from .job_manager import DifferentInstrument, JobCommand, JobManager
+from .message import RESPONSES_STREAM_ID, Message
 
 logger = structlog.get_logger(__name__)
 
@@ -21,14 +22,18 @@ class JobManagerAdapter:
     2. We keep the legacy one-source-one-job behavior, replacing old jobs if a new one
        is started. The long-term goal is to change this to a more flexible mechanism,
        but this, too, would require frontend changes.
+
+    Both action methods return ``list[Message]``: an acknowledgement message (when
+    a ``message_id`` was supplied) plus any data-stream messages produced
+    synchronously by the action (e.g. results from one-shot jobs that finalize
+    inline during ``schedule_job``). The list is empty when there is nothing to
+    publish.
     """
 
     def __init__(self, *, job_manager: JobManager) -> None:
         self._job_manager = job_manager
 
-    def job_command(
-        self, source_name: str, value: dict
-    ) -> CommandAcknowledgement | None:
+    def job_command(self, source_name: str, value: dict) -> list[Message]:
         _ = source_name  # Legacy, not used.
         command = JobCommand.model_validate(value)
 
@@ -43,29 +48,24 @@ class JobManagerAdapter:
                 job_id=str(command.job_id),
                 message="Assuming handled by another worker",
             )
-            return None
+            return []
         except Exception as e:
             logger.exception("job_command_failed", action=command.action)
-            if command.message_id is not None:
-                return CommandAcknowledgement(
-                    message_id=command.message_id,
-                    device=str(command.job_id) if command.job_id else "all",
-                    response=AcknowledgementResponse.ERR,
-                    message=str(e),
-                )
-            return None
-        else:
-            if command.message_id is not None:
-                return CommandAcknowledgement(
-                    message_id=command.message_id,
-                    device=str(command.job_id) if command.job_id else "all",
-                    response=AcknowledgementResponse.ACK,
-                )
-            return None
+            return _ack_messages(
+                message_id=command.message_id,
+                device=str(command.job_id) if command.job_id else "all",
+                response=AcknowledgementResponse.ERR,
+                message=str(e),
+            )
+        return _ack_messages(
+            message_id=command.message_id,
+            device=str(command.job_id) if command.job_id else "all",
+            response=AcknowledgementResponse.ACK,
+        )
 
     def set_workflow_with_config(
         self, source_name: str, value: dict | None
-    ) -> CommandAcknowledgement | None:
+    ) -> list[Message]:
         config = WorkflowConfig.model_validate(value)
 
         try:
@@ -83,24 +83,45 @@ class JobManagerAdapter:
                 workflow_id=str(config.identifier),
                 message="Assuming handled by another worker",
             )
-            return None
+            return []
         except Exception as e:
             logger.exception(
                 "workflow_start_failed", workflow_id=str(config.identifier)
             )
-            if config.message_id is not None:
-                return CommandAcknowledgement(
-                    message_id=config.message_id,
-                    device=source_name,
-                    response=AcknowledgementResponse.ERR,
-                    message=str(e),
-                )
-            return None
-        else:
-            if config.message_id is not None:
-                return CommandAcknowledgement(
-                    message_id=config.message_id,
-                    device=source_name,
-                    response=AcknowledgementResponse.ACK,
-                )
-            return None
+            return _ack_messages(
+                message_id=config.message_id,
+                device=source_name,
+                response=AcknowledgementResponse.ERR,
+                message=str(e),
+            )
+
+        # Drain any messages produced inline by one-shot jobs (data result +
+        # JobStatus(stopped)) so they reach the sink on the same loop tick as
+        # the ack, with no dependency on data traffic to drive emission.
+        return (
+            _ack_messages(
+                message_id=config.message_id,
+                device=source_name,
+                response=AcknowledgementResponse.ACK,
+            )
+            + self._job_manager.drain_pending_messages()
+        )
+
+
+def _ack_messages(
+    *,
+    message_id: str | None,
+    device: str,
+    response: AcknowledgementResponse,
+    message: str | None = None,
+) -> list[Message]:
+    """Return the ack message wrapped in a list, or an empty list if not requested."""
+    if message_id is None:
+        return []
+    ack = CommandAcknowledgement(
+        message_id=message_id,
+        device=device,
+        response=response,
+        message=message,
+    )
+    return [Message(stream=RESPONSES_STREAM_ID, value=ack)]

--- a/src/ess/livedata/core/orchestrating_processor.py
+++ b/src/ess/livedata/core/orchestrating_processor.py
@@ -13,9 +13,9 @@ import structlog
 from ess.livedata import __version__
 
 from ..handlers.config_handler import ConfigProcessor
+from ..kafka.stream_mapping import StreamMapping
 from .handler import Accumulator, PreprocessorFactory
 from .job import (
-    JobResult,
     JobState,
     JobStatus,
     ServiceState,
@@ -35,7 +35,6 @@ from .message import (
     RunStart,
     RunStop,
     StreamId,
-    StreamKind,
     Tin,
     Tout,
 )
@@ -148,6 +147,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         source: MessageSource[Message[Tin]],
         sink: MessageSink[Tout],
         preprocessor_factory: PreprocessorFactory[Tin, Tout],
+        stream_mapping: StreamMapping | None = None,
         message_batcher: MessageBatcher | None = None,
         job_threads: int = 1,
         stream_stats_provider: StreamStatsProvider | None = None,
@@ -157,7 +157,10 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         self._message_preprocessor = MessagePreprocessor(factory=preprocessor_factory)
         instrument = preprocessor_factory.instrument
         self._job_manager = JobManager(
-            job_factory=JobFactory(instrument=instrument), job_threads=job_threads
+            job_factory=JobFactory(
+                instrument=instrument, stream_mapping=stream_mapping
+            ),
+            job_threads=job_threads,
         )
         self._job_manager_adapter = JobManagerAdapter(job_manager=self._job_manager)
         self._message_batcher = message_batcher or AdaptiveMessageBatcher()
@@ -294,9 +297,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         self._batches_processed += 1
         self._maybe_log_metrics()
 
-        result_messages.extend(
-            [_job_result_to_message(result) for result in valid_results]
-        )
+        result_messages.extend(result.to_message() for result in valid_results)
         self._sink.publish_messages(result_messages)
 
     def _report_status(self) -> None:
@@ -308,10 +309,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
 
         # Publish job statuses
         job_statuses = self._job_manager.get_all_job_statuses()
-        messages = [
-            _job_status_to_message(status, timestamp=timestamp)
-            for status in job_statuses
-        ]
+        messages = [status.to_message(timestamp=timestamp) for status in job_statuses]
 
         # Publish service heartbeat
         service_status = self._get_service_status(job_statuses)
@@ -390,9 +388,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         timestamp = Timestamp.now()
         job_statuses = self._job_manager.get_all_job_statuses()
         messages = [
-            _job_status_to_message(
-                replace(status, state=JobState.stopped), timestamp=timestamp
-            )
+            replace(status, state=JobState.stopped).to_message(timestamp=timestamp)
             for status in job_statuses
         ]
         service_status = self._get_service_status(job_statuses)
@@ -403,24 +399,6 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
             logger.exception('Failed to send final heartbeat')
 
         self._job_manager.shutdown()
-
-
-def _job_result_to_message(result: JobResult) -> Message:
-    """
-    Convert a workflow result to a message for publishing.
-
-    JobId is unique on its own, but we include the workflow ID to make it easier to
-    identify the job in the frontend.
-    """
-    return Message(
-        timestamp=result.start_time or Timestamp.from_ns(0),
-        stream=StreamId(kind=StreamKind.LIVEDATA_DATA, name=result.stream_name),
-        value=result.data,
-    )
-
-
-def _job_status_to_message(status: JobStatus, timestamp: Timestamp) -> Message:
-    return Message(timestamp=timestamp, stream=STATUS_STREAM_ID, value=status)
 
 
 def _service_status_to_message(status: ServiceStatus, timestamp: Timestamp) -> Message:

--- a/src/ess/livedata/handlers/config_handler.py
+++ b/src/ess/livedata/handlers/config_handler.py
@@ -9,11 +9,10 @@ from typing import Any
 
 import structlog
 
-from ..config.acknowledgement import CommandAcknowledgement
 from ..config.models import ConfigKey
 from ..core.job_manager import JobCommand
 from ..core.job_manager_adapter import JobManagerAdapter
-from ..core.message import RESPONSES_STREAM_ID, Message
+from ..core.message import Message
 from ..kafka.message_adapter import RawConfigItem
 
 logger = structlog.get_logger(__name__)
@@ -63,9 +62,7 @@ class ConfigProcessor:
             JobCommand.key: self._job_manager_adapter.job_command,
         }
 
-    def process_messages(
-        self, messages: list[Message[RawConfigItem]]
-    ) -> list[Message[CommandAcknowledgement]]:
+    def process_messages(self, messages: list[Message[RawConfigItem]]) -> list[Message]:
         """
         Process config messages and handle workflow_config and job_command updates.
 
@@ -77,7 +74,9 @@ class ConfigProcessor:
         Returns
         -------
         :
-            List of response messages containing CommandAcknowledgements.
+            Response messages produced by the actions: acknowledgements bound for
+            the responses stream plus any data-stream messages from actions that
+            ran inline (e.g. one-shot job results from ``set_workflow_with_config``).
         """
         # Group latest updates by key and source
         latest_updates: defaultdict[str, dict[str | None, ConfigUpdate]] = defaultdict(
@@ -108,7 +107,7 @@ class ConfigProcessor:
                 logger.exception('error_processing_config_message')
 
         # Process the latest updates
-        response_messages: list[Message[CommandAcknowledgement]] = []
+        response_messages: list[Message] = []
 
         for config_key, source_updates in latest_updates.items():
             for source_name, update in source_updates.items():
@@ -119,12 +118,7 @@ class ConfigProcessor:
                     if (action := self._actions.get(config_key)) is None:
                         logger.debug('unknown_config_key', config_key=config_key)
                         continue
-                    result = action(source_name, update.value)
-                    if result is not None:
-                        response_messages.append(
-                            Message(stream=RESPONSES_STREAM_ID, value=result)
-                        )
-
+                    response_messages.extend(action(source_name, update.value))
                 except Exception:
                     logger.exception(
                         'error_processing_config_key',

--- a/src/ess/livedata/service_factory.py
+++ b/src/ess/livedata/service_factory.py
@@ -34,6 +34,7 @@ from .kafka.source import (
     KafkaMessageSource,
 )
 from .kafka.stream_counter import StreamCounter
+from .kafka.stream_mapping import StreamMapping
 from .logging_config import configure_logging
 from .sinks import PlotToPngSink
 
@@ -64,6 +65,7 @@ class DataServiceBuilder(Generic[Traw, Tin, Tout]):
         job_threads: int = 5,
         stream_counter: StreamCounter | None = None,
         message_batcher: MessageBatcher | None = None,
+        stream_mapping: StreamMapping | None = None,
     ) -> None:
         """
         Parameters
@@ -103,6 +105,7 @@ class DataServiceBuilder(Generic[Traw, Tin, Tout]):
         self._job_threads = job_threads
         self._stream_counter = stream_counter
         self._message_batcher = message_batcher
+        self._stream_mapping = stream_mapping
         if isinstance(preprocessor_factory, JobBasedPreprocessorFactoryBase):
             # Ensure only jobs from the active namespace can be created by JobFactory.
             preprocessor_factory.instrument.active_namespace = name
@@ -211,6 +214,7 @@ class DataServiceBuilder(Generic[Traw, Tin, Tout]):
             ),
             sink=sink,
             preprocessor_factory=self._preprocessor_factory,
+            stream_mapping=self._stream_mapping,
             job_threads=self._job_threads,
             stream_stats_provider=self._stream_counter,
             message_batcher=self._message_batcher,

--- a/src/ess/livedata/services/data_reduction.py
+++ b/src/ess/livedata/services/data_reduction.py
@@ -46,6 +46,7 @@ def make_reduction_service_builder(
         adapter=adapter,
         preprocessor_factory=preprocessor_factory,
         stream_counter=stream_counter,
+        stream_mapping=scoped,
     )
 
 

--- a/src/ess/livedata/services/detector_data.py
+++ b/src/ess/livedata/services/detector_data.py
@@ -47,6 +47,7 @@ def make_detector_service_builder(
         adapter=adapter,
         preprocessor_factory=preprocessor_factory,
         stream_counter=stream_counter,
+        stream_mapping=scoped,
     )
 
 

--- a/src/ess/livedata/services/monitor_data.py
+++ b/src/ess/livedata/services/monitor_data.py
@@ -40,6 +40,7 @@ def make_monitor_service_builder(
         adapter=adapter,
         preprocessor_factory=preprocessor_factory,
         stream_counter=stream_counter,
+        stream_mapping=scoped,
     )
 
 

--- a/src/ess/livedata/services/timeseries.py
+++ b/src/ess/livedata/services/timeseries.py
@@ -57,6 +57,7 @@ def make_timeseries_service_builder(
         preprocessor_factory=preprocessor_factory,
         stream_counter=stream_counter,
         message_batcher=NaiveMessageBatcher(),
+        stream_mapping=scoped,
     )
 
 

--- a/tests/core/job_manager_adapter_test.py
+++ b/tests/core/job_manager_adapter_test.py
@@ -4,10 +4,14 @@ import uuid
 
 import pytest
 
-from ess.livedata.config.acknowledgement import AcknowledgementResponse
+from ess.livedata.config.acknowledgement import (
+    AcknowledgementResponse,
+    CommandAcknowledgement,
+)
 from ess.livedata.config.workflow_spec import JobId
 from ess.livedata.core.job_manager import JobAction, JobCommand
 from ess.livedata.core.job_manager_adapter import JobManagerAdapter
+from ess.livedata.core.message import RESPONSES_STREAM_ID
 
 
 class FakeJobManager:
@@ -15,6 +19,8 @@ class FakeJobManager:
 
     def __init__(self):
         self.job_command_calls = []
+        self.scheduled = []
+        self.pending_messages: list = []
         self.should_raise_key_error = False
         self.should_raise_exception = False
 
@@ -25,8 +31,19 @@ class FakeJobManager:
         if self.should_raise_exception:
             raise RuntimeError("Test exception")
 
+    def schedule_job(self, *, source_name, config):
+        self.scheduled.append((source_name, config))
+        if self.should_raise_exception:
+            raise RuntimeError("Test exception")
+        return JobId(source_name=source_name, job_number=uuid.uuid4())
 
-class TestJobManagerAdapter:
+    def drain_pending_messages(self):
+        drained = self.pending_messages
+        self.pending_messages = []
+        return drained
+
+
+class TestJobManagerAdapterJobCommand:
     @pytest.fixture
     def fake_job_manager(self):
         return FakeJobManager()
@@ -35,10 +52,11 @@ class TestJobManagerAdapter:
     def adapter(self, fake_job_manager):
         return JobManagerAdapter(job_manager=fake_job_manager)
 
-    def test_job_command_success_with_message_id(self, adapter, fake_job_manager):
-        """Test successful job command returns ACK when message_id is provided."""
+    def test_job_command_success_with_message_id_returns_ack_message(
+        self, adapter, fake_job_manager
+    ):
         job_id = JobId(source_name="test_source", job_number=uuid.uuid4())
-        result = adapter.job_command(
+        messages = adapter.job_command(
             source_name="ignored",
             value={
                 "action": JobAction.reset.value,
@@ -50,78 +68,163 @@ class TestJobManagerAdapter:
             },
         )
 
-        assert result is not None
-        assert result.message_id == "test-msg-id"
-        assert result.response == AcknowledgementResponse.ACK
+        assert len(messages) == 1
+        message = messages[0]
+        assert message.stream == RESPONSES_STREAM_ID
+        assert isinstance(message.value, CommandAcknowledgement)
+        assert message.value.message_id == "test-msg-id"
+        assert message.value.response == AcknowledgementResponse.ACK
         assert len(fake_job_manager.job_command_calls) == 1
 
-    def test_job_command_success_without_message_id(self, adapter, fake_job_manager):
-        """Test successful job command returns None when no message_id."""
-        result = adapter.job_command(
+    def test_job_command_success_without_message_id_returns_empty(
+        self, adapter, fake_job_manager
+    ):
+        messages = adapter.job_command(
             source_name="ignored",
             value={"action": JobAction.reset.value},
         )
 
-        assert result is None
+        assert messages == []
         assert len(fake_job_manager.job_command_calls) == 1
 
-    def test_job_command_key_error_silently_ignored(self, adapter, fake_job_manager):
-        """Test that KeyError (job not found) is silently ignored.
+    def test_job_command_key_error_silently_returns_empty(
+        self, adapter, fake_job_manager
+    ):
+        """KeyError (job not found) is silently ignored.
 
-        When multiple backend services receive the same job command, only the service
-        that owns the job should respond. Services that don't have the job should
-        silently ignore it (return None) rather than returning an ERR.
+        Multiple backend services receive the same job command; only the owner
+        responds. Non-owners return an empty list rather than ERR.
         """
         fake_job_manager.should_raise_key_error = True
 
-        job_id = JobId(source_name="test_source", job_number=uuid.uuid4())
-        result = adapter.job_command(
+        messages = adapter.job_command(
             source_name="ignored",
             value={
                 "action": JobAction.stop.value,
-                "job_id": {
-                    "source_name": job_id.source_name,
-                    "job_number": str(job_id.job_number),
-                },
                 "message_id": "test-msg-id",
             },
         )
 
-        # Should return None (no response) instead of ERR
-        assert result is None
+        assert messages == []
 
-    def test_job_command_other_exception_returns_err(self, adapter, fake_job_manager):
-        """Test that non-KeyError exceptions return ERR acknowledgement."""
-        fake_job_manager.should_raise_exception = True
-
-        job_id = JobId(source_name="test_source", job_number=uuid.uuid4())
-        result = adapter.job_command(
-            source_name="ignored",
-            value={
-                "action": JobAction.stop.value,
-                "job_id": {
-                    "source_name": job_id.source_name,
-                    "job_number": str(job_id.job_number),
-                },
-                "message_id": "test-msg-id",
-            },
-        )
-
-        assert result is not None
-        assert result.message_id == "test-msg-id"
-        assert result.response == AcknowledgementResponse.ERR
-        assert "Test exception" in result.message
-
-    def test_job_command_other_exception_without_message_id_returns_none(
+    def test_job_command_other_exception_returns_err_message(
         self, adapter, fake_job_manager
     ):
-        """Test that exceptions without message_id return None."""
         fake_job_manager.should_raise_exception = True
 
-        result = adapter.job_command(
+        messages = adapter.job_command(
+            source_name="ignored",
+            value={
+                "action": JobAction.stop.value,
+                "message_id": "test-msg-id",
+            },
+        )
+
+        assert len(messages) == 1
+        ack = messages[0].value
+        assert isinstance(ack, CommandAcknowledgement)
+        assert ack.message_id == "test-msg-id"
+        assert ack.response == AcknowledgementResponse.ERR
+        assert "Test exception" in ack.message
+
+    def test_job_command_other_exception_without_message_id_returns_empty(
+        self, adapter, fake_job_manager
+    ):
+        fake_job_manager.should_raise_exception = True
+
+        messages = adapter.job_command(
             source_name="ignored",
             value={"action": JobAction.stop.value},
         )
 
-        # No message_id means no response even on error
-        assert result is None
+        assert messages == []
+
+
+class TestJobManagerAdapterSetWorkflowWithConfig:
+    @pytest.fixture
+    def fake_job_manager(self):
+        return FakeJobManager()
+
+    @pytest.fixture
+    def adapter(self, fake_job_manager):
+        return JobManagerAdapter(job_manager=fake_job_manager)
+
+    def _config(self, message_id="msg-1"):
+        from ess.livedata.config.workflow_spec import WorkflowConfig, WorkflowId
+
+        return WorkflowConfig(
+            identifier=WorkflowId(
+                instrument="test",
+                namespace="data_reduction",
+                name="wf",
+                version=1,
+            ),
+            message_id=message_id,
+        ).model_dump(mode="json")
+
+    def test_returns_only_ack_when_no_pending_messages(self, adapter, fake_job_manager):
+        messages = adapter.set_workflow_with_config(
+            source_name="src", value=self._config()
+        )
+
+        assert len(messages) == 1
+        ack = messages[0].value
+        assert isinstance(ack, CommandAcknowledgement)
+        assert ack.response == AcknowledgementResponse.ACK
+        assert messages[0].stream == RESPONSES_STREAM_ID
+        assert len(fake_job_manager.scheduled) == 1
+
+    def test_returns_ack_then_drained_messages(self, adapter, fake_job_manager):
+        """Pending messages from inline one-shot jobs are drained and returned."""
+        from ess.livedata.core.message import (
+            STATUS_STREAM_ID,
+            Message,
+            StreamId,
+            StreamKind,
+        )
+
+        # Two stand-in messages: one data-stream, one status-stream — exactly
+        # what JobManager._run_one_shot stashes for a one-shot job.
+        data_message = Message(
+            stream=StreamId(kind=StreamKind.LIVEDATA_DATA, name='r'),
+            value='data-payload',
+        )
+        status_message = Message(stream=STATUS_STREAM_ID, value='status-payload')
+        fake_job_manager.pending_messages = [data_message, status_message]
+
+        messages = adapter.set_workflow_with_config(
+            source_name="src", value=self._config()
+        )
+
+        assert len(messages) == 3
+        assert isinstance(messages[0].value, CommandAcknowledgement)
+        assert messages[1] is data_message
+        assert messages[2] is status_message
+        assert fake_job_manager.pending_messages == []
+
+    def test_different_instrument_returns_empty(self, adapter, fake_job_manager):
+        from ess.livedata.core.job_manager import DifferentInstrument
+
+        def raise_different(*, source_name, config):
+            raise DifferentInstrument()
+
+        fake_job_manager.schedule_job = raise_different
+
+        messages = adapter.set_workflow_with_config(
+            source_name="src", value=self._config()
+        )
+
+        assert messages == []
+
+    def test_exception_returns_err_ack(self, adapter, fake_job_manager):
+        fake_job_manager.should_raise_exception = True
+
+        messages = adapter.set_workflow_with_config(
+            source_name="src", value=self._config()
+        )
+
+        assert len(messages) == 1
+        ack = messages[0].value
+        assert isinstance(ack, CommandAcknowledgement)
+        assert ack.response == AcknowledgementResponse.ERR
+        assert "Test exception" in ack.message

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -2041,3 +2041,186 @@ class TestPeekPendingStreams:
         manager.schedule_job("src", config)
 
         assert manager.peek_pending_streams(start_time=100) == {"src"}
+
+
+class _OneShotInstrumentSetup:
+    """Helper for constructing an Instrument + StreamMapping for one-shot tests."""
+
+    @staticmethod
+    def make(
+        *,
+        source_name: str,
+        register_as_detector: bool,
+        physical_detectors: dict | None = None,
+    ):
+        from ess.livedata.config.instrument import Instrument
+        from ess.livedata.kafka.stream_mapping import StreamMapping
+
+        detector_names = [source_name] if register_as_detector else []
+        instrument = Instrument(name='test', detector_names=detector_names)
+        instrument.active_namespace = 'data_reduction'
+
+        handle = instrument.register_spec(
+            name='wf',
+            version=1,
+            title='Test',
+            description='Test',
+            source_names=[source_name],
+            outputs=SimpleTestOutputs,
+        )
+
+        @handle.attach_factory()
+        def wf_factory():
+            return FakeProcessor()
+
+        mapping = StreamMapping(
+            instrument='test',
+            detectors=physical_detectors or {},
+            monitors={},
+            livedata_commands_topic='cmd',
+            livedata_data_topic='data',
+            livedata_responses_topic='resp',
+            livedata_roi_topic='roi',
+            livedata_status_topic='status',
+        )
+        return instrument, mapping
+
+    @staticmethod
+    def workflow_id():
+        return WorkflowId(
+            instrument='test',
+            namespace='data_reduction',
+            name='wf',
+            version=1,
+        )
+
+
+class TestJobFactoryOneShotDetection:
+    def test_marks_one_shot_when_no_physical_streams_resolved(self):
+        from ess.livedata.kafka.stream_mapping import InputStreamKey
+
+        instrument, mapping = _OneShotInstrumentSetup.make(
+            source_name='choppers',
+            register_as_detector=False,
+            physical_detectors={InputStreamKey(topic='t', source_name='det1'): 'det1'},
+        )
+        factory = JobFactory(instrument, stream_mapping=mapping)
+        config = WorkflowConfig(identifier=_OneShotInstrumentSetup.workflow_id())
+        job = factory.create(
+            job_id=JobId(source_name='choppers', job_number='uuid-1'), config=config
+        )
+        assert job.is_one_shot is True
+
+    def test_does_not_mark_one_shot_when_physical_streams_resolved(self):
+        from ess.livedata.kafka.stream_mapping import InputStreamKey
+
+        instrument, mapping = _OneShotInstrumentSetup.make(
+            source_name='det1',
+            register_as_detector=True,
+            physical_detectors={InputStreamKey(topic='t', source_name='det1'): 'det1'},
+        )
+        factory = JobFactory(instrument, stream_mapping=mapping)
+        config = WorkflowConfig(identifier=_OneShotInstrumentSetup.workflow_id())
+        job = factory.create(
+            job_id=JobId(source_name='det1', job_number='uuid-2'), config=config
+        )
+        assert job.is_one_shot is False
+
+    def test_does_not_mark_one_shot_when_logical_expands_to_physical(self):
+        """Bifrost-style logical name expands to a non-empty set of physical names."""
+        from ess.livedata.kafka.stream_mapping import InputStreamKey
+
+        instrument, mapping = _OneShotInstrumentSetup.make(
+            source_name='unified_detector',
+            register_as_detector=True,
+            physical_detectors={
+                InputStreamKey(topic='t', source_name='bank_a'): 'bank_a',
+                InputStreamKey(topic='t', source_name='bank_b'): 'bank_b',
+            },
+        )
+        factory = JobFactory(instrument, stream_mapping=mapping)
+        config = WorkflowConfig(identifier=_OneShotInstrumentSetup.workflow_id())
+        job = factory.create(
+            job_id=JobId(source_name='unified_detector', job_number='uuid-3'),
+            config=config,
+        )
+        assert job.is_one_shot is False
+
+    def test_disables_detection_when_stream_mapping_is_none(self):
+        instrument, _ = _OneShotInstrumentSetup.make(
+            source_name='choppers', register_as_detector=False
+        )
+        factory = JobFactory(instrument)  # no stream_mapping
+        config = WorkflowConfig(identifier=_OneShotInstrumentSetup.workflow_id())
+        job = factory.create(
+            job_id=JobId(source_name='choppers', job_number='uuid-4'), config=config
+        )
+        assert job.is_one_shot is False
+
+
+class TestJobManagerOneShot:
+    def _make_manager(self):
+        instrument, mapping = _OneShotInstrumentSetup.make(
+            source_name='choppers', register_as_detector=False
+        )
+        factory = JobFactory(instrument, stream_mapping=mapping)
+        return JobManager(factory), instrument, mapping
+
+    def test_one_shot_job_finalizes_inline_during_schedule_job(self):
+        from ess.livedata.core.message import StreamKind
+
+        manager, _, _ = self._make_manager()
+        config = WorkflowConfig(identifier=_OneShotInstrumentSetup.workflow_id())
+
+        job_id = manager.schedule_job('choppers', config)
+
+        # Result + status available immediately, with no message-driven activation.
+        messages = manager.drain_pending_messages()
+        kinds = [m.stream.kind for m in messages]
+        assert StreamKind.LIVEDATA_DATA in kinds
+        assert StreamKind.LIVEDATA_STATUS in kinds
+
+        status_msgs = [
+            m for m in messages if m.stream.kind == StreamKind.LIVEDATA_STATUS
+        ]
+        assert len(status_msgs) == 1
+        status = status_msgs[0].value
+        assert status.job_id == job_id
+        assert status.state == JobState.stopped
+        assert status.error_message is None
+
+    def test_one_shot_job_does_not_enter_scheduled_or_active_state(self):
+        manager, _, _ = self._make_manager()
+        config = WorkflowConfig(identifier=_OneShotInstrumentSetup.workflow_id())
+
+        manager.schedule_job('choppers', config)
+
+        assert manager.all_jobs == []
+        assert manager.active_jobs == []
+
+    def test_drain_pending_messages_clears_buffer(self):
+        manager, _, _ = self._make_manager()
+        config = WorkflowConfig(identifier=_OneShotInstrumentSetup.workflow_id())
+
+        manager.schedule_job('choppers', config)
+        first = manager.drain_pending_messages()
+        second = manager.drain_pending_messages()
+
+        assert len(first) == 2  # data result + stopped-status
+        assert second == []
+
+    def test_normal_job_does_not_produce_pending_messages(self, fake_job_factory):
+        """Sanity check: jobs without one-shot stamping behave as before."""
+        manager = JobManager(fake_job_factory)
+        config = WorkflowConfig(
+            identifier=WorkflowId(
+                instrument='test',
+                namespace='data_reduction',
+                name='wf',
+                version=1,
+            )
+        )
+        manager.schedule_job('det1', config)
+
+        assert manager.drain_pending_messages() == []
+        assert len(manager.all_jobs) == 1

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -38,6 +38,43 @@ class TestJobResult:
             '"job_number":"' + str(job_number) + '"},"output_name":"result"}'
         )
 
+    def test_to_message_uses_data_stream_kind(self):
+        from ess.livedata.core.message import StreamKind
+
+        workflow_id = WorkflowId(
+            instrument="TEST",
+            namespace="data_reduction",
+            name="test_workflow",
+            version=1,
+        )
+        result = JobResult(
+            job_id=JobId(source_name="src", job_number=uuid.uuid4()),
+            workflow_id=workflow_id,
+            start_time=Timestamp.from_ns(100),
+            end_time=Timestamp.from_ns(200),
+            data=sc.DataGroup({'out': sc.DataArray(sc.scalar(3.14))}),
+        )
+        message = result.to_message()
+        assert message.stream.kind == StreamKind.LIVEDATA_DATA
+        assert message.stream.name == result.stream_name
+        assert message.value is result.data
+        assert message.timestamp == Timestamp.from_ns(100)
+
+    def test_to_message_falls_back_to_zero_timestamp(self):
+        result = JobResult(
+            job_id=JobId(source_name="src", job_number=uuid.uuid4()),
+            workflow_id=WorkflowId(
+                instrument="TEST",
+                namespace="data_reduction",
+                name="wf",
+                version=1,
+            ),
+            start_time=None,
+            end_time=None,
+            data=None,
+        )
+        assert result.to_message().timestamp == Timestamp.from_ns(0)
+
 
 class FakeProcessor(Workflow):
     """Fake implementation of Workflow for testing."""

--- a/tests/handlers/config_handler_test.py
+++ b/tests/handlers/config_handler_test.py
@@ -323,6 +323,38 @@ class TestConfigProcessor:
         assert len(mock_job_manager.workflow_calls) == 0
         assert len(result_messages) == 0
 
+    def test_process_aggregates_extra_messages_from_action(self):
+        """Actions that return ack + data messages flow both to the response list."""
+        from ess.livedata.core.message import StreamId, StreamKind
+
+        mock_job_manager = MockJobManagerAdapter()
+        data_stream = StreamId(kind=StreamKind.LIVEDATA_DATA, name='one_shot_result')
+        mock_job_manager.extra_messages_for_workflow = [
+            Message(stream=data_stream, value='one_shot_payload')
+        ]
+        processor = ConfigProcessor(job_manager_adapter=mock_job_manager)
+
+        messages = [
+            Message(
+                value=RawConfigItem(
+                    key=b'src/svc/workflow_config',
+                    value=json.dumps({'workflow': 'wf', 'message_id': 'mid'}).encode(
+                        'utf-8'
+                    ),
+                ),
+                timestamp=1,
+                stream=COMMANDS_STREAM_ID,
+            )
+        ]
+
+        result_messages = processor.process_messages(messages)
+
+        # Both the ack (responses stream) and the data-stream message are returned.
+        streams = {m.stream for m in result_messages}
+        assert RESPONSES_STREAM_ID in streams
+        assert data_stream in streams
+        assert len(result_messages) == 2
+
     def test_job_manager_exception_handling(self):
         mock_job_manager = MockJobManagerAdapter()
         mock_job_manager.should_raise_exception = True
@@ -352,29 +384,33 @@ class MockJobManagerAdapter:
     def __init__(self):
         self.workflow_calls = []
         self.job_command_calls = []
+        self.extra_messages_for_workflow: list[Message] = []
         self.should_raise_exception = False
 
     def job_command(self, source_name, command):
         self.job_command_calls.append((source_name, command))
         if self.should_raise_exception:
             raise ValueError("Test exception")
-        # Return acknowledgement only if message_id is present
         message_id = command.get("message_id")
         if message_id is None:
-            return None
-        return CommandAcknowledgement(
+            return []
+        ack = CommandAcknowledgement(
             message_id=message_id,
             device=str(command.get("job_id", "all")),
             response=AcknowledgementResponse.ACK,
         )
+        return [Message(stream=RESPONSES_STREAM_ID, value=ack)]
 
     def set_workflow_with_config(self, source_name, config):
         self.workflow_calls.append((source_name, config))
         if self.should_raise_exception:
             raise ValueError("Test exception")
-        # Return acknowledgement (always for workflow config in mock)
-        return CommandAcknowledgement(
+        ack = CommandAcknowledgement(
             message_id=config.get("message_id", "mock-msg-id"),
             device=source_name,
             response=AcknowledgementResponse.ACK,
         )
+        return [
+            Message(stream=RESPONSES_STREAM_ID, value=ack),
+            *self.extra_messages_for_workflow,
+        ]

--- a/tests/services/one_shot_job_test.py
+++ b/tests/services/one_shot_job_test.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""End-to-end tests for the one-shot job mechanism.
+
+A "one-shot" job is one whose primary source resolves to zero physical streams.
+JobManager finalizes such jobs synchronously inside ``schedule_job`` and the
+result reaches the sink via the config-handler return path on the same loop
+tick as the ack — with no dependency on data traffic to drive activation or
+emission.
+
+The mechanism lives in the orchestrator core, not in any particular service.
+We exercise it via the data_reduction service builder simply because it is
+the most readily available wiring; the same path applies to every service
+using ``OrchestratingProcessor``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import scipp as sc
+
+from ess.livedata.config import instrument_registry, workflow_spec
+from ess.livedata.config.models import ConfigKey
+from ess.livedata.config.workflow_spec import DefaultOutputs, WorkflowId
+from ess.livedata.core.job import JobState
+from ess.livedata.core.message import StreamKind
+from ess.livedata.core.timestamp import Timestamp
+from ess.livedata.services.data_reduction import make_reduction_service_builder
+from tests.helpers.livedata_app import LivedataApp
+
+ONE_SHOT_WORKFLOW_NAME = 'one_shot_test_workflow'
+
+# A workflow source name is treated as one-shot iff
+# ``resolve_stream_names({source}, instrument, stream_mapping)`` yields the
+# empty set. That happens precisely when the name is absent from all three of:
+#   - ``StreamMapping.all_stream_names`` (no physical stream subscribed),
+#   - ``instrument.detector_names`` (no logical→physical detector expansion),
+#   - ``instrument.monitors`` (no logical→physical monitor expansion).
+# We pick a name that satisfies all three to drive the chopperless code path
+# for these tests. No Kafka adapter, no message merging, no routing wiring
+# beyond the standard service builder is involved — one-shot detection is
+# purely a property of the routing tables.
+#
+# A real consumer (the planned chopper workflow) shares this exact mechanism
+# for its chopperless case: the workflow declares a single logical source
+# name and resolves to the empty set on instruments without chopper PVs. The
+# chopper-equipped case lives in the routing layer (logical→physical
+# expansion plus a merging adapter that rewrites incoming chopper messages
+# to the same logical name); that wiring is orthogonal to the mechanism
+# under test here.
+ONE_SHOT_SOURCE = 'no_physical_stream'
+
+ONE_SHOT_OUTPUT_VALUE = 42.0
+
+
+class _OneShotWorkflow:
+    """Test workflow that emits a fixed result on finalize.
+
+    Matches the ``Workflow`` protocol; ``accumulate``/``clear`` are unreachable
+    for a one-shot job (no data is ever pushed) but must exist for protocol
+    compliance.
+    """
+
+    def accumulate(
+        self, data: dict[str, Any], *, start_time: Timestamp, end_time: Timestamp
+    ) -> None:
+        pass
+
+    def finalize(self) -> dict[str, Any]:
+        return {'result': sc.DataArray(sc.scalar(ONE_SHOT_OUTPUT_VALUE))}
+
+    def clear(self) -> None:
+        pass
+
+
+def _ensure_one_shot_spec_registered() -> WorkflowId:
+    """Register the one-shot workflow spec on the dummy instrument.
+
+    Idempotent: spec registration is a global side effect on the shared
+    registry; subsequent calls within the same process are no-ops. Returns the
+    workflow id either way so callers can address the workflow uniformly.
+    """
+    instrument = instrument_registry['dummy']
+    workflow_id = WorkflowId(
+        instrument='dummy',
+        namespace='data_reduction',
+        name=ONE_SHOT_WORKFLOW_NAME,
+        version=1,
+    )
+    if workflow_id in instrument.workflow_factory:
+        return workflow_id
+    handle = instrument.register_spec(
+        namespace='data_reduction',
+        name=ONE_SHOT_WORKFLOW_NAME,
+        version=1,
+        title='One-shot test',
+        description='Test workflow with no physical streams.',
+        source_names=[ONE_SHOT_SOURCE],
+        outputs=DefaultOutputs,
+    )
+
+    @handle.attach_factory()
+    def _one_shot_factory() -> _OneShotWorkflow:
+        return _OneShotWorkflow()
+
+    return workflow_id
+
+
+@pytest.fixture
+def app() -> LivedataApp:
+    # Building the service builder triggers ``load_factories`` on the dummy
+    # instrument, which is what populates ``instrument_registry['dummy']``
+    # via the dummy specs module import. Register the test workflow afterwards
+    # so the dummy instrument is ready to host it.
+    builder = make_reduction_service_builder(instrument='dummy')
+    workflow_id = _ensure_one_shot_spec_registered()
+    livedata_app = LivedataApp.from_service_builder(builder)
+    livedata_app.workflow_id = workflow_id  # type: ignore[attr-defined]
+    return livedata_app
+
+
+def _publish_start_command(
+    app: LivedataApp, workflow_id: WorkflowId, message_id: str | None = None
+) -> None:
+    config_key = ConfigKey(
+        source_name=ONE_SHOT_SOURCE,
+        service_name='data_reduction',
+        key='workflow_config',
+    )
+    config = workflow_spec.WorkflowConfig(identifier=workflow_id, message_id=message_id)
+    app.publish_config_message(key=config_key, value=config.model_dump(mode='json'))
+
+
+def test_start_command_emits_result_with_no_data_traffic(app: LivedataApp) -> None:
+    """Single config message → single step → ack + result, no data ever flows."""
+    _publish_start_command(app, app.workflow_id, message_id='msg-1')
+
+    app.service.step()
+
+    streams_by_kind = {m.stream.kind for m in app.sink.messages}
+    assert StreamKind.LIVEDATA_RESPONSES in streams_by_kind
+    assert StreamKind.LIVEDATA_DATA in streams_by_kind
+
+    data_messages = [
+        m for m in app.sink.messages if m.stream.kind == StreamKind.LIVEDATA_DATA
+    ]
+    assert len(data_messages) == 1
+    assert data_messages[0].value.values == ONE_SHOT_OUTPUT_VALUE
+
+
+def test_result_emitted_on_first_step_after_command(app: LivedataApp) -> None:
+    """Result is bound to the command-bearing tick, not deferred to a later one."""
+    # First step with no commands and no data: no result must be emitted.
+    app.service.step()
+    assert all(m.stream.kind != StreamKind.LIVEDATA_DATA for m in app.sink.messages)
+
+    _publish_start_command(app, app.workflow_id)
+    app.service.step()
+
+    data_messages = [
+        m for m in app.sink.messages if m.stream.kind == StreamKind.LIVEDATA_DATA
+    ]
+    assert len(data_messages) == 1
+
+
+def test_no_result_emitted_when_no_command_sent(app: LivedataApp) -> None:
+    """Sanity check: idle service produces no data messages on its own."""
+    for _ in range(3):
+        app.service.step()
+
+    assert all(m.stream.kind != StreamKind.LIVEDATA_DATA for m in app.sink.messages)
+
+
+def test_ack_and_result_carry_matching_workflow_identity(app: LivedataApp) -> None:
+    """The ack and the data result both refer to the same scheduled job."""
+    _publish_start_command(app, app.workflow_id, message_id='msg-corr')
+
+    app.service.step()
+
+    ack_messages = [
+        m for m in app.sink.messages if m.stream.kind == StreamKind.LIVEDATA_RESPONSES
+    ]
+    data_messages = [
+        m for m in app.sink.messages if m.stream.kind == StreamKind.LIVEDATA_DATA
+    ]
+    assert len(ack_messages) == 1
+    assert ack_messages[0].value.message_id == 'msg-corr'
+    assert len(data_messages) == 1
+    # Result stream name encodes workflow_id; verify it matches the started one.
+    assert app.workflow_id.name in data_messages[0].stream.name
+
+
+def test_one_shot_job_emits_stopped_status(app: LivedataApp) -> None:
+    """Without a stopped status, the dashboard would keep displaying the job
+    as running because the one-shot job never enters the active/scheduled
+    state that ``_report_status`` walks. Verify the status reaches the sink.
+    """
+    _publish_start_command(app, app.workflow_id)
+
+    app.service.step()
+
+    # Status messages land on a dedicated bucket of FakeMessageSink. Filter
+    # to the JobStatus-shaped messages for the workflow under test (the bucket
+    # also receives ServiceStatus heartbeats).
+    one_shot_statuses = [
+        m
+        for m in app.sink.status_messages
+        if hasattr(m.value, 'workflow_id') and m.value.workflow_id == app.workflow_id
+    ]
+    assert len(one_shot_statuses) == 1
+    status = one_shot_statuses[0].value
+    assert status.state == JobState.stopped
+    assert status.error_message is None


### PR DESCRIPTION
## Summary
- Generic mechanism for jobs whose primary source resolves to zero physical streams: finalize inline during `schedule_job`, no scheduled/active state, result emitted through the config-handler return path on the same loop tick as the ack — no dependency on data traffic for activation or emission.
- Detection in `JobFactory` via `resolve_stream_names`; one-shot jobs bypass the normal lifecycle.
- Action return type changes from `CommandAcknowledgement | None` to `list[Message]` so a single command can carry an ack plus any synchronously-produced result messages; `ConfigProcessor` extends from this list and `OrchestratingProcessor` publishes via its existing per-loop sink call.
- Preparatory work for #894 (dynamic TOF lookup-table workflow); chopperless instruments are the first concrete user.

## Test plan
- [x] Unit tests for one-shot detection in `JobFactory` (with/without stream mapping, logical→physical expansion still resolves non-empty).
- [x] Unit tests for synchronous activation in `JobManager.schedule_job` — no entry in `_scheduled_jobs`/`_active_jobs`, `drain_pending_results` semantics.
- [x] Unit tests for the new `list[Message]` action signatures in `JobManagerAdapter` and aggregation in `ConfigProcessor`.
- [x] Unit tests for `JobResult.to_message()`.
- [x] End-to-end test in `tests/services/one_shot_job_test.py`: config message → single `step()` → ack + result both reach the sink, no data ever fed in.