### PR TITLE
Fix Overlay1DPlotter ignoring line style options

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -816,20 +816,36 @@ class BarsPlotter(Plotter):
 
 class Overlay1DPlotter(Plotter):
     """
-    Plotter that slices 2D data along the first dimension and overlays as 1D curves.
+    Plotter that slices 2D data along the first dimension and overlays as 1D elements.
 
-    Takes 2D data with dims [slice_dim, plot_dim] and creates an overlay of 1D curves,
+    Takes 2D data with dims [slice_dim, plot_dim] and creates an overlay of 1D elements,
     one for each position along the first dimension. Useful for visualizing multiple
     spectra (e.g., ROI spectra) from a single 2D array.
 
     Colors are assigned by coordinate value (not position) when coordinates are
     integer-like, providing stable color identity across updates.
+
+    Supports the same line style options (mode, errors) as LinePlotter.
     """
+
+    _BASE_METHOD: ClassVar[dict[str, str]] = {
+        'line': 'curve',
+        'points': 'scatter',
+        'histogram': 'histogram',
+    }
+    _ERROR_METHOD: ClassVar[dict[str, str]] = {
+        'bars': 'error_bars',
+        'band': 'spread',
+    }
+    _HISTOGRAM_FALLBACK: ClassVar[str] = 'line'
 
     def __init__(
         self,
         scale_opts: PlotScaleParams,
         tick_params: TickParams | None = None,
+        *,
+        mode: str = 'line',
+        errors: str = 'bars',
         **kwargs,
     ):
         """
@@ -841,10 +857,16 @@ class Overlay1DPlotter(Plotter):
             Scaling options for axes.
         tick_params:
             Tick configuration parameters.
+        mode:
+            Rendering mode: 'line', 'points', or 'histogram'.
+        errors:
+            Error display mode: 'bars', 'band', or 'none'.
         **kwargs:
             Additional keyword arguments passed to the base class.
         """
         super().__init__(**kwargs)
+        self._mode = mode
+        self._errors = errors
         self._base_opts: dict[str, Any] = {
             'logx': scale_opts.x_scale == PlotScale.log,
             'logy': scale_opts.y_scale == PlotScale.log,
@@ -864,6 +886,8 @@ class Overlay1DPlotter(Plotter):
             scale_opts=params.plot_scale,
             tick_params=params.ticks,
             normalize_to_rate=params.rate.normalize_to_rate,
+            mode=params.line.mode,
+            errors=params.line.errors,
         )
 
     def plot(
@@ -876,9 +900,9 @@ class Overlay1DPlotter(Plotter):
         **kwargs,
     ) -> hv.Overlay | hv.Element:
         """
-        Create overlaid curves from a 2D DataArray.
+        Create overlaid elements from a 2D DataArray.
 
-        Slices along the first dimension and creates a curve for each slice.
+        Slices along the first dimension and creates an element for each slice.
         """
         del kwargs, label  # Unused
         if data.ndim != 2:
@@ -899,10 +923,19 @@ class Overlay1DPlotter(Plotter):
         else:
             coord_values = np.arange(slice_size)
 
-        # Pre-convert bin-edge coords to midpoints (shared across all slices)
-        data = self._convert_bin_edges_to_midpoints(data, dim=data.dims[1])
+        plot_dim = data.dims[1]
+        has_edges = plot_dim in data.coords and data.coords.is_edges(plot_dim)
+        use_histogram = self._mode == 'histogram' and has_edges
+        actual_mode = (
+            self._mode
+            if use_histogram
+            else (self._mode if self._mode != 'histogram' else self._HISTOGRAM_FALLBACK)
+        )
 
-        curves: list[hv.Element] = []
+        if not use_histogram:
+            data = self._convert_bin_edges_to_midpoints(data, dim=plot_dim)
+
+        elements: list[hv.Element] = []
         for i in range(slice_size):
             slice_data = data[slice_dim, i]
             if output_display_name:
@@ -914,12 +947,28 @@ class Overlay1DPlotter(Plotter):
             color = self._colors[color_idx]
 
             curve_label = f"{slice_dim}={coord_val}"
