### PR TITLE
Geometry script: handle NXdisk_chopper and trim NXlogs

### DIFF
--- a/src/ess/livedata/scripts/make_geometry_nexus.py
+++ b/src/ess/livedata/scripts/make_geometry_nexus.py
@@ -45,6 +45,47 @@ def _copy_monitor_fields(src_group: h5py.Group, dst_group: h5py.Group) -> None:
     src_group.copy('depends_on', dst_group)
 
 
+def _copy_nxlog_placeholder(src: h5py.Group, dst: h5py.Group) -> None:
+    """Copy an NXlog group structure with sample arrays truncated to length 0.
+
+    Production NeXus files may contain logs with thousands of samples; the
+    geometry artifact wants only the schema (dtype, units, attributes) so
+    downstream consumers see the field shape without historical data.
+    Scalar children (e.g. ``average_value``) are copied verbatim.
+    """
+    _copy_attributes(src, dst)
+    for child_name, child in src.items():
+        if isinstance(child, h5py.Dataset) and child.ndim >= 1:
+            ds = dst.create_dataset(
+                child_name,
+                shape=(0, *child.shape[1:]),
+                dtype=child.dtype,
+            )
+            _copy_attributes(child, ds)
+        else:
+            src.copy(child_name, dst)
+
+
+def _nx_class(obj: h5py.Group | h5py.Dataset) -> str:
+    nx_class = obj.attrs.get('NX_class', b'')
+    if isinstance(nx_class, bytes):
+        nx_class = nx_class.decode()
+    return nx_class
+
+
+def _copy_child(src: h5py.Group, key: str, dst: h5py.Group) -> None:
+    """Copy ``src[key]`` into ``dst``, trimming NXlog children to length-0.
+
+    No NXlog is ever copied verbatim: the geometry artifact carries only
+    schema (dtype, units, attributes), never historical samples.
+    """
+    child = src[key]
+    if isinstance(child, h5py.Group) and _nx_class(child) == 'NXlog':
+        _copy_nxlog_placeholder(child, dst.create_group(key))
+    else:
+        src.copy(key, dst)
+
+
 def _read_depends_on(value: bytes | str) -> str | None:
     if isinstance(value, bytes):
         value = value.decode()
@@ -89,8 +130,10 @@ def _resolve_depends_on_chains(fin: h5py.File, fout: h5py.File) -> None:
 
     After copying geometry components, ``depends_on`` chains may reference
     nodes that were not copied — for example an NXlog group inside an
