### PR TITLE
Drop `WorkflowId.namespace`, introduce `WorkflowGroup`

### DIFF
--- a/docs/user-guide/adding-new-instruments.md
+++ b/docs/user-guide/adding-new-instruments.md
@@ -66,9 +66,11 @@ ESSlivedata uses a **two-phase registration pattern** to separate specifications
 Register workflow specifications with explicit metadata and return a handle:
 
 ```python
+from ess.livedata.config.workflow_spec import DETECTORS, REDUCTION
+
 # Register a detector view spec
 view_handle = instrument.register_spec(
-    namespace='detector_data',
+    group=DETECTORS,
     name='detector1_xy',
     version=1,
     title='Detector 1 XY View',
@@ -79,7 +81,7 @@ view_handle = instrument.register_spec(
 
 # Register a data reduction workflow spec
 workflow_handle = instrument.register_spec(
-    namespace='data_reduction',
+    group=REDUCTION,
     name='my_workflow',
     version=1,
     title='My Workflow',
@@ -442,6 +444,7 @@ __all__ = ['detector_fakes', 'setup_factories', 'stream_mapping']
 
 ```python
 from ess.livedata.config import Instrument, instrument_registry
+from ess.livedata.config.workflow_spec import DETECTORS
 from ess.livedata.handlers.detector_view_specs import DetectorViewParams
 
 # Create instrument
