### PR TITLE
Fix: Move graphviz import to TYPE_CHECKING guard

### DIFF
--- a/src/ess/livedata/handlers/stream_processor_workflow.py
+++ b/src/ess/livedata/handlers/stream_processor_workflow.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import graphviz
+if TYPE_CHECKING:
+    import graphviz
+
 import sciline
 import sciline.typing
 from ess.reduce import streaming


### PR DESCRIPTION
`graphviz` is not a deployment dependency — it is only needed for the return type annotation on `visualize()`. Since `from __future__ import annotations` is already in the module, all annotations are deferred strings at runtime, so guarding the import under `TYPE_CHECKING` is sufficient.

This broke deployment on TBL due to failing imports. This was introduced in #755.