### PR TITLE
Make stream statistics sticky in ServiceRegistry

### DIFF
--- a/src/ess/livedata/dashboard/service_registry.py
+++ b/src/ess/livedata/dashboard/service_registry.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import time
+from dataclasses import replace
 
 import structlog
 
@@ -45,9 +46,22 @@ class ServiceRegistry:
         return self._worker_statuses
 
     def status_updated(self, status: ServiceStatus) -> None:
-        """Update the stored worker status and record timestamp."""
+        """Update the stored worker status and record timestamp.
+
+        ``stream_stats`` is sticky: if the new status has ``stream_stats=None``
+        and we already have a status with stream_stats for this worker, we
+        preserve the previous value. The publisher only attaches a fresh
+        snapshot every ``_metrics_interval`` (~30 s) but heartbeats every ~2 s,
+        so without this the latest stored status would have no stream_stats
+        most of the time, and new sessions would have to wait for the next
+        snapshot to display anything.
+        """
         worker_key = make_worker_key(status)
         logger.debug("Worker status updated: %s -> %s", worker_key, status.state)
+        if status.stream_stats is None:
+            previous = self._worker_statuses.get(worker_key)
+            if previous is not None and previous.stream_stats is not None:
+                status = replace(status, stream_stats=previous.stream_stats)
         self._worker_statuses[worker_key] = status
         self._worker_timestamps[worker_key] = time.time_ns()
 

--- a/src/ess/livedata/dashboard/widgets/backend_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/backend_status_widget.py
@@ -202,8 +202,6 @@ class WorkerStatusRow:
             margin=0,
         )
 
-        self._last_stream_stats: StreamStats | None = None
-
         # Set initial content
         self.update(status, is_stale, last_seen_seconds_ago)
 
@@ -268,22 +266,17 @@ class WorkerStatusRow:
             time_text = f"Up: {_format_duration(uptime)}"
         self._uptime_pane.object = f"<span>{time_text}</span>"
 
-        # Cache stream stats when a new snapshot arrives
-        if status.stream_stats is not None:
-            self._last_stream_stats = status.stream_stats
-
-        # Stats
+        # Stats. ServiceRegistry preserves the last non-None stream_stats, so
+        # status.stream_stats is the most recent known snapshot.
         jobs_text = f"Jobs: {status.active_job_count}"
         batch_text = f"Batch: {status.batch_interval_s:.0f}s"
-        msgs_text = _format_stream_stats_summary(self._last_stream_stats)
+        msgs_text = _format_stream_stats_summary(status.stream_stats)
         self._stats_pane.object = (
             f"<span>{jobs_text} | {msgs_text} | {batch_text}</span>"
         )
 
         # Full-width expandable stream details
-        self._details_pane.object = _format_stream_stats_details(
-            self._last_stream_stats
-        )
+        self._details_pane.object = _format_stream_stats_details(status.stream_stats)
 
     def _calculate_uptime(self, started_at: Timestamp) -> float:
         """Calculate uptime in seconds from started_at timestamp."""

--- a/tests/dashboard/service_registry_test.py
+++ b/tests/dashboard/service_registry_test.py
@@ -4,7 +4,12 @@
 
 import time
 
-from ess.livedata.core.job import ServiceState, ServiceStatus
+from ess.livedata.core.job import (
+    ServiceState,
+    ServiceStatus,
+    StreamStat,
+    StreamStats,
+)
 from ess.livedata.core.timestamp import Duration, Timestamp
 from ess.livedata.dashboard.service_registry import ServiceRegistry, make_worker_key
 
@@ -294,6 +299,79 @@ class TestServiceRegistry:
         )
         registry.status_updated(status)
         assert registry.get_inactive_worker_keys() == []
+
+    def test_status_updated_preserves_stream_stats_when_new_status_has_none(
+        self,
+    ) -> None:
+        """The publisher only attaches a fresh snapshot every ~30 s but
+        heartbeats every ~2 s, so most ``ServiceStatus`` updates carry
+        ``stream_stats=None``. The registry must keep the last known snapshot
+        so a session opening between drains can render stats immediately."""
+        registry = ServiceRegistry()
+        stats = StreamStats(
+            window_seconds=30.0,
+            streams=(StreamStat(topic="t", source_name="s", stream="x", count=42),),
+        )
+        with_stats = ServiceStatus(
+            instrument="dream",
+            service_name="ns1",
+            worker_id="worker1",
+            state=ServiceState.running,
+            started_at=Timestamp.from_ns(1000),
+            active_job_count=2,
+            stream_stats=stats,
+        )
+        without_stats = ServiceStatus(
+            instrument="dream",
+            service_name="ns1",
+            worker_id="worker1",
+            state=ServiceState.running,
+            started_at=Timestamp.from_ns(1000),
+            active_job_count=3,
+            stream_stats=None,
+        )
+
+        registry.status_updated(with_stats)
+        registry.status_updated(without_stats)
+
+        stored = registry.worker_statuses[make_worker_key(without_stats)]
+        assert stored.active_job_count == 3
+        assert stored.stream_stats == stats
+
+    def test_status_updated_overwrites_stream_stats_with_fresh_snapshot(self) -> None:
+        registry = ServiceRegistry()
+        old = StreamStats(
+            window_seconds=30.0,
+            streams=(StreamStat(topic="t", source_name="s", stream="x", count=10),),
+        )
+        new = StreamStats(
+            window_seconds=30.0,
+            streams=(StreamStat(topic="t", source_name="s", stream="x", count=99),),
+        )
+        first = ServiceStatus(
+            instrument="dream",
+            service_name="ns1",
+            worker_id="worker1",
+            state=ServiceState.running,
+            started_at=Timestamp.from_ns(1000),
+            active_job_count=1,
+            stream_stats=old,
+        )
+        second = ServiceStatus(
+            instrument="dream",
+            service_name="ns1",
+            worker_id="worker1",
+            state=ServiceState.running,
+            started_at=Timestamp.from_ns(1000),
+            active_job_count=1,
+            stream_stats=new,
+        )
+
+        registry.status_updated(first)
+        registry.status_updated(second)
+
+        stored = registry.worker_statuses[make_worker_key(second)]
+        assert stored.stream_stats == new
 
     def test_remove_inactive_workers_removes_stopped_and_stale(self) -> None:
         registry = ServiceRegistry(heartbeat_timeout_ns=1_000_000)


### PR DESCRIPTION
## Summary

Stream statistics in the System Status tab's "Backend Workers" section took up to ~30 s to appear in a new session, even though the dashboard process is persistent and continuously consuming `ServiceStatus` messages.

Backend services publish `ServiceStatus` heartbeats every ~2 s but only attach a fresh `stream_stats` snapshot once per `_metrics_interval` (~30 s) — `_get_service_status` reads `_pending_stream_stats` and resets it to `None`. So roughly 14 of every 15 heartbeats arrive with `stream_stats=None`, and `ServiceRegistry.status_updated` overwrote the stored entry on each one. A session opening between drains read a `stream_stats=None` entry from the registry and showed "No stream data" until the next drain.

Fix: keep `stream_stats` sticky on the dashboard side. When an incoming status has `stream_stats=None` and the previously stored status has stats, preserve them. The per-row cache in `WorkerStatusRow` is now redundant and removed.

## Test plan

- [x] Unit tests for sticky preservation and fresh-snapshot overwrite in `service_registry_test.py`
- [x] Full dashboard test suite (1341 tests) passes
- [x] Open a fresh session against a running backend; "Backend Workers" stream stats render immediately