### PR TITLE
Cap default source pre-selection in config modals

### DIFF
--- a/src/ess/livedata/dashboard/configuration_adapter.py
+++ b/src/ess/livedata/dashboard/configuration_adapter.py
@@ -11,6 +11,15 @@ from ess.livedata.config.workflow_spec import AuxSources
 
 Model = TypeVar('Model')
 
+DEFAULT_SOURCE_PRESELECTION_CAP = 5
+"""Maximum number of sources to pre-select by default.
+
+Above this threshold, ``initial_source_names`` defaults to an empty list so
+the user is not faced with a long pre-selection that they have to trim. The
+configuration widget exposes "Select all" / "Select none" buttons so the
+user can opt into the full set with a single click.
+"""
+
 
 class ConfigurationState(BaseModel):
     """
@@ -153,19 +162,34 @@ class ConfigurationAdapter(ABC, Generic[Model]):
         """
         Initially selected source names.
 
-        Returns the pre-configured source names (filtered to available sources),
-        or all available sources if none were specified. An explicit empty list
-        is preserved (e.g., for 2D outputs where no source should be pre-selected).
-        If a non-empty list filters down to nothing (all sources became unavailable),
-        falls back to all available sources.
+        Returns the pre-configured source names (filtered to available sources).
+        An explicit empty list is preserved (e.g., for 2D outputs where no source
+        should be pre-selected).
+
+        When no stored configuration exists (``config_state is None``), defaults
+        to all available sources but caps at ``DEFAULT_SOURCE_PRESELECTION_CAP``:
+        beyond that, returns an empty list to avoid overwhelming the user. The
+        cap also applies to a caller-supplied list in the no-stored-config case,
+        since the list then represents intent (e.g., "configure these unconfigured
+        sources") rather than a previous selection. When stored configuration is
+        present, the caller-supplied list is trusted as-is — restoring a saved
+        selection (e.g., editing an existing plot or workflow group) must never
+        silently drop entries.
         """
         if self._initial_source_names is not None:
             if not self._initial_source_names:
                 return []
             available = set(self.source_names)
             filtered = [s for s in self._initial_source_names if s in available]
-            return filtered if filtered else self.source_names
-        return self.source_names
+            if filtered:
+                if self._config_state is None:
+                    return self._cap_default_preselection(filtered)
+                return filtered
+        return self._cap_default_preselection(self.source_names)
+
+    def _cap_default_preselection(self, names: list[str]) -> list[str]:
+        """Return ``names`` if within the preselection cap, else empty list."""
+        return names if len(names) <= DEFAULT_SOURCE_PRESELECTION_CAP else []
 
     @property
     def initial_parameter_values(self) -> dict[str, Any]:

--- a/src/ess/livedata/dashboard/widgets/configuration_widget.py
+++ b/src/ess/livedata/dashboard/widgets/configuration_widget.py
@@ -125,7 +125,9 @@ class ConfigurationWidget:
             select_all_btn,
             select_none_btn,
             sizing_mode='stretch_width',
-            margin=(0, 0, 4, 0),
+            # Match MultiChoice's default horizontal margin so the right-aligned
+            # buttons line up with the selector's right edge.
+            margin=(0, 10, 4, 10),
         )
 
     def _select_all_sources(self) -> None:

--- a/src/ess/livedata/dashboard/widgets/configuration_widget.py
+++ b/src/ess/livedata/dashboard/widgets/configuration_widget.py
@@ -42,6 +42,7 @@ class ConfigurationWidget:
         """
         self._config = config
         self._source_selector = self._create_source_selector()
+        self._source_select_buttons = self._create_source_select_buttons()
         self._aux_sources_widget = self._create_aux_sources_widget()
         self._source_error_pane = pn.pane.HTML("", sizing_mode='stretch_width')
         self._model_widget = self._create_model_widget()
@@ -79,6 +80,65 @@ class ConfigurationWidget:
             placeholder="Select source names to apply workflow to",
             sizing_mode='stretch_width',
         )
