### PR TITLE
Retain buffered data after workflow stop; fix multi-source plot loss on stop

### DIFF
--- a/src/ess/livedata/dashboard/active_job_registry.py
+++ b/src/ess/livedata/dashboard/active_job_registry.py
@@ -59,15 +59,14 @@ class ActiveJobRegistry:
             self._active.add(job_number)
 
     def deactivate(self, job_number: JobNumber) -> None:
-        """Remove a job number from the active set and clean up its data.
+        """Remove a job number from the active set.
 
-        Removes DataService entries and JobService status entries keyed
-        by the given job number. Serialized against ``ingestion_guard``
-        to prevent dict-iteration crashes or orphaned buffers.
+        Does not delete buffered data — call :py:meth:`cleanup` separately
+        when the job's data is no longer needed. Serialized against
+        ``ingestion_guard`` so the ingest filter sees a consistent view.
         """
         with self._lock:
             self._active.discard(job_number)
-            self._cleanup(job_number)
 
     def restore(self, job_number: JobNumber) -> None:
         """Add a job number without acquiring the lock.
@@ -76,18 +75,24 @@ class ActiveJobRegistry:
         """
         self._active.add(job_number)
 
-    def _cleanup(self, job_number: JobNumber) -> None:
-        """Remove buffered data and status tracking for a job number."""
-        keys_to_remove = [
-            key
-            for key in self._data_service
-            if isinstance(key, ResultKey) and key.job_id.job_number == job_number
-        ]
-        for key in keys_to_remove:
-            del self._data_service[key]
-        self._job_service.remove_jobs_by_number(job_number)
-        logger.info(
-            "Cleaned up job data",
-            job_number=str(job_number),
-            data_keys_removed=len(keys_to_remove),
-        )
+    def cleanup(self, job_number: JobNumber) -> None:
+        """Remove buffered data and status tracking for a job number.
+
+        Independent of active-set membership: callers may retain buffered
+        data after deactivation so that newly created plots can bind to a
+        recently stopped job's results.
+        """
+        with self._lock:
+            keys_to_remove = [
+                key
+                for key in self._data_service
+                if isinstance(key, ResultKey) and key.job_id.job_number == job_number
+            ]
+            for key in keys_to_remove:
+                del self._data_service[key]
+            self._job_service.remove_jobs_by_number(job_number)
+            logger.info(
+                "Cleaned up job data",
+                job_number=str(job_number),
+                data_keys_removed=len(keys_to_remove),
+            )

--- a/src/ess/livedata/dashboard/active_job_registry.py
+++ b/src/ess/livedata/dashboard/active_job_registry.py
@@ -31,6 +31,24 @@ class ActiveJobRegistry:
     UI thread. The ingestion thread holds ``ingestion_guard()`` while
     processing messages; the UI thread calls ``activate`` / ``deactivate``
     when starting or stopping jobs.
+
+    Data lifecycle
+    --------------
+    Active-set membership and buffered-data eviction are intentionally
+    decoupled into two methods:
+
+    - :py:meth:`deactivate` removes a job from the active set, causing
+      ``Orchestrator.forward`` to filter out any further results published
+      for that job. This happens as soon as a job stops, so late messages
+      are dropped immediately.
+    - :py:meth:`cleanup` deletes the buffered data for a job. Callers defer
+      this so a just-stopped job's data stays available to plots that may
+      be created or reconfigured while the workflow is stopped (see
+      :py:meth:`LayerSubscription.start`'s previous-job fallback).
+
+    :py:class:`JobOrchestrator` invokes ``cleanup`` only when a job leaves
+    ``state.previous`` — i.e. when a newer stop or commit replaces it.
+    Stopping a workflow does **not** by itself call ``cleanup``.
     """
 
     def __init__(self, *, data_service: DataService, job_service: JobService) -> None:
@@ -80,7 +98,23 @@ class ActiveJobRegistry:
 
         Independent of active-set membership: callers may retain buffered
         data after deactivation so that newly created plots can bind to a