@@ -457,7 +460,7 @@ instrument_registry.register(instrument)
 
 # Register detector view spec
 panel_0_view_handle = instrument.register_spec(
-    namespace='detector_data',
+    group=DETECTORS,
     name='panel_0_xy',
     version=1,
     title='Panel 0',

--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -259,6 +259,7 @@ class Instrument:
         source_names: Sequence[str],
         transform: Callable[[sc.DataArray, str], sc.DataArray] | None = None,
         namespace: str = 'detector_data',
+        service: str | None = None,
         roi_support: bool = True,
         output_ndim: int | None = None,
         reduction_dim: str | list[str] | None = None,
@@ -322,6 +323,7 @@ class Instrument:
         params = make_detector_view_params(spectrum_view=spectrum_view)
         handle = self.register_spec(
             namespace=namespace,
+            service=service,
             name=name,
             version=1,
             title=title,
@@ -351,6 +353,7 @@ class Instrument:
         self,
         *,
         namespace: str = 'data_reduction',
+        service: str | None = None,
         name: str,
         version: int,
         title: str,
@@ -372,6 +375,10 @@ class Instrument:
         ----------
         namespace:
             Namespace for the workflow (default: 'data_reduction').
+        service:
+            Name of the backend service responsible for running this workflow.
+            Defaults to ``namespace`` (service and namespace match today; the
+            coupling is removed in a later stage).
         name:
             Name to register the workflow under.
         version:
@@ -415,7 +422,7 @@ class Instrument:
             outputs=outputs,
             reset_on_run_transition=reset_on_run_transition,
         )
-        return self.workflow_factory.register_spec(spec)
+        return self.workflow_factory.register_spec(spec, service=service)
 
     def load_factories(self) -> None:
         """

--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -16,7 +16,7 @@ import scippnexus as snx
 
 from ess.livedata.handlers.workflow_factory import SpecHandle, WorkflowFactory
 
-from .workflow_spec import AuxSources, WorkflowSpec
+from .workflow_spec import DETECTORS, REDUCTION, AuxSources, WorkflowGroup, WorkflowSpec
 
 
 class SourceMetadata(pydantic.BaseModel):
@@ -258,7 +258,7 @@ class Instrument:
         description: str,
         source_names: Sequence[str],
         transform: Callable[[sc.DataArray, str], sc.DataArray] | None = None,
-        namespace: str = 'detector_data',
+        group: WorkflowGroup = DETECTORS,
         service: str | None = None,
         roi_support: bool = True,
         output_ndim: int | None = None,
@@ -290,9 +290,10 @@ class Instrument:
             If reduction_dim is specified, the transform should NOT include
             summing - that is handled separately to enable proper ROI index mapping.
             If None, identity (no reshaping).
-        namespace:
-            Service namespace this view belongs to. Determines which service
-            runs the workflow (e.g. ``'detector_data'`` or ``'monitor_data'``).
+        group:
+            Display-oriented :class:`WorkflowGroup` this view belongs to.
+            The group's ``name`` (e.g. ``'detector_data'`` or ``'monitor_data'``)
+            also determines which service runs the workflow today.
         roi_support:
             Whether ROI selection is supported for this view.
         output_ndim:
@@ -322,7 +323,7 @@ class Instrument:
         )
         params = make_detector_view_params(spectrum_view=spectrum_view)
         handle = self.register_spec(
-            namespace=namespace,
+            group=group,
             service=service,
             name=name,
             version=1,
@@ -352,7 +353,7 @@ class Instrument:
     def register_spec(
         self,
         *,
-        namespace: str = 'data_reduction',
+        group: WorkflowGroup = REDUCTION,
         service: str | None = None,
         name: str,
         version: int,
@@ -373,11 +374,13 @@ class Instrument:
 
         Parameters
         ----------
-        namespace:
-            Namespace for the workflow (default: 'data_reduction').
+        group:
+            Display-oriented :class:`WorkflowGroup` for the workflow
+            (default: ``REDUCTION``). The group's ``name`` is also used as
+            the workflow namespace today.
         service:
             Name of the backend service responsible for running this workflow.
-            Defaults to ``namespace`` (service and namespace match today; the
+            Defaults to ``group.name`` (service and namespace match today; the
             coupling is removed in a later stage).
         name:
             Name to register the workflow under.
@@ -411,7 +414,8 @@ class Instrument:
         """
         spec = WorkflowSpec(
             instrument=self.name,
-            namespace=namespace,
+            namespace=group.name,
+            group=group,
             name=name,
             version=version,
             title=title,

--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -291,8 +291,9 @@ class Instrument:
             If None, identity (no reshaping).
         group:
             Display-oriented :class:`WorkflowGroup` this view belongs to.
-            The group's ``name`` (e.g. ``'detector_data'`` or ``'monitor_data'``)
-            also determines which service runs the workflow today.
+        service:
+            Name of the backend service responsible for running this workflow.
+            Defaults to ``group.name``.
         roi_support:
             Whether ROI selection is supported for this view.
         output_ndim:
@@ -378,8 +379,7 @@ class Instrument:
             (default: ``REDUCTION``).
         service:
             Name of the backend service responsible for running this workflow.
-            Defaults to ``group.name`` (service and group identifier match
-            today; the coupling is removed in a later stage).
+            Defaults to ``group.name``.
         name:
             Name to register the workflow under.
         version:

--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -93,7 +93,6 @@ class Instrument:
     source_metadata: dict[str, SourceMetadata] = field(default_factory=dict)
     _detector_numbers: dict[str, sc.Variable] = field(default_factory=dict)
     _nexus_file: str | None = None
-    active_namespace: str | None = None
     _detector_group_names: dict[str, str] = field(default_factory=dict)
     _timeseries_workflow_handle: SpecHandle | None = field(default=None, init=False)
     _logical_views: list[LogicalViewConfig] = field(default_factory=list, init=False)
@@ -274,7 +273,7 @@ class Instrument:
         Parameters
         ----------
         name:
-            Unique name for the view within the given namespace.
+            Unique name for the view within the given group.
         title:
             Human-readable title for the view.
         description:
@@ -376,12 +375,11 @@ class Instrument:
         ----------
         group:
             Display-oriented :class:`WorkflowGroup` for the workflow
-            (default: ``REDUCTION``). The group's ``name`` is also used as
-            the workflow namespace today.
+            (default: ``REDUCTION``).
         service:
             Name of the backend service responsible for running this workflow.
-            Defaults to ``group.name`` (service and namespace match today; the
-            coupling is removed in a later stage).
+            Defaults to ``group.name`` (service and group identifier match
+            today; the coupling is removed in a later stage).
         name:
             Name to register the workflow under.
         version:
@@ -414,7 +412,6 @@ class Instrument:
         """
         spec = WorkflowSpec(
             instrument=self.name,
-            namespace=group.name,
             group=group,
             name=name,
             version=version,

--- a/src/ess/livedata/config/instruments/dream/specs.py
+++ b/src/ess/livedata/config/instruments/dream/specs.py
@@ -11,7 +11,12 @@ import scipp as sc
 
 from ess.livedata import parameter_models
 from ess.livedata.config import Instrument, SourceMetadata, instrument_registry
-from ess.livedata.config.workflow_spec import AuxInput, AuxSources, WorkflowOutputsBase
+from ess.livedata.config.workflow_spec import (
+    DETECTORS,
+    AuxInput,
+    AuxSources,
+    WorkflowOutputsBase,
+)
 from ess.livedata.handlers.detector_view_specs import (
     DetectorROIAuxSources,
     DetectorViewOutputs,
@@ -174,7 +179,7 @@ class DreamDetectorViewParams(DetectorViewParams):
 # Replaces both the legacy DetectorProjection and the Sciline detector view
 # registrations.
 projection_handle = instrument.register_spec(
-    namespace='detector_data',
+    group=DETECTORS,
     name='detector_projection',
     version=1,
     title='Detector Projection',

--- a/src/ess/livedata/config/instruments/dummy/specs.py
+++ b/src/ess/livedata/config/instruments/dummy/specs.py
@@ -8,7 +8,7 @@ import pydantic
 import scipp as sc
 
 from ess.livedata.config import Instrument, instrument_registry
-from ess.livedata.config.workflow_spec import WorkflowOutputsBase
+from ess.livedata.config.workflow_spec import DETECTORS, WorkflowOutputsBase
 from ess.livedata.handlers.detector_view_specs import (
     DetectorViewOutputs,
     DetectorViewParams,
@@ -50,7 +50,7 @@ monitor_handle = register_monitor_workflow_specs(
 # Note: We don't use register_detector_view_specs here because dummy uses
 # DetectorLogicalView which doesn't follow the projection pattern.
 panel_0_view_handle = instrument.register_spec(
-    namespace='detector_data',
+    group=DETECTORS,
     name='panel_0_xy',
     version=1,
     title='Panel 0',
@@ -62,7 +62,7 @@ panel_0_view_handle = instrument.register_spec(
 
 # Register area detector view spec
 area_panel_view_handle = instrument.register_spec(
-    namespace='detector_data',
+    group=DETECTORS,
     name='area_panel_xy',
     version=1,
     title='Area Panel',

--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -11,7 +11,12 @@ import scipp as sc
 
 from ess.livedata import parameter_models
 from ess.livedata.config import Instrument, SourceMetadata, instrument_registry
-from ess.livedata.config.workflow_spec import AuxInput, AuxSources, WorkflowOutputsBase
+from ess.livedata.config.workflow_spec import (
+    MONITORS,
+    AuxInput,
+    AuxSources,
+    WorkflowOutputsBase,
+)
 from ess.livedata.handlers.detector_view.types import TransformValueStream
 from ess.livedata.handlers.detector_view_specs import (
     DetectorROIAuxSources,
@@ -256,7 +261,7 @@ instrument.add_logical_view(
     title='Beam monitor: counts per pixel',
     description='Per-pixel event counts for pixellated beam monitors.',
     source_names=['beam_monitor_m3'],
-    namespace='monitor_data',
+    group=MONITORS,
     roi_support=False,
     output_ndim=1,
 )

--- a/src/ess/livedata/config/instruments/nmx/specs.py
+++ b/src/ess/livedata/config/instruments/nmx/specs.py
@@ -5,6 +5,7 @@ NMX instrument spec registration.
 """
 
 from ess.livedata.config import Instrument, instrument_registry
+from ess.livedata.config.workflow_spec import DETECTORS
 from ess.livedata.handlers.detector_view_specs import (
     DetectorViewOutputs,
     DetectorViewParams,
@@ -34,7 +35,7 @@ monitor_handle = register_monitor_workflow_specs(
 
 # Register detector view spec for the panel_xy view
 panel_xy_view_handle = instrument.register_spec(
-    namespace='detector_data',
+    group=DETECTORS,
     name='panel_xy',
     version=1,
     title='Detector counts',

--- a/src/ess/livedata/config/instruments/tbl/specs.py
+++ b/src/ess/livedata/config/instruments/tbl/specs.py
@@ -5,6 +5,7 @@ TBL workflow spec registration.
 """
 
 from ess.livedata.config import Instrument, SourceMetadata, instrument_registry
+from ess.livedata.config.workflow_spec import DETECTORS
 from ess.livedata.handlers.detector_view_specs import DetectorViewOutputs
 from ess.livedata.handlers.monitor_workflow_specs import (
     TOAOnlyMonitorDataParams,
@@ -85,7 +86,7 @@ instrument.add_logical_view(
 )
 
 orca_view_handle = instrument.register_spec(
-    namespace='detector_data',
+    group=DETECTORS,
     name='tbl_area_detector_orca',
     version=1,
     title='Orca Detector',

--- a/src/ess/livedata/config/route_derivation.py
+++ b/src/ess/livedata/config/route_derivation.py
@@ -26,7 +26,7 @@ def gather_source_names(
     """
     names: set[str] = set()
     for spec in instrument.workflow_factory.values():
-        if spec.namespace != namespace:
+        if spec.group.name != namespace:
             continue
         names.update(spec.source_names)
         if spec.aux_sources:

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -78,24 +78,22 @@ TIMESERIES = WorkflowGroup(
 
 class WorkflowId(BaseModel, frozen=True):
     instrument: str
-    namespace: str
     name: str
     version: int
 
     def __str__(self) -> str:
-        return f"{self.instrument}/{self.namespace}/{self.name}/{self.version}"
+        return f"{self.instrument}/{self.name}/{self.version}"
 
     @staticmethod
     def from_string(workflow_id_str: str) -> WorkflowId:
         """Parse WorkflowId from string representation."""
         parts = workflow_id_str.split('/')
-        if len(parts) != 4:
+        if len(parts) != 3:
             raise ValueError(f"Invalid WorkflowId string format: {workflow_id_str}")
         return WorkflowId(
             instrument=parts[0],
-            namespace=parts[1],
-            name=parts[2],
-            version=int(parts[3]),
+            name=parts[1],
+            version=int(parts[2]),
         )
 
 
@@ -219,10 +217,6 @@ class WorkflowSpec(BaseModel):
     instrument: str = Field(
         description="Name of the instrument this workflow is associated with."
     )
-    namespace: str = Field(
-        default='data_reduction',
-        description="Namespace for the workflow, used to group workflows logically.",
-    )
     group: WorkflowGroup = Field(
         description=(
             "Display-oriented group this workflow belongs to. Carries the UI "
@@ -313,11 +307,10 @@ class WorkflowSpec(BaseModel):
         """
         Get a unique identifier for the workflow.
 
-        The identifier is a combination of instrument, namespace, name, and version.
+        The identifier is a combination of instrument, name, and version.
         """
         return WorkflowId(
             instrument=self.instrument,
-            namespace=self.namespace,
             name=self.name,
             version=self.version,
         )

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -10,7 +10,7 @@ import uuid
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 import scipp as sc
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -39,6 +39,41 @@ class DefaultOutputs(WorkflowOutputsBase):
     """
 
     result: sc.DataArray = Field(title='Result', description='Workflow output.')
+
+
+class WorkflowGroup(BaseModel, frozen=True):
+    """Display-oriented grouping for workflow specs.
+
+    Groups bundle related workflows for the dashboard UI. Identity is by
+    the ``name`` field; the ``Literal`` constraint locks the set of legal
+    categories to prevent ad-hoc construction sneaking in new ones.
+    """
+
+    name: Literal['data_reduction', 'monitor_data', 'detector_data', 'timeseries']
+    title: str
+    description: str = ''
+
+
+REDUCTION = WorkflowGroup(
+    name='data_reduction',
+    title='Reduction',
+    description='Scientific data reduction workflows.',
+)
+MONITORS = WorkflowGroup(
+    name='monitor_data',
+    title='Monitors',
+    description='Beam monitor data workflows.',
+)
+DETECTORS = WorkflowGroup(
+    name='detector_data',
+    title='Detectors',
+    description='Detector data workflows.',
+)
+TIMESERIES = WorkflowGroup(
+    name='timeseries',
+    title='Timeseries',
+    description='Timeseries log data workflows.',
+)
 
 
 class WorkflowId(BaseModel, frozen=True):
@@ -187,6 +222,14 @@ class WorkflowSpec(BaseModel):
     namespace: str = Field(
         default='data_reduction',
         description="Namespace for the workflow, used to group workflows logically.",
+    )
+    group: WorkflowGroup = Field(
+        description=(
+            "Display-oriented group this workflow belongs to. Carries the UI "
+            "title and description; the ``name`` field is the canonical category "
+            "identifier (one of ``data_reduction``, ``monitor_data``, "
+            "``detector_data``, ``timeseries``)."
+        ),
     )
     name: str = Field(description="Name of the workflow. Used internally.")
     version: int = Field(description="Version of the workflow.")

--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -141,7 +141,7 @@ class ServiceStatus:
     """Complete status information for a backend service worker."""
 
     instrument: str
-    namespace: str
+    service_name: str
     worker_id: str  # UUID as string
     state: ServiceState
     started_at: Timestamp

--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -83,8 +83,9 @@ class JobCommand(pydantic.BaseModel):
 
 
 class JobFactory:
-    def __init__(self, instrument: Instrument) -> None:
+    def __init__(self, instrument: Instrument, *, service_name: str) -> None:
         self._instrument = instrument
+        self._service_name = service_name
 
     def get_workflow_spec(self, workflow_id: WorkflowId) -> WorkflowSpec | None:
         """Get the workflow specification for a given workflow ID."""
@@ -128,12 +129,12 @@ class JobFactory:
         workflow_id = config.identifier
         if workflow_id is None:
             raise ValueError("WorkflowConfig must have an identifier to create a Job")
+        factory = self._instrument.workflow_factory
         if (workflow_id.instrument != self._instrument.name) or (
-            workflow_id.namespace != self._instrument.active_namespace
+            factory.get_service(workflow_id) != self._service_name
         ):
             raise DifferentInstrument()
 
-        factory = self._instrument.workflow_factory
         workflow_spec = factory.get(workflow_id)
         if workflow_spec is None:
             raise WorkflowNotFoundError(f"WorkflowSpec with Id {workflow_id} not found")

--- a/src/ess/livedata/core/orchestrating_processor.py
+++ b/src/ess/livedata/core/orchestrating_processor.py
@@ -171,7 +171,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
 
         # Service heartbeat state
         self._instrument = instrument.name
-        self._namespace = service_name
+        self._service_name = service_name
         self._worker_id = str(uuid.uuid4())
         self._started_at = Timestamp.now()
         self._service_state = ServiceState.starting
@@ -327,7 +327,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         self._pending_stream_stats = None
         return ServiceStatus(
             instrument=self._instrument,
-            namespace=self._namespace,
+            service_name=self._service_name,
             worker_id=self._worker_id,
             state=self._service_state,
             started_at=self._started_at,

--- a/src/ess/livedata/core/orchestrating_processor.py
+++ b/src/ess/livedata/core/orchestrating_processor.py
@@ -148,6 +148,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         source: MessageSource[Message[Tin]],
         sink: MessageSink[Tout],
         preprocessor_factory: PreprocessorFactory[Tin, Tout],
+        service_name: str,
         message_batcher: MessageBatcher | None = None,
         job_threads: int = 1,
         stream_stats_provider: StreamStatsProvider | None = None,
@@ -157,7 +158,8 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
         self._message_preprocessor = MessagePreprocessor(factory=preprocessor_factory)
         instrument = preprocessor_factory.instrument
         self._job_manager = JobManager(
-            job_factory=JobFactory(instrument=instrument), job_threads=job_threads
+            job_factory=JobFactory(instrument=instrument, service_name=service_name),
+            job_threads=job_threads,
         )
         self._job_manager_adapter = JobManagerAdapter(job_manager=self._job_manager)
         self._message_batcher = message_batcher or AdaptiveMessageBatcher()
@@ -169,7 +171,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
 
         # Service heartbeat state
         self._instrument = instrument.name
-        self._namespace = instrument.active_namespace or "unknown"
+        self._namespace = service_name
         self._worker_id = str(uuid.uuid4())
         self._started_at = Timestamp.now()
         self._service_state = ServiceState.starting

--- a/src/ess/livedata/dashboard/service_registry.py
+++ b/src/ess/livedata/dashboard/service_registry.py
@@ -19,7 +19,7 @@ SERVICE_HEARTBEAT_TIMEOUT_NS = 30_000_000_000
 
 def make_worker_key(status: ServiceStatus) -> str:
     """Create a unique key for a worker from its status."""
-    return f"{status.instrument}:{status.namespace}:{status.worker_id}"
+    return f"{status.instrument}:{status.service_name}:{status.worker_id}"
 
 
 class ServiceRegistry:
@@ -67,7 +67,7 @@ class ServiceRegistry:
         Parameters
         ----------
         worker_key
-            The worker key (instrument:namespace:worker_id) to check.
+            The worker key (instrument:service_name:worker_id) to check.
 
         Returns
         -------

--- a/src/ess/livedata/dashboard/widgets/backend_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/backend_status_widget.py
@@ -32,7 +32,7 @@ class WorkerUIConstants:
     STALE_COLOR = StatusColors.ERROR
 
     # Sizes
-    NAMESPACE_WIDTH = 200
+    SERVICE_WIDTH = 200
     WORKER_ID_WIDTH = 150
     STATUS_WIDTH = 90
     VERSION_WIDTH = 200
@@ -154,8 +154,8 @@ class WorkerStatusRow:
         last_seen_seconds_ago: float | None = None,
     ) -> None:
         # Create stable pane references
-        self._namespace_pane = pn.pane.HTML(
-            width=WorkerUIConstants.NAMESPACE_WIDTH,
+        self._service_pane = pn.pane.HTML(
+            width=WorkerUIConstants.SERVICE_WIDTH,
             margin=WorkerUIConstants.STANDARD_MARGIN,
         )
         self._worker_id_pane = pn.pane.HTML(
@@ -180,7 +180,7 @@ class WorkerStatusRow:
         )
 
         row = pn.Row(
-            self._namespace_pane,
+            self._service_pane,
             self._worker_id_pane,
             self._status_pane,
             self._version_pane,
@@ -233,9 +233,9 @@ class WorkerStatusRow:
         last_seen_seconds_ago: float | None = None,
     ) -> None:
         """Update the row content in-place."""
-        # Namespace
-        namespace_text = f"{status.instrument}:{status.namespace}"
-        self._namespace_pane.object = f"<b>{namespace_text}</b>"
+        # Service
+        service_text = f"{status.instrument}:{status.service_name}"
+        self._service_pane.object = f"<b>{service_text}</b>"
 
         # Worker ID (truncated)
         worker_id_short = status.worker_id[:8]
@@ -341,8 +341,8 @@ class BackendStatusWidget:
         )
         self._table_header = pn.Row(
             pn.pane.HTML(
-                f'<span style="{header_style}">Namespace</span>',
-                width=WorkerUIConstants.NAMESPACE_WIDTH,
+                f'<span style="{header_style}">Service</span>',
+                width=WorkerUIConstants.SERVICE_WIDTH,
                 margin=WorkerUIConstants.STANDARD_MARGIN,
             ),
             pn.pane.HTML(

--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -46,10 +46,9 @@ from .wizard import Wizard, WizardStep
 logger = structlog.get_logger(__name__)
 
 # Synthetic workflow ID for static overlays (no actual workflow subscription)
-STATIC_OVERLAY_NAMESPACE = "static_overlay"
+STATIC_OVERLAY_GROUP = "static_overlay"
 STATIC_OVERLAY_WORKFLOW = WorkflowId(
     instrument="static",
-    namespace=STATIC_OVERLAY_NAMESPACE,
     name="geometric",
     version=1,
 )
@@ -297,7 +296,7 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
         super().__init__()
         self._workflow_registry = dict(workflow_registry)
         self._initial_config = initial_config
-        self._selected_namespace: str | None = None
+        self._selected_group: str | None = None
         self._selected_workflow_id: WorkflowId | None = None
         self._selected_output: str | None = None
 
@@ -307,7 +306,7 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
         self._output_container = pn.Column(sizing_mode='stretch_width')
 
         # Create all button widgets once (reuse by updating options)
-        self._namespace_buttons = self._create_namespace_buttons()
+        self._group_buttons = self._create_group_buttons()
         self._workflow_buttons = self._create_workflow_buttons()
         self._output_buttons = self._create_output_buttons()
         self._workflow_description = pn.pane.HTML(
@@ -346,12 +345,12 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
         """Description text for this step."""
         return "Choose the workflow and output to visualize."
 
-    def _format_namespace_label(self, namespace: str) -> str:
-        """Format namespace name for display.
-
-        Example: 'data_reduction' -> 'Data Reduction'.
-        """
-        return namespace.replace('_', ' ').title()
+    def _group_for_workflow(self, workflow_id: WorkflowId) -> str | None:
+        """Return the group identifier for a workflow id, or None if unknown."""
+        if workflow_id == STATIC_OVERLAY_WORKFLOW:
+            return STATIC_OVERLAY_GROUP
+        spec = self._workflow_registry.get(workflow_id)
+        return spec.group.name if spec is not None else None
 
     def _initialize_selections(self, initial_config: PlotConfig | None) -> None:
         """Initialize selections and bind handlers afterward to avoid cascades."""
@@ -359,8 +358,9 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
         with pn.io.hold():
             if initial_config is not None:
                 # Edit mode: pre-select from config
-                self._selected_namespace = initial_config.workflow_id.namespace
-                self._namespace_buttons.value = initial_config.workflow_id.namespace
+                group_value = self._group_for_workflow(initial_config.workflow_id)
+                self._selected_group = group_value
+                self._group_buttons.value = group_value
                 self._update_workflow_options()
                 self._selected_workflow_id = initial_config.workflow_id
                 self._workflow_buttons.value = initial_config.workflow_id
@@ -371,11 +371,11 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
                     self._name_input.value = initial_config.output_name
                 else:
                     self._output_buttons.value = initial_config.output_name
-            elif self._namespace_buttons.options:
+            elif self._group_buttons.options:
                 # New mode: select first available option
-                namespace_value = next(iter(self._namespace_buttons.options.values()))
-                self._selected_namespace = namespace_value
-                self._namespace_buttons.value = namespace_value
+                group_value = next(iter(self._group_buttons.options.values()))
+                self._selected_group = group_value
+                self._group_buttons.value = group_value
                 self._update_workflow_options()
                 if self._workflow_buttons.options:
                     workflow_value = next(iter(self._workflow_buttons.options.values()))
@@ -392,7 +392,7 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
                             self._output_buttons.value = output_value
 
         # Bind handlers after initial values are set
-        self._namespace_buttons.param.watch(self._on_namespace_change, 'value')
+        self._group_buttons.param.watch(self._on_group_change, 'value')
         self._workflow_buttons.param.watch(self._on_workflow_change, 'value')
         self._output_buttons.param.watch(self._on_output_change, 'value')
         self._name_input.param.watch(self._on_name_input_change, 'value')
@@ -400,18 +400,21 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
         self._update_output_description()
         self._validate()
 
-    def _create_namespace_buttons(self) -> pn.widgets.RadioButtonGroup:
-        """Create namespace selection radio buttons (handler bound later)."""
-        namespaces = sorted(
-            {wid.namespace for wid in self._workflow_registry.keys()},
-            reverse=True,
-        )
-        options = {self._format_namespace_label(ns): ns for ns in namespaces}
-        # Add synthetic "Static Overlay" namespace for geometric overlays
-        options["Static Overlay"] = STATIC_OVERLAY_NAMESPACE
+    def _create_group_buttons(self) -> pn.widgets.RadioButtonGroup:
+        """Create workflow-group selection radio buttons (handler bound later)."""
+        # Deduplicate by group identifier; keep first-seen title for display.
+        groups: dict[str, str] = {}
+        for spec in self._workflow_registry.values():
+            groups.setdefault(spec.group.name, spec.group.title)
+        options = {
+            title: name
+            for name, title in sorted(groups.items(), key=lambda item: item[0])
+        }
+        # Add synthetic "Static Overlay" group for geometric overlays
+        options["Static Overlay"] = STATIC_OVERLAY_GROUP
 
         return pn.widgets.RadioButtonGroup(
-            name='Namespace',
+            name='Group',
             options=options,
             orientation='horizontal',
             button_type='primary',
@@ -452,12 +455,12 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
             sizing_mode='stretch_width',
         )
 
-    def _on_namespace_change(self, event) -> None:
-        """Handle namespace selection change."""
+    def _on_group_change(self, event) -> None:
+        """Handle workflow-group selection change."""
         # Batch all cascading widget updates
         with pn.io.hold():
             if event.new is not None:
-                self._selected_namespace = event.new
+                self._selected_group = event.new
                 self._selected_workflow_id = None
                 self._selected_output = None
                 self._update_workflow_options()
@@ -476,7 +479,7 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
                         self._selected_output = first_output
                         self._output_buttons.value = first_output
             else:
-                self._selected_namespace = None
+                self._selected_group = None
                 self._selected_workflow_id = None
                 self._selected_output = None
         self._update_workflow_description()
@@ -549,20 +552,20 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
         self._validate()
 
     def _update_workflow_options(self) -> None:
-        """Update workflow button options based on selected namespace."""
-        if self._selected_namespace is None:
+        """Update workflow button options based on selected group."""
+        if self._selected_group is None:
             self._workflow_buttons.options = {}
             return
 
-        # Handle synthetic static overlay namespace
-        if self._selected_namespace == STATIC_OVERLAY_NAMESPACE:
+        # Handle synthetic static overlay group
+        if self._selected_group == STATIC_OVERLAY_GROUP:
             self._workflow_buttons.options = {"Geometric": STATIC_OVERLAY_WORKFLOW}
             return
 
         filtered_workflows = [
             (wid, spec)
             for wid, spec in self._workflow_registry.items()
-            if wid.namespace == self._selected_namespace
+            if spec.group.name == self._selected_group
         ]
 
         if not filtered_workflows:
@@ -609,13 +612,13 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
         self._output_buttons.options = options
 
     def _update_content(self) -> None:
-        """Update content with namespace selector above workflow/output columns."""
+        """Update content with group selector above workflow/output columns."""
         self._content_container.clear()
 
-        # Namespace selector on top (horizontal)
-        namespace_section = pn.Column(
-            pn.pane.Markdown("**Namespace**"),
-            self._namespace_buttons,
+        # Group selector on top (horizontal)
+        group_section = pn.Column(
+            pn.pane.Markdown("**Group**"),
+            self._group_buttons,
             sizing_mode='stretch_width',
         )
 
@@ -634,22 +637,22 @@ class WorkflowAndOutputSelectionStep(WizardStep[None, OutputSelection]):
 
         two_columns = pn.Row(workflow_col, output_col, sizing_mode='stretch_width')
 
-        self._content_container.append(namespace_section)
+        self._content_container.append(group_section)
         self._content_container.append(two_columns)
 
     def _validate(self) -> None:
         """Update validity based on selections."""
         is_valid = (
-            self._selected_namespace is not None
+            self._selected_group is not None
             and self._selected_workflow_id is not None
             and self._selected_output is not None
         )
         self._notify_ready_changed(is_valid)
 
     def is_valid(self) -> bool:
-        """Whether namespace, workflow, and output have all been selected."""
+        """Whether group, workflow, and output have all been selected."""
         return (
-            self._selected_namespace is not None
+            self._selected_group is not None
             and self._selected_workflow_id is not None
             and self._selected_output is not None
         )

--- a/src/ess/livedata/handlers/detector_view_specs.py
+++ b/src/ess/livedata/handlers/detector_view_specs.py
@@ -26,7 +26,13 @@ import scipp as sc
 from .. import parameter_models
 from ..config import models
 from ..config.instrument import Instrument
-from ..config.workflow_spec import AuxInput, AuxSources, JobId, WorkflowOutputsBase
+from ..config.workflow_spec import (
+    DETECTORS,
+    AuxInput,
+    AuxSources,
+    JobId,
+    WorkflowOutputsBase,
+)
 from ..handlers.workflow_factory import SpecHandle
 
 CoordinateMode = Literal['toa', 'wavelength']
@@ -567,7 +573,7 @@ def register_detector_view_spec(
         raise ValueError(f"Unsupported projection: {projection}")
 
     return instrument.register_spec(
-        namespace="detector_data",
+        group=DETECTORS,
         name=name,
         version=1,
         title=title,

--- a/src/ess/livedata/handlers/monitor_workflow_specs.py
+++ b/src/ess/livedata/handlers/monitor_workflow_specs.py
@@ -9,7 +9,7 @@ import scipp as sc
 
 from .. import parameter_models
 from ..config.instrument import Instrument
-from ..config.workflow_spec import AuxSources, WorkflowOutputsBase
+from ..config.workflow_spec import MONITORS, AuxSources, WorkflowOutputsBase
 from ..handlers.detector_view_specs import CoordinateMode, CoordinateModeSettings
 from ..handlers.workflow_factory import SpecHandle
 
@@ -235,7 +235,7 @@ def register_monitor_workflow_specs(
         description = f"{description}<br><br>{extra_description}"
 
     return instrument.register_spec(
-        namespace='monitor_data',
+        group=MONITORS,
         name='monitor_histogram',
         version=1,
         title="Beam monitor",

--- a/src/ess/livedata/handlers/timeseries_workflow_specs.py
+++ b/src/ess/livedata/handlers/timeseries_workflow_specs.py
@@ -8,7 +8,7 @@ import pydantic
 import scipp as sc
 
 from ..config.instrument import Instrument
-from ..config.workflow_spec import WorkflowOutputsBase
+from ..config.workflow_spec import TIMESERIES, WorkflowOutputsBase
 from ..handlers.workflow_factory import SpecHandle
 
 
@@ -55,7 +55,7 @@ def register_timeseries_workflow_specs(
         return None
 
     return instrument.register_spec(
-        namespace='timeseries',
+        group=TIMESERIES,
         name='timeseries_data',
         version=1,
         title="Timeseries data",

--- a/src/ess/livedata/handlers/workflow_factory.py
+++ b/src/ess/livedata/handlers/workflow_factory.py
@@ -49,6 +49,7 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
     def __init__(self) -> None:
         self._factories: dict[WorkflowId, Callable[[], Workflow]] = {}
         self._workflow_specs: dict[WorkflowId, WorkflowSpec] = {}
+        self._services: dict[WorkflowId, str] = {}
 
     def __getitem__(self, key: WorkflowId) -> WorkflowSpec:
         return self._workflow_specs[key]
@@ -59,7 +60,9 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
     def __len__(self) -> int:
         return len(self._workflow_specs)
 
-    def register_spec(self, spec: WorkflowSpec) -> SpecHandle:
+    def register_spec(
+        self, spec: WorkflowSpec, *, service: str | None = None
+    ) -> SpecHandle:
         """
         Register workflow spec, return handle for later factory attachment.
 
@@ -71,6 +74,12 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         ----------
         spec:
             Workflow specification to register.
+        service:
+            Name of the backend service responsible for running this workflow.
+            Used by ``JobFactory`` to reject workflows not belonging to the
+            current service. Defaults to ``spec.namespace`` (namespace and
+            service name are identical today; the coupling is removed in a
+            later stage).
 
         Returns
         -------
@@ -80,7 +89,12 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         if spec_id in self._workflow_specs:
             raise ValueError(f"Workflow spec '{spec_id}' already registered.")
         self._workflow_specs[spec_id] = spec
+        self._services[spec_id] = service if service is not None else spec.namespace
         return SpecHandle(workflow_id=spec_id, _factory=self)
+
+    def get_service(self, workflow_id: WorkflowId) -> str | None:
+        """Return the backend service name that runs the given workflow."""
+        return self._services.get(workflow_id)
 
     def attach_factory(
         self, workflow_id: WorkflowId

--- a/src/ess/livedata/handlers/workflow_factory.py
+++ b/src/ess/livedata/handlers/workflow_factory.py
@@ -77,9 +77,9 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         service:
             Name of the backend service responsible for running this workflow.
             Used by ``JobFactory`` to reject workflows not belonging to the
-            current service. Defaults to ``spec.namespace`` (namespace and
-            service name are identical today; the coupling is removed in a
-            later stage).
+            current service. Defaults to ``spec.group.name`` (group identifier
+            and service name are identical today; the coupling is removed in
+            a later stage).
 
         Returns
         -------
@@ -89,7 +89,7 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         if spec_id in self._workflow_specs:
             raise ValueError(f"Workflow spec '{spec_id}' already registered.")
         self._workflow_specs[spec_id] = spec
-        self._services[spec_id] = service if service is not None else spec.namespace
+        self._services[spec_id] = service if service is not None else spec.group.name
         return SpecHandle(workflow_id=spec_id, _factory=self)
 
     def get_service(self, workflow_id: WorkflowId) -> str | None:

--- a/src/ess/livedata/handlers/workflow_factory.py
+++ b/src/ess/livedata/handlers/workflow_factory.py
@@ -77,9 +77,7 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         service:
             Name of the backend service responsible for running this workflow.
             Used by ``JobFactory`` to reject workflows not belonging to the
-            current service. Defaults to ``spec.group.name`` (group identifier
-            and service name are identical today; the coupling is removed in
-            a later stage).
+            current service. Defaults to ``spec.group.name``.
 
         Returns
         -------

--- a/src/ess/livedata/kafka/x5f2_compat.py
+++ b/src/ess/livedata/kafka/x5f2_compat.py
@@ -133,32 +133,36 @@ def service_state_to_nicos_status_constant(state: ServiceState) -> NicosStatus:
 
 class ServiceServiceId(pydantic.BaseModel):
     """
-    Helper class for handling service_id in instrument:namespace:worker_id format.
+    Helper class for handling service_id in instrument:service_name:worker_id format.
 
     NICOS expects a format of device_name:signal_name. For service heartbeats, we use
-    instrument:namespace:worker_uuid to uniquely identify each worker.
+    instrument:service_name:worker_uuid to uniquely identify each worker.
     """
 
     instrument: str = pydantic.Field(description="Instrument name")
-    namespace: str = pydantic.Field(description="Service namespace")
+    service_name: str = pydantic.Field(description="Backend service name")
     worker_id: str = pydantic.Field(description="Worker UUID as string")
 
     @classmethod
     def from_string(cls, service_id: str) -> ServiceServiceId:
-        """Parse service_id string in format 'instrument:namespace:worker_id'."""
+        """Parse service_id string in format 'instrument:service_name:worker_id'."""
         try:
             # Split on colons - expect exactly 3 parts
             parts = service_id.rsplit(':', 2)
             if len(parts) != 3:
                 raise ValueError("Expected 3 colon-separated parts")
-            instrument, namespace, worker_id = parts
+            instrument, service_name, worker_id = parts
             # Validate worker_id is a valid UUID
             uuid.UUID(worker_id)
-            return cls(instrument=instrument, namespace=namespace, worker_id=worker_id)
+            return cls(
+                instrument=instrument,
+                service_name=service_name,
+                worker_id=worker_id,
+            )
         except (ValueError, TypeError) as e:
             raise ValueError(
                 f"Invalid service_id format '{service_id}'. "
-                "Expected 'instrument:namespace:worker_uuid'"
+                "Expected 'instrument:service_name:worker_uuid'"
             ) from e
 
     @classmethod
@@ -166,13 +170,13 @@ class ServiceServiceId(pydantic.BaseModel):
         """Create ServiceServiceId from ServiceStatus."""
         return cls(
             instrument=status.instrument,
-            namespace=status.namespace,
+            service_name=status.service_name,
             worker_id=status.worker_id,
         )
 
     def to_string(self) -> str:
-        """Convert to service_id string in format 'instrument:namespace:worker_id'."""
-        return f"{self.instrument}:{self.namespace}:{self.worker_id}"
+        """Convert to string in format 'instrument:service_name:worker_id'."""
+        return f"{self.instrument}:{self.service_name}:{self.worker_id}"
 
     def __str__(self) -> str:
         return self.to_string()
@@ -201,7 +205,7 @@ class ServiceStatusPayload(pydantic.BaseModel):
         default="service", description="Message type for explicit typing"
     )
     instrument: str = pydantic.Field(description="Instrument name")
-    namespace: str = pydantic.Field(description="Service namespace")
+    service_name: str = pydantic.Field(description="Backend service name")
     worker_id: str = pydantic.Field(description="Worker UUID as string")
     state: ServiceState = pydantic.Field(description="Current state of the service")
     started_at: Timestamp = pydantic.Field(description="Service start time")
@@ -237,7 +241,7 @@ class ServiceStatusMessage(pydantic.BaseModel):
         default='0.0.0', description="Version of the software"
     )
     service_id: ServiceServiceId = pydantic.Field(
-        description="Service identifier as instrument:namespace:worker_id"
+        description="Service identifier as instrument:service_name:worker_id"
     )
     host_name: str = pydantic.Field(default='', description="Host name")
     process_id: int = pydantic.Field(default=0, description="Process ID")
@@ -292,7 +296,7 @@ class ServiceStatusMessage(pydantic.BaseModel):
                 status=service_state_to_nicos_status_constant(status.state),
                 message=ServiceStatusPayload(
                     instrument=status.instrument,
-                    namespace=status.namespace,
+                    service_name=status.service_name,
                     worker_id=status.worker_id,
                     state=status.state,
                     started_at=status.started_at,
@@ -309,7 +313,7 @@ class ServiceStatusMessage(pydantic.BaseModel):
         message = self.status_json.message
         return ServiceStatus(
             instrument=message.instrument,
-            namespace=message.namespace,
+            service_name=message.service_name,
             worker_id=message.worker_id,
             state=message.state,
             started_at=message.started_at,

--- a/src/ess/livedata/service_factory.py
+++ b/src/ess/livedata/service_factory.py
@@ -13,7 +13,7 @@ import structlog
 from .config import config_names
 from .config.config_loader import load_config
 from .core import MessageSink, Processor
-from .core.handler import JobBasedPreprocessorFactoryBase, PreprocessorFactory
+from .core.handler import PreprocessorFactory
 from .core.message import Message, MessageSource
 from .core.message_batcher import (
     AdaptiveMessageBatcher,
@@ -93,6 +93,7 @@ class DataServiceBuilder(Generic[Traw, Tin, Tout]):
             one based on its CLI argument.
         """
         self._name = f'{instrument}_{name}'
+        self._service_name = name
         self._log_level = log_level
         self._topics: list[KafkaTopic] | None = None
         self._instrument = instrument
@@ -103,9 +104,6 @@ class DataServiceBuilder(Generic[Traw, Tin, Tout]):
         self._job_threads = job_threads
         self._stream_counter = stream_counter
         self._message_batcher = message_batcher
-        if isinstance(preprocessor_factory, JobBasedPreprocessorFactoryBase):
-            # Ensure only jobs from the active namespace can be created by JobFactory.
-            preprocessor_factory.instrument.active_namespace = name
 
     @property
     def instrument(self) -> str:
@@ -211,6 +209,7 @@ class DataServiceBuilder(Generic[Traw, Tin, Tout]):
             ),
             sink=sink,
             preprocessor_factory=self._preprocessor_factory,
+            service_name=self._service_name,
             job_threads=self._job_threads,
             stream_stats_provider=self._stream_counter,
             message_batcher=self._message_batcher,

--- a/tests/config/grid_template_test.py
+++ b/tests/config/grid_template_test.py
@@ -31,7 +31,7 @@ def _make_plot_cell(
     config = PlotConfig(
         data_sources={
             PRIMARY: DataSourceConfig(
-                workflow_id=WorkflowId.from_string('test/ns/wf/1'),
+                workflow_id=WorkflowId.from_string('test/wf/1'),
                 output_name='output',
                 source_names=['source1'],
             )

--- a/tests/config/instrument_test.py
+++ b/tests/config/instrument_test.py
@@ -9,7 +9,7 @@ from ess.livedata.config.instrument import (
     InstrumentRegistry,
     SourceMetadata,
 )
-from ess.livedata.config.workflow_spec import WorkflowOutputsBase
+from ess.livedata.config.workflow_spec import MONITORS, REDUCTION, WorkflowOutputsBase
 from ess.livedata.handlers.workflow_factory import (
     Workflow,
     WorkflowFactory,
@@ -190,7 +190,7 @@ class TestInstrument:
 
         # Phase 1: Register spec
         handle = instrument.register_spec(
-            namespace="test_namespace",
+            group=MONITORS,
             name="test_workflow",
             version=1,
             title="Test Workflow",
@@ -204,7 +204,8 @@ class TestInstrument:
         assert len(specs) == 1
         spec = next(iter(specs.values()))
         assert spec.instrument == "test_instrument"
-        assert spec.namespace == "test_namespace"
+        assert spec.namespace == "monitor_data"
+        assert spec.group is MONITORS
         assert spec.name == "test_workflow"
         assert spec.version == 1
         assert spec.title == "Test Workflow"
@@ -343,7 +344,7 @@ class TestInstrumentRegisterSpec:
         instrument = Instrument(name="test_instrument")
 
         handle = instrument.register_spec(
-            namespace="custom_namespace",
+            group=REDUCTION,
             name="test_workflow",
             version=1,
             title="Test Workflow",
@@ -360,7 +361,8 @@ class TestInstrumentRegisterSpec:
         spec_id = handle.workflow_id
         spec = instrument.workflow_factory[spec_id]
         assert spec.instrument == "test_instrument"
-        assert spec.namespace == "custom_namespace"
+        assert spec.namespace == "data_reduction"
+        assert spec.group is REDUCTION
         assert spec.name == "test_workflow"
         assert spec.version == 1
         assert spec.title == "Test Workflow"

--- a/tests/config/instrument_test.py
+++ b/tests/config/instrument_test.py
@@ -82,7 +82,6 @@ class TestInstrument:
         assert instrument.name == "test_instrument"
         assert isinstance(instrument.workflow_factory, WorkflowFactory)
         assert instrument.f144_attribute_registry == {}
-        assert instrument.active_namespace is None
         assert instrument.detector_names == []
 
     def test_instrument_creation_with_custom_values(self):
@@ -94,13 +93,11 @@ class TestInstrument:
             name="custom_instrument",
             workflow_factory=custom_factory,
             f144_attribute_registry=f144_registry,
-            active_namespace="custom_namespace",
         )
 
         assert instrument.name == "custom_instrument"
         assert instrument.workflow_factory is custom_factory
         assert instrument.f144_attribute_registry == f144_registry
-        assert instrument.active_namespace == "custom_namespace"
 
     def test_configure_detector_with_explicit_number(self):
         """Test configuring detector with explicit detector number."""
@@ -204,7 +201,6 @@ class TestInstrument:
         assert len(specs) == 1
         spec = next(iter(specs.values()))
         assert spec.instrument == "test_instrument"
-        assert spec.namespace == "monitor_data"
         assert spec.group is MONITORS
         assert spec.name == "test_workflow"
         assert spec.version == 1
@@ -250,7 +246,7 @@ class TestInstrument:
         specs = instrument.workflow_factory
         assert len(specs) == 1
         spec = next(iter(specs.values()))
-        assert spec.namespace == "data_reduction"  # default
+        assert spec.group is REDUCTION  # default
         assert spec.description == ""  # default
         assert spec.source_names == []  # default
         assert spec.aux_sources is None  # default
@@ -361,7 +357,6 @@ class TestInstrumentRegisterSpec:
         spec_id = handle.workflow_id
         spec = instrument.workflow_factory[spec_id]
         assert spec.instrument == "test_instrument"
-        assert spec.namespace == "data_reduction"
         assert spec.group is REDUCTION
         assert spec.name == "test_workflow"
         assert spec.version == 1
@@ -384,7 +379,7 @@ class TestInstrumentRegisterSpec:
         )
 
         spec = instrument.workflow_factory[handle.workflow_id]
-        assert spec.namespace == "data_reduction"  # default
+        assert spec.group is REDUCTION  # default
         assert spec.description == ""  # default
         assert spec.source_names == []  # default
         assert spec.params is None  # default

--- a/tests/config/registered_workflow_factories_test.py
+++ b/tests/config/registered_workflow_factories_test.py
@@ -144,19 +144,13 @@ def test_workflow_roundtrip(instrument_name: str, workflow_id: WorkflowId):
     # Pick the first available source, or use empty string if none specified
     source_name = spec.source_names[0] if spec.source_names else "test_source"
 
-    # Set active namespace to match the workflow namespace
-    # (in production this is set when the service starts)
-    original_namespace = instrument.active_namespace
-    instrument.active_namespace = workflow_id.namespace
-    try:
-        job_factory = JobFactory(instrument)
-        job_id = JobId(source_name=source_name, job_number=uuid.uuid4())
+    # Use the workflow's registered service name (in production set by the service)
+    service_name = instrument.workflow_factory.get_service(workflow_id)
+    job_factory = JobFactory(instrument, service_name=service_name)
+    job_id = JobId(source_name=source_name, job_number=uuid.uuid4())
 
-        # This should not raise - it validates params and aux_sources internally
-        job = job_factory.create(job_id=job_id, config=workflow_config)
-    finally:
-        # Restore original namespace
-        instrument.active_namespace = original_namespace
+    # This should not raise - it validates params and aux_sources internally
+    job = job_factory.create(job_id=job_id, config=workflow_config)
 
     # Verify job was created successfully
     assert job is not None

--- a/tests/config/registered_workflow_factories_test.py
+++ b/tests/config/registered_workflow_factories_test.py
@@ -23,16 +23,15 @@ from ess.livedata.dashboard.workflow_configuration_adapter import (
 )
 
 
-def _is_slow_workflow(workflow_id):
+def _is_slow_workflow(workflow_id, spec):
     """Check if a workflow is known to be slow (>2s)."""
+    from ess.livedata.config.workflow_spec import REDUCTION
+
     # Bifrost data reduction workflows are slow due to complex spectroscopy setup
-    if (
-        workflow_id.instrument == 'bifrost'
-        and workflow_id.namespace == 'data_reduction'
-    ):
+    if workflow_id.instrument == 'bifrost' and spec.group is REDUCTION:
         return True
     # LOKI i_of_q workflows are slow due to SANS reduction complexity
-    if workflow_id.instrument == 'loki' and workflow_id.namespace == 'data_reduction':
+    if workflow_id.instrument == 'loki' and spec.group is REDUCTION:
         if workflow_id.name.startswith('i_of_q'):
             return True
     return False
@@ -50,7 +49,8 @@ def _collect_workflow_factories():
         instrument = instrument_registry[instrument_name]
         instrument.load_factories()
         for workflow_id in instrument.workflow_factory:
-            marks = [pytest.mark.slow] if _is_slow_workflow(workflow_id) else []
+            spec = instrument.workflow_factory[workflow_id]
+            marks = [pytest.mark.slow] if _is_slow_workflow(workflow_id, spec) else []
             workflows.append(
                 pytest.param(
                     instrument_name, workflow_id, id=str(workflow_id), marks=marks
@@ -97,7 +97,7 @@ def test_workflow_roundtrip(instrument_name: str, workflow_id: WorkflowId):
     4. Backend can instantiate workflow from config (JobFactory)
     """
     # Skip known workflows that require data files not available in CI
-    if str(workflow_id) == "dream/data_reduction/powder_reduction_with_vanadium/1":
+    if str(workflow_id) == "dream/powder_reduction_with_vanadium/1":
         pytest.skip(
             "Workflow requires vanadium data file "
             "(268227_00024779_Vana_inc_BC_offset_240_deg_wlgth.hdf) "

--- a/tests/config/route_derivation_test.py
+++ b/tests/config/route_derivation_test.py
@@ -7,7 +7,14 @@ from ess.livedata.config.route_derivation import (
     gather_source_names,
     resolve_stream_names,
 )
-from ess.livedata.config.workflow_spec import AuxInput, AuxSources, DefaultOutputs
+from ess.livedata.config.workflow_spec import (
+    DETECTORS,
+    MONITORS,
+    REDUCTION,
+    AuxInput,
+    AuxSources,
+    DefaultOutputs,
+)
 from ess.livedata.kafka.stream_mapping import InputStreamKey, StreamMapping
 
 
@@ -20,7 +27,7 @@ def instrument_with_specs() -> Instrument:
         monitors=["mon_1", "mon_2"],
     )
     instrument.register_spec(
-        namespace="detector_data",
+        group=DETECTORS,
         name="projection",
         version=1,
         title="Projection",
@@ -33,7 +40,7 @@ def instrument_with_specs() -> Instrument:
         outputs=DefaultOutputs,
     )
     instrument.register_spec(
-        namespace="detector_data",
+        group=DETECTORS,
         name="special_view",
         version=1,
         title="Special",
@@ -41,7 +48,7 @@ def instrument_with_specs() -> Instrument:
         outputs=DefaultOutputs,
     )
     instrument.register_spec(
-        namespace="data_reduction",
+        group=REDUCTION,
         name="reduction",
         version=1,
         title="Reduction",
@@ -56,7 +63,7 @@ def instrument_with_specs() -> Instrument:
         outputs=DefaultOutputs,
     )
     instrument.register_spec(
-        namespace="monitor_data",
+        group=MONITORS,
         name="monitor_workflow",
         version=1,
         title="Monitor",

--- a/tests/config/workflow_output_validation_test.py
+++ b/tests/config/workflow_output_validation_test.py
@@ -42,7 +42,7 @@ def _get_source_name_for_workflow(
     if workflow_spec.source_names:
         return workflow_spec.source_names[0]
     # Fallback mappings for namespaces without explicit source_names
-    namespace = workflow_spec.namespace
+    namespace = workflow_spec.group.name
     if namespace == 'timeseries':
         # Timeseries workflows don't need a specific source
         return 'timeseries'
@@ -62,7 +62,7 @@ def _collect_workflow_outputs_for_validation():
 
         for workflow_id in instrument.workflow_factory:
             spec = instrument.workflow_factory[workflow_id]
-            builder_fn = _get_service_builder(spec.namespace)
+            builder_fn = _get_service_builder(spec.group.name)
             if builder_fn is None:
                 # Skip workflows in unknown namespaces
                 continue
@@ -130,16 +130,16 @@ def test_workflow_outputs_match_declared_model(
     4. Validates that each output matches its declared template
     """
     # Skip workflows that require external data files
-    if str(workflow_id) == "dream/data_reduction/powder_reduction_with_vanadium/1":
+    if str(workflow_id) == "dream/powder_reduction_with_vanadium/1":
         pytest.skip("Requires vanadium data file not available in test environment")
 
     instrument = instrument_registry[instrument_name]
     spec = instrument.workflow_factory[workflow_id]
 
     # Get the appropriate service builder for this namespace
-    builder_fn = _get_service_builder(spec.namespace)
+    builder_fn = _get_service_builder(spec.group.name)
     if builder_fn is None:
-        pytest.skip(f"No service builder for namespace '{spec.namespace}'")
+        pytest.skip(f"No service builder for namespace '{spec.group.name}'")
 
     # Create the service
     builder = builder_fn(instrument=instrument_name)
@@ -149,7 +149,7 @@ def test_workflow_outputs_match_declared_model(
     source_name = _get_source_name_for_workflow(instrument_name, spec)
     config_key = models.ConfigKey(
         source_name=source_name,
-        service_name=spec.namespace,
+        service_name=spec.group.name,
         key="workflow_config",
     )
     workflow_config = workflow_spec.WorkflowConfig(identifier=workflow_id)
@@ -158,11 +158,11 @@ def test_workflow_outputs_match_declared_model(
 
     # Publish fake events to trigger workflow execution
     # Different namespaces need different event types
-    if spec.namespace in ('detector_data', 'data_reduction'):
+    if spec.group.name in ('detector_data', 'data_reduction'):
         app.publish_events(size=1000, time=1)
-    if spec.namespace in ('monitor_data', 'data_reduction'):
+    if spec.group.name in ('monitor_data', 'data_reduction'):
         app.publish_monitor_events(size=500, time=1)
-    if spec.namespace == 'timeseries':
+    if spec.group.name == 'timeseries':
         # Timeseries needs log data
         app.publish_log_message(source_name='proton_charge', time=1.0, value=100.0)
 

--- a/tests/config/workflow_spec_test.py
+++ b/tests/config/workflow_spec_test.py
@@ -27,7 +27,6 @@ class SimpleTestOutputs(WorkflowOutputsBase):
 def sample_workflow_id() -> WorkflowId:
     return WorkflowId(
         instrument="INSTRUMENT",
-        namespace="NAMESPACE",
         name="NAME",
         version=1,
     )
@@ -671,12 +670,9 @@ class TestFindTimeseriesOutputs:
                 ),
             )
 
-        workflow_id = WorkflowId(
-            instrument='test', namespace='timeseries', name='test', version=1
-        )
+        workflow_id = WorkflowId(instrument='test', name='test', version=1)
         spec = WorkflowSpec(
             instrument='test',
-            namespace='timeseries',
             name='test',
             version=1,
             title='Test',
@@ -706,12 +702,9 @@ class TestFindTimeseriesOutputs:
                 ),
             )
 
-        workflow_id = WorkflowId(
-            instrument='test', namespace='other', name='test', version=1
-        )
+        workflow_id = WorkflowId(instrument='test', name='test', version=1)
         spec = WorkflowSpec(
             instrument='test',
-            namespace='other',
             name='test',
             version=1,
             title='Test',
@@ -735,12 +728,9 @@ class TestFindTimeseriesOutputs:
                 default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
             )
 
-        workflow_id = WorkflowId(
-            instrument='test', namespace='other', name='test', version=1
-        )
+        workflow_id = WorkflowId(instrument='test', name='test', version=1)
         spec = WorkflowSpec(
             instrument='test',
-            namespace='other',
             name='test',
             version=1,
             title='Test',
@@ -762,12 +752,9 @@ class TestFindTimeseriesOutputs:
         class NoFactoryOutputs(WorkflowOutputsBase):
             delta: sc.DataArray = Field(title='Delta')
 
-        workflow_id = WorkflowId(
-            instrument='test', namespace='other', name='test', version=1
-        )
+        workflow_id = WorkflowId(instrument='test', name='test', version=1)
         spec = WorkflowSpec(
             instrument='test',
-            namespace='other',
             name='test',
             version=1,
             title='Test',
@@ -809,16 +796,11 @@ class TestFindTimeseriesOutputs:
                 ),
             )
 
-        workflow_id_1 = WorkflowId(
-            instrument='test', namespace='timeseries', name='ts1', version=1
-        )
-        workflow_id_2 = WorkflowId(
-            instrument='test', namespace='detector', name='det1', version=1
-        )
+        workflow_id_1 = WorkflowId(instrument='test', name='ts1', version=1)
+        workflow_id_2 = WorkflowId(instrument='test', name='det1', version=1)
 
         spec1 = WorkflowSpec(
             instrument='test',
-            namespace='timeseries',
             name='ts1',
             version=1,
             title='TS 1',
@@ -830,7 +812,6 @@ class TestFindTimeseriesOutputs:
         )
         spec2 = WorkflowSpec(
             instrument='test',
-            namespace='detector',
             name='det1',
             version=1,
             title='Det 1',

--- a/tests/config/workflow_spec_test.py
+++ b/tests/config/workflow_spec_test.py
@@ -5,6 +5,8 @@ import scipp as sc
 from pydantic import Field
 
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
+    TIMESERIES,
     AuxInput,
     AuxSources,
     JobId,
@@ -52,6 +54,7 @@ class TestWorkflowSpecAuxSources:
             description="A test workflow",
             params=None,
             outputs=SimpleTestOutputs,
+            group=REDUCTION,
         )
         assert spec.aux_sources is None
 
@@ -77,6 +80,7 @@ class TestWorkflowSpecAuxSources:
             params=None,
             aux_sources=aux,
             outputs=SimpleTestOutputs,
+            group=REDUCTION,
         )
         assert spec.aux_sources is not None
         assert isinstance(spec.aux_sources, AuxSources)
@@ -106,6 +110,7 @@ class TestWorkflowSpecOutputs:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
         assert spec.outputs is TestOutputs
 
@@ -132,6 +137,7 @@ class TestWorkflowSpecOutputs:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
 
         template = spec.get_output_template('result')
@@ -161,6 +167,7 @@ class TestWorkflowSpecOutputs:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
 
         template = spec.get_output_template('nonexistent')
@@ -182,6 +189,7 @@ class TestWorkflowSpecOutputs:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
 
         template = spec.get_output_template('result')
@@ -206,6 +214,7 @@ class TestWorkflowSpecOutputs:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
 
         template1 = spec.get_output_template('result')
@@ -230,6 +239,7 @@ class TestGetOutputTitle:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
         assert spec.get_output_title('result') == 'I(d)'
 
@@ -245,6 +255,7 @@ class TestGetOutputTitle:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
         assert spec.get_output_title('result') == 'result'
 
@@ -260,6 +271,7 @@ class TestGetOutputTitle:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
         assert spec.get_output_title('nonexistent') == 'nonexistent'
 
@@ -279,6 +291,7 @@ class TestGetOutputDescription:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
         assert spec.get_output_description('result') == 'A detailed description.'
 
@@ -294,6 +307,7 @@ class TestGetOutputDescription:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
         assert spec.get_output_description('result') is None
 
@@ -309,6 +323,7 @@ class TestGetOutputDescription:
             description="A test workflow",
             params=None,
             outputs=TestOutputs,
+            group=REDUCTION,
         )
         assert spec.get_output_description('nonexistent') is None
 
@@ -669,6 +684,7 @@ class TestFindTimeseriesOutputs:
             params=None,
             outputs=TimeseriesOutputs,
             source_names=['source1', 'source2'],
+            group=TIMESERIES,
         )
 
         results = find_timeseries_outputs({workflow_id: spec})
@@ -703,6 +719,7 @@ class TestFindTimeseriesOutputs:
             params=None,
             outputs=NonTimeseriesOutputs,
             source_names=['source1'],
+            group=REDUCTION,
         )
 
         results = find_timeseries_outputs({workflow_id: spec})
@@ -731,6 +748,7 @@ class TestFindTimeseriesOutputs:
             params=None,
             outputs=NoTimeCoordOutputs,
             source_names=['source1'],
+            group=REDUCTION,
         )
 
         results = find_timeseries_outputs({workflow_id: spec})
@@ -757,6 +775,7 @@ class TestFindTimeseriesOutputs:
             params=None,
             outputs=NoFactoryOutputs,
             source_names=['source1'],
+            group=REDUCTION,
         )
 
         results = find_timeseries_outputs({workflow_id: spec})
@@ -807,6 +826,7 @@ class TestFindTimeseriesOutputs:
             params=None,
             outputs=TimeseriesOutputs,
             source_names=['src1'],
+            group=TIMESERIES,
         )
         spec2 = WorkflowSpec(
             instrument='test',
@@ -818,6 +838,7 @@ class TestFindTimeseriesOutputs:
             params=None,
             outputs=NonTimeseriesOutputs,
             source_names=['src2'],
+            group=REDUCTION,
         )
 
         results = find_timeseries_outputs({workflow_id_1: spec1, workflow_id_2: spec2})

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -1487,7 +1487,6 @@ class TestJobFactoryRender:
 
         # Setup instrument and workflow
         instrument = Instrument(name='test')
-        instrument.active_namespace = 'data_reduction'
 
         handle = instrument.register_spec(
             name='test_workflow',
@@ -1504,7 +1503,7 @@ class TestJobFactoryRender:
             return FakeProcessor()
 
         # Create JobFactory and job config
-        factory = JobFactory(instrument)
+        factory = JobFactory(instrument, service_name='data_reduction')
         workflow_id = WorkflowId(
             instrument='test',
             namespace='data_reduction',
@@ -1535,7 +1534,6 @@ class TestJobFactoryRender:
 
         # Setup
         instrument = Instrument(name='test')
-        instrument.active_namespace = 'data_reduction'
 
         handle = instrument.register_spec(
             name='default_workflow',
@@ -1551,7 +1549,7 @@ class TestJobFactoryRender:
         def default_workflow():
             return FakeProcessor()
 
-        factory = JobFactory(instrument)
+        factory = JobFactory(instrument, service_name='data_reduction')
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
@@ -1580,7 +1578,6 @@ class TestJobFactoryRender:
         from ess.livedata.config.instrument import Instrument
 
         instrument = Instrument(name='test')
-        instrument.active_namespace = 'data_reduction'
 
         handle = instrument.register_spec(
             name='no_aux_workflow',
@@ -1595,7 +1592,7 @@ class TestJobFactoryRender:
         def no_aux_workflow():
             return FakeProcessor()
 
-        factory = JobFactory(instrument)
+        factory = JobFactory(instrument, service_name='data_reduction')
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
@@ -1617,7 +1614,6 @@ class TestJobFactoryRender:
         from ess.livedata.config.workflow_spec import AuxSources
 
         instrument = Instrument(name='test')
-        instrument.active_namespace = 'data_reduction'
 
         handle = instrument.register_spec(
             name='optional_aux_workflow',
@@ -1633,7 +1629,7 @@ class TestJobFactoryRender:
         def optional_aux_workflow():
             return FakeProcessor()
 
-        factory = JobFactory(instrument)
+        factory = JobFactory(instrument, service_name='data_reduction')
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
@@ -1667,7 +1663,6 @@ class TestJobFactoryRender:
                 }
 
         instrument = Instrument(name='test')
-        instrument.active_namespace = 'data_reduction'
 
         handle = instrument.register_spec(
             name='source_prefix_workflow',
@@ -1683,7 +1678,7 @@ class TestJobFactoryRender:
         def source_prefix_workflow():
             return FakeProcessor()
 
-        factory = JobFactory(instrument)
+        factory = JobFactory(instrument, service_name='data_reduction')
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
@@ -1731,7 +1726,6 @@ class TestJobFactoryRender:
                 }
 
         instrument = Instrument(name='test')
-        instrument.active_namespace = 'data_reduction'
 
         handle = instrument.register_spec(
             name='defaulted_aux_workflow',
@@ -1747,7 +1741,7 @@ class TestJobFactoryRender:
         def defaulted_aux_workflow():
             return FakeProcessor()
 
-        factory = JobFactory(instrument)
+        factory = JobFactory(instrument, service_name='data_reduction')
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -69,7 +69,6 @@ def base_workflow_config():
     return WorkflowConfig(
         identifier=WorkflowId(
             instrument="test",
-            namespace="data_reduction",
             name="test_workflow",
             version=1,
         )
@@ -82,7 +81,6 @@ def scheduled_workflow_config():
     return WorkflowConfig(
         identifier=WorkflowId(
             instrument="test",
-            namespace="data_reduction",
             name="scheduled_workflow",
             version=1,
         ),
@@ -98,7 +96,6 @@ def delayed_start_config():
     return WorkflowConfig(
         identifier=WorkflowId(
             instrument="test",
-            namespace="data_reduction",
             name="delayed_workflow",
             version=1,
         ),
@@ -209,7 +206,6 @@ class TestJobManager:
         config1 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="early_workflow",
                 version=1,
             ),
@@ -218,7 +214,6 @@ class TestJobManager:
         config2 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="late_workflow",
                 version=1,
             ),
@@ -418,7 +413,6 @@ class TestJobManager:
         config2 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="workflow2",
                 version=1,
             ),
@@ -514,7 +508,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -551,7 +544,6 @@ class TestJobManager:
         config1 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="workflow1",
                 version=1,
             ),
@@ -560,7 +552,6 @@ class TestJobManager:
         config2 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="workflow2",
                 version=1,
             ),
@@ -569,7 +560,6 @@ class TestJobManager:
         config3 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="workflow3",
                 version=1,
             ),
@@ -629,7 +619,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -666,7 +655,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -706,7 +694,6 @@ class TestJobManager:
         config1 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="workflow1",
                 version=1,
             ),
@@ -715,7 +702,6 @@ class TestJobManager:
         config2 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="workflow2",
                 version=1,
             ),
@@ -724,7 +710,6 @@ class TestJobManager:
         config3 = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="workflow3",
                 version=1,
             ),
@@ -779,7 +764,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -810,16 +794,12 @@ class TestJobManager:
 
         # Test future start
         config_future = WorkflowConfig(
-            identifier=WorkflowId(
-                instrument="test", namespace="data_reduction", name="future", version=1
-            ),
+            identifier=WorkflowId(instrument="test", name="future", version=1),
             schedule=JobSchedule(start_time=Timestamp.from_ns(200)),
         )
         # Test past start (should activate immediately when data arrives)
         config_past = WorkflowConfig(
-            identifier=WorkflowId(
-                instrument="test", namespace="data_reduction", name="past", version=1
-            ),
+            identifier=WorkflowId(instrument="test", name="past", version=1),
             schedule=JobSchedule(start_time=Timestamp.from_ns(50)),
         )
 
@@ -863,7 +843,6 @@ class TestJobManager:
         config_valid = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="valid_workflow",
                 version=1,
             ),
@@ -878,7 +857,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -909,7 +887,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -937,7 +914,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -984,7 +960,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -1031,7 +1006,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             ),
@@ -1056,7 +1030,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             )
@@ -1100,7 +1073,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             )
@@ -1145,7 +1117,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             )
@@ -1180,7 +1151,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             )
@@ -1250,7 +1220,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             )
@@ -1283,7 +1252,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             )
@@ -1328,7 +1296,6 @@ class TestJobManager:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="test_workflow",
                 version=1,
             )
@@ -1506,7 +1473,6 @@ class TestJobFactoryRender:
         factory = JobFactory(instrument, service_name='data_reduction')
         workflow_id = WorkflowId(
             instrument='test',
-            namespace='data_reduction',
             name='test_workflow',
             version=1,
         )
@@ -1553,7 +1519,6 @@ class TestJobFactoryRender:
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
-                namespace='data_reduction',
                 name='default_workflow',
                 version=1,
             )
@@ -1596,7 +1561,6 @@ class TestJobFactoryRender:
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
-                namespace='data_reduction',
                 name='no_aux_workflow',
                 version=1,
             )
@@ -1633,7 +1597,6 @@ class TestJobFactoryRender:
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
-                namespace='data_reduction',
                 name='optional_aux_workflow',
                 version=1,
             )
@@ -1682,7 +1645,6 @@ class TestJobFactoryRender:
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
-                namespace='data_reduction',
                 name='source_prefix_workflow',
                 version=1,
             )
@@ -1745,7 +1707,6 @@ class TestJobFactoryRender:
         spec = instrument.workflow_factory[
             WorkflowId(
                 instrument='test',
-                namespace='data_reduction',
                 name='defaulted_aux_workflow',
                 version=1,
             )
@@ -1797,7 +1758,6 @@ def _make_workflow_config(source_name: str) -> WorkflowConfig:
     return WorkflowConfig(
         identifier=WorkflowId(
             instrument="test",
-            namespace="data_reduction",
             name=f"workflow_{source_name}",
             version=1,
         )
@@ -1953,7 +1913,6 @@ class TestPeekPendingStreams:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="wf",
                 version=1,
             ),
@@ -1975,7 +1934,6 @@ class TestPeekPendingStreams:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="wf",
                 version=1,
             ),
@@ -1993,7 +1951,6 @@ class TestPeekPendingStreams:
         config_a = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="wf_a",
                 version=1,
             ),
@@ -2002,7 +1959,6 @@ class TestPeekPendingStreams:
         config_b = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="wf_b",
                 version=1,
             ),
@@ -2027,7 +1983,6 @@ class TestPeekPendingStreams:
         config = WorkflowConfig(
             identifier=WorkflowId(
                 instrument="test",
-                namespace="data_reduction",
                 name="wf",
                 version=1,
             ),

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -18,7 +18,6 @@ class TestJobResult:
         """stream_name uses default output_name; UnrollingSinkAdapter replaces it."""
         workflow_id = WorkflowId(
             instrument="TEST",
-            namespace="data_reduction",
             name="test_workflow",
             version=1,
         )
@@ -33,7 +32,7 @@ class TestJobResult:
             error_message=None,
         )
         assert result.stream_name == (
-            '{"workflow_id":{"instrument":"TEST","namespace":"data_reduction",'
+            '{"workflow_id":{"instrument":"TEST",'
             '"name":"test_workflow","version":1},"job_id":{"source_name":"test_source",'
             '"job_number":"' + str(job_number) + '"},"output_name":"result"}'
         )
@@ -86,7 +85,6 @@ def fake_processor():
 def sample_workflow_id():
     return WorkflowId(
         instrument="TEST",
-        namespace="data_reduction",
         name="test_workflow",
         version=1,
     )

--- a/tests/core/run_transition_test.py
+++ b/tests/core/run_transition_test.py
@@ -20,9 +20,7 @@ from .job_test import FakeProcessor
 
 
 def _workflow_id(name: str = 'test') -> WorkflowId:
-    return WorkflowId(
-        instrument="test", namespace="data_reduction", name=name, version=1
-    )
+    return WorkflowId(instrument="test", name=name, version=1)
 
 
 def _make_config(name: str = 'test') -> WorkflowConfig:

--- a/tests/dashboard/active_job_registry_test.py
+++ b/tests/dashboard/active_job_registry_test.py
@@ -10,7 +10,7 @@ from ess.livedata.dashboard.active_job_registry import ActiveJobRegistry
 from ess.livedata.dashboard.data_service import DataService
 from ess.livedata.dashboard.job_service import JobService
 
-_workflow_id = WorkflowId(instrument="test", namespace="ns", name="wf", version=1)
+_workflow_id = WorkflowId(instrument="test", name="wf", version=1)
 
 
 def _make_result_key(job_number, source_name="det1", output_name="result"):

--- a/tests/dashboard/config_store_test.py
+++ b/tests/dashboard/config_store_test.py
@@ -38,17 +38,13 @@ def temp_config_file():
 @pytest.fixture
 def workflow_id_1():
     """First test WorkflowId."""
-    return WorkflowId(
-        instrument='dummy', namespace='reduction', name='powder_workflow', version=1
-    )
+    return WorkflowId(instrument='dummy', name='powder_workflow', version=1)
 
 
 @pytest.fixture
 def workflow_id_2():
     """Second test WorkflowId."""
-    return WorkflowId(
-        instrument='dummy', namespace='reduction', name='imaging_workflow', version=1
-    )
+    return WorkflowId(instrument='dummy', name='imaging_workflow', version=1)
 
 
 @pytest.fixture
@@ -121,7 +117,6 @@ class TestInMemoryConfigStore:
         for i in range(6):
             wf_id = WorkflowId(
                 instrument='dummy',
-                namespace='reduction',
                 name=f'workflow_{i}',
                 version=1,
             )
@@ -131,12 +126,8 @@ class TestInMemoryConfigStore:
         assert len(store) == 4
 
         # First two should be evicted (oldest)
-        wf_id_0 = WorkflowId(
-            instrument='dummy', namespace='reduction', name='workflow_0', version=1
-        )
-        wf_id_1 = WorkflowId(
-            instrument='dummy', namespace='reduction', name='workflow_1', version=1
-        )
+        wf_id_0 = WorkflowId(instrument='dummy', name='workflow_0', version=1)
+        wf_id_1 = WorkflowId(instrument='dummy', name='workflow_1', version=1)
         assert str(wf_id_0) not in store
         assert str(wf_id_1) not in store
 
@@ -144,7 +135,6 @@ class TestInMemoryConfigStore:
         for i in range(2, 6):
             wf_id = WorkflowId(
                 instrument='dummy',
-                namespace='reduction',
                 name=f'workflow_{i}',
                 version=1,
             )
@@ -158,7 +148,6 @@ class TestInMemoryConfigStore:
         for i in range(150):
             wf_id = WorkflowId(
                 instrument='dummy',
-                namespace='reduction',
                 name=f'workflow_{i}',
                 version=1,
             )
@@ -283,7 +272,6 @@ class TestFileBackedConfigStore:
         for i in range(6):
             wf_id = WorkflowId(
                 instrument='dummy',
-                namespace='reduction',
                 name=f'workflow_{i}',
                 version=1,
             )
@@ -293,12 +281,8 @@ class TestFileBackedConfigStore:
         assert len(store) == 4
 
         # First two should be evicted (oldest)
-        wf_id_0 = WorkflowId(
-            instrument='dummy', namespace='reduction', name='workflow_0', version=1
-        )
-        wf_id_1 = WorkflowId(
-            instrument='dummy', namespace='reduction', name='workflow_1', version=1
-        )
+        wf_id_0 = WorkflowId(instrument='dummy', name='workflow_0', version=1)
+        wf_id_1 = WorkflowId(instrument='dummy', name='workflow_1', version=1)
         assert str(wf_id_0) not in store
         assert str(wf_id_1) not in store
 
@@ -306,7 +290,6 @@ class TestFileBackedConfigStore:
         for i in range(2, 6):
             wf_id = WorkflowId(
                 instrument='dummy',
-                namespace='reduction',
                 name=f'workflow_{i}',
                 version=1,
             )
@@ -362,9 +345,7 @@ class TestFileBackedConfigStore:
             nested_path = Path(tmpdir) / 'subdir1' / 'subdir2' / 'config.yaml'
 
             store = FileBackedConfigStore(nested_path)
-            wf_id = WorkflowId(
-                instrument='dummy', namespace='reduction', name='test', version=1
-            )
+            wf_id = WorkflowId(instrument='dummy', name='test', version=1)
             store[str(wf_id)] = {'params': {}}
 
             assert nested_path.exists()
@@ -389,7 +370,6 @@ class TestFileBackedConfigStore:
         for i in range(150):
             wf_id = WorkflowId(
                 instrument='dummy',
-                namespace='reduction',
                 name=f'workflow_{i}',
                 version=1,
             )
@@ -448,9 +428,7 @@ class TestConfigStoreManager:
             assert store1 is store2
 
             # Add data to first reference
-            wf_id = WorkflowId(
-                instrument='dummy', namespace='reduction', name='test', version=1
-            )
+            wf_id = WorkflowId(instrument='dummy', name='test', version=1)
             store1[str(wf_id)] = {'params': {'value': 42}}
 
             # Data should be visible through second reference
@@ -470,9 +448,7 @@ class TestConfigStoreManager:
 
             # Add 6 configs to trigger eviction
             for i in range(6):
-                wf_id = WorkflowId(
-                    instrument='dummy', namespace='reduction', name=f'wf_{i}', version=1
-                )
+                wf_id = WorkflowId(instrument='dummy', name=f'wf_{i}', version=1)
                 store[str(wf_id)] = {'params': {'value': i}}
 
             # Should have evicted 40% (2 configs), leaving 4
@@ -481,9 +457,7 @@ class TestConfigStoreManager:
     def test_file_stores_persist_data(self):
         """Test that file stores created by manager persist data."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            wf_id = WorkflowId(
-                instrument='dummy', namespace='reduction', name='test', version=1
-            )
+            wf_id = WorkflowId(instrument='dummy', name='test', version=1)
             config_value = {'params': {'value': 42}}
 
             # Create manager and store data
@@ -506,12 +480,8 @@ class TestConfigStoreManager:
             workflow_store = manager.get_store('workflow_configs')
             plotter_store = manager.get_store('plotter_configs')
 
-            wf_id1 = WorkflowId(
-                instrument='dummy', namespace='reduction', name='wf1', version=1
-            )
-            wf_id2 = WorkflowId(
-                instrument='dummy', namespace='plotting', name='plot1', version=1
-            )
+            wf_id1 = WorkflowId(instrument='dummy', name='wf1', version=1)
+            wf_id2 = WorkflowId(instrument='dummy', name='plot1', version=1)
 
             # Add to different stores
             workflow_store[str(wf_id1)] = {'params': {'a': 1}}
@@ -535,12 +505,8 @@ class TestConfigStoreManager:
             dream_store = manager_dream.get_store('workflow_configs')
 
             # Create WorkflowIds for each instrument
-            dummy_wf_id = WorkflowId(
-                instrument='dummy', namespace='reduction', name='workflow1', version=1
-            )
-            dream_wf_id = WorkflowId(
-                instrument='dream', namespace='reduction', name='workflow1', version=1
-            )
+            dummy_wf_id = WorkflowId(instrument='dummy', name='workflow1', version=1)
+            dream_wf_id = WorkflowId(instrument='dream', name='workflow1', version=1)
 
             dummy_config = {'params': {'threshold': 100.0}}
             dream_config = {'params': {'threshold': 200.0}}

--- a/tests/dashboard/conftest.py
+++ b/tests/dashboard/conftest.py
@@ -37,7 +37,6 @@ def workflow_id():
     """Create a test WorkflowId."""
     return WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow',
         version=1,
     )
@@ -48,7 +47,6 @@ def workflow_id_2():
     """Create a second test WorkflowId."""
     return WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow_2',
         version=1,
     )
@@ -63,7 +61,6 @@ def workflow_spec(workflow_id):
     """
     return WorkflowSpec(
         instrument=workflow_id.instrument,
-        namespace=workflow_id.namespace,
         name=workflow_id.name,
         version=workflow_id.version,
         title='Test Workflow',
@@ -81,7 +78,6 @@ def workflow_spec_2(workflow_id_2):
     """Create a second WorkflowSpec with params for testing."""
     return WorkflowSpec(
         instrument=workflow_id_2.instrument,
-        namespace=workflow_id_2.namespace,
         name=workflow_id_2.name,
         version=workflow_id_2.version,
         title='Test Workflow 2',

--- a/tests/dashboard/conftest.py
+++ b/tests/dashboard/conftest.py
@@ -7,6 +7,7 @@ import pytest
 import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
     WorkflowId,
     WorkflowOutputsBase,
     WorkflowSpec,
@@ -71,6 +72,7 @@ def workflow_spec(workflow_id):
         params=TestWorkflowParams,
         aux_sources=None,
         outputs=SimpleTestOutputs,
+        group=REDUCTION,
     )
 
 
@@ -88,6 +90,7 @@ def workflow_spec_2(workflow_id_2):
         params=TestWorkflowParams,
         aux_sources=None,
         outputs=SimpleTestOutputs,
+        group=REDUCTION,
     )
 
 

--- a/tests/dashboard/correlation_plotter_test.py
+++ b/tests/dashboard/correlation_plotter_test.py
@@ -35,9 +35,7 @@ def _make_line_renderer() -> LinePlotter:
 def _make_result_key(source_name: str) -> ResultKey:
     """Create a ResultKey for testing with the given source name."""
     return ResultKey(
-        workflow_id=WorkflowId(
-            instrument='test', namespace='test', name='test', version=1
-        ),
+        workflow_id=WorkflowId(instrument='test', name='test', version=1),
         job_id=JobId(source_name=source_name, job_number=1),
         output_name='result',
     )

--- a/tests/dashboard/data_subscriber_test.py
+++ b/tests/dashboard/data_subscriber_test.py
@@ -19,7 +19,6 @@ def workflow_id() -> WorkflowId:
     """Sample workflow ID."""
     return WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow',
         version=1,
     )

--- a/tests/dashboard/job_orchestrator_test.py
+++ b/tests/dashboard/job_orchestrator_test.py
@@ -72,7 +72,6 @@ def workflow_with_params() -> WorkflowSpec:
     """Workflow spec with params model."""
     return WorkflowSpec(
         instrument="test",
-        namespace="testing",
         name="with_params",
         version=1,
         title="Workflow With Params",
@@ -89,7 +88,6 @@ def workflow_with_params_and_aux() -> WorkflowSpec:
     """Workflow spec with both params and aux sources."""
     return WorkflowSpec(
         instrument="test",
-        namespace="testing",
         name="with_params_and_aux",
         version=1,
         title="Workflow With Params and Aux",
@@ -107,7 +105,6 @@ def workflow_no_params() -> WorkflowSpec:
     """Workflow spec without params model."""
     return WorkflowSpec(
         instrument="test",
-        namespace="testing",
         name="no_params",
         version=1,
         title="Workflow Without Params",
@@ -124,7 +121,6 @@ def workflow_empty_sources() -> WorkflowSpec:
     """Workflow spec with empty source_names."""
     return WorkflowSpec(
         instrument="test",
-        namespace="testing",
         name="empty_sources",
         version=1,
         title="Workflow With Empty Sources",
@@ -141,7 +137,6 @@ def workflow_params_without_defaults() -> WorkflowSpec:
     """Workflow spec with params that can't be instantiated (required fields)."""
     return WorkflowSpec(
         instrument="test",
-        namespace="testing",
         name="params_without_defaults",
         version=1,
         title="Workflow With Required Params",
@@ -158,7 +153,6 @@ def workflow_with_enum_params() -> WorkflowSpec:
     """Workflow spec with params containing enum fields."""
     return WorkflowSpec(
         instrument="test",
-        namespace="testing",
         name="with_enum_params",
         version=1,
         title="Workflow With Enum Params",
@@ -390,9 +384,7 @@ class TestJobOrchestratorInitialization:
         """get_staged_config should raise KeyError for unknown workflow_id."""
         orchestrator = make_orchestrator(workflow_with_params)
 
-        unknown_id = WorkflowId(
-            instrument="unknown", namespace="unknown", name="unknown", version=99
-        )
+        unknown_id = WorkflowId(instrument="unknown", name="unknown", version=99)
 
         # Should raise KeyError for unknown workflow
         with pytest.raises(KeyError):
@@ -1097,9 +1089,7 @@ class TestJobOrchestratorWorkflowStateVersion:
         """get_workflow_state_version returns 0 for unknown workflow IDs."""
         orchestrator = make_orchestrator(workflow_with_params)
 
-        unknown_id = WorkflowId(
-            instrument="unknown", namespace="unknown", name="unknown", version=99
-        )
+        unknown_id = WorkflowId(instrument="unknown", name="unknown", version=99)
         assert orchestrator.get_workflow_state_version(unknown_id) == 0
 
     def test_stage_config_increments_version(
@@ -1309,7 +1299,6 @@ class TestJobOrchestratorWorkflowStateVersion:
 
         workflow_2 = WorkflowSpec(
             instrument="test",
-            namespace="testing",
             name="different_workflow",
             version=1,
             title="Different Workflow",

--- a/tests/dashboard/job_orchestrator_test.py
+++ b/tests/dashboard/job_orchestrator_test.py
@@ -12,6 +12,7 @@ import yaml
 
 from ess.livedata.config.models import ConfigKey
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
     AuxSources,
     WorkflowConfig,
     WorkflowId,
@@ -79,6 +80,7 @@ def workflow_with_params() -> WorkflowSpec:
         source_names=["det_1", "det_2"],
         params=WorkflowParams,
         outputs=SimpleTestOutputs,
+        group=REDUCTION,
     )
 
 
@@ -96,6 +98,7 @@ def workflow_with_params_and_aux() -> WorkflowSpec:
         params=WorkflowParams,
         aux_sources=test_aux_sources,
         outputs=SimpleTestOutputs,
+        group=REDUCTION,
     )
 
 
@@ -112,6 +115,7 @@ def workflow_no_params() -> WorkflowSpec:
         source_names=["det_1", "det_2"],
         params=None,
         outputs=SimpleTestOutputs,
+        group=REDUCTION,
     )
 
 
@@ -128,6 +132,7 @@ def workflow_empty_sources() -> WorkflowSpec:
         source_names=[],
         params=WorkflowParams,
         outputs=SimpleTestOutputs,
+        group=REDUCTION,
     )
 
 
@@ -144,6 +149,7 @@ def workflow_params_without_defaults() -> WorkflowSpec:
         source_names=["det_1"],
         params=ParamsWithRequiredFields,
         outputs=SimpleTestOutputs,
+        group=REDUCTION,
     )
 
 
@@ -160,6 +166,7 @@ def workflow_with_enum_params() -> WorkflowSpec:
         source_names=["det_1"],
         params=ParamsWithEnum,
         outputs=SimpleTestOutputs,
+        group=REDUCTION,
     )
 
 
@@ -1309,6 +1316,7 @@ class TestJobOrchestratorWorkflowStateVersion:
             description="A different workflow for testing",
             stream_kind="detector",
             params=workflow_with_params.params,
+            group=REDUCTION,
         )
         workflow_id_2 = workflow_2.get_id()
 

--- a/tests/dashboard/layer_subscription_test.py
+++ b/tests/dashboard/layer_subscription_test.py
@@ -98,7 +98,6 @@ def workflow_id() -> WorkflowId:
     """Sample workflow ID."""
     return WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow',
         version=1,
     )
@@ -109,7 +108,6 @@ def workflow_id_2() -> WorkflowId:
     """Second sample workflow ID."""
     return WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow_2',
         version=1,
     )

--- a/tests/dashboard/orchestrator_test.py
+++ b/tests/dashboard/orchestrator_test.py
@@ -483,7 +483,7 @@ class TestOrchestratorServiceStatusRouting:
 
         status = ServiceStatus(
             instrument="dream",
-            namespace="test_namespace",
+            service_name="test_namespace",
             worker_id="worker123",
             state=ServiceState.running,
             started_at=1000000000,

--- a/tests/dashboard/orchestrator_test.py
+++ b/tests/dashboard/orchestrator_test.py
@@ -141,7 +141,6 @@ class TestOrchestrator:
 
         workflow_id = WorkflowId(
             instrument="test_instrument",
-            namespace="test_namespace",
             name="test_workflow",
             version=1,
         )
@@ -170,13 +169,11 @@ class TestOrchestrator:
 
         workflow_id1 = WorkflowId(
             instrument="test_instrument",
-            namespace="test_namespace",
             name="workflow1",
             version=1,
         )
         workflow_id2 = WorkflowId(
             instrument="test_instrument",
-            namespace="test_namespace",
             name="workflow2",
             version=1,
         )
@@ -216,7 +213,6 @@ class TestOrchestrator:
 
         workflow_id = WorkflowId(
             instrument="test_instrument",
-            namespace="test_namespace",
             name="test_workflow",
             version=1,
         )
@@ -250,7 +246,6 @@ class TestOrchestrator:
 
         workflow_id = WorkflowId(
             instrument="test_instrument",
-            namespace="test_namespace",
             name="test_workflow",
             version=1,
         )
@@ -279,7 +274,6 @@ class TestOrchestrator:
 
         workflow_id = WorkflowId(
             instrument="test_instrument",
-            namespace="test_namespace",
             name="test_workflow",
             version=1,
         )
@@ -325,7 +319,6 @@ class TestOrchestrator:
 
         workflow_id = WorkflowId(
             instrument="test_instrument",
-            namespace="test_namespace",
             name="test_workflow",
             version=1,
         )
@@ -380,7 +373,6 @@ class TestOrchestrator:
 
         workflow_id = WorkflowId(
             instrument="test_instrument",
-            namespace="test_namespace",
             name="test_workflow",
             version=1,
         )
@@ -516,7 +508,6 @@ class TestOrchestratorServiceStatusRouting:
 
         workflow_id = WorkflowId(
             instrument="dream",
-            namespace="test_namespace",
             name="test_workflow",
             version=1,
         )
@@ -556,9 +547,7 @@ class TestOrchestratorJobFiltering:
         job_number = make_job_number()
         orchestrator, data_service, _ = self._make_orchestrator([job_number])
 
-        workflow_id = WorkflowId(
-            instrument="test", namespace="ns", name="wf", version=1
-        )
+        workflow_id = WorkflowId(instrument="test", name="wf", version=1)
         job_id = JobId(source_name="det1", job_number=job_number)
         result_key = ResultKey(
             workflow_id=workflow_id, job_id=job_id, output_name="result"
@@ -573,9 +562,7 @@ class TestOrchestratorJobFiltering:
         inactive_number = make_job_number()
         orchestrator, data_service, _ = self._make_orchestrator([active_number])
 
-        workflow_id = WorkflowId(
-            instrument="test", namespace="ns", name="wf", version=1
-        )
+        workflow_id = WorkflowId(instrument="test", name="wf", version=1)
         job_id = JobId(source_name="det1", job_number=inactive_number)
         result_key = ResultKey(
             workflow_id=workflow_id, job_id=job_id, output_name="result"
@@ -591,9 +578,7 @@ class TestOrchestratorJobFiltering:
         job_number = make_job_number()
         orchestrator, _, job_service = self._make_orchestrator([job_number])
 
-        workflow_id = WorkflowId(
-            instrument="test", namespace="ns", name="wf", version=1
-        )
+        workflow_id = WorkflowId(instrument="test", name="wf", version=1)
         job_id = JobId(source_name="det1", job_number=job_number)
         status = JobStatus(
             job_id=job_id, workflow_id=workflow_id, state=JobState.active
@@ -609,9 +594,7 @@ class TestOrchestratorJobFiltering:
         inactive_number = make_job_number()
         orchestrator, _, job_service = self._make_orchestrator([active_number])
 
-        workflow_id = WorkflowId(
-            instrument="test", namespace="ns", name="wf", version=1
-        )
+        workflow_id = WorkflowId(instrument="test", name="wf", version=1)
         job_id = JobId(source_name="det1", job_number=inactive_number)
         status = JobStatus(
             job_id=job_id, workflow_id=workflow_id, state=JobState.active

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -44,7 +44,6 @@ def data_key():
     """Create a test ResultKey."""
     workflow_id = WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow',
         version=1,
     )
@@ -886,7 +885,6 @@ class TestSlicerPlotter:
 
         workflow_id2 = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -979,7 +977,6 @@ class TestPlotterLabelChanges:
         """Create a test ResultKey with output_name."""
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -1027,7 +1024,6 @@ class TestPlotterOverlayMode:
         """Create first test ResultKey."""
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -1041,7 +1037,6 @@ class TestPlotterOverlayMode:
         """Create second test ResultKey."""
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -1195,7 +1190,6 @@ class TestBarsPlotter:
         """Test that output_name is used as the vdims column name."""
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -1249,7 +1243,6 @@ class TestBarsPlotter:
 
         workflow_id = WorkflowId(
             instrument='test',
-            namespace='test',
             name='test',
             version=1,
         )
@@ -1526,7 +1519,6 @@ class TestLagIndicator:
         """Create a test ResultKey."""
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -1588,7 +1580,6 @@ class TestLagIndicator:
 
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -1652,7 +1643,6 @@ class TestTwoStageArchitecture:
         """Create a test ResultKey."""
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -1754,7 +1744,6 @@ class TestSaveFilenameHookOnDynamicMap:
     def _make_key(source_name: str) -> ResultKey:
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )
@@ -1985,7 +1974,6 @@ class TestRateNormalizationIntegration:
         """Create a test ResultKey."""
         workflow_id = WorkflowId(
             instrument='test_instrument',
-            namespace='test_namespace',
             name='test_workflow',
             version=1,
         )

--- a/tests/dashboard/plotter_compute_benchmark.py
+++ b/tests/dashboard/plotter_compute_benchmark.py
@@ -19,7 +19,6 @@ hv.extension('bokeh')
 def _make_result_key(source_name: str = 'test_source') -> ResultKey:
     workflow_id = WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow',
         version=1,
     )

--- a/tests/dashboard/plotting_controller_test.py
+++ b/tests/dashboard/plotting_controller_test.py
@@ -6,6 +6,7 @@ import pytest
 import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
     WorkflowOutputsBase,
     WorkflowSpec,
 )
@@ -61,6 +62,7 @@ class TestGetAvailablePlottersFromSpec:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         plotters, has_template = plotting_controller.get_available_plotters_from_spec(
@@ -93,6 +95,7 @@ class TestGetAvailablePlottersFromSpec:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         plotters, has_template = plotting_controller.get_available_plotters_from_spec(
@@ -117,6 +120,7 @@ class TestGetAvailablePlottersFromSpec:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         plotters, has_template = plotting_controller.get_available_plotters_from_spec(
@@ -220,6 +224,7 @@ class TestGetAvailableOverlays:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         overlays = plotting_controller.get_available_overlays(
@@ -250,6 +255,7 @@ class TestGetAvailableOverlays:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         overlays = plotting_controller.get_available_overlays(
@@ -290,6 +296,7 @@ class TestGetAvailableOverlays:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         overlays = plotting_controller.get_available_overlays(
@@ -334,6 +341,7 @@ class TestGetAvailableOverlays:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         overlays = plotting_controller.get_available_overlays(
@@ -390,6 +398,7 @@ class TestGetAvailableOverlays:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         overlays = plotting_controller.get_available_overlays(
@@ -434,6 +443,7 @@ class TestGetAvailableOverlays:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         overlays = plotting_controller.get_available_overlays(
@@ -473,6 +483,7 @@ class TestGetAvailableOverlays:
             description='Test',
             outputs=TestOutputs,
             params=None,
+            group=REDUCTION,
         )
 
         overlays = plotting_controller.get_available_overlays(
@@ -566,6 +577,7 @@ class TestOutputHasTimeCoord:
             description='D',
             outputs=Outputs,
             params=None,
+            group=REDUCTION,
         )
         assert output_has_time_coord(spec, 'current') is True
 
@@ -586,6 +598,7 @@ class TestOutputHasTimeCoord:
             description='D',
             outputs=Outputs,
             params=None,
+            group=REDUCTION,
         )
         assert output_has_time_coord(spec, 'cumulative') is False
 
@@ -601,5 +614,6 @@ class TestOutputHasTimeCoord:
             description='D',
             outputs=Outputs,
             params=None,
+            group=REDUCTION,
         )
         assert output_has_time_coord(spec, 'result') is True

--- a/tests/dashboard/roi_readback_plots_test.py
+++ b/tests/dashboard/roi_readback_plots_test.py
@@ -25,7 +25,6 @@ hv.extension('bokeh')
 def result_key() -> ResultKey:
     workflow_id = WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow',
         version=1,
     )

--- a/tests/dashboard/save_filename_test.py
+++ b/tests/dashboard/save_filename_test.py
@@ -7,6 +7,7 @@ import pydantic
 import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
     WorkflowId,
     WorkflowOutputsBase,
     WorkflowSpec,
@@ -49,6 +50,7 @@ _WORKFLOW_REGISTRY = {
         description='test',
         params=None,
         outputs=_TestOutputs,
+        group=REDUCTION,
     )
 }
 

--- a/tests/dashboard/save_filename_test.py
+++ b/tests/dashboard/save_filename_test.py
@@ -27,7 +27,7 @@ from ess.livedata.dashboard.save_filename import (
     make_save_filename_hook,
 )
 
-_WF_ID = WorkflowId(instrument='dream', namespace='ns', name='wf', version=1)
+_WF_ID = WorkflowId(instrument='dream', name='wf', version=1)
 
 
 class _TestOutputs(WorkflowOutputsBase):
@@ -72,9 +72,7 @@ def _make_layer(
     instrument: str = 'dream',
     static: bool = False,
 ) -> Layer:
-    workflow_id = WorkflowId(
-        instrument=instrument, namespace='ns', name='wf', version=1
-    )
+    workflow_id = WorkflowId(instrument=instrument, name='wf', version=1)
     sources = [] if static else (source_names or ['monitor'])
     config = PlotConfig(
         data_sources={

--- a/tests/dashboard/service_registry_test.py
+++ b/tests/dashboard/service_registry_test.py
@@ -13,7 +13,7 @@ class TestMakeWorkerKey:
     def test_creates_key_from_status(self) -> None:
         status = ServiceStatus(
             instrument="dream",
-            namespace="test_namespace",
+            service_name="test_namespace",
             worker_id="abc123",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -28,7 +28,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry()
         status = ServiceStatus(
             instrument="dream",
-            namespace="test_namespace",
+            service_name="test_namespace",
             worker_id="abc123",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -45,7 +45,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry()
         status1 = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -53,7 +53,7 @@ class TestServiceRegistry:
         )
         status2 = ServiceStatus(
             instrument="dream",
-            namespace="ns2",
+            service_name="ns2",
             worker_id="worker2",
             state=ServiceState.starting,
             started_at=Timestamp.from_ns(2000),
@@ -71,7 +71,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry()
         status_old = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -79,7 +79,7 @@ class TestServiceRegistry:
         )
         status_new = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -97,7 +97,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry()
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -114,7 +114,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry(heartbeat_timeout_ns=1_000_000)  # 1 ms
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -135,7 +135,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry(heartbeat_timeout_ns=1_000_000)  # 1 ms
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.stopped,  # Terminal state
             started_at=Timestamp.from_ns(1000),
@@ -158,7 +158,7 @@ class TestServiceRegistry:
         # Add a worker that will become stale
         status_stale = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="stale_worker",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -172,7 +172,7 @@ class TestServiceRegistry:
         # Add a fresh worker
         status_fresh = ServiceStatus(
             instrument="dream",
-            namespace="ns2",
+            service_name="ns2",
             worker_id="fresh_worker",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(2000),
@@ -190,7 +190,7 @@ class TestServiceRegistry:
         started_at_ns = Timestamp.now() - Duration.from_seconds(60)
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=started_at_ns,
@@ -213,7 +213,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry()
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -237,7 +237,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry()
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -259,7 +259,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry()
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.stopped,
             started_at=Timestamp.from_ns(1000),
@@ -272,7 +272,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry(heartbeat_timeout_ns=1_000_000)
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -286,7 +286,7 @@ class TestServiceRegistry:
         registry = ServiceRegistry()
         status = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="worker1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -300,7 +300,7 @@ class TestServiceRegistry:
 
         stopped = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="stopped1",
             state=ServiceState.stopped,
             started_at=Timestamp.from_ns(1000),
@@ -308,7 +308,7 @@ class TestServiceRegistry:
         )
         stale = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="stale1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),
@@ -321,7 +321,7 @@ class TestServiceRegistry:
         # Add a fresh running worker
         fresh = ServiceStatus(
             instrument="dream",
-            namespace="ns1",
+            service_name="ns1",
             worker_id="fresh1",
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000),

--- a/tests/dashboard/stream_manager_test.py
+++ b/tests/dashboard/stream_manager_test.py
@@ -34,7 +34,7 @@ def sample_data() -> sc.DataArray:
 @pytest.fixture
 def workflow_id() -> WorkflowId:
     """Sample workflow ID."""
-    return WorkflowId(instrument="test", namespace="ns", name="wf", version=1)
+    return WorkflowId(instrument="test", name="wf", version=1)
 
 
 def make_key(workflow_id: WorkflowId, source_name: str = "source") -> ResultKey:

--- a/tests/dashboard/time_info_test.py
+++ b/tests/dashboard/time_info_test.py
@@ -33,7 +33,6 @@ hv.extension('bokeh')
 def workflow_id():
     return WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name='test_workflow',
         version=1,
     )

--- a/tests/dashboard/widgets/backend_status_widget_test.py
+++ b/tests/dashboard/widgets/backend_status_widget_test.py
@@ -16,12 +16,12 @@ from ess.livedata.dashboard.widgets.backend_status_widget import (
 def _make_status(
     *,
     worker_id: str = "worker1",
-    namespace: str = "ns1",
+    service_name: str = "ns1",
     state: ServiceState = ServiceState.running,
 ) -> ServiceStatus:
     return ServiceStatus(
         instrument="dream",
-        namespace=namespace,
+        service_name=service_name,
         worker_id=worker_id,
         state=state,
         started_at=Timestamp.now(),

--- a/tests/dashboard/widgets/plot_config_modal_test.py
+++ b/tests/dashboard/widgets/plot_config_modal_test.py
@@ -30,7 +30,7 @@ class FakeInstrumentConfig:
 
 
 def _make_workflow_id(name: str = "timeseries") -> WorkflowId:
-    return WorkflowId(instrument="test", namespace="ns", name=name, version=1)
+    return WorkflowId(instrument="test", name=name, version=1)
 
 
 class Bins(pydantic.BaseModel):

--- a/tests/dashboard/widgets/plot_config_modal_test.py
+++ b/tests/dashboard/widgets/plot_config_modal_test.py
@@ -4,6 +4,7 @@ import pydantic
 import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
     WorkflowId,
     WorkflowOutputsBase,
     WorkflowSpec,
@@ -217,6 +218,7 @@ def _make_workflow_spec(title: str, outputs: type[WorkflowOutputsBase]) -> Workf
         description="",
         params=None,
         outputs=outputs,
+        group=REDUCTION,
     )
 
 

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -156,9 +156,7 @@ def _inject_layer(
     config = PlotConfig(
         data_sources={
             'primary': DataSourceConfig(
-                workflow_id=WorkflowId(
-                    instrument='test', namespace='test', name='wf', version=1
-                ),
+                workflow_id=WorkflowId(instrument='test', name='wf', version=1),
                 source_names=['src'],
                 output_name='result',
             )

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -64,7 +64,7 @@ class TestGetPlotCellDisplayInfo:
                 title='Cumulative',
             )
 
-        wf_id = WorkflowId(instrument='test', namespace='ns', name='wf', version=1)
+        wf_id = WorkflowId(instrument='test', name='wf', version=1)
         spec = WorkflowSpec(
             instrument='test',
             name='wf',
@@ -110,7 +110,7 @@ class TestGetPlotCellDisplayInfo:
                 title='Current',
             )
 
-        wf_id = WorkflowId(instrument='test', namespace='ns', name='wf', version=1)
+        wf_id = WorkflowId(instrument='test', name='wf', version=1)
         spec = WorkflowSpec(
             instrument='test',
             name='wf',

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -4,6 +4,7 @@ import pydantic
 import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
     WorkflowId,
     WorkflowOutputsBase,
     WorkflowSpec,
@@ -73,6 +74,7 @@ class TestGetPlotCellDisplayInfo:
             outputs=CumulativeOutputs,
             params=None,
             source_names=['src1'],
+            group=REDUCTION,
         )
         registry = {wf_id: spec}
 
@@ -118,6 +120,7 @@ class TestGetPlotCellDisplayInfo:
             outputs=CurrentOutputs,
             params=None,
             source_names=['src1'],
+            group=REDUCTION,
         )
         registry = {wf_id: spec}
 

--- a/tests/dashboard/widgets/workflow_status_widget_test.py
+++ b/tests/dashboard/widgets/workflow_status_widget_test.py
@@ -568,9 +568,7 @@ class TestWorkflowStatusWidgetWithJobs:
         job_id = JobId(source_name='test', job_number='test-uuid')
         job_status = JobStatus(
             job_id=job_id,
-            workflow_id=WorkflowId(
-                instrument='test', namespace='test', name='test', version=1
-            ),
+            workflow_id=WorkflowId(instrument='test', name='test', version=1),
             state=JobState.active,
         )
 

--- a/tests/dashboard/workflow_controller_test.py
+++ b/tests/dashboard/workflow_controller_test.py
@@ -76,9 +76,7 @@ def source_names() -> list[str]:
 @pytest.fixture
 def workflow_id() -> WorkflowId:
     """Test workflow ID."""
-    return WorkflowId(
-        instrument='test_instrument', namespace='abc', name="test_workflow", version=1
-    )
+    return WorkflowId(instrument='test_instrument', name="test_workflow", version=1)
 
 
 @pytest.fixture
@@ -86,7 +84,6 @@ def workflow_spec(workflow_id: WorkflowId) -> WorkflowSpec:
     """Test workflow specification."""
     return WorkflowSpec(
         instrument=workflow_id.instrument,
-        namespace=workflow_id.namespace,
         name=workflow_id.name,
         version=workflow_id.version,
         title="Test Workflow",
@@ -415,9 +412,7 @@ class TestWorkflowController:
         workflow_controller: WorkflowControllerFixture,
     ):
         """Test that get_workflow_config returns None for non-existent workflow."""
-        nonexistent_id = WorkflowId(
-            instrument='test', namespace='test', name='nonexistent', version=1
-        )
+        nonexistent_id = WorkflowId(instrument='test', name='nonexistent', version=1)
 
         # Act
         result = workflow_controller.controller.get_workflow_config(nonexistent_id)

--- a/tests/dashboard/workflow_controller_test.py
+++ b/tests/dashboard/workflow_controller_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from ess.livedata.config.models import ConfigKey
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
     WorkflowConfig,
     WorkflowId,
     WorkflowSpec,
@@ -92,6 +93,7 @@ def workflow_spec(workflow_id: WorkflowId) -> WorkflowSpec:
         description="A test workflow for unit testing",
         source_names=["detector_1", "detector_2"],
         params=SomeWorkflowParams,
+        group=REDUCTION,
     )
 
 
@@ -266,6 +268,7 @@ class TestWorkflowController:
             description="First workflow",
             source_names=sources_1,
             params=SomeWorkflowParams,
+            group=REDUCTION,
         )
         workflow_spec_2 = WorkflowSpec(
             instrument="test_instrument",
@@ -275,6 +278,7 @@ class TestWorkflowController:
             description="Second workflow",
             source_names=sources_2,
             params=SomeWorkflowParams,
+            group=REDUCTION,
         )
         workflow_id_1 = workflow_spec_1.get_id()
         workflow_id_2 = workflow_spec_2.get_id()

--- a/tests/handlers/detector_view_specs_test.py
+++ b/tests/handlers/detector_view_specs_test.py
@@ -152,7 +152,7 @@ class TestRegisterDetectorViewSpecs:
         # Verify spec details
         spec = instrument.workflow_factory[spec_id]
         assert spec.instrument == "test_instrument"
-        assert spec.namespace == "detector_data"
+        assert spec.group.name == "detector_data"
         assert spec.name == "detector_xy_projection"
         assert spec.source_names == source_names
 

--- a/tests/handlers/monitor_workflow_test.py
+++ b/tests/handlers/monitor_workflow_test.py
@@ -565,14 +565,15 @@ class TestRegisterMonitorWorkflowSpecs:
         handle = register_monitor_workflow_specs(test_instrument, source_names=[])
         assert handle is None
 
-    def test_registered_spec_has_correct_namespace(self, test_instrument):
-        """Verify the spec is registered in monitor_data namespace."""
+    def test_registered_spec_has_correct_group(self, test_instrument):
+        """Verify the spec is registered in the monitor_data group."""
         # Explicit registration
         handle = register_monitor_workflow_specs(
             test_instrument, source_names=['monitor_1', 'monitor_2']
         )
         assert handle is not None
-        assert handle.workflow_id.namespace == 'monitor_data'
+        spec = test_instrument.workflow_factory[handle.workflow_id]
+        assert spec.group.name == 'monitor_data'
 
     def test_spec_uses_monitor_data_params(self, test_instrument):
         """Verify the spec uses MonitorDataParams by default."""
@@ -679,7 +680,6 @@ class TestDreamMonitorWorkflowFactory:
         setup_factories(instrument)
         workflow_id = WorkflowId(
             instrument='dream',
-            namespace='monitor_data',
             name='monitor_histogram',
             version=1,
         )

--- a/tests/handlers/workflow_factory_test.py
+++ b/tests/handlers/workflow_factory_test.py
@@ -6,6 +6,7 @@ from ess.reduce.streaming import StreamProcessor
 from pydantic import BaseModel, ValidationError
 
 from ess.livedata.config.workflow_spec import (
+    REDUCTION,
     AuxInput,
     AuxSources,
     WorkflowConfig,
@@ -50,6 +51,7 @@ def workflow_spec(workflow_id):
         title="Pretty name",
         description="Test description",
         params=None,
+        group=REDUCTION,
     )
 
 
@@ -65,6 +67,7 @@ def workflow_spec_with_sources(workflow_id):
         description="Test",
         source_names=["source1", "source2"],
         params=None,
+        group=REDUCTION,
     )
 
 
@@ -180,6 +183,7 @@ class TestWorkflowFactory:
             description="Test",
             source_names=["source1"],
             params=None,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -208,6 +212,7 @@ class TestWorkflowFactory:
             title="test-workflow",
             description="Test",
             params=MyParams,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -238,6 +243,7 @@ class TestWorkflowFactory:
             title="test-workflow",
             description="Test",
             params=MyParams,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -286,6 +292,7 @@ class TestWorkflowFactory:
             description=workflow_spec_with_sources.description,
             source_names=["allowed-source"],
             params=None,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -321,6 +328,7 @@ class TestWorkflowFactory:
             title="workflow1",
             description="Test 1",
             params=None,
+            group=REDUCTION,
         )
         spec2 = WorkflowSpec(
             instrument=workflow_id2.instrument,
@@ -330,6 +338,7 @@ class TestWorkflowFactory:
             title="workflow2",
             description="Test 2",
             params=None,
+            group=REDUCTION,
         )
 
         handle1 = factory.register_spec(spec1)
@@ -386,6 +395,7 @@ class TestWorkflowFactory:
             title="V1",
             description="Test 1",
             params=None,
+            group=REDUCTION,
         )
         spec2 = WorkflowSpec(
             instrument=workflow_id2.instrument,
@@ -395,6 +405,7 @@ class TestWorkflowFactory:
             title="V2",
             description="Test 2",
             params=None,
+            group=REDUCTION,
         )
 
         handle1 = factory.register_spec(spec1)
@@ -439,6 +450,7 @@ class TestWorkflowFactory:
             title="",
             description="Test",
             params=None,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -473,6 +485,7 @@ class TestWorkflowFactory:
             description="Test",
             source_names=sources,
             params=None,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -514,6 +527,7 @@ class TestWorkflowFactory:
             description="Test",
             params=None,
             aux_sources=my_aux_sources,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -546,6 +560,7 @@ class TestWorkflowFactory:
             title="test-workflow",
             description="Test",
             params=None,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -575,6 +590,7 @@ class TestWorkflowFactory:
             title="test-workflow",
             description="Test",
             params=None,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -612,6 +628,7 @@ class TestWorkflowFactory:
             description="Test",
             params=None,
             aux_sources=my_aux_sources,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -647,6 +664,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=None,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -671,6 +689,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=None,
+            group=REDUCTION,
         )
 
         factory.register_spec(spec)
@@ -695,6 +714,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=None,
+            group=REDUCTION,
         )
 
         factory.register_spec(spec)
@@ -719,6 +739,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=None,
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -752,6 +773,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=MyParams,  # Explicit params!
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -788,6 +810,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=MyParams,  # Spec expects MyParams
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -815,6 +838,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=MyParams,  # Spec has params
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -842,6 +866,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=None,  # Spec has no params
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)
@@ -882,6 +907,7 @@ class TestTwoPhaseRegistration:
             title="test-workflow",
             description="Test",
             params=MyParams,  # Explicit params
+            group=REDUCTION,
         )
 
         handle = factory.register_spec(spec)

--- a/tests/handlers/workflow_factory_test.py
+++ b/tests/handlers/workflow_factory_test.py
@@ -34,7 +34,6 @@ def workflow_id():
     """Fixture to create a WorkflowId for testing."""
     return WorkflowId(
         instrument="test-instrument",
-        namespace="test-namespace",
         name="test-workflow",
         version=1,
     )
@@ -45,7 +44,6 @@ def workflow_spec(workflow_id):
     """Fixture to create a basic WorkflowSpec for testing."""
     return WorkflowSpec(
         instrument=workflow_id.instrument,
-        namespace=workflow_id.namespace,
         name=workflow_id.name,
         version=workflow_id.version,
         title="Pretty name",
@@ -60,7 +58,6 @@ def workflow_spec_with_sources(workflow_id):
     """Fixture to create a WorkflowSpec with source names for testing."""
     return WorkflowSpec(
         instrument=workflow_id.instrument,
-        namespace=workflow_id.namespace,
         name=workflow_id.name,
         version=workflow_id.version,
         title="test-workflow",
@@ -170,13 +167,11 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -200,13 +195,11 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -231,13 +224,11 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -265,7 +256,6 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         non_existent_id = WorkflowId(
             instrument="non-existent",
-            namespace="non-existent",
             name="non-existent",
             version=1,
         )
@@ -278,14 +268,12 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         # Override source_names for this specific test
         spec = WorkflowSpec(
             instrument=workflow_spec_with_sources.instrument,
-            namespace=workflow_spec_with_sources.namespace,
             name=workflow_spec_with_sources.name,
             version=workflow_spec_with_sources.version,
             title=workflow_spec_with_sources.title,
@@ -310,19 +298,16 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id1 = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="workflow1",
             version=1,
         )
         workflow_id2 = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="workflow2",
             version=1,
         )
         spec1 = WorkflowSpec(
             instrument=workflow_id1.instrument,
-            namespace=workflow_id1.namespace,
             name=workflow_id1.name,
             version=workflow_id1.version,
             title="workflow1",
@@ -332,7 +317,6 @@ class TestWorkflowFactory:
         )
         spec2 = WorkflowSpec(
             instrument=workflow_id2.instrument,
-            namespace=workflow_id2.namespace,
             name=workflow_id2.name,
             version=workflow_id2.version,
             title="workflow2",
@@ -377,19 +361,16 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id1 = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="same-name",
             version=1,
         )
         workflow_id2 = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="same-name",
             version=2,
         )
         spec1 = WorkflowSpec(
             instrument=workflow_id1.instrument,
-            namespace=workflow_id1.namespace,
             name=workflow_id1.name,
             version=workflow_id1.version,
             title="V1",
@@ -399,7 +380,6 @@ class TestWorkflowFactory:
         )
         spec2 = WorkflowSpec(
             instrument=workflow_id2.instrument,
-            namespace=workflow_id2.namespace,
             name=workflow_id2.name,
             version=workflow_id2.version,
             title="V2",
@@ -439,12 +419,9 @@ class TestWorkflowFactory:
 
     def test_empty_name(self):
         factory = WorkflowFactory()
-        workflow_id = WorkflowId(
-            instrument="test-instrument", namespace="test-namespace", name="", version=1
-        )
+        workflow_id = WorkflowId(instrument="test-instrument", name="", version=1)
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="",
@@ -472,13 +449,11 @@ class TestWorkflowFactory:
         sources = ["Source1", "SOURCE2"]
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -514,13 +489,11 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -548,13 +521,11 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -578,13 +549,11 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -615,13 +584,11 @@ class TestWorkflowFactory:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -652,13 +619,11 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -677,13 +642,11 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -702,13 +665,11 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -727,13 +688,11 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -761,13 +720,11 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -794,7 +751,6 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
@@ -804,7 +760,6 @@ class TestTwoPhaseRegistration:
 
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -826,13 +781,11 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -854,13 +807,11 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",
@@ -882,7 +833,6 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
@@ -895,13 +845,11 @@ class TestTwoPhaseRegistration:
         factory = WorkflowFactory()
         workflow_id = WorkflowId(
             instrument="test-instrument",
-            namespace="test-namespace",
             name="test-workflow",
             version=1,
         )
         spec = WorkflowSpec(
             instrument=workflow_id.instrument,
-            namespace=workflow_id.namespace,
             name=workflow_id.name,
             version=workflow_id.version,
             title="test-workflow",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -38,7 +38,6 @@ def test_my_workflow(integration_env):
     # Define the workflow type to test
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )

--- a/tests/integration/config_persistence_test.py
+++ b/tests/integration/config_persistence_test.py
@@ -44,7 +44,6 @@ def test_workflow_params_stored_and_retrieved_via_config_store(
     # Define workflow parameters with non-default values
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -105,7 +104,6 @@ def test_adapter_filters_removed_sources(tmp_path) -> None:
     """
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -159,7 +157,6 @@ def test_config_persists_across_adapter_recreations(
     """
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -205,7 +202,6 @@ def test_incompatible_config_falls_back_to_defaults(tmp_path) -> None:
     """
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -286,7 +282,6 @@ def test_plot_orchestrator_persistence_across_backend_restarts(tmp_path) -> None
         # Add a cell with plot configuration
         workflow_id = WorkflowId(
             instrument='dummy',
-            namespace='monitor_data',
             name='monitor_histogram',
             version=1,
         )
@@ -462,7 +457,6 @@ def test_plot_orchestrator_persists_pydantic_params_with_enums(tmp_path) -> None
 
         workflow_id = WorkflowId(
             instrument='dummy',
-            namespace='monitor_data',
             name='monitor_histogram',
             version=1,
         )
@@ -523,7 +517,6 @@ def test_plot_orchestrator_persists_multi_layer_cells(tmp_path) -> None:
 
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )

--- a/tests/integration/helpers_test.py
+++ b/tests/integration/helpers_test.py
@@ -41,7 +41,6 @@ def make_workflow_id(name: str, version: int = 1) -> WorkflowId:
     """Helper to create WorkflowId for tests."""
     return WorkflowId(
         instrument='test_instrument',
-        namespace='test_namespace',
         name=name,
         version=version,
     )

--- a/tests/integration/job_state_persistence_test.py
+++ b/tests/integration/job_state_persistence_test.py
@@ -21,7 +21,6 @@ def test_active_job_persisted_and_restored(tmp_path) -> None:
     """
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -89,7 +88,6 @@ def test_subscriber_notified_on_job_restoration(tmp_path) -> None:
     """
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -141,7 +139,6 @@ def test_job_transition_persists_previous_job(tmp_path) -> None:
     """
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -206,7 +203,6 @@ def test_corrupted_job_state_does_not_break_restoration(tmp_path) -> None:
     """
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -252,7 +248,6 @@ def test_no_active_job_persists_empty_state(tmp_path) -> None:
     """
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )

--- a/tests/integration/workflow_lifecycle_test.py
+++ b/tests/integration/workflow_lifecycle_test.py
@@ -30,7 +30,6 @@ def test_workflow_can_start_and_receive_data(integration_env: IntegrationEnv) ->
     # Define workflow parameters for monitor histogram workflow
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )
@@ -72,7 +71,6 @@ def test_workflow_status_updates(integration_env: IntegrationEnv) -> None:
 
     workflow_id = WorkflowId(
         instrument='dummy',
-        namespace='monitor_data',
         name='monitor_histogram',
         version=1,
     )

--- a/tests/kafka/sink_serializers_test.py
+++ b/tests/kafka/sink_serializers_test.py
@@ -235,7 +235,6 @@ def _make_job_status(**overrides) -> JobStatus:
         'job_id': JobId(source_name='detector_1', job_number=uuid.uuid4()),
         'workflow_id': WorkflowId(
             instrument='test_inst',
-            namespace='data_reduction',
             name='test_workflow',
             version=1,
         ),

--- a/tests/kafka/sink_serializers_test.py
+++ b/tests/kafka/sink_serializers_test.py
@@ -219,7 +219,7 @@ class TestF144Serializer:
 def _make_service_status(**overrides) -> ServiceStatus:
     defaults: dict = {
         'instrument': 'dream',
-        'namespace': 'data_reduction',
+        'service_name': 'data_reduction',
         'worker_id': str(uuid.uuid4()),
         'state': ServiceState.running,
         'started_at': Timestamp.from_ns(1_700_000_000_000_000_000),

--- a/tests/kafka/status_message_test.py
+++ b/tests/kafka/status_message_test.py
@@ -42,7 +42,6 @@ def make_job_status(**overrides) -> JobStatus:
         "job_id": JobId(source_name="detector_1", job_number=uuid.uuid4()),
         "workflow_id": WorkflowId(
             instrument="test_inst",
-            namespace="data_reduction",
             name="test_workflow",
             version=1,
         ),
@@ -244,9 +243,7 @@ class TestJobStatusMessage:
     def test_to_job_status_minimal(self):
         """Test converting minimal JobStatusMessage to JobStatus."""
         job_id = JobId(source_name="test", job_number=uuid.uuid4())
-        workflow_id = WorkflowId(
-            instrument="test", namespace="ns", name="wf", version=1
-        )
+        workflow_id = WorkflowId(instrument="test", name="wf", version=1)
 
         status_msg = JobStatusMessage(
             service_id=ServiceId.from_job_id(job_id),
@@ -271,9 +268,7 @@ class TestJobStatusMessage:
     def test_to_job_status_complete(self):
         """Test converting complete JobStatusMessage to JobStatus."""
         job_id = JobId(source_name="test", job_number=uuid.uuid4())
-        workflow_id = WorkflowId(
-            instrument="test", namespace="ns", name="wf", version=1
-        )
+        workflow_id = WorkflowId(instrument="test", name="wf", version=1)
 
         status_msg = JobStatusMessage(
             service_id=ServiceId.from_job_id(job_id),
@@ -428,7 +423,6 @@ class TestRoundTripConversion:
         """Test round-trip conversion with complex WorkflowId."""
         workflow_id = WorkflowId(
             instrument="complex-instrument-name",
-            namespace="special_namespace",
             name="workflow_with_underscores",
             version=42,
         )
@@ -604,9 +598,7 @@ class TestMessageTypeField:
         """Test that x5f2 serialized job status includes message_type in status_json."""
         job_status = JobStatus(
             job_id=JobId(source_name="test", job_number=uuid.uuid4()),
-            workflow_id=WorkflowId(
-                instrument="test", namespace="ns", name="wf", version=1
-            ),
+            workflow_id=WorkflowId(instrument="test", name="wf", version=1),
             state=JobState.active,
         )
 
@@ -937,9 +929,7 @@ class TestX5f2ToStatusDiscriminator:
         """Test that job status with message_type='job' returns JobStatus."""
         job_status = JobStatus(
             job_id=JobId(source_name="detector1", job_number=uuid.uuid4()),
-            workflow_id=WorkflowId(
-                instrument="test", namespace="ns", name="wf", version=1
-            ),
+            workflow_id=WorkflowId(instrument="test", name="wf", version=1),
             state=JobState.active,
         )
 
@@ -956,9 +946,7 @@ class TestX5f2ToStatusDiscriminator:
         Legacy messages without message_type field should return JobStatus.
         """
         job_id = JobId(source_name="detector1", job_number=uuid.uuid4())
-        workflow_id = WorkflowId(
-            instrument="test", namespace="ns", name="wf", version=1
-        )
+        workflow_id = WorkflowId(instrument="test", name="wf", version=1)
 
         # Manually create x5f2 data WITHOUT message_type field (legacy format)
         status_json = json.dumps(

--- a/tests/kafka/status_message_test.py
+++ b/tests/kafka/status_message_test.py
@@ -60,7 +60,7 @@ def make_service_status(**overrides) -> ServiceStatus:
     """Create a ServiceStatus with defaults that can be overridden."""
     defaults = {
         "instrument": "dream",
-        "namespace": "data_reduction",
+        "service_name": "data_reduction",
         "worker_id": str(uuid.uuid4()),
         "state": ServiceState.running,
         "started_at": Timestamp.from_ns(1000000000),
@@ -652,7 +652,7 @@ class TestServiceServiceId:
         service_id = ServiceServiceId.from_string(service_id_str)
 
         assert service_id.instrument == "dream"
-        assert service_id.namespace == "data_reduction"
+        assert service_id.service_name == "data_reduction"
         assert service_id.worker_id == worker_id
 
     def test_from_string_invalid_format_no_colons(self):
@@ -670,7 +670,7 @@ class TestServiceServiceId:
         worker_id = str(uuid.uuid4())
         status = ServiceStatus(
             instrument="dream",
-            namespace="data_reduction",
+            service_name="data_reduction",
             worker_id=worker_id,
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000000000),
@@ -679,14 +679,14 @@ class TestServiceServiceId:
         service_id = ServiceServiceId.from_service_status(status)
 
         assert service_id.instrument == "dream"
-        assert service_id.namespace == "data_reduction"
+        assert service_id.service_name == "data_reduction"
         assert service_id.worker_id == worker_id
 
     def test_to_string(self):
         """Test converting ServiceServiceId to string format."""
         worker_id = str(uuid.uuid4())
         service_id = ServiceServiceId(
-            instrument="dream", namespace="data_reduction", worker_id=worker_id
+            instrument="dream", service_name="data_reduction", worker_id=worker_id
         )
 
         expected = f"dream:data_reduction:{worker_id}"
@@ -697,7 +697,7 @@ class TestServiceServiceId:
         """Test that string conversion is reversible."""
         original = ServiceServiceId(
             instrument="bifrost",
-            namespace="monitor_data",
+            service_name="monitor_data",
             worker_id=str(uuid.uuid4()),
         )
 
@@ -706,7 +706,7 @@ class TestServiceServiceId:
         parsed = ServiceServiceId.from_string(service_id_str)
 
         assert parsed.instrument == original.instrument
-        assert parsed.namespace == original.namespace
+        assert parsed.service_name == original.service_name
         assert parsed.worker_id == original.worker_id
 
 
@@ -718,7 +718,7 @@ class TestServiceStatusPayload:
         worker_id = str(uuid.uuid4())
         payload = ServiceStatusPayload(
             instrument="dream",
-            namespace="data_reduction",
+            service_name="data_reduction",
             worker_id=worker_id,
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000000000),
@@ -728,7 +728,7 @@ class TestServiceStatusPayload:
 
         assert payload.message_type == "service"
         assert payload.instrument == "dream"
-        assert payload.namespace == "data_reduction"
+        assert payload.service_name == "data_reduction"
         assert payload.worker_id == worker_id
         assert payload.state == ServiceState.running
         assert payload.active_job_count == 5
@@ -737,7 +737,7 @@ class TestServiceStatusPayload:
         """Test creating ServiceStatusPayload with error."""
         payload = ServiceStatusPayload(
             instrument="dream",
-            namespace="data_reduction",
+            service_name="data_reduction",
             worker_id=str(uuid.uuid4()),
             state=ServiceState.error,
             started_at=Timestamp.from_ns(1000000000),
@@ -759,7 +759,7 @@ class TestServiceStatusMessage:
 
         assert msg.software_name == "livedata"
         assert msg.service_id.instrument == status.instrument
-        assert msg.service_id.namespace == status.namespace
+        assert msg.service_id.service_name == status.service_name
         assert msg.service_id.worker_id == status.worker_id
         assert msg.status_json.message.state == status.state
         assert msg.status_json.message.active_job_count == status.active_job_count
@@ -787,7 +787,7 @@ class TestServiceStatusMessage:
         converted = msg.to_service_status()
 
         assert converted.instrument == original.instrument
-        assert converted.namespace == original.namespace
+        assert converted.service_name == original.service_name
         assert converted.worker_id == original.worker_id
         assert converted.state == original.state
         assert converted.started_at == original.started_at
@@ -812,7 +812,7 @@ class TestServiceStatusX5F2Integration:
         first heartbeat after PR #829 introduced Timestamp."""
         status = ServiceStatus(
             instrument="dream",
-            namespace="data_reduction",
+            service_name="data_reduction",
             worker_id=str(uuid.uuid4()),
             state=ServiceState.running,
             started_at=Timestamp.now(),
@@ -844,7 +844,7 @@ class TestServiceStatusX5F2Integration:
         converted = x5f2_to_service_status(x5f2_data)
 
         assert converted.instrument == original.instrument
-        assert converted.namespace == original.namespace
+        assert converted.service_name == original.service_name
         assert converted.worker_id == original.worker_id
         assert converted.state == original.state
         assert converted.started_at == original.started_at
@@ -893,7 +893,7 @@ class TestServiceStatusX5F2Integration:
         """Test that service_id has the correct format."""
         status = make_service_status(
             instrument="dream",
-            namespace="data_reduction",
+            service_name="data_reduction",
             worker_id="7c9e6679-7425-40de-944b-e07fc1f90ae7",
         )
         x5f2_data = service_status_to_x5f2(status)
@@ -1004,7 +1004,7 @@ class TestX5f2ToStatusDiscriminator:
         worker_id = str(uuid.uuid4())
         service_status = ServiceStatus(
             instrument="dream",
-            namespace="data_reduction",
+            service_name="data_reduction",
             worker_id=worker_id,
             state=ServiceState.running,
             started_at=Timestamp.from_ns(1000000000),
@@ -1016,7 +1016,7 @@ class TestX5f2ToStatusDiscriminator:
 
         assert isinstance(result, ServiceStatus)
         assert result.instrument == service_status.instrument
-        assert result.namespace == service_status.namespace
+        assert result.service_name == service_status.service_name
         assert result.worker_id == service_status.worker_id
         assert result.state == service_status.state
 

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -273,7 +273,7 @@ def test_service_can_recover_after_bad_workflow_id_was_set(
         source_name='panel_0', service_name="data_reduction", key="workflow_config"
     )
     identifier = workflow_spec.WorkflowId(
-        instrument='dummy', namespace='data_reduction', name='abcde12345', version=1
+        instrument='dummy', name='abcde12345', version=1
     )
     bad_workflow_id = workflow_spec.WorkflowConfig(
         identifier=identifier,  # Invalid workflow ID
@@ -365,7 +365,7 @@ def test_active_workflow_keeps_running_when_bad_workflow_id_or_params_were_set(
 
     # Try to set an invalid workflow ID
     identifier = workflow_spec.WorkflowId(
-        instrument='dummy', namespace='data_reduction', name='abcde12345', version=1
+        instrument='dummy', name='abcde12345', version=1
     )
     bad_workflow_id = workflow_spec.WorkflowConfig(
         identifier=identifier,  # Invalid workflow ID

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -21,7 +21,7 @@ def _get_workflow_from_registry(
     instrument_config = instrument_registry[instrument]
     workflow_registry = instrument_config.workflow_factory
     for wid, spec in workflow_registry.items():
-        if spec.namespace == namespace:
+        if spec.group.name == namespace:
             if name is None or name == spec.name:
                 return wid, spec
     raise ValueError(f"Namespace {namespace} not found in specs")
@@ -123,7 +123,7 @@ def test_service_can_recover_after_bad_workflow_id_was_set(
         source_name='panel_0', service_name="detector_data", key="workflow_config"
     )
     identifier = workflow_spec.WorkflowId(
-        instrument='dummy', namespace='detector_data', name='abcde12345', version=1
+        instrument='dummy', name='abcde12345', version=1
     )
     bad_workflow_id = workflow_spec.WorkflowConfig(
         identifier=identifier,  # Invalid workflow ID
@@ -185,7 +185,7 @@ def test_active_workflow_keeps_running_when_bad_workflow_id_was_set(
     # Try to set an invalid workflow ID
     bad_workflow_id = workflow_spec.WorkflowConfig(
         identifier=workflow_spec.WorkflowId(
-            instrument='dummy', namespace='detector_data', name='abcde12345', version=1
+            instrument='dummy', name='abcde12345', version=1
         )  # Invalid workflow ID
     )
     app.publish_config_message(key=config_key, value=bad_workflow_id.model_dump())

--- a/tests/services/monitor_data_test.py
+++ b/tests/services/monitor_data_test.py
@@ -27,7 +27,7 @@ def _get_workflow_from_registry(
     instrument_config = instrument_registry[instrument]
     workflow_registry = instrument_config.workflow_factory
     for wid, spec in workflow_registry.items():
-        if spec.namespace == namespace:
+        if spec.group.name == namespace:
             return wid, spec
     raise ValueError(f"Namespace {namespace} not found in specs")
 

--- a/tests/services/shutdown_test.py
+++ b/tests/services/shutdown_test.py
@@ -20,7 +20,7 @@ def _make_detector_app() -> LivedataApp:
 def _get_workflow_id() -> workflow_spec.WorkflowId:
     instrument_config = instrument_registry['dummy']
     for wid, spec in instrument_config.workflow_factory.items():
-        if spec.namespace == 'detector_data':
+        if spec.group.name == 'detector_data':
             return wid
     raise ValueError("detector_data workflow not found")
 

--- a/tests/services/timeseries_test.py
+++ b/tests/services/timeseries_test.py
@@ -26,7 +26,7 @@ def _get_workflow_from_registry(
     instrument_config = instrument_registry[instrument]
     workflow_registry = instrument_config.workflow_factory
     for wid, spec in workflow_registry.items():
-        if spec.namespace == namespace:
+        if spec.group.name == namespace:
             return wid, spec
     raise ValueError(f"Namespace {namespace} not found in specs")
 


### PR DESCRIPTION
## Summary

Reduces `WorkflowId` identity from `(instrument, namespace, name, version)` to `(instrument, name, version)` and replaces the `namespace` field with a display-oriented `WorkflowGroup`.

## Why

`WorkflowSpec.namespace` was carrying three unrelated responsibilities: workflow identity, the routing key `JobFactory` used to accept/reject jobs, and the dashboard's display category. Splitting them:

- Routing now uses an explicit `service` tag tracked by `WorkflowFactory`, consulted via `get_service(workflow_id)`. The service's own name is the comparison key, no longer read from `WorkflowId`.
- Display grouping becomes a typed `WorkflowGroup` with canonical `REDUCTION` / `MONITORS` / `DETECTORS` / `TIMESERIES` constants and a `Literal`-locked `name` to keep ad-hoc categories from sneaking in.
- Identity drops the field entirely; `WorkflowId` strings are now 3-part (`instrument/name/version`).

With the awkward semantics gone, the upcoming move into `ess.livedata.schemas` becomes mechanical.

## Note

- **No wire-format compatibility.** `JobStatusPayload` workflow-id strings, `ResultKey` JSON, and persisted configs all pick up the 3-part form.