-    NXpositioner that acts as a transformation node.  This function follows
-    all chains and copies missing nodes (groups and datasets) as-is.
+    NXpositioner that acts as a transformation node. NXlog groups are
+    copied as length-0 placeholders so historical motor samples in the
+    source do not bloat the geometry artifact; everything else is copied
+    as-is.
     """
     resolved: set[str] = set()
     while True:
@@ -104,7 +147,8 @@ def _resolve_depends_on_chains(fin: h5py.File, fout: h5py.File) -> None:
                 continue
             _ensure_parent_groups(fin, fout, path)
             parent_path = path.rsplit('/', 1)[0] if '/' in path else ''
-            fin.copy(path, fout[parent_path or '/'])
+            leaf = path.rsplit('/', 1)[-1]
+            _copy_child(fin[parent_path or '/'], leaf, fout[parent_path or '/'])
 
 
 def write_minimal_geometry(
@@ -153,9 +197,24 @@ def write_minimal_geometry(
                         ensure_parent_groups(name)
                         dst_group: h5py.Group = fout.create_group(name)
                         _copy_attributes(obj, dst_group)
-                        # Copy all contents of the transformations group
                         for key in obj:
-                            obj.copy(key, dst_group)
+                            _copy_child(obj, key, dst_group)
+                    elif nx_class == 'NXdisk_chopper':
+                        ensure_parent_groups(name)
+                        dst_group: h5py.Group = fout.create_group(name)
+                        _copy_attributes(obj, dst_group)
+                        # Static fields (slits, radius, delay, …) copy
+                        # verbatim; NXlog children (rotation_speed, phase)
+                        # become length-0 placeholders via ``_copy_child``.
+                        # Nested NXtransformations is skipped — the visitor
+                        # reaches its dedicated branch on the descent.
+                        for key, child in obj.items():
+                            if (
+                                isinstance(child, h5py.Group)
+                                and _nx_class(child) == 'NXtransformations'
+                            ):
+                                continue
+                            _copy_child(obj, key, dst_group)
 
         # Copy root attributes
         _copy_attributes(fin, fout)

--- a/src/ess/livedata/scripts/make_geometry_nexus.py
+++ b/src/ess/livedata/scripts/make_geometry_nexus.py
@@ -195,14 +195,25 @@ def write_minimal_geometry(
                         obj.copy('depends_on', dst_group)
                     elif nx_class == 'NXtransformations':
                         ensure_parent_groups(name)
-                        dst_group: h5py.Group = fout.create_group(name)
-                        _copy_attributes(obj, dst_group)
+                        # The group may already exist because a parent NXlog
+                        # placeholder copied a nested NXtransformations
+                        # recursively. Treat the branch as idempotent: copy
+                        # attributes and missing children only.
+                        if name in fout:
+                            dst_group: h5py.Group = fout[name]
+                        else:
+                            dst_group: h5py.Group = fout.create_group(name)
+                            _copy_attributes(obj, dst_group)
                         for key in obj:
-                            _copy_child(obj, key, dst_group)
+                            if key not in dst_group:
+                                _copy_child(obj, key, dst_group)
                     elif nx_class == 'NXdisk_chopper':
                         ensure_parent_groups(name)
-                        dst_group: h5py.Group = fout.create_group(name)
-                        _copy_attributes(obj, dst_group)
+                        if name in fout:
+                            dst_group: h5py.Group = fout[name]
+                        else:
+                            dst_group: h5py.Group = fout.create_group(name)
+                            _copy_attributes(obj, dst_group)
                         # Static fields (slits, radius, delay, …) copy
                         # verbatim; NXlog children (rotation_speed, phase)
                         # become length-0 placeholders via ``_copy_child``.
@@ -214,7 +225,8 @@ def write_minimal_geometry(
                                 and _nx_class(child) == 'NXtransformations'
                             ):
                                 continue
-                            _copy_child(obj, key, dst_group)
+                            if key not in dst_group:
+                                _copy_child(obj, key, dst_group)
 
         # Copy root attributes
         _copy_attributes(fin, fout)

--- a/src/ess/livedata/scripts/make_geometry_nexus.py
+++ b/src/ess/livedata/scripts/make_geometry_nexus.py
@@ -173,6 +173,16 @@ def _resolve_depends_on_chains(fin: h5py.File, fout: h5py.File) -> None:
             _copy_child(fin[parent_path or '/'], leaf, fout[parent_path or '/'])
 
 
+_HANDLED_NX_CLASSES = (
+    'NXdetector',
+    'NXmonitor',
+    'NXsource',
+    'NXsample',
+    'NXtransformations',
+    'NXdisk_chopper',
+)
+
+
 def write_minimal_geometry(
     input_filename: Path, output_filename: Path, use_pixel_shape: bool = True
 ) -> None:
@@ -183,17 +193,16 @@ def write_minimal_geometry(
             if not isinstance(obj, h5py.Group) or 'NX_class' not in obj.attrs:
                 return
             nx_class = _nx_class(obj)
+            if nx_class not in _HANDLED_NX_CLASSES:
+                return
+            dst = _get_or_create_dst(fin, fout, name, obj)
             if nx_class == 'NXdetector':
-                dst = _get_or_create_dst(fin, fout, name, obj)
                 _copy_detector_fields(obj, dst, use_pixel_shape=use_pixel_shape)
             elif nx_class == 'NXmonitor':
-                dst = _get_or_create_dst(fin, fout, name, obj)
                 _copy_monitor_fields(obj, dst)
             elif nx_class in ('NXsource', 'NXsample'):
-                dst = _get_or_create_dst(fin, fout, name, obj)
                 obj.copy('depends_on', dst)
-            elif nx_class in ('NXtransformations', 'NXdisk_chopper'):
-                dst = _get_or_create_dst(fin, fout, name, obj)
+            else:  # NXtransformations or NXdisk_chopper
                 for key in obj:
                     _copy_child(obj, key, dst)
 

--- a/src/ess/livedata/scripts/make_geometry_nexus.py
+++ b/src/ess/livedata/scripts/make_geometry_nexus.py
@@ -45,13 +45,21 @@ def _copy_monitor_fields(src_group: h5py.Group, dst_group: h5py.Group) -> None:
     src_group.copy('depends_on', dst_group)
 
 
+def _nx_class(obj: h5py.Group | h5py.Dataset) -> str:
+    nx_class = obj.attrs.get('NX_class', b'')
+    if isinstance(nx_class, bytes):
+        nx_class = nx_class.decode()
+    return nx_class
+
+
 def _copy_nxlog_placeholder(src: h5py.Group, dst: h5py.Group) -> None:
-    """Copy an NXlog group structure with sample arrays truncated to length 0.
+    """Copy an NXlog group, trimming length-N datasets to length 0.
 
     Production NeXus files may contain logs with thousands of samples; the
     geometry artifact wants only the schema (dtype, units, attributes) so
     downstream consumers see the field shape without historical data.
-    Scalar children (e.g. ``average_value``) are copied verbatim.
+    Scalar datasets are kept verbatim; nested groups (including any further
+    NXlogs) are dispatched through :func:`_copy_child`.
     """
     _copy_attributes(src, dst)
     for child_name, child in src.items():
@@ -63,27 +71,29 @@ def _copy_nxlog_placeholder(src: h5py.Group, dst: h5py.Group) -> None:
             )
             _copy_attributes(child, ds)
         else:
-            src.copy(child_name, dst)
-
-
-def _nx_class(obj: h5py.Group | h5py.Dataset) -> str:
-    nx_class = obj.attrs.get('NX_class', b'')
-    if isinstance(nx_class, bytes):
-        nx_class = nx_class.decode()
-    return nx_class
+            _copy_child(src, child_name, dst)
 
 
 def _copy_child(src: h5py.Group, key: str, dst: h5py.Group) -> None:
-    """Copy ``src[key]`` into ``dst``, trimming NXlog children to length-0.
+    """Copy ``src[key]`` into ``dst``, trimming any NXlog descendants.
 