+
+    def _create_source_select_buttons(self) -> pn.Row | None:
+        """Create 'Select all' / 'Select none' buttons for the source selector."""
+        if self._source_selector is None:
+            return None
+
+        compact_btn_css = [
+            f"""
+            button {{
+                font-size: 12px !important;
+                padding: 2px 8px !important;
+                border: 1px solid {Colors.BORDER} !important;
+                border-radius: 4px !important;
+            }}
+            button:hover {{
+                background-color: {Colors.BG_MUTED} !important;
+            }}
+            """
+        ]
+
+        select_all_btn = pn.widgets.Button(
+            name='Select all',
+            button_type='light',
+            width=90,
+            height=26,
+            margin=(0, 4, 0, 0),
+            stylesheets=compact_btn_css,
+        )
+        select_all_btn.on_click(lambda _: self._select_all_sources())
+
+        select_none_btn = pn.widgets.Button(
+            name='Select none',
+            button_type='light',
+            width=90,
+            height=26,
+            margin=0,
+            stylesheets=compact_btn_css,
+        )
+        select_none_btn.on_click(lambda _: self._select_no_sources())
+
+        return pn.Row(
+            pn.Spacer(sizing_mode='stretch_width'),
+            select_all_btn,
+            select_none_btn,
+            sizing_mode='stretch_width',
+            margin=(0, 0, 4, 0),
+        )
+
+    def _select_all_sources(self) -> None:
+        """Set source selector value to all available sources."""
+        if self._source_selector is None:
+            return
+        self._source_selector.value = sorted(self._source_selector.options.values())
+
+    def _select_no_sources(self) -> None:
+        """Clear source selector value."""
+        if self._source_selector is None:
+            return
+        self._source_selector.value = []
 
     def _create_aux_sources_widget(self) -> AuxSourcesWidget | None:
         """Create auxiliary sources widget."""
@@ -138,6 +198,8 @@ class ConfigurationWidget:
         """Collect items that belong in the 'General' tab (sources/aux/errors)."""
         items: list[Any] = []
         if self._source_selector is not None:
+            if self._source_select_buttons is not None:
+                items.append(self._source_select_buttons)
             items.append(self._source_selector)
             items.append(self._source_error_pane)
         if self._aux_sources_widget is not None:

--- a/tests/dashboard/configuration_adapter_test.py
+++ b/tests/dashboard/configuration_adapter_test.py
@@ -6,6 +6,7 @@ import pydantic
 
 from ess.livedata.config.workflow_spec import AuxInput, AuxSources
 from ess.livedata.dashboard.configuration_adapter import (
+    DEFAULT_SOURCE_PRESELECTION_CAP,
     ConfigurationAdapter,
     ConfigurationState,
 )
@@ -120,6 +121,64 @@ class TestInitialSourceNames:
         adapter = ConcreteAdapter(
             available_sources=['source1', 'source2', 'source3'],
             initial_source_names=[],
+        )
+        assert adapter.initial_source_names == []
+
+    def test_default_returns_all_at_cap(self) -> None:
+        """Defaulting returns all sources when exactly at the cap."""
+        sources = [f's{i}' for i in range(DEFAULT_SOURCE_PRESELECTION_CAP)]
+        adapter = ConcreteAdapter(available_sources=sources)
+        assert adapter.initial_source_names == sources
+
+    def test_default_returns_empty_above_cap(self) -> None:
+        """Defaulting returns empty list when source count exceeds the cap."""
+        sources = [f's{i}' for i in range(DEFAULT_SOURCE_PRESELECTION_CAP + 1)]
+        adapter = ConcreteAdapter(available_sources=sources)
+        assert adapter.initial_source_names == []
+
+    def test_explicit_list_above_cap_without_config_state_returns_empty(self) -> None:
+        """Caller-supplied list exceeding the cap is emptied when no config exists.
+
+        Without stored configuration, the explicit list reflects intent only
+        (e.g., "configure these unconfigured sources"), so the cap applies.
+        """
+        sources = [f's{i}' for i in range(DEFAULT_SOURCE_PRESELECTION_CAP + 3)]
+        adapter = ConcreteAdapter(
+            available_sources=sources,
+            initial_source_names=sources,
+        )
+        assert adapter.initial_source_names == []
+
+    def test_explicit_list_above_cap_with_config_state_preserved(self) -> None:
+        """Caller-supplied list is preserved when stored configuration exists.
+
+        Stored configuration indicates the user is editing existing data — the
+        prior selection must not be silently truncated by the cap.
+        """
+        sources = [f's{i}' for i in range(DEFAULT_SOURCE_PRESELECTION_CAP + 3)]
+        adapter = ConcreteAdapter(
+            available_sources=sources,
+            config_state=ConfigurationState(params={'value': 1}),
+            initial_source_names=sources,
+        )
+        assert adapter.initial_source_names == sources
+
+    def test_explicit_list_at_cap_preserved(self) -> None:
+        """Caller-supplied list within the cap is returned as-is."""
+        sources = [f's{i}' for i in range(DEFAULT_SOURCE_PRESELECTION_CAP + 5)]
+        selected = sources[:DEFAULT_SOURCE_PRESELECTION_CAP]
+        adapter = ConcreteAdapter(
+            available_sources=sources,
+            initial_source_names=selected,
+        )
+        assert adapter.initial_source_names == selected
+
+    def test_fallback_above_cap_returns_empty(self) -> None:
+        """Fallback from unavailable sources also respects the cap."""
+        sources = [f's{i}' for i in range(DEFAULT_SOURCE_PRESELECTION_CAP + 2)]
+        adapter = ConcreteAdapter(
+            available_sources=sources,
+            initial_source_names=['nonexistent1', 'nonexistent2'],
         )
         assert adapter.initial_source_names == []
 

