### PR TITLE
fix: meaning of `start` and `stop` in bin-edge widget with log scale

### DIFF
--- a/src/ess/livedata/parameter_models.py
+++ b/src/ess/livedata/parameter_models.py
@@ -235,7 +235,7 @@ class EnergyEdges(EdgesModel):
 
 def make_edges(*, model: EdgesModel, dim: str, unit: str) -> sc.Variable:
     """Convert the edges to a scipp variable."""
-    op = {Scale.LINEAR: sc.linspace, Scale.LOG: sc.logspace}[model.scale]
+    op = {Scale.LINEAR: sc.linspace, Scale.LOG: sc.geomspace}[model.scale]
     return op(
         dim=dim, start=model.start, stop=model.stop, num=model.num_bins + 1, unit=unit
     )

--- a/tests/parameter_models_test.py
+++ b/tests/parameter_models_test.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
+
+import scipp as sc
+
+from ess.livedata.parameter_models import Scale, WavelengthEdges
+
+
+def test_log_edges_are_geometrically_spaced_between_bounds() -> None:
+    edges = WavelengthEdges(
+        start=1.0, stop=100.0, num_bins=2, scale=Scale.LOG
+    ).get_edges()
+
+    expected = sc.array(dims=['wavelength'], values=[1.0, 10.0, 100.0], unit='Å')
+    assert sc.allclose(edges, expected)


### PR DESCRIPTION
Fixes #908 

Bug in the edge-widget in the workflow configuration page:

When the scale was set to scale.LOG the `start` and `stop` entries in the selector represented `log10(...)` of the start and stop of the desired range.

With this fix the `start` and `stop` entries in the widget represent the start and stop value of the range, which is the behavior users would expect.