-    No NXlog is ever copied verbatim: the geometry artifact carries only
-    schema (dtype, units, attributes), never historical samples.
+    Datasets are copied verbatim. NXlog groups become length-0 placeholders.
+    Other groups are recreated and recursed into so that NXlogs anywhere
+    below get trimmed. No-op if ``key`` already exists in ``dst``.
     """
+    if key in dst:
+        return
     child = src[key]
-    if isinstance(child, h5py.Group) and _nx_class(child) == 'NXlog':
-        _copy_nxlog_placeholder(child, dst.create_group(key))
-    else:
+    if isinstance(child, h5py.Dataset):
         src.copy(key, dst)
+        return
+    if _nx_class(child) == 'NXlog':
+        _copy_nxlog_placeholder(child, dst.create_group(key))
+        return
+    sub_dst = dst.create_group(key)
+    _copy_attributes(child, sub_dst)
+    for sub_key in child:
+        _copy_child(child, sub_key, sub_dst)
 
 
 def _read_depends_on(value: bytes | str) -> str | None:
@@ -125,6 +135,18 @@ def _ensure_parent_groups(fin: h5py.File, fout: h5py.File, path: str) -> None:
             _copy_attributes(fin[current], fout[current])
 
 
+def _get_or_create_dst(
+    fin: h5py.File, fout: h5py.File, name: str, src: h5py.Group
+) -> h5py.Group:
+    """Return ``fout[name]``, creating it (and parents) from ``src`` if absent."""
+    _ensure_parent_groups(fin, fout, name)
+    if name in fout:
+        return fout[name]
+    dst = fout.create_group(name)
+    _copy_attributes(src, dst)
+    return dst
+
+
 def _resolve_depends_on_chains(fin: h5py.File, fout: h5py.File) -> None:
     """Copy any ``depends_on`` targets that are missing from the output file.
 