--- a/tests/dashboard/widgets/configuration_widget_test.py
+++ b/tests/dashboard/widgets/configuration_widget_test.py
@@ -190,6 +190,29 @@ class TestNoParamsWidget:
         assert widget.get_failing_field_names() == []
 
 
+class TestSourceSelectButtons:
+    def test_buttons_present_when_source_selector_exists(self) -> None:
+        widget = ConfigurationWidget(_Adapter(source_names=['s1', 's2']))
+        assert widget._source_select_buttons is not None
+
+    def test_buttons_absent_when_no_sources(self) -> None:
+        widget = ConfigurationWidget(_Adapter(model=_EmptyModel, source_names=[]))
+        assert widget._source_selector is None
+        assert widget._source_select_buttons is None
+
+    def test_select_all_populates_value_with_all_sources(self) -> None:
+        widget = ConfigurationWidget(_Adapter(source_names=['s1', 's2', 's3']))
+        widget._source_selector.value = []
+        widget._select_all_sources()
+        assert sorted(widget._source_selector.value) == ['s1', 's2', 's3']
+
+    def test_select_none_clears_value(self) -> None:
+        widget = ConfigurationWidget(_Adapter(source_names=['s1', 's2', 's3']))
+        widget._source_selector.value = ['s1', 's2']
+        widget._select_no_sources()
+        assert widget._source_selector.value == []
+
+
 @pytest.fixture(autouse=True)
 def _panel_extensions_loaded():
     """Ensure Panel extensions required by pn.Tabs etc. are loaded."""


### PR DESCRIPTION
## Summary

Restores a cap on default source pre-selection in workflow and plot configuration modals, so that opening a fresh timeseries workflow (or any modal with many sources and no stored configuration) no longer arrives with 50+ source rows pre-selected. The original cap was added in d8c748768 and silently dropped during the single-source `ConfigurationState` refactor in 8e0ae4e54. The narrower replacement in ab904013d only covered 2D+ plot outputs.

`ConfigurationAdapter.initial_source_names` now returns an empty list once the source count exceeds `DEFAULT_SOURCE_PRESELECTION_CAP` (5), but only when `config_state is None`. When stored configuration exists (editing an existing plot, or gear-clicking a configured workflow group) the prior selection is preserved as-is — the cap must never silently truncate existing data.

`ConfigurationWidget` gains a small Select all / Select none button row above the source `MultiChoice`, always shown when the selector exists, providing a one-click escape hatch both for fresh-with-cap and for trimming a restored selection.

## Example

<img width="641" height="414" alt="workflow config modal with added select-all and select-none buttons" src="https://github.com/user-attachments/assets/07ba51f9-67ac-48df-8422-62c804a7c965" />

## Test plan

- [x] Open a fresh timeseries workflow on an instrument with many log sources (e.g. DREAM): the gear modal opens with no sources selected, Select all populates the full list.
- [x] Stage a few sources, commit, gear-click the configured group: the prior selection is preserved unchanged.
- [x] Open an existing 1D plot with many selected sources: prior selection is preserved.
- [x] Open a fresh 1D plot on a workflow with many sources: no sources pre-selected.
- [x] Verify Select all / Select none buttons align with the right edge of the source MultiChoice.