### PR TITLE
Fix workflow visualization for workflows with aux sources

### DIFF
--- a/src/ess/livedata/scripts/visualize_workflows.py
+++ b/src/ess/livedata/scripts/visualize_workflows.py
@@ -5,9 +5,12 @@
 
 import argparse
 import sys
+import uuid
 from pathlib import Path
 
 import structlog
+
+from ess.livedata.config.workflow_spec import JobId, WorkflowConfig, WorkflowId
 
 logger = structlog.get_logger(__name__)
 
@@ -52,8 +55,6 @@ def main() -> None:
             print(wid)
         return
 
-    from ess.livedata.config.workflow_spec import WorkflowId
-
     if args.workflow is not None:
         target = WorkflowId.from_string(args.workflow)
         if target not in factory:
@@ -70,11 +71,17 @@ def main() -> None:
     rendered = 0
     for wid, spec in items:
         source_name = spec.source_names[0] if spec.source_names else ""
-        from ess.livedata.config.workflow_spec import WorkflowConfig
-
-        config = WorkflowConfig(identifier=wid, params={})
+        job_id = JobId(source_name=source_name, job_number=uuid.uuid4())
+        config = WorkflowConfig(identifier=wid, job_id=job_id, params={})
+        aux_source_names = (
+            spec.aux_sources.render(job_id=job_id) if spec.aux_sources else None
+        )
         try:
-            workflow = factory.create(source_name=source_name, config=config)
+            workflow = factory.create(
+                source_name=source_name,
+                config=config,
+                aux_source_names=aux_source_names,
+            )
         except Exception as e:
             logger.warning(
                 "Failed to create workflow", workflow_id=str(wid), error=str(e)
@@ -83,7 +90,7 @@ def main() -> None:
         if not hasattr(workflow, 'visualize'):
             continue
         try:
-            graph = workflow.visualize()
+            graph = workflow.visualize(graph_attr={'rankdir': 'LR'})
         except Exception as e:
             logger.warning(
                 "Failed to visualize workflow", workflow_id=str(wid), error=str(e)

--- a/src/ess/livedata/scripts/visualize_workflows.py
+++ b/src/ess/livedata/scripts/visualize_workflows.py
@@ -44,6 +44,12 @@ def main() -> None:
     parser.add_argument(
         '--list', action='store_true', help='List workflow IDs and exit'
     )
+    parser.add_argument(
+        '--rankdir',
+        choices=('LR', 'TB', 'RL', 'BT'),
+        default='LR',
+        help='Graph layout direction (default: LR)',
+    )
     args = parser.parse_args()
 
     instrument = _load_instrument(args.instrument)
@@ -90,7 +96,7 @@ def main() -> None:
         if not hasattr(workflow, 'visualize'):
             continue
         try:
-            graph = workflow.visualize(graph_attr={'rankdir': 'LR'})
+            graph = workflow.visualize(graph_attr={'rankdir': args.rankdir})
         except Exception as e:
             logger.warning(
                 "Failed to visualize workflow", workflow_id=str(wid), error=str(e)


### PR DESCRIPTION
## Summary

`esslivedata-workflows` failed for workflows whose factories index into `aux_source_names` (e.g. `loki/i_of_q/1`, which reads `aux_source_names['incident_monitor']` / `['transmission_monitor']`). The script now mirrors what `JobManager` does:

- Resolve aux source names via `AuxSources.render(job_id=...)`, so subclass logic (e.g. `DetectorROIAuxSources` prefixing with job_id) runs the same way it does in production.
- Pass the rendered names into `factory.create(aux_source_names=...)`.

Drive-by fixes in the same script:

- The placeholder `JobId` now uses a real `uuid.uuid4()` for `job_number` (the field is typed as UUID, not `str`) and the workflow's actual `source_name`, so `aux_sources.render()` produces sensible names.
- Workflow graphs render left-to-right by default; configurable via `--rankdir {LR,TB,RL,BT}`.

## Test plan

- [x] `esslivedata-workflows --instrument loki --workflow loki/i_of_q/1` renders an SVG
- [x] `esslivedata-workflows --instrument <inst>` renders all workflows for `loki`, `dummy`, `dream`, `bifrost`, `odin`, `nmx`, `tbl` (the single failure in `dream/powder_reduction_with_vanadium/1` is an unrelated missing-data-file dependency, handled gracefully)
- [x] `--rankdir TB` overrides the default layout
- [x] Existing `tests/handlers/visualize_workflows_test.py` passes