@@ -157,78 +179,24 @@ def write_minimal_geometry(
     """Create minimal geometry file with only detector positions and transformations."""
     with h5py.File(input_filename, 'r') as fin, h5py.File(output_filename, 'w') as fout:
 
-        def ensure_parent_groups(name: str) -> None:
-            parts: list[str] = name.split('/')
-            current_path: str = ''
-            for part in parts[:-1]:  # Skip the last part (current group name)
-                if not part:
-                    continue
-                current_path = f"{current_path}/{part}"
-                if current_path not in fout:
-                    src_group: h5py.Group = fin[current_path]
-                    dst_group: h5py.Group = fout.create_group(current_path)
-                    _copy_attributes(src_group, dst_group)
-
         def visit_and_copy(name: str, obj: h5py.Group | h5py.Dataset) -> None:
-            if isinstance(obj, h5py.Group):
-                if 'NX_class' in obj.attrs:
-                    nx_class: str | bytes = obj.attrs['NX_class']
-                    if isinstance(nx_class, bytes):
-                        nx_class = nx_class.decode()
+            if not isinstance(obj, h5py.Group) or 'NX_class' not in obj.attrs:
+                return
+            nx_class = _nx_class(obj)
+            if nx_class == 'NXdetector':
+                dst = _get_or_create_dst(fin, fout, name, obj)
+                _copy_detector_fields(obj, dst, use_pixel_shape=use_pixel_shape)
+            elif nx_class == 'NXmonitor':
+                dst = _get_or_create_dst(fin, fout, name, obj)
+                _copy_monitor_fields(obj, dst)
+            elif nx_class in ('NXsource', 'NXsample'):
+                dst = _get_or_create_dst(fin, fout, name, obj)
+                obj.copy('depends_on', dst)
+            elif nx_class in ('NXtransformations', 'NXdisk_chopper'):
+                dst = _get_or_create_dst(fin, fout, name, obj)
+                for key in obj:
+                    _copy_child(obj, key, dst)
 
-                    if nx_class == 'NXdetector':
-                        ensure_parent_groups(name)
-                        dst_group: h5py.Group = fout.create_group(name)
-                        _copy_attributes(obj, dst_group)
-                        _copy_detector_fields(
-                            obj, dst_group, use_pixel_shape=use_pixel_shape
-                        )
-                    elif nx_class == 'NXmonitor':
-                        ensure_parent_groups(name)
-                        dst_group: h5py.Group = fout.create_group(name)
-                        _copy_attributes(obj, dst_group)
-                        _copy_monitor_fields(obj, dst_group)
-                    elif nx_class in ('NXsource', 'NXsample'):
-                        ensure_parent_groups(name)
-                        dst_group: h5py.Group = fout.create_group(name)
-                        _copy_attributes(obj, dst_group)
-                        obj.copy('depends_on', dst_group)
-                    elif nx_class == 'NXtransformations':
-                        ensure_parent_groups(name)
-                        # The group may already exist because a parent NXlog
-                        # placeholder copied a nested NXtransformations
-                        # recursively. Treat the branch as idempotent: copy
-                        # attributes and missing children only.
-                        if name in fout:
-                            dst_group: h5py.Group = fout[name]
-                        else:
-                            dst_group: h5py.Group = fout.create_group(name)
-                            _copy_attributes(obj, dst_group)
-                        for key in obj:
-                            if key not in dst_group:
-                                _copy_child(obj, key, dst_group)
-                    elif nx_class == 'NXdisk_chopper':
-                        ensure_parent_groups(name)
-                        if name in fout:
-                            dst_group: h5py.Group = fout[name]
-                        else:
-                            dst_group: h5py.Group = fout.create_group(name)
-                            _copy_attributes(obj, dst_group)
-                        # Static fields (slits, radius, delay, …) copy
-                        # verbatim; NXlog children (rotation_speed, phase)
-                        # become length-0 placeholders via ``_copy_child``.
-                        # Nested NXtransformations is skipped — the visitor
-                        # reaches its dedicated branch on the descent.
-                        for key, child in obj.items():
-                            if (
-                                isinstance(child, h5py.Group)
-                                and _nx_class(child) == 'NXtransformations'
-                            ):
-                                continue
-                            if key not in dst_group:
-                                _copy_child(obj, key, dst_group)
-
-        # Copy root attributes
         _copy_attributes(fin, fout)
         fin.visititems(visit_and_copy)
         _resolve_depends_on_chains(fin, fout)

--- a/tests/make_geometry_nexus_test.py
+++ b/tests/make_geometry_nexus_test.py
@@ -250,6 +250,54 @@ def nexus_with_populated_chopper_logs(tmp_path):
     return path
 
 
+def test_nested_nxtransformations_inside_nxlog_does_not_conflict(tmp_path):
+    """A real ESTIA structure: outer NXtransformations contains an NXlog
+    whose own children include another NXtransformations (motor stage with
+    chained transforms). The outer branch's recursive NXlog copy must not
+    conflict with the visitor's later descent into the inner group.
+    """
+    src = tmp_path / 'input.nxs'
+    with h5py.File(src, 'w') as f:
+        entry = f.create_group('entry')
+        entry.attrs['NX_class'] = 'NXentry'
+        inst = entry.create_group('instrument')
+        inst.attrs['NX_class'] = 'NXinstrument'
+
+        outer = inst.create_group('stage/transformations')
+        outer.attrs['NX_class'] = 'NXtransformations'
+        rx = outer.create_group('rx')
+        rx.attrs['NX_class'] = 'NXlog'
+        rx.create_dataset('time', data=np.arange(100, dtype='int64'))
+        rx.create_dataset('value', data=np.zeros(100))
+        # Nested NXtransformations inside the NXlog.
+        inner = rx.create_group('transformations')
+        inner.attrs['NX_class'] = 'NXtransformations'
+        ds = inner.create_dataset('rotation', data=0.0)
+        ds.attrs['transformation_type'] = 'rotation'
+        ds.attrs['vector'] = [0.0, 0.0, 1.0]
+        ds.attrs['units'] = 'deg'
+        ds.attrs['depends_on'] = '.'
+
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(src, output)
+
+    with h5py.File(output, 'r') as f:
+        # Outer NXtransformations preserved.
+        assert f['entry/instrument/stage/transformations'].attrs['NX_class'] == (
+            'NXtransformations'
+        )
+        # NXlog trimmed.
+        rx = f['entry/instrument/stage/transformations/rx']
+        assert rx.attrs['NX_class'] == 'NXlog'
+        # Inner NXtransformations preserved with its dataset.
+        inner_path = (
+            'entry/instrument/stage/transformations/rx/transformations/rotation'
+        )
+        inner_ds = f[inner_path]
+        assert inner_ds[()] == pytest.approx(0.0)
+        assert inner_ds.attrs['transformation_type'] == 'rotation'
+
+
 def test_nxlog_inside_nxtransformations_is_trimmed(tmp_path):
     """An NXtransformations group may contain a streamed transformation
     (NXlog with rotation/translation values). Its samples must be trimmed

--- a/tests/make_geometry_nexus_test.py
+++ b/tests/make_geometry_nexus_test.py
@@ -131,3 +131,241 @@ def test_copies_nxlog_children(nexus_with_nxlog_chain, tmp_path):
         assert 'time' in value_log
         assert 'value' in value_log
         assert 'average_value' in value_log
+
+
+@pytest.fixture
+def nexus_with_disk_chopper(tmp_path):
+    """NeXus file with an NXdisk_chopper carrying static geometry fields,
+    length-0 NXlog placeholders for streamed values, and a transformations
+    group reached via depends_on."""
+    path = tmp_path / 'input.nxs'
+    with h5py.File(path, 'w') as f:
+        f.attrs['default'] = 'entry'
+        entry = f.create_group('entry')
+        entry.attrs['NX_class'] = 'NXentry'
+        inst = entry.create_group('instrument')
+        inst.attrs['NX_class'] = 'NXinstrument'
+
+        chop = inst.create_group('chopper1')
+        chop.attrs['NX_class'] = 'NXdisk_chopper'
+        chop.create_dataset(
+            'depends_on',
+            data='/entry/instrument/chopper1/transformations/location',
+        )
+        # Static geometry fields
+        slits = chop.create_dataset('slits', data=2)
+        chop.create_dataset(
+            'slit_edges', data=np.array([0.0, 90.0, 180.0, 270.0])
+        ).attrs['units'] = 'deg'
+        chop.create_dataset('slit_height', data=0.1).attrs['units'] = 'm'
+        chop.create_dataset('radius', data=0.35).attrs['units'] = 'm'
+        chop.create_dataset('delay', data=0.0).attrs['units'] = 's'
+        slits.attrs['units'] = ''
+
+        # Length-0 NXlog placeholders for streamed values
+        for log_name in ('rotation_speed', 'phase'):
+            log = chop.create_group(log_name)
+            log.attrs['NX_class'] = 'NXlog'
+            log.create_dataset('time', data=np.array([], dtype='uint64'))
+            log.create_dataset('value', data=np.array([], dtype='float64'))
+
+        tr = chop.create_group('transformations')
+        tr.attrs['NX_class'] = 'NXtransformations'
+        ds = tr.create_dataset('location', data=15.0)
+        ds.attrs['transformation_type'] = 'translation'
+        ds.attrs['vector'] = [0.0, 0.0, 1.0]
+        ds.attrs['units'] = 'm'
+        ds.attrs['depends_on'] = '.'
+
+    return path
+
+
+def test_copies_disk_chopper_static_fields(nexus_with_disk_chopper, tmp_path):
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(nexus_with_disk_chopper, output)
+
+    with h5py.File(output, 'r') as f:
+        chop = f['entry/instrument/chopper1']
+        assert chop.attrs['NX_class'] == 'NXdisk_chopper'
+        assert chop['slits'][()] == 2
+        np.testing.assert_array_equal(chop['slit_edges'][:], [0.0, 90.0, 180.0, 270.0])
+        assert chop['radius'][()] == pytest.approx(0.35)
+        assert chop['delay'][()] == pytest.approx(0.0)
+
+
+def test_copies_disk_chopper_nxlog_placeholders(nexus_with_disk_chopper, tmp_path):
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(nexus_with_disk_chopper, output)
+
+    with h5py.File(output, 'r') as f:
+        for log_name in ('rotation_speed', 'phase'):
+            log = f[f'entry/instrument/chopper1/{log_name}']
+            assert isinstance(log, h5py.Group)
+            assert log.attrs['NX_class'] == 'NXlog'
+            assert log['time'].shape == (0,)
+            assert log['value'].shape == (0,)
+
+
+def test_copies_disk_chopper_transformations(nexus_with_disk_chopper, tmp_path):
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(nexus_with_disk_chopper, output)
+
+    with h5py.File(output, 'r') as f:
+        tr = f['entry/instrument/chopper1/transformations/location']
+        assert tr[()] == pytest.approx(15.0)
+        assert tr.attrs['transformation_type'] == 'translation'
+
+
+@pytest.fixture
+def nexus_with_populated_chopper_logs(tmp_path):
+    """NXdisk_chopper whose NXlog children carry real samples (as a
+    production file would) — the geometry artifact must trim these to
+    length-0 placeholders while preserving dtype, units, and attributes.
+    """
+    path = tmp_path / 'input.nxs'
+    with h5py.File(path, 'w') as f:
+        entry = f.create_group('entry')
+        entry.attrs['NX_class'] = 'NXentry'
+        inst = entry.create_group('instrument')
+        inst.attrs['NX_class'] = 'NXinstrument'
+
+        chop = inst.create_group('chopper1')
+        chop.attrs['NX_class'] = 'NXdisk_chopper'
+        chop.create_dataset('radius', data=0.35).attrs['units'] = 'm'
+
+        # Populated log: 1000 samples of phase readback.
+        phase = chop.create_group('phase')
+        phase.attrs['NX_class'] = 'NXlog'
+        phase.create_dataset(
+            'time',
+            data=np.arange(1000, dtype='int64'),
+        ).attrs['units'] = 'ns'
+        phase.create_dataset(
+            'value',
+            data=np.linspace(0.0, 359.0, 1000, dtype='float32'),
+        ).attrs['units'] = 'deg'
+        # A scalar child that should survive verbatim.
+        phase.create_dataset('average_value', data=180.0).attrs['units'] = 'deg'
+
+    return path
+
+
+def test_nxlog_inside_nxtransformations_is_trimmed(tmp_path):
+    """An NXtransformations group may contain a streamed transformation
+    (NXlog with rotation/translation values). Its samples must be trimmed
+    even though the parent group is the dedicated NXtransformations branch.
+    """
+    src = tmp_path / 'input.nxs'
+    with h5py.File(src, 'w') as f:
+        entry = f.create_group('entry')
+        entry.attrs['NX_class'] = 'NXentry'
+        inst = entry.create_group('instrument')
+        inst.attrs['NX_class'] = 'NXinstrument'
+        det = inst.create_group('detector_0')
+        det.attrs['NX_class'] = 'NXdetector'
+        det.create_dataset(
+            'depends_on', data='/entry/instrument/detector_0/transformations/rotation'
+        )
+        det.create_dataset('detector_number', data=np.arange(5))
+        det.create_dataset('x_pixel_offset', data=np.zeros(5))
+        det.create_dataset('y_pixel_offset', data=np.zeros(5))
+
+        tr = det.create_group('transformations')
+        tr.attrs['NX_class'] = 'NXtransformations'
+        log = tr.create_group('rotation')
+        log.attrs['NX_class'] = 'NXlog'
+        log.attrs['transformation_type'] = 'rotation'
+        log.attrs['vector'] = np.array([0.0, 1.0, 0.0])
+        log.attrs['depends_on'] = '.'
+        log.create_dataset('time', data=np.arange(2000, dtype='int64'))
+        log.create_dataset(
+            'value', data=np.linspace(0.0, 90.0, 2000, dtype='float64')
+        ).attrs['units'] = 'deg'
+
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(src, output)
+
+    with h5py.File(output, 'r') as f:
+        log = f['entry/instrument/detector_0/transformations/rotation']
+        assert log.attrs['NX_class'] == 'NXlog'
+        assert log.attrs['transformation_type'] == 'rotation'
+        assert log['time'].shape == (0,)
+        assert log['value'].shape == (0,)
+        assert log['value'].attrs['units'] == 'deg'
+
+
+@pytest.fixture
+def nexus_with_populated_motor_log(tmp_path):
+    """NXpositioner whose value NXlog (reached via depends_on) carries real
+    samples — production motor readback. The geometry artifact must trim
+    these to length-0 while keeping the transformation attributes the
+    depends_on chain needs.
+    """
+    path = tmp_path / 'input.nxs'
+    with h5py.File(path, 'w') as f:
+        entry = f.create_group('entry')
+        entry.attrs['NX_class'] = 'NXentry'
+        inst = entry.create_group('instrument')
+        inst.attrs['NX_class'] = 'NXinstrument'
+
+        carriage = inst.create_group('carriage')
+        carriage.attrs['NX_class'] = 'NXpositioner'
+        value_log = carriage.create_group('value')
+        value_log.attrs['NX_class'] = 'NXlog'
+        value_log.attrs['transformation_type'] = 'translation'
+        value_log.attrs['vector'] = np.array([0.0, 0.0, 1.0])
+        value_log.attrs['depends_on'] = '.'
+        # 5000 motor readbacks recorded during the run.
+        value_log.create_dataset('time', data=np.arange(5000, dtype='int64')).attrs[
+            'units'
+        ] = 'ns'
+        value_log.create_dataset(
+            'value', data=np.linspace(0.0, 100.0, 5000, dtype='float64')
+        ).attrs['units'] = 'mm'
+
+        det = inst.create_group('detector_0')
+        det.attrs['NX_class'] = 'NXdetector'
+        det.create_dataset('depends_on', data='/entry/instrument/carriage/value')
+        det.create_dataset('detector_number', data=np.arange(5))
+        det.create_dataset('x_pixel_offset', data=np.zeros(5))
+        det.create_dataset('y_pixel_offset', data=np.zeros(5))
+    return path
+
+
+def test_motor_log_reached_via_depends_on_is_trimmed(
+    nexus_with_populated_motor_log, tmp_path
+):
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(nexus_with_populated_motor_log, output)
+
+    with h5py.File(output, 'r') as f:
+        log = f['entry/instrument/carriage/value']
+        assert log.attrs['NX_class'] == 'NXlog'
+        # Transformation attributes preserved — depends_on chain still resolves.
+        assert log.attrs['transformation_type'] == 'translation'
+        np.testing.assert_array_equal(log.attrs['vector'], [0.0, 0.0, 1.0])
+        # Samples dropped, schema preserved.
+        assert log['time'].shape == (0,)
+        assert log['time'].dtype == np.int64
+        assert log['value'].shape == (0,)
+        assert log['value'].dtype == np.float64
+        assert log['value'].attrs['units'] == 'mm'
+
+
+def test_disk_chopper_log_data_is_trimmed(nexus_with_populated_chopper_logs, tmp_path):
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(nexus_with_populated_chopper_logs, output)
+
+    with h5py.File(output, 'r') as f:
+        phase = f['entry/instrument/chopper1/phase']
+        assert phase.attrs['NX_class'] == 'NXlog'
+        # Samples dropped, schema preserved.
+        assert phase['time'].shape == (0,)
+        assert phase['time'].dtype == np.int64
+        assert phase['time'].attrs['units'] == 'ns'
+        assert phase['value'].shape == (0,)
+        assert phase['value'].dtype == np.float32
+        assert phase['value'].attrs['units'] == 'deg'
+        # Scalar child survives verbatim.
+        assert phase['average_value'][()] == pytest.approx(180.0)
+        assert phase['average_value'].attrs['units'] == 'deg'

--- a/tests/make_geometry_nexus_test.py
+++ b/tests/make_geometry_nexus_test.py
@@ -218,10 +218,10 @@ def test_copies_disk_chopper_transformations(nexus_with_disk_chopper, tmp_path):
 
 
 def test_nested_nxtransformations_inside_nxlog_does_not_conflict(tmp_path):
-    """A real ESTIA structure: outer NXtransformations contains an NXlog
-    whose own children include another NXtransformations (motor stage with
-    chained transforms). The outer branch's recursive NXlog copy must not
-    conflict with the visitor's later descent into the inner group.
+    """Case where an outer NXtransformations contains an NXlog whose own
+    children include another NXtransformations (motor stage with chained
+    transforms). The outer branch's recursive NXlog copy must not conflict
+    with the visitor's later descent into the inner group.
     """
     src = tmp_path / 'input.nxs'
     with h5py.File(src, 'w') as f:

--- a/tests/make_geometry_nexus_test.py
+++ b/tests/make_geometry_nexus_test.py
@@ -159,11 +159,11 @@ def nexus_with_disk_chopper(tmp_path):
         ).attrs['units'] = 'deg'
         chop.create_dataset('slit_height', data=0.1).attrs['units'] = 'm'
         chop.create_dataset('radius', data=0.35).attrs['units'] = 'm'