-            curve = to_holoviews(slice_data, label=curve_label)
-            curve = curve.opts(
-                color=color, framewise=framewise, **self._base_opts, **self._sizing_opts
+            converter = HvConverter1d(slice_data, value_label=output_display_name)
+            base_method = getattr(converter, self._BASE_METHOD[actual_mode])
+            base = base_method(label=curve_label).opts(
+                color=color, framewise=framewise, **self._base_opts
             )
-            curves.append(curve)
 
-        if len(curves) == 1:
-            return curves[0]
-        return hv.Overlay(curves).opts(shared_axes=True)
+            if slice_data.variances is not None and self._errors != 'none':
+                if use_histogram:
+                    mid = self._convert_bin_edges_to_midpoints(slice_data)
+                    converter = HvConverter1d(mid, value_label=output_display_name)
+                error_method = getattr(converter, self._ERROR_METHOD[self._errors])
+                error_el = error_method(label=curve_label).opts(
+                    color=color,
+                    framewise=framewise,
+                    **self._base_opts,
+                    **self._sizing_opts,
+                )
+                elements.append(base.opts(**self._sizing_opts))
+                elements.append(error_el)
+            else:
+                elements.append(base.opts(**self._sizing_opts))
+
+        if len(elements) == 1:
+            return elements[0]
+        return hv.Overlay(elements).opts(shared_axes=True)

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -948,6 +948,7 @@ class Overlay1DPlotter(Plotter):
 
             if slice_data.variances is not None and self._errors != 'none':
                 if use_histogram:
+                    # Error elements need midpoint coords (N values, not N+1 edges)
                     mid = slice_data.assign_coords(
                         {
                             slice_data.dim: sc.midpoints(

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, ClassVar, cast
+from typing import Any, cast
 
 import holoviews as hv
 import numpy as np
@@ -561,6 +561,38 @@ class Plotter:
         )
 
 
+_LINE1D_BASE_METHOD: dict[str, str] = {
+    'line': 'curve',
+    'points': 'scatter',
+    'histogram': 'histogram',
+}
+_LINE1D_ERROR_METHOD: dict[str, str] = {
+    'bars': 'error_bars',
+    'band': 'spread',
+}
+_LINE1D_HISTOGRAM_FALLBACK = 'line'
+
+
+def _resolve_line1d_mode(
+    mode: str, data: sc.DataArray, dim: str | None = None
+) -> tuple[str, sc.DataArray]:
+    """Return (actual_mode, data) with bin edges converted to midpoints if needed.
+
+    When mode is 'histogram' but the data has no bin-edge coordinate on ``dim``,
+    falls back to 'line'. When mode is not 'histogram', bin edges are always
+    converted to midpoints.
+    """
+    if dim is None:
+        dim = data.dim
+    has_edges = dim in data.coords and data.coords.is_edges(dim)
+    if mode == 'histogram' and has_edges:
+        return 'histogram', data
+    actual_mode = mode if mode != 'histogram' else _LINE1D_HISTOGRAM_FALLBACK
+    if has_edges:
+        data = data.assign_coords({dim: sc.midpoints(data.coords[dim])})
+    return actual_mode, data
+
+
 class LinePlotter(Plotter):
     """Plotter for 1D plots from scipp DataArrays.
 
@@ -625,18 +657,6 @@ class LinePlotter(Plotter):
             params, normalize_to_rate=params.rate.normalize_to_rate
         )
 
-    _BASE_METHOD: ClassVar[dict[str, str]] = {
-        'line': 'curve',
-        'points': 'scatter',
-        'histogram': 'histogram',
-    }
-    _ERROR_METHOD: ClassVar[dict[str, str]] = {
-        'bars': 'error_bars',
-        'band': 'spread',
-    }
-
-    _HISTOGRAM_FALLBACK: ClassVar[str] = 'line'
-
     def plot(
         self,
         data: sc.DataArray,
@@ -647,29 +667,22 @@ class LinePlotter(Plotter):
         **kwargs,
     ) -> hv.Element | hv.Overlay:
         """Create a 1D plot from a scipp DataArray."""
-        converter = HvConverter1d(data, value_label=output_display_name)
-        if self._mode == 'histogram' and converter.has_edges:
-            mode = 'histogram'
-            da = data
-        else:
-            mode = self._mode if self._mode != 'histogram' else self._HISTOGRAM_FALLBACK
-            da = self._convert_bin_edges_to_midpoints(data)
-            converter = HvConverter1d(da, value_label=output_display_name)
-
+        mode, da = _resolve_line1d_mode(self._mode, data)
+        converter = HvConverter1d(da, value_label=output_display_name)
         framewise = self._update_autoscaler_and_get_framewise(da, data_key)
         opts = dict(framewise=framewise, **self._base_opts)
 
-        base_method = getattr(converter, self._BASE_METHOD[mode])
+        base_method = getattr(converter, _LINE1D_BASE_METHOD[mode])
         base = base_method(label=label).opts(**opts)
 
         if da.variances is not None and self._errors != 'none':
             if mode == 'histogram':
                 # Error elements need midpoint coords (N values, not N+1 edges)
                 converter = HvConverter1d(
-                    self._convert_bin_edges_to_midpoints(da),
+                    da.assign_coords({da.dim: sc.midpoints(da.coords[da.dim])}),
                     value_label=output_display_name,
                 )
-            error_method = getattr(converter, self._ERROR_METHOD[self._errors])
+            error_method = getattr(converter, _LINE1D_ERROR_METHOD[self._errors])
             error_element = error_method(label=label).opts(**opts, **self._sizing_opts)
             # Apply sizing opts to child elements individually. Bokeh needs
             # responsive/aspect on each element to size the figure correctly;
@@ -828,17 +841,6 @@ class Overlay1DPlotter(Plotter):
     Supports the same line style options (mode, errors) as LinePlotter.
     """
 
-    _BASE_METHOD: ClassVar[dict[str, str]] = {
-        'line': 'curve',
-        'points': 'scatter',
-        'histogram': 'histogram',
-    }
-    _ERROR_METHOD: ClassVar[dict[str, str]] = {
-        'bars': 'error_bars',
-        'band': 'spread',
-    }
-    _HISTOGRAM_FALLBACK: ClassVar[str] = 'line'
-
     def __init__(
         self,
         scale_opts: PlotScaleParams,
@@ -923,17 +925,8 @@ class Overlay1DPlotter(Plotter):
         else:
             coord_values = np.arange(slice_size)
 
-        plot_dim = data.dims[1]
-        has_edges = plot_dim in data.coords and data.coords.is_edges(plot_dim)
-        use_histogram = self._mode == 'histogram' and has_edges
-        actual_mode = (
-            self._mode
-            if use_histogram
-            else (self._mode if self._mode != 'histogram' else self._HISTOGRAM_FALLBACK)
-        )
-
-        if not use_histogram:
-            data = self._convert_bin_edges_to_midpoints(data, dim=plot_dim)
+        actual_mode, data = _resolve_line1d_mode(self._mode, data, dim=data.dims[1])
+        use_histogram = actual_mode == 'histogram'
 
         elements: list[hv.Element] = []
         for i in range(slice_size):
@@ -948,16 +941,22 @@ class Overlay1DPlotter(Plotter):
 
             curve_label = f"{slice_dim}={coord_val}"
             converter = HvConverter1d(slice_data, value_label=output_display_name)
-            base_method = getattr(converter, self._BASE_METHOD[actual_mode])
+            base_method = getattr(converter, _LINE1D_BASE_METHOD[actual_mode])
             base = base_method(label=curve_label).opts(
                 color=color, framewise=framewise, **self._base_opts
             )
 
             if slice_data.variances is not None and self._errors != 'none':
                 if use_histogram:
-                    mid = self._convert_bin_edges_to_midpoints(slice_data)
+                    mid = slice_data.assign_coords(
+                        {
+                            slice_data.dim: sc.midpoints(
+                                slice_data.coords[slice_data.dim]
+                            )
+                        }
+                    )
                     converter = HvConverter1d(mid, value_label=output_display_name)
-                error_method = getattr(converter, self._ERROR_METHOD[self._errors])
+                error_method = getattr(converter, _LINE1D_ERROR_METHOD[self._errors])
                 error_el = error_method(label=curve_label).opts(
                     color=color,
                     framewise=framewise,

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1517,6 +1517,118 @@ class TestOverlay1DPlotter:
             vdim = curve.vdims[0]
             assert vdim.label == 'values'
 
+    def test_points_mode_produces_scatter(self, data_2d_with_roi_coord, data_key):
+        params = PlotParams1d(line=Line1dParams(mode=Line1dRenderMode.points))
+        plotter = plots.Overlay1DPlotter.from_params(params)
+        result = plotter.plot(data_2d_with_roi_coord, data_key)
+        assert isinstance(result, hv.Overlay)
+        for elem in result:
+            assert isinstance(elem, hv.Scatter)
+
+    def test_histogram_mode_produces_histograms(self, data_key):
+        params = PlotParams1d(line=Line1dParams(mode=Line1dRenderMode.histogram))
+        plotter = plots.Overlay1DPlotter.from_params(params)
+        toa_edges = sc.array(dims=['toa'], values=[0.0, 10.0, 20.0, 30.0], unit='us')
+        data = sc.DataArray(
+            sc.array(dims=['roi', 'toa'], values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+            coords={
+                'roi': sc.array(dims=['roi'], values=[0, 1], unit=None),
+                'toa': toa_edges,
+            },
+        )
+        result = plotter.plot(data, data_key)
+        assert isinstance(result, hv.Overlay)
+        for elem in result:
+            assert isinstance(elem, hv.Histogram)
+
+    def test_histogram_mode_without_bin_edges_falls_back_to_curve(
+        self, data_2d_with_roi_coord, data_key
+    ):
+        params = PlotParams1d(line=Line1dParams(mode=Line1dRenderMode.histogram))
+        plotter = plots.Overlay1DPlotter.from_params(params)
+        result = plotter.plot(data_2d_with_roi_coord, data_key)
+        for elem in result:
+            assert isinstance(elem, hv.Curve)
+
+    def test_error_bars_with_variances(self, data_key):
+        params = PlotParams1d(
+            line=Line1dParams(mode=Line1dRenderMode.line, errors=ErrorDisplay.bars)
+        )
+        plotter = plots.Overlay1DPlotter.from_params(params)
+        data = sc.DataArray(
+            sc.array(
+                dims=['roi', 'toa'],
+                values=[[1.0, 2.0], [3.0, 4.0]],
+                variances=[[0.1, 0.2], [0.3, 0.4]],
+                unit='counts',
+            ),
+            coords={
+                'roi': sc.array(dims=['roi'], values=[0, 1], unit=None),
+                'toa': sc.array(dims=['toa'], values=[10.0, 20.0], unit='us'),
+            },
+        )
+        result = plotter.plot(data, data_key)
+        assert isinstance(result, hv.Overlay)
+        elements = list(result)
+        # 2 slices x (Curve + ErrorBars)
+        assert len(elements) == 4
+        assert isinstance(elements[0], hv.Curve)
+        assert isinstance(elements[1], hv.ErrorBars)
+        assert isinstance(elements[2], hv.Curve)
+        assert isinstance(elements[3], hv.ErrorBars)
+
+    def test_error_band_with_variances(self, data_key):
+        params = PlotParams1d(
+            line=Line1dParams(mode=Line1dRenderMode.line, errors=ErrorDisplay.band)
+        )
+        plotter = plots.Overlay1DPlotter.from_params(params)
+        data = sc.DataArray(
+            sc.array(
+                dims=['roi', 'toa'],
+                values=[[1.0, 2.0], [3.0, 4.0]],
+                variances=[[0.1, 0.2], [0.3, 0.4]],
+                unit='counts',
+            ),
+            coords={
+                'roi': sc.array(dims=['roi'], values=[0, 1], unit=None),
+                'toa': sc.array(dims=['toa'], values=[10.0, 20.0], unit='us'),
+            },
+        )
+        result = plotter.plot(data, data_key)
+        elements = list(result)
+        assert isinstance(elements[0], hv.Curve)
+        assert isinstance(elements[1], hv.Spread)
+
+    def test_errors_none_suppresses_error_display(self, data_key):
+        params = PlotParams1d(
+            line=Line1dParams(mode=Line1dRenderMode.line, errors=ErrorDisplay.none)
+        )
+        plotter = plots.Overlay1DPlotter.from_params(params)
+        data = sc.DataArray(
+            sc.array(
+                dims=['roi', 'toa'],
+                values=[[1.0, 2.0], [3.0, 4.0]],
+                variances=[[0.1, 0.2], [0.3, 0.4]],
+                unit='counts',
+            ),
+            coords={
+                'roi': sc.array(dims=['roi'], values=[0, 1], unit=None),
+                'toa': sc.array(dims=['toa'], values=[10.0, 20.0], unit='us'),
+            },
+        )
+        result = plotter.plot(data, data_key)
+        for elem in result:
+            assert isinstance(elem, hv.Curve)
+
+    def test_no_variances_no_errors_displayed(self, data_2d_with_roi_coord, data_key):
+        params = PlotParams1d(
+            line=Line1dParams(mode=Line1dRenderMode.line, errors=ErrorDisplay.bars)
+        )
+        plotter = plots.Overlay1DPlotter.from_params(params)
+        result = plotter.plot(data_2d_with_roi_coord, data_key)
+        for elem in result:
+            assert isinstance(elem, hv.Curve)
+
 
 class TestLagIndicator:
     """Tests for lag indicator functionality in plotters."""


### PR DESCRIPTION
Line mode (line/points/histogram) and error display (bars/band/none) configured via `PlotParams1d.line` were silently ignored by `Overlay1DPlotter`. It always rendered plain `hv.Curve` elements regardless of settings.

**Root cause:** `from_params` never read `params.line`, and `plot` always called `to_holoviews()` which produces a `Curve` unconditionally.

**Fix:** Add `mode` and `errors` to `__init__` and `from_params`, then replace the hard-coded `to_holoviews()` call with `HvConverter1d`-based rendering — the same approach used by `LinePlotter`. Histogram mode with bin-edge coordinates is also supported, with the same midpoint-fallback logic as `LinePlotter`.

The duplicate `_BASE_METHOD`/`_ERROR_METHOD`/`_HISTOGRAM_FALLBACK` class variables and the bin-edge/mode resolution logic are extracted to module-level constants and a shared helper `_resolve_line1d_mode`.

## Test plan
- [x] Try different modes in UI