-        recently stopped job's results.
+        recently stopped job's results. See the class docstring for the
+        data lifecycle that governs when callers should run this.
+
+        Deletes are batched inside a DataService transaction so subscribers
+        observe a single atomic eviction rather than a sequence of partial
+        states. Without batching, a multi-source subscriber would receive
+        an intermediate trigger with only the not-yet-deleted keys present,
+        causing plots to re-render with a subset of their sources before
+        the final empty notification arrives.
+
+        With today's orchestration there is no live subscriber bound to a
+        job's keys at the moment its data is cleaned up (subscribers
+        rebind to the new job before the old data is dropped), so the
+        transaction is currently defensive. Keeping the guarantee here
+        prevents the bug from resurfacing if a future caller — e.g. a UI
+        action that explicitly evicts a job — runs cleanup while plots
+        are still subscribed.
         """
         with self._lock:
             keys_to_remove = [
@@ -88,8 +122,9 @@ class ActiveJobRegistry:
                 for key in self._data_service
                 if isinstance(key, ResultKey) and key.job_id.job_number == job_number
             ]
-            for key in keys_to_remove:
-                del self._data_service[key]
+            with self._data_service.transaction():
+                for key in keys_to_remove:
+                    del self._data_service[key]
             self._job_service.remove_jobs_by_number(job_number)
             logger.info(
                 "Cleaned up job data",

--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -395,12 +395,14 @@ class JobOrchestrator:
                 for job_id in state.current.job_ids()
             )
             logger.debug('Will stop %d old jobs in batch', len(state.current.jobs))
-            # Remove outgoing job from the active set and clean up its buffered
-            # data. Any final results the backend publishes before processing
-            # the stop command will be discarded by the ingest filter in
-            # Orchestrator.forward(). This is acceptable: the user has requested
-            # new parameters, so results from the old configuration are stale.
+            # The outgoing job becomes the new state.previous. Buffered data
+            # for it is retained so layers created while the workflow is
+            # stopped can still display the last known state. The job that was
+            # previously kept as state.previous is dropped here, so its
+            # buffered data is no longer reachable and is cleaned up.
             self._deactivate_previous_job(state)
+            if state.previous is not None:
+                self._active_job_registry.cleanup(state.previous.job_number)
             state.previous = state.current
 
         # Send workflow configs to all staged sources
@@ -465,10 +467,12 @@ class JobOrchestrator:
         return self._active_job_registry
 
     def _deactivate_previous_job(self, state: WorkflowState) -> None:
-        """Deactivate the previous job, removing it from the active set and cleaning up.
+        """Deactivate the current job (which is becoming state.previous).
 
-        Delegates to ActiveJobRegistry which handles locking, active-set removal,
-        DataService cleanup, and JobService cleanup atomically.
+        Removes the job from the active set so that late results published
+        before the backend processes the stop command are discarded. Buffered
+        data is retained so the just-stopped job can still feed plots; it is
+        cleaned up by the caller once state.previous is overwritten.
         """
         if state.current is None:
             return
@@ -778,17 +782,24 @@ class JobOrchestrator:
     def _deactivate_workflow(
         self, workflow_id: WorkflowId, reason: StoppedReason
     ) -> None:
-        """Clear active job state, clean up data, persist, and notify subscribers."""
+        """Clear active job state, persist, and notify subscribers.
+
+        The just-stopped job becomes state.previous and its buffered data is
+        retained so that plots created while the workflow is stopped can
+        still display its last results. The prior state.previous (if any) is
+        dropped here and its buffered data is cleaned up.
+        """
         state = self._workflows[workflow_id]
         job_number = state.current.job_number if state.current else None
 
         if state.current is not None:
             for job_id in state.current.job_ids():
                 self._job_states.pop(job_id, None)
-        if job_number is not None:
-            self._active_job_registry.deactivate(job_number)
-        state.previous = state.current
-        state.current = None
+            self._active_job_registry.deactivate(state.current.job_number)
+            if state.previous is not None:
+                self._active_job_registry.cleanup(state.previous.job_number)
+            state.previous = state.current
+            state.current = None
         state.stopped_reason = reason
 
         self._persist_state_to_store(workflow_id)

--- a/src/ess/livedata/dashboard/layer_subscription.py
+++ b/src/ess/livedata/dashboard/layer_subscription.py
@@ -95,7 +95,10 @@ class LayerSubscription:
         Subscribe to all workflows.
 
         Call after construction. May fire on_ready synchronously if all