-        chop.create_dataset('delay', data=0.0).attrs['units'] = 's'
         slits.attrs['units'] = ''
 
-        # Length-0 NXlog placeholders for streamed values
-        for log_name in ('rotation_speed', 'phase'):
+        # Length-0 NXlog placeholders for streamed values. ``delay`` is
+        # dynamic — operators retune it during a run.
+        for log_name in ('rotation_speed', 'phase', 'delay'):
             log = chop.create_group(log_name)
             log.attrs['NX_class'] = 'NXlog'
             log.create_dataset('time', data=np.array([], dtype='uint64'))
@@ -190,7 +190,6 @@ def test_copies_disk_chopper_static_fields(nexus_with_disk_chopper, tmp_path):
         assert chop['slits'][()] == 2
         np.testing.assert_array_equal(chop['slit_edges'][:], [0.0, 90.0, 180.0, 270.0])
         assert chop['radius'][()] == pytest.approx(0.35)
-        assert chop['delay'][()] == pytest.approx(0.0)
 
 
 def test_copies_disk_chopper_nxlog_placeholders(nexus_with_disk_chopper, tmp_path):
@@ -198,7 +197,9 @@ def test_copies_disk_chopper_nxlog_placeholders(nexus_with_disk_chopper, tmp_pat
     write_minimal_geometry(nexus_with_disk_chopper, output)
 
     with h5py.File(output, 'r') as f:
-        for log_name in ('rotation_speed', 'phase'):
+        # ``delay`` is dynamic in production (operators tune it live), hence
+        # an NXlog rather than a static dataset.
+        for log_name in ('rotation_speed', 'phase', 'delay'):
             log = f[f'entry/instrument/chopper1/{log_name}']
             assert isinstance(log, h5py.Group)
             assert log.attrs['NX_class'] == 'NXlog'
@@ -214,40 +215,6 @@ def test_copies_disk_chopper_transformations(nexus_with_disk_chopper, tmp_path):
         tr = f['entry/instrument/chopper1/transformations/location']
         assert tr[()] == pytest.approx(15.0)
         assert tr.attrs['transformation_type'] == 'translation'
-
-
-@pytest.fixture
-def nexus_with_populated_chopper_logs(tmp_path):
-    """NXdisk_chopper whose NXlog children carry real samples (as a
-    production file would) — the geometry artifact must trim these to
-    length-0 placeholders while preserving dtype, units, and attributes.
-    """
-    path = tmp_path / 'input.nxs'
-    with h5py.File(path, 'w') as f:
-        entry = f.create_group('entry')
-        entry.attrs['NX_class'] = 'NXentry'
-        inst = entry.create_group('instrument')
-        inst.attrs['NX_class'] = 'NXinstrument'
-
-        chop = inst.create_group('chopper1')
-        chop.attrs['NX_class'] = 'NXdisk_chopper'
-        chop.create_dataset('radius', data=0.35).attrs['units'] = 'm'
-
-        # Populated log: 1000 samples of phase readback.
-        phase = chop.create_group('phase')
-        phase.attrs['NX_class'] = 'NXlog'
-        phase.create_dataset(
-            'time',
-            data=np.arange(1000, dtype='int64'),
-        ).attrs['units'] = 'ns'
-        phase.create_dataset(
-            'value',
-            data=np.linspace(0.0, 359.0, 1000, dtype='float32'),
-        ).attrs['units'] = 'deg'
-        # A scalar child that should survive verbatim.
-        phase.create_dataset('average_value', data=180.0).attrs['units'] = 'deg'
-
-    return path
 
 
 def test_nested_nxtransformations_inside_nxlog_does_not_conflict(tmp_path):
@@ -268,7 +235,9 @@ def test_nested_nxtransformations_inside_nxlog_does_not_conflict(tmp_path):
         rx = outer.create_group('rx')
         rx.attrs['NX_class'] = 'NXlog'
         rx.create_dataset('time', data=np.arange(100, dtype='int64'))
-        rx.create_dataset('value', data=np.zeros(100))
+        rx.create_dataset(
+            'value', data=np.linspace(0.0, 1.0, 100, dtype='float64')
+        ).attrs['units'] = 'deg'
         # Nested NXtransformations inside the NXlog.
         inner = rx.create_group('transformations')
         inner.attrs['NX_class'] = 'NXtransformations'
@@ -286,9 +255,13 @@ def test_nested_nxtransformations_inside_nxlog_does_not_conflict(tmp_path):
         assert f['entry/instrument/stage/transformations'].attrs['NX_class'] == (
             'NXtransformations'
         )
-        # NXlog trimmed.
+        # NXlog samples trimmed; dtype/units/attributes preserved.
         rx = f['entry/instrument/stage/transformations/rx']
         assert rx.attrs['NX_class'] == 'NXlog'
+        assert rx['time'].shape == (0,)
+        assert rx['value'].shape == (0,)
+        assert rx['value'].dtype == np.float64
+        assert rx['value'].attrs['units'] == 'deg'
         # Inner NXtransformations preserved with its dataset.
         inner_path = (
             'entry/instrument/stage/transformations/rx/transformations/rotation'
@@ -342,15 +315,14 @@ def test_nxlog_inside_nxtransformations_is_trimmed(tmp_path):
         assert log['value'].attrs['units'] == 'deg'
 
 
-@pytest.fixture
-def nexus_with_populated_motor_log(tmp_path):
+def test_motor_log_reached_via_depends_on_is_trimmed(tmp_path):
     """NXpositioner whose value NXlog (reached via depends_on) carries real
     samples — production motor readback. The geometry artifact must trim
     these to length-0 while keeping the transformation attributes the
     depends_on chain needs.
     """
-    path = tmp_path / 'input.nxs'
-    with h5py.File(path, 'w') as f:
+    src = tmp_path / 'input.nxs'
+    with h5py.File(src, 'w') as f:
         entry = f.create_group('entry')
         entry.attrs['NX_class'] = 'NXentry'
         inst = entry.create_group('instrument')
@@ -377,14 +349,9 @@ def nexus_with_populated_motor_log(tmp_path):
         det.create_dataset('detector_number', data=np.arange(5))
         det.create_dataset('x_pixel_offset', data=np.zeros(5))
         det.create_dataset('y_pixel_offset', data=np.zeros(5))
-    return path
 
-
-def test_motor_log_reached_via_depends_on_is_trimmed(
-    nexus_with_populated_motor_log, tmp_path
-):
     output = tmp_path / 'output.nxs'
-    write_minimal_geometry(nexus_with_populated_motor_log, output)
+    write_minimal_geometry(src, output)
 
     with h5py.File(output, 'r') as f:
         log = f['entry/instrument/carriage/value']
@@ -400,20 +367,45 @@ def test_motor_log_reached_via_depends_on_is_trimmed(
         assert log['value'].attrs['units'] == 'mm'
 
 
-def test_disk_chopper_log_data_is_trimmed(nexus_with_populated_chopper_logs, tmp_path):
+def test_disk_chopper_log_data_is_trimmed(tmp_path):
+    """NXdisk_chopper whose NXlog children carry real samples (as a
+    production file would) — the geometry artifact must trim these to
+    length-0 placeholders while preserving dtype, units, and attributes.
+    """
+    src = tmp_path / 'input.nxs'
+    with h5py.File(src, 'w') as f:
+        entry = f.create_group('entry')
+        entry.attrs['NX_class'] = 'NXentry'
+        inst = entry.create_group('instrument')
+        inst.attrs['NX_class'] = 'NXinstrument'
+
+        chop = inst.create_group('chopper1')
+        chop.attrs['NX_class'] = 'NXdisk_chopper'
+        chop.create_dataset('radius', data=0.35).attrs['units'] = 'm'
+
+        # Populated log: 1000 samples of phase readback.
+        phase = chop.create_group('phase')
+        phase.attrs['NX_class'] = 'NXlog'
+        phase.create_dataset('time', data=np.arange(1000, dtype='int64')).attrs[
+            'units'
+        ] = 'ns'
+        phase.create_dataset(
+            'value', data=np.linspace(0.0, 359.0, 1000, dtype='float32')
+        ).attrs['units'] = 'deg'
+        # A scalar child that should survive verbatim.
+        phase.create_dataset('average_value', data=180.0).attrs['units'] = 'deg'
+
     output = tmp_path / 'output.nxs'
-    write_minimal_geometry(nexus_with_populated_chopper_logs, output)
+    write_minimal_geometry(src, output)
 
     with h5py.File(output, 'r') as f:
         phase = f['entry/instrument/chopper1/phase']
         assert phase.attrs['NX_class'] == 'NXlog'
-        # Samples dropped, schema preserved.
         assert phase['time'].shape == (0,)
         assert phase['time'].dtype == np.int64
         assert phase['time'].attrs['units'] == 'ns'
         assert phase['value'].shape == (0,)
         assert phase['value'].dtype == np.float32
         assert phase['value'].attrs['units'] == 'deg'
-        # Scalar child survives verbatim.
         assert phase['average_value'][()] == pytest.approx(180.0)
         assert phase['average_value'].attrs['units'] == 'deg'


### PR DESCRIPTION
## Summary

- Add an `NXdisk_chopper` branch to `write_minimal_geometry` so the geometry artifact carries chopper static fields (slits, radius, slit_edges, delay, etc.) and NXlog placeholders for streamed values (rotation_speed, phase). Required for the upcoming dynamic wavelength lookup-table workflow which feeds chopper geometry into `DiskChopper.from_nexus`.
- Trim every NXlog group to length-0 datasets that preserve dtype, units, and attributes — the artifact must never carry historical samples regardless of what the source contains. Production NeXus files with populated motor readbacks or chopper logs were previously bloating the output via `_resolve_depends_on_chains` and the `NXtransformations` branch.
- Make `NXtransformations` and `NXdisk_chopper` branches idempotent. ESTIA exposed a latent bug where a recursive NXlog copy pulls in a nested `NXtransformations` before the visitor's dedicated branch reaches it; reuse the existing destination group when present and only copy missing children.

Verified end-to-end on real LOKI / ESTIA / ODIN files: 4–10 NXdisk_chopper groups preserved per file, output 1.4–1.7 MB regardless of input size (largest input 2.4 GB → 1.5 MB).

## Test plan

- [x] Unit tests cover NXdisk_chopper static fields, NXlog trimming inside choppers, NXlog inside NXtransformations, motor logs reached via depends_on, and the nested NXtransformations-in-NXlog case.
- [x] Manual: ran the script against `coda_loki_999999_00026352.hdf` (4 choppers), `coda_estia_999999_00027641.hdf` (1), `coda_estia_999999_00000814.hdf` (1, regression case for the idempotence fix), `odin_chopper_test_424250_00000034.hdf` (10), `coda_odin_999999_00000800.hdf` (10).