### PR TITLE
CI: per-instrument smoke check to catch missing-deps deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,73 @@ jobs:
       tox-env: ${{ matrix.python.tox-env }}
     secrets: inherit
 
+  instrument-check:
+    # Verify that an instrument deployment can construct its backend services
+    # using only the dependencies declared in its extras. Catches imports that
+    # accidentally depend on packages installed only via ``[test]`` or another
+    # instrument's extras, which would break in production.
+    name: Backend deps (${{ matrix.instrument }})
+    needs: formatting
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { instrument: dummy, extras: '' }
+          - { instrument: tbl, extras: '' }
+          - { instrument: bifrost, extras: bifrost }
+          - { instrument: dream, extras: dream }
+          - { instrument: loki, extras: loki }
+          - { instrument: odin, extras: odin }
+          - { instrument: estia, extras: estia }
+          - { instrument: nmx, extras: nmx }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: '.github/workflows/python-version-ci'
+      - run: python -m pip install --upgrade pip
+      - name: Install package with instrument extras
+        run: |
+          if [ -n "${{ matrix.extras }}" ]; then
+            python -m pip install ".[${{ matrix.extras }}]"
+          else
+            python -m pip install .
+          fi
+      - name: Smoke-check backend services
+        run: |
+          for svc in monitor_data detector_data data_reduction timeseries; do
+            echo "::group::$svc"
+            python -m ess.livedata.services.$svc \
+              --instrument ${{ matrix.instrument }} --check
+            echo "::endgroup::"
+          done
+
+  dashboard-check:
+    # Verify the dashboard can be constructed for every instrument using only
+    # the [dashboard] extra (which has no instrument-specific dependencies).
+    # If this fails for some instrument, either the dashboard has acquired a
+    # hidden instrument dependency or [dashboard] is missing something.
+    name: Dashboard deps
+    needs: formatting
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: '.github/workflows/python-version-ci'
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install ".[dashboard]"
+      - name: Smoke-check dashboard for each instrument
+        run: |
+          for inst in dummy tbl bifrost dream loki odin estia nmx; do
+            echo "::group::$inst"
+            python -m ess.livedata.dashboard.reduction \
+              --instrument $inst --transport none \
+              --no-fetch-announcements --check
+            echo "::endgroup::"
+          done
+
   docs:
     needs: tests
     uses: ./.github/workflows/docs.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,28 +59,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { instrument: dummy, extras: '' }
-          - { instrument: tbl, extras: '' }
-          - { instrument: bifrost, extras: bifrost }
-          - { instrument: dream, extras: dream }
-          - { instrument: loki, extras: loki }
-          - { instrument: odin, extras: odin }
-          - { instrument: estia, extras: estia }
-          - { instrument: nmx, extras: nmx }
+        instrument: [bifrost, dream, dummy, estia, loki, nmx, odin, tbl]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
       - run: python -m pip install --upgrade pip
-      - name: Install package with instrument extras
-        run: |
-          if [ -n "${{ matrix.extras }}" ]; then
-            python -m pip install ".[${{ matrix.extras }}]"
-          else
-            python -m pip install .
-          fi
+      - run: python -m pip install ".[${{ matrix.instrument }}]"
       - name: Smoke-check backend services
         run: |
           for svc in monitor_data detector_data data_reduction timeseries; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     # accidentally depend on packages installed only via ``[test]`` or another
     # instrument's extras, which would break in production.
     name: Backend deps (${{ matrix.instrument }})
-    needs: formatting
+    needs: tests
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -82,7 +82,7 @@ jobs:
     # If this fails for some instrument, either the dashboard has acquired a
     # hidden instrument dependency or [dashboard] is missing something.
     name: Dashboard deps
-    needs: formatting
+    needs: tests
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,18 +64,20 @@ bifrost = [
 dream = [
     "essdiffraction>=26.4.0",
 ]
-loki = [
-    "esssans>=26.4.0",
-]
-odin = [
-    "essimaging>=26.4.0",
-]
+dummy = []
 estia = [
     "essreflectometry>=26.4.0",
+]
+loki = [
+    "esssans>=26.4.0",
 ]
 nmx = [
     "essnmx>=26.4.0",
 ]
+odin = [
+    "essimaging>=26.4.0",
+]
+tbl = []
 dashboard = [
   "bokeh",
   "holoviews",

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -201,6 +201,15 @@ def get_arg_parser() -> argparse.ArgumentParser:
         help='Cookie secret for basic authentication sessions. '
         'Can also be set via LIVEDATA_BASIC_AUTH_COOKIE_SECRET env var.',
     )
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        default=False,
+        help='Construct the dashboard for the selected instrument and exit '
+        'without starting the Bokeh server. Combine with --transport none to '
+        'verify all required dependencies are importable without contacting '
+        'Kafka.',
+    )
     return parser
 
 