-        workflows are already running.
+        workflows are already running. If no workflow is currently running
+        but every role has a previously stopped job, synthesises start+stop
+        notifications so the layer binds to the retained buffered data and
+        ends up in the STOPPED state with a plot.
         """
         from .job_orchestrator import WorkflowCallbacks
 
@@ -108,6 +111,23 @@ class LayerSubscription:
                 ),
             )
             self._subscription_ids.append(sub_id)
+
+        if self._job_numbers:
+            # At least one role started immediately. Any remaining roles will
+            # come up via the normal subscription when their workflows start.
+            return
+
+        previous_jobs: list[tuple[str, JobNumber]] = []
+        for role, ds in self._data_sources.items():
+            job_number = self._job_orchestrator.get_previous_job_number(ds.workflow_id)
+            if job_number is None:
+                return
+            previous_jobs.append((role, job_number))
+
+        for role, job_number in previous_jobs:
+            self._on_workflow_started(role, job_number)
+        for role, job_number in previous_jobs:
+            self._handle_workflow_stopped(role, job_number)
 
     def _on_workflow_started(self, role: str, job_number: JobNumber) -> None:
         """Handle workflow start for a specific role."""

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -95,6 +95,10 @@ class JobOrchestratorProtocol(Protocol):
         """Get the workflow registry containing all managed workflows."""
         ...
 
+    def get_previous_job_number(self, workflow_id: WorkflowId) -> JobNumber | None:
+        """Get the job_number of the most recently stopped job, if any."""
+        ...
+
 
 @dataclass(frozen=True)
 class CellGeometry:

--- a/tests/dashboard/active_job_registry_test.py
+++ b/tests/dashboard/active_job_registry_test.py
@@ -7,7 +7,8 @@ import scipp as sc
 from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
 from ess.livedata.core.job import JobState, JobStatus
 from ess.livedata.dashboard.active_job_registry import ActiveJobRegistry
-from ess.livedata.dashboard.data_service import DataService
+from ess.livedata.dashboard.data_service import DataService, DataServiceSubscriber
+from ess.livedata.dashboard.extractors import LatestValueExtractor
 from ess.livedata.dashboard.job_service import JobService
 
 _workflow_id = WorkflowId(instrument="test", name="wf", version=1)
@@ -118,3 +119,42 @@ class TestCleanup:
 
         assert key in ds
         assert len(ds) == 1
+
+    def test_multi_key_cleanup_does_not_emit_partial_state(self):
+        """A subscriber on multiple keys must not receive a partial-state
+        notification while cleanup is in progress.
+
+        Regression for: stopping a workflow used to make multi-source plots
+        re-render with only one source. Each per-key delete fired a
+        subscriber notification in which the not-yet-deleted keys were
+        still present, so plotter.compute ran with a strict subset of
+        sources before the final empty notification.
+        """
+        registry, ds, _ = _make_registry()
+        job_number = uuid.uuid4()
+
+        key_a = _make_result_key(job_number, source_name="det1")
+        key_b = _make_result_key(job_number, source_name="det2")
+        ds[key_a] = sc.scalar(1.0)
+        ds[key_b] = sc.scalar(2.0)
+
+        triggers: list[set[ResultKey]] = []
+
+        class RecordingSubscriber(DataServiceSubscriber):
+            @property
+            def extractors(self):
+                return {
+                    key_a: LatestValueExtractor(),
+                    key_b: LatestValueExtractor(),
+                }
+
+            def trigger(self, store):
+                triggers.append(set(store.keys()))
+
+        ds.register_subscriber(RecordingSubscriber())
+        triggers.clear()  # discard initial trigger from registration
+
+        registry.cleanup(job_number)
+
+        # Every notification must show either both keys or neither — never one.
+        assert all(t in ({key_a, key_b}, set()) for t in triggers), triggers

--- a/tests/dashboard/active_job_registry_test.py
+++ b/tests/dashboard/active_job_registry_test.py
@@ -28,6 +28,34 @@ def _make_registry():
 
 
 class TestDeactivate:
+    def test_removes_job_number_from_active_set(self):
+        registry, _ds, _js = _make_registry()
+        job_number = uuid.uuid4()
+
+        registry.restore(job_number)
+        assert registry.is_active(job_number)
+
+        registry.deactivate(job_number)
+        assert not registry.is_active(job_number)
+
+    def test_retains_buffered_data(self):
+        registry, ds, _ = _make_registry()
+        job_number = uuid.uuid4()
+
+        key = _make_result_key(job_number)
+        ds[key] = sc.scalar(1.0)
+
+        registry.restore(job_number)
+        registry.deactivate(job_number)
+
+        assert key in ds
+
+    def test_unknown_job_number_is_noop(self):
+        registry, _ds, _js = _make_registry()
+        registry.deactivate(uuid.uuid4())  # no exception
+
+
+class TestCleanup:
     def test_removes_matching_data_service_entries(self):
         registry, ds, _ = _make_registry()
         job_number = uuid.uuid4()
@@ -37,8 +65,7 @@ class TestDeactivate:
         ds[key_a] = sc.scalar(1.0)
         ds[key_b] = sc.scalar(2.0)
 
-        registry.restore(job_number)
-        registry.deactivate(job_number)
+        registry.cleanup(job_number)
 
         assert len(ds) == 0
 
@@ -52,8 +79,7 @@ class TestDeactivate:
         )
         assert len(js.job_statuses) == 1
 
-        registry.restore(job_number)
-        registry.deactivate(job_number)
+        registry.cleanup(job_number)
 
         assert len(js.job_statuses) == 0
 
@@ -62,13 +88,11 @@ class TestDeactivate:
         keep_number = uuid.uuid4()
         remove_number = uuid.uuid4()
 
-        # Data for both jobs
         keep_key = _make_result_key(keep_number)
         remove_key = _make_result_key(remove_number)
         ds[keep_key] = sc.scalar(1.0)
         ds[remove_key] = sc.scalar(2.0)
 
-        # Status for both jobs
         for jn in (keep_number, remove_number):
             job_id = JobId(source_name="det1", job_number=jn)
             js.status_updated(
@@ -77,15 +101,11 @@ class TestDeactivate:
                 )
             )
 
-        registry.restore(keep_number)
-        registry.restore(remove_number)
-        registry.deactivate(remove_number)
+        registry.cleanup(remove_number)
 
         assert keep_key in ds
         assert remove_key not in ds
         assert len(js.job_statuses) == 1
-        assert registry.is_active(keep_number)
-        assert not registry.is_active(remove_number)
 
     def test_unknown_job_number_is_noop(self):
         registry, ds, _js = _make_registry()
@@ -94,8 +114,7 @@ class TestDeactivate:
         key = _make_result_key(existing)
         ds[key] = sc.scalar(1.0)
 
-        # Deactivate a job number that was never activated
-        registry.deactivate(uuid.uuid4())
+        registry.cleanup(uuid.uuid4())
 
         assert key in ds
         assert len(ds) == 1

--- a/tests/dashboard/job_orchestrator_test.py
+++ b/tests/dashboard/job_orchestrator_test.py
@@ -1506,15 +1506,16 @@ class TestWorkflowSubscriptions:
         assert started_job_numbers[0] == job_ids[0].job_number
 
 
-class TestCommitCleansUpPreviousJobData:
-    """Tests that commit_workflow cleans up DataService and JobService entries
-    from the previous job set."""
+class TestStoppedJobDataRetention:
+    """Buffered data for a stopped job is retained as long as the job is
+    referenced as state.previous; it is cleaned up only when state.previous
+    is replaced."""
 
-    def test_commit_removes_previous_data_service_entries(
+    def test_recommit_retains_just_stopped_job_data(
         self,
         workflow_with_params: WorkflowSpec,
     ):
-        """Recommitting a workflow removes DataService entries from the old job."""
+        """Re-commit keeps the now-stopped job's data: it becomes state.previous."""
         from ess.livedata.config.workflow_spec import JobId, ResultKey
 
         workflow_id = workflow_with_params.get_id()
