### PR TITLE
fix: set estia monitor stream name

### DIFF
--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -198,7 +198,7 @@ f144_log_streams = {
 instrument = Instrument(
     name='estia',
     detector_names=detector_names,
-    monitors=['cbm'],
+    monitors=['cbm1'],
     f144_attribute_registry={
         name: {'units': info['units']} for name, info in f144_log_streams.items()
     },

--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -16,7 +16,6 @@ from ess.livedata.handlers.monitor_workflow_specs import (
     register_monitor_workflow_specs,
 )
 
-from .._ess import GENERIC_CBM_DESCRIPTION_NOTE, GENERIC_CBM_MONITORS
 from .views import get_multiblade_view
 
 detector_names = ['multiblade_detector']
@@ -199,7 +198,7 @@ f144_log_streams = {
 instrument = Instrument(
     name='estia',
     detector_names=detector_names,
-    monitors=list(GENERIC_CBM_MONITORS),
+    monitors=['cbm'],
     f144_attribute_registry={
         name: {'units': info['units']} for name, info in f144_log_streams.items()
     },
@@ -217,7 +216,6 @@ monitor_handle = register_monitor_workflow_specs(
     instrument,
     instrument.monitors,
     params=TOAOnlyMonitorDataParams,
-    extra_description=GENERIC_CBM_DESCRIPTION_NOTE,
 )
 
 

--- a/src/ess/livedata/config/instruments/estia/streams.py
+++ b/src/ess/livedata/config/instruments/estia/streams.py
@@ -2,10 +2,12 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """ESTIA instrument stream mapping configuration."""
 
+from ess.livedata import StreamKind
 from ess.livedata.config.env import StreamingEnv
+from ess.livedata.config.streams import stream_kind_to_topic
 from ess.livedata.kafka import InputStreamKey, StreamLUT, StreamMapping
 
-from .._ess import make_common_stream_mapping_inputs, make_dev_stream_mapping
+from .._ess import _make_livedata_topics, make_dev_stream_mapping
 from .specs import f144_log_streams, instrument
 
 # Fake detector configuration: detector_name -> (first_id, last_id)
@@ -38,12 +40,17 @@ stream_mapping = {
         log_names=list(instrument.f144_attribute_registry.keys()),
     ),
     StreamingEnv.PROD: StreamMapping(
-        **make_common_stream_mapping_inputs(
-            instrument='estia',
-            monitor_names=instrument.monitors,
-            cbm_start=0,
-        ),
+        monitors={
+            InputStreamKey(
+                topic=stream_kind_to_topic(
+                    instrument='estia', kind=StreamKind.MONITOR_EVENTS
+                ),
+                source_name='cbm',
+            ): 'cbm'
+        },
+        instrument='estia',
         detectors=_make_estia_detectors(),
         logs=_make_estia_logs(),
+        **_make_livedata_topics('estia'),
     ),
 }

--- a/src/ess/livedata/config/instruments/estia/streams.py
+++ b/src/ess/livedata/config/instruments/estia/streams.py
@@ -45,8 +45,8 @@ stream_mapping = {
                 topic=stream_kind_to_topic(
                     instrument='estia', kind=StreamKind.MONITOR_EVENTS
                 ),
-                source_name='cbm',
-            ): 'cbm'
+                source_name='cbm1',
+            ): 'cbm1'
         },
         instrument='estia',
         detectors=_make_estia_detectors(),


### PR DESCRIPTION
Fixes the monitor naming to match the name ECDC gave the monitor.

It's also a bit nicer to only show the single monitor in the UI instead of the 9 generic ones.