@@ -220,7 +229,10 @@ def main() -> None:
         disable_stdout=no_stdout_log,
     )
 
+    check = args.pop('check')
     app = ReductionApp(log_level=log_level, **args)
+    if check:
+        return
     app.start(blocking=True)
 
 

--- a/src/ess/livedata/service_factory.py
+++ b/src/ess/livedata/service_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import sys
 from collections.abc import Callable
 from contextlib import ExitStack
 from typing import Any, Generic, NoReturn, TypeVar
@@ -260,6 +261,14 @@ class DataServiceRunner:
             ' SimpleMessageBatcher (pre-existing default); "rate-aware" uses'
             ' RateAwareMessageBatcher (per-stream pulse-slot completion).',
         )
+        self._parser.add_argument(
+            '--check',
+            action='store_true',
+            default=False,
+            help='Build the service for the selected instrument and exit '
+            'without connecting to Kafka. Verifies that all dependencies '
+            'required by the instrument are importable.',
+        )
 
     @property
     def parser(self) -> argparse.ArgumentParser:
@@ -300,7 +309,11 @@ class DataServiceRunner:
         sink_type = args.pop('sink_type')
         job_threads = args.pop('job_threads')
         batcher_name = args.pop('batcher')
+        check = args.pop('check')
         builder = self._make_builder(**args)
+        if check:
+            logger.info("check_ok", instrument=builder.instrument)
+            sys.exit(0)
         builder.job_threads = job_threads
         if job_threads > 1:
             logger.info("job_threads", threads=job_threads)

--- a/tests/service_factory_test.py
+++ b/tests/service_factory_test.py
@@ -56,6 +56,18 @@ def test_job_threads_flag_defaults_to_five():
     assert args.job_threads == 5
 
 
+def test_check_flag_defaults_to_false():
+    runner = _make_runner()
+    args = runner.parser.parse_args(['--instrument', 'dummy'])
+    assert args.check is False
+
+
+def test_check_flag_is_registered():
+    runner = _make_runner()
+    args = runner.parser.parse_args(['--check', '--instrument', 'dummy'])
+    assert args.check is True
+
+
 def test_sciline_with_sync_pool_runs_on_calling_thread():
     """Setting dask pool to SynchronousExecutor makes sciline run on the calling thread.
 


### PR DESCRIPTION
## Summary

A recent production incident shipped a backend whose imports required a package not declared in the relevant instrument's extra. The existing `package-test` job did not catch it because it only imports the top-level package — heavy science-package imports happen lazily inside `setup_factories`, and so are only reached when the service is actually constructed.

This PR adds a fast, fully Kafka-free smoke check that catches that bug class on every PR.

- New `--check` flag on the four backend services and on the reduction dashboard. For backend services the check runs after `make_builder()` (which calls `load_factories()`); for the dashboard it runs after `ReductionApp(...)` is constructed and is meant to be combined with `--transport none` so no Kafka client is created. The flag exits with status 0 on success, non-zero on any import / construction error.
- New `instrument-check` CI job: matrix over all eight supported instruments. Each cell installs the package with that instrument's extra only (no `[test]`) and runs all four backend services with `--check`.
- New `dashboard-check` CI job: installs `[dashboard]` only and runs the dashboard `--check` for every instrument. If it passes, the `[dashboard]` extra is provably sufficient for every instrument; this also gives us the evidence to act on issue #906.
- Empty `dummy = []` and `tbl = []` extras so the matrix and any downstream tooling can treat every instrument uniformly via `pip install esslivedata[<instrument>]`.

## Test plan

- [x] `pytest tests/service_factory_test.py` passes locally (parser tests for new flag).
- [x] All four backend services × {dummy, dream, bifrost} succeed with `--check` locally; uninstalling `essdiffraction` makes `--instrument dream` exit non-zero with a clean `ModuleNotFoundError` while `dummy`/`bifrost` are unaffected.
- [x] Dashboard `--check` succeeds for all eight instruments locally with `[test]` installed, and still succeeds for every instrument after uninstalling `essdiffraction` and `essspectroscopy` (validating the premise of issue #906).