@@ -1523,11 +1524,9 @@ class TestCommitCleansUpPreviousJobData:
             workflow_with_params, data_service=data_service
         )
 
-        # First commit
         job_ids = orchestrator.commit_workflow(workflow_id)
         old_job_number = job_ids[0].job_number
 
-        # Simulate backend publishing results for the old job
         for source_name in workflow_with_params.source_names:
             key = ResultKey(
                 workflow_id=workflow_id,
@@ -1537,47 +1536,15 @@ class TestCommitCleansUpPreviousJobData:
 
         assert len(data_service) == len(workflow_with_params.source_names)
 
-        # Re-commit — should clean up old entries
         orchestrator.commit_workflow(workflow_id)
 
-        assert len(data_service) == 0
+        assert len(data_service) == len(workflow_with_params.source_names)
 
-    def test_commit_removes_previous_job_service_entries(
+    def test_second_recommit_evicts_oldest_job_data(
         self,
         workflow_with_params: WorkflowSpec,
     ):
-        """Recommitting removes JobService status entries from previous job."""
-        from ess.livedata.core.job import JobState, JobStatus
-
-        workflow_id = workflow_with_params.get_id()
-        job_service = JobService()
-        orchestrator = make_orchestrator(workflow_with_params, job_service=job_service)
-
-        # First commit
-        job_ids = orchestrator.commit_workflow(workflow_id)
-
-        # Simulate backend broadcasting status for old jobs
-        for job_id in job_ids:
-            job_service.status_updated(
-                JobStatus(
-                    job_id=job_id,
-                    workflow_id=workflow_id,
-                    state=JobState.active,
-                )
-            )
-
-        assert len(job_service.job_statuses) == len(job_ids)
-
-        # Re-commit — should clean up old status entries
-        orchestrator.commit_workflow(workflow_id)
-
-        assert len(job_service.job_statuses) == 0
-
-    def test_commit_does_not_remove_data_from_other_workflows(
-        self,
-        workflow_with_params: WorkflowSpec,
-    ):
-        """Cleanup only affects the recommitted workflow, not other workflows."""
+        """When state.previous is replaced, its data is cleaned up."""
         from ess.livedata.config.workflow_spec import JobId, ResultKey
 
         workflow_id = workflow_with_params.get_id()
@@ -1586,21 +1553,75 @@ class TestCommitCleansUpPreviousJobData:
             workflow_with_params, data_service=data_service
         )
 
-        # First commit
-        job_ids = orchestrator.commit_workflow(workflow_id)
-        old_job_number = job_ids[0].job_number
+        job_ids_a = orchestrator.commit_workflow(workflow_id)
+        job_number_a = job_ids_a[0].job_number
+        for source_name in workflow_with_params.source_names:
+            data_service[
+                ResultKey(
+                    workflow_id=workflow_id,
+                    job_id=JobId(source_name=source_name, job_number=job_number_a),
+                )
+            ] = sc.scalar(1.0)
 
-        # Add data for old job
-        key = ResultKey(
-            workflow_id=workflow_id,
-            job_id=JobId(
-                source_name=workflow_with_params.source_names[0],
-                job_number=old_job_number,
-            ),
+        job_ids_b = orchestrator.commit_workflow(workflow_id)
+        job_number_b = job_ids_b[0].job_number
+        for source_name in workflow_with_params.source_names:
+            data_service[
+                ResultKey(
+                    workflow_id=workflow_id,
+                    job_id=JobId(source_name=source_name, job_number=job_number_b),
+                )
+            ] = sc.scalar(2.0)
+
+        orchestrator.commit_workflow(workflow_id)
+
+        # A is dropped (replaced as state.previous); B is retained.
+        keys = list(data_service)
+        assert all(k.job_id.job_number != job_number_a for k in keys)
+        assert any(k.job_id.job_number == job_number_b for k in keys)
+
+    def test_stop_retains_just_stopped_job_data(
+        self,
+        workflow_with_params: WorkflowSpec,
+    ):
+        """stop_workflow does not delete the stopped job's buffered data."""
+        from ess.livedata.config.workflow_spec import JobId, ResultKey
+
+        workflow_id = workflow_with_params.get_id()
+        data_service = DataService()
+        orchestrator = make_orchestrator(
+            workflow_with_params, data_service=data_service
         )
-        data_service[key] = sc.scalar(1.0)
 
-        # Add data with a different (unrelated) job_number
+        job_ids = orchestrator.commit_workflow(workflow_id)
+        job_number = job_ids[0].job_number
+        for source_name in workflow_with_params.source_names:
+            data_service[
+                ResultKey(
+                    workflow_id=workflow_id,
+                    job_id=JobId(source_name=source_name, job_number=job_number),
+                )
+            ] = sc.scalar(1.0)
+
+        orchestrator.stop_workflow(workflow_id)
+
+        assert len(data_service) == len(workflow_with_params.source_names)
+
+    def test_commit_does_not_remove_data_from_other_workflows(
+        self,
+        workflow_with_params: WorkflowSpec,
+    ):
+        """Recommit-driven cleanup is scoped by job_number, not workflow."""
+        from ess.livedata.config.workflow_spec import JobId, ResultKey
+
+        workflow_id = workflow_with_params.get_id()
+        data_service = DataService()
+        orchestrator = make_orchestrator(
+            workflow_with_params, data_service=data_service
+        )
+
+        orchestrator.commit_workflow(workflow_id)
+
         import uuid
 
         unrelated_key = ResultKey(
@@ -1612,10 +1633,8 @@ class TestCommitCleansUpPreviousJobData:
         )
         data_service[unrelated_key] = sc.scalar(2.0)
 
-        assert len(data_service) == 2
-
-        # Re-commit — only the old job_number's data should be removed
+        # Two more commits so the cleanup boundary moves past the first job.
+        orchestrator.commit_workflow(workflow_id)
         orchestrator.commit_workflow(workflow_id)
 
-        assert len(data_service) == 1
         assert unrelated_key in data_service

--- a/tests/dashboard/layer_subscription_test.py
+++ b/tests/dashboard/layer_subscription_test.py
@@ -34,11 +34,20 @@ class FakeJobOrchestrator:
         self._subscriptions: dict[SubscriptionId, WorkflowCallbacks] = {}
         self._workflow_subscriptions: dict[WorkflowId, set[SubscriptionId]] = {}
         self._running_jobs: dict[WorkflowId, JobNumber] = {}
+        self._previous_jobs: dict[WorkflowId, JobNumber] = {}
         self._next_sub_id = 0
 
     def add_running_job(self, workflow_id: WorkflowId, job_number: JobNumber) -> None:
         """Mark a workflow as running with the given job number."""
         self._running_jobs[workflow_id] = job_number
+
+    def add_previous_job(self, workflow_id: WorkflowId, job_number: JobNumber) -> None:
+        """Mark a workflow as having a stopped (previous) job with retained data."""
+        self._previous_jobs[workflow_id] = job_number
+
+    def get_previous_job_number(self, workflow_id: WorkflowId) -> JobNumber | None:
+        """Return the most recently stopped job number, if any."""
+        return self._previous_jobs.get(workflow_id)
 
     def subscribe_to_workflow(
         self,
@@ -86,6 +95,7 @@ class FakeJobOrchestrator:
     ) -> None:
         """Simulate workflow stopping (notifies only subscribers for workflow)."""
         self._running_jobs.pop(workflow_id, None)
+        self._previous_jobs[workflow_id] = job_number
         for sub_id in self._workflow_subscriptions.get(workflow_id, set()):
             if sub_id in self._subscriptions:
                 callbacks = self._subscriptions[sub_id]

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -1907,6 +1907,113 @@ class TestDataSubscriptionCleanup:
         assert len(fake_data_service._subscribers) == subscriber_count_with_layer - 1
 
 
+class TestPlotAfterWorkflowStopped:
+    """A layer created after the workflow has stopped binds to the retained
+    buffered data from the previous job and ends up in the STOPPED state
+    with a cached plot."""
+
+    def _add_data(
+        self,
+        fake_data_service,
+        workflow_id,
+        config,
+        job_number,
+    ):
+        import scipp as sc
+
+        from ess.livedata.config.workflow_spec import JobId, ResultKey
+
+        for source_name in config.source_names:
+            key = ResultKey(
+                workflow_id=workflow_id,
+                job_id=JobId(source_name=source_name, job_number=job_number),
+                output_name=config.output_name,
+            )
+            fake_data_service[key] = sc.scalar(1.0)
+
+    def test_new_layer_after_stop_displays_retained_data(
+        self,
+        plot_orchestrator,
+        plot_cell,
+        workflow_id,
+        workflow_spec,
+        job_orchestrator,
+        fake_data_service,
+        plot_data_service,
+    ):
+        from ess.livedata.dashboard.plot_data_service import LayerState
+
+        job_ids = commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
+        self._add_data(
+            fake_data_service, workflow_id, plot_cell[1], job_ids[0].job_number
+        )
+        job_orchestrator.stop_workflow(workflow_id)
+
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=1, ncols=1)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
+        )
+        layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+
+        state = plot_data_service.get(layer_id)
+        assert state is not None
+        assert state.state == LayerState.STOPPED
+        assert state.plotter is not None
+        assert state.plotter.has_cached_state()
+
+    def test_update_layer_config_after_stop_displays_retained_data(
+        self,
+        plot_orchestrator,
+        plot_cell,
+        workflow_id,
+        workflow_spec,
+        job_orchestrator,
+        fake_data_service,
+        plot_data_service,
+    ):
+        from ess.livedata.dashboard.plot_data_service import LayerState
+
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=1, ncols=1)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
+        )
+        original_layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+
+        job_ids = commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
+        self._add_data(
+            fake_data_service, workflow_id, plot_cell[1], job_ids[0].job_number
+        )
+        job_orchestrator.stop_workflow(workflow_id)
+
+        plot_orchestrator.update_layer_config(original_layer_id, plot_cell[1])
+
+        new_layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+        assert new_layer_id != original_layer_id
+
+        state = plot_data_service.get(new_layer_id)
+        assert state is not None
+        assert state.state == LayerState.STOPPED
+        assert state.plotter.has_cached_state()
+
+    def test_new_layer_with_no_previous_job_stays_waiting(
+        self,
+        plot_orchestrator,
+        plot_cell,
+        plot_data_service,
+    ):
+        from ess.livedata.dashboard.plot_data_service import LayerState
+
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=1, ncols=1)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
+        )
+        layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+
+        state = plot_data_service.get(layer_id)
+        assert state is not None
+        assert state.state == LayerState.WAITING_FOR_JOB
+
+
 class TestTitleResolver:
     """Tests for TitleResolver construction in multi-layer cells."""
 

--- a/tests/dashboard/restart_cleanup_test.py
+++ b/tests/dashboard/restart_cleanup_test.py
@@ -85,27 +85,49 @@ class TestRestartCleanup:
     and late-arriving old data is rejected by the ingest filter.
     """
 
-    def test_old_data_is_removed_after_recommit(self, workflow_spec):
-        """Data from the previous job is not present after recommit."""
+    def test_old_data_is_retained_after_recommit(self, workflow_spec):
+        """Data from the previous job is retained after a single recommit
+        so that newly created plots can bind to it."""
         orchestrator, job_orchestrator, data_service, _ = _make_system(workflow_spec)
         workflow_id = workflow_spec.get_id()
 
-        # First commit
         job_ids = job_orchestrator.commit_workflow(workflow_id)
         old_number = job_ids[0].job_number
 
-        # Simulate data arriving for old job via Orchestrator.forward()
         for source_name in workflow_spec.source_names:
             key = _make_result_key(workflow_id, source_name, old_number)
             orchestrator.forward(_data_stream_id(key), sc.scalar(1.0))
 
         assert len(data_service) == len(workflow_spec.source_names)
 
-        # Recommit
         job_orchestrator.commit_workflow(workflow_id)
 
-        # Old data should be gone
-        assert len(data_service) == 0
+        assert all(k.job_id.job_number == old_number for k in data_service)
+        assert len(data_service) == len(workflow_spec.source_names)
+
+    def test_old_data_evicted_when_state_previous_is_replaced(self, workflow_spec):
+        """A second recommit evicts the original job, which has been pushed
+        out of state.previous."""
+        orchestrator, job_orchestrator, data_service, _ = _make_system(workflow_spec)
+        workflow_id = workflow_spec.get_id()
+
+        job_ids = job_orchestrator.commit_workflow(workflow_id)
+        oldest_number = job_ids[0].job_number
+        for sn in workflow_spec.source_names:
+            key = _make_result_key(workflow_id, sn, oldest_number)
+            orchestrator.forward(_data_stream_id(key), sc.scalar(1.0))
+
+        mid_ids = job_orchestrator.commit_workflow(workflow_id)
+        mid_number = mid_ids[0].job_number
+        for sn in workflow_spec.source_names:
+            key = _make_result_key(workflow_id, sn, mid_number)
+            orchestrator.forward(_data_stream_id(key), sc.scalar(2.0))
+
+        job_orchestrator.commit_workflow(workflow_id)
+
+        # The oldest job has been pushed out; mid is now state.previous.
+        assert all(k.job_id.job_number != oldest_number for k in data_service)
+        assert any(k.job_id.job_number == mid_number for k in data_service)
 
     def test_late_data_for_old_job_is_rejected(self, workflow_spec):
         """Data arriving for the old job after recommit does not enter DataService."""
@@ -131,25 +153,20 @@ class TestRestartCleanup:
         orchestrator, job_orchestrator, data_service, _ = _make_system(workflow_spec)
         workflow_id = workflow_spec.get_id()
 
-        # First commit + data
         job_ids_1 = job_orchestrator.commit_workflow(workflow_id)
         old_number = job_ids_1[0].job_number
         for sn in workflow_spec.source_names:
             key = _make_result_key(workflow_id, sn, old_number)
             orchestrator.forward(_data_stream_id(key), sc.scalar(1.0))
 
-        # Recommit
         job_ids_2 = job_orchestrator.commit_workflow(workflow_id)
         new_number = job_ids_2[0].job_number
 
-        # New data arrives
         data = sc.scalar(99.0)
         for sn in workflow_spec.source_names:
             key = _make_result_key(workflow_id, sn, new_number)
             orchestrator.forward(_data_stream_id(key), data)
 
-        assert len(data_service) == len(workflow_spec.source_names)
-        # Verify it's the new data
         for sn in workflow_spec.source_names:
             key = _make_result_key(workflow_id, sn, new_number)
             assert key in data_service
@@ -186,11 +203,9 @@ class TestRestartCleanup:
         wf_id_1 = workflow_spec.get_id()
         wf_id_2 = workflow_spec_2.get_id()
 
-        # Commit both workflows
         jobs_1 = job_orchestrator.commit_workflow(wf_id_1)
         jobs_2 = job_orchestrator.commit_workflow(wf_id_2)
 
-        # Data for both workflows
         key_1 = _make_result_key(
             wf_id_1, workflow_spec.source_names[0], jobs_1[0].job_number
         )
@@ -200,31 +215,31 @@ class TestRestartCleanup:
         orchestrator.forward(_data_stream_id(key_1), sc.scalar(1.0))
         orchestrator.forward(_data_stream_id(key_2), sc.scalar(2.0))
 
-        assert len(data_service) == 2
-
-        # Recommit only workflow 1
+        # Two further recommits of wf1 push its first job out of state.previous.
+        job_orchestrator.commit_workflow(wf_id_1)
         job_orchestrator.commit_workflow(wf_id_1)
 
-        # Workflow 2's data survives
         assert key_2 in data_service
         assert key_1 not in data_service
 
-    def test_multiple_restarts_do_not_leak(self, workflow_spec):
-        """Repeated restarts do not leave orphaned data in DataService."""
+    def test_multiple_restarts_retain_at_most_two_jobs(self, workflow_spec):
+        """Repeated restarts retain only the active job and the most recent
+        previous job; older jobs are evicted."""
         orchestrator, job_orchestrator, data_service, _ = _make_system(workflow_spec)
         workflow_id = workflow_spec.get_id()
 
+        job_numbers: list = []
         for _ in range(5):
             job_ids = job_orchestrator.commit_workflow(workflow_id)
             job_number = job_ids[0].job_number
-
-            # Simulate data arriving
+            job_numbers.append(job_number)
             for sn in workflow_spec.source_names:
                 key = _make_result_key(workflow_id, sn, job_number)
                 orchestrator.forward(_data_stream_id(key), sc.scalar(1.0))
 
-        # After 5 restarts, only the last job's data should remain
-        assert len(data_service) == len(workflow_spec.source_names)
+        retained = {k.job_id.job_number for k in data_service}
+        # State.current = last; state.previous = second-to-last
+        assert retained == {job_numbers[-1], job_numbers[-2]}
 
 
 class TestConcurrentForwardAndCommit:

--- a/tests/dashboard/restart_cleanup_test.py
+++ b/tests/dashboard/restart_cleanup_test.py
@@ -340,9 +340,10 @@ class TestConcurrentForwardAndCommit:
 
         assert not errors, f"Forward loop crashed: {errors[0]}"
 
-        # Only the last job's data should be present
+        # Only state.current and state.previous may have retained data —
+        # everything older must be evicted.
         last_number = current_job_ids[0][0].job_number
+        previous_number = job_orchestrator.get_previous_job_number(workflow_id)
+        allowed = {last_number, previous_number}
         for key in data_service:
-            assert key.job_id.job_number == last_number, (
-                f"Orphaned key from old job: {key}"
-            )
+            assert key.job_id.job_number in allowed, f"Orphaned key from old job: {key}"


### PR DESCRIPTION
## Summary

Two related fixes for what plots show when a workflow stops.

**1. Retain buffered data on stop.** Buffers for a stopped job are now kept (referenced as ``state.previous``) instead of being deleted immediately. Plots created or reconfigured while a workflow is stopped now bind to that retained data and end up in the ``STOPPED`` state with a cached plot, rather than sitting in ``WAITING_FOR_JOB`` showing "Waiting for workflow…".

**2. Batch deletes during eviction.** ``ActiveJobRegistry.cleanup`` now wraps its per-key deletes in a ``DataService`` transaction so subscribers see one atomic eviction instead of a series of partial states. This also closes a separate, previously-shipping bug: stopping a workflow with a multi-source plot caused all but the last source to vanish, because each ``del`` fired a subscriber notification with the not-yet-deleted keys still present, and the plotter re-rendered with a subset of sources before the final empty notification arrived. Fix (1) keeps the cleanup path off the stop path today; fix (2) keeps the bug from resurfacing if a future caller (e.g. a UI eviction action) runs cleanup with active subscribers.

## Motivation

Previously, stopping a workflow called ``ActiveJobRegistry.deactivate``, which wiped DataService buffers for that job. Existing plots only kept rendering because the plotter held cached Bokeh state — there was no longer any DataService entry. A user creating a new plot for the same quantity (or reconfiguring an existing one) hit a dead end: ``LayerSubscription`` couldn't see a running job to subscribe to, and even if it could, the buffer was already gone.

## Approach

- ``ActiveJobRegistry.deactivate`` now only removes the job from the active set. A new ``cleanup`` method handles buffer + status purge separately. The class docstring spells out the resulting two-phase data lifecycle.
- ``JobOrchestrator`` defers cleanup: data is dropped only when a job is pushed out of ``state.previous`` by a later commit or stop.
- ``LayerSubscription.start`` synthesises ``on_started`` + ``on_stopped`` callbacks using ``get_previous_job_number`` when no live job exists. The synchronous replay path in ``DataService.register_subscriber`` then delivers the retained data to the new layer.
- ``cleanup`` runs its deletes inside a ``DataService.transaction()``.

## Trade-offs

- Each workflow can hold up to 2 generations of buffered data (``state.current`` + ``state.previous``) instead of 1. The cost is bounded (linear in workflow count, capped at one extra generation per workflow) but real for high-volume outputs. Tracked in #927; no eviction UI is added here.
- If the original plot used ``LatestValueExtractor`` (single-value buffer), a newly created windowed plot can only show one point — full history was never retained. Unchanged by this PR.

## Test plan

- [x] Unit tests for ``ActiveJobRegistry`` split (deactivate vs cleanup)
- [x] Regression test: multi-key cleanup does not emit a partial-state notification (verified to fail without the transaction wrap)
- [x] Retention-semantics tests at ``JobOrchestrator`` and full-system levels
- [x] End-to-end ``PlotOrchestrator`` tests: new layer after stop, reconfigure after stop, no-previous fallback
- [x] Manual verification in dashboard: stop a workflow → create new plot → confirm it shows last data and labels as stopped
- [x] Manual verification: multi-source plot survives ``stop_workflow`` with all sources still rendered