### PR TITLE
Handle unit of da00 reference_time variable

### DIFF
--- a/src/ess/livedata/core/timestamp.py
+++ b/src/ess/livedata/core/timestamp.py
@@ -18,17 +18,6 @@ from typing import Any
 _NS_PER_S = 1_000_000_000
 _NS_PER_MS = 1_000_000
 
-# Integer scale factors from each supported SI time unit to nanoseconds.
-# Both ASCII ``'us'`` and the Unicode ``'µs'`` are accepted for microseconds
-# since producers in the wild use either spelling.
-_NS_PER_UNIT: dict[str, int] = {
-    'ns': 1,
-    'us': 1_000,
-    'µs': 1_000,
-    'ms': _NS_PER_MS,
-    's': _NS_PER_S,
-}
-
 
 @total_ordering
 class Duration:
@@ -180,18 +169,24 @@ class Timestamp:
     def from_unit(cls, value: int, *, unit: str | None) -> Timestamp:
         """Create a timestamp from an integer count of ``unit`` since the epoch.
 
-        Supports ``'ns'``, ``'us'``/``'µs'``, ``'ms'``, and ``'s'``. Raises
-        ``ValueError`` for any other ``unit`` (including ``None``). The strict
-        check prevents wire-format misinterpretation -- a microsecond value
-        treated as nanoseconds would silently map recent times into early 1970.
+        Delegates to scipp's unit machinery, accepting any UDUNITS-compatible
+        time unit (e.g., ``'ns'``, ``'us'``, ``'µs'``, ``'ms'``, ``'s'``, plus
+        the corresponding long forms). Raises ``ValueError`` for ``None``,
+        dimensionless, or non-time units, so wire-format misinterpretation --
+        microseconds treated as nanoseconds would silently map recent times
+        into early 1970 -- surfaces as a hard error.
+
+        Numpy ``uint64`` values must be cast to ``int`` by the caller since
+        scipp does not support unsigned integers; standard ns-epoch values
+        fit comfortably in ``int64`` (until ~year 2262).
         """
-        scale = _NS_PER_UNIT.get(unit)
-        if scale is None:
-            raise ValueError(
-                f"Unsupported time unit {unit!r}; expected one of "
-                f"{sorted(_NS_PER_UNIT)}"
-            )
-        return cls(ns=int(value) * scale)
+        import scipp as sc
+
+        try:
+            ns = sc.scalar(int(value), unit=unit).to(unit='ns').value
+        except sc.UnitError as e:
+            raise ValueError(f"Unsupported time unit {unit!r}: {e}") from None
+        return cls(ns=int(ns))
 
     @classmethod
     def from_scipp(cls, var: Any) -> Timestamp:

--- a/src/ess/livedata/core/timestamp.py
+++ b/src/ess/livedata/core/timestamp.py
@@ -18,6 +18,17 @@ from typing import Any
 _NS_PER_S = 1_000_000_000
 _NS_PER_MS = 1_000_000
 
+# Integer scale factors from each supported SI time unit to nanoseconds.
+# Both ASCII ``'us'`` and the Unicode ``'µs'`` are accepted for microseconds
+# since producers in the wild use either spelling.
+_NS_PER_UNIT: dict[str, int] = {
+    'ns': 1,
+    'us': 1_000,
+    'µs': 1_000,
+    'ms': _NS_PER_MS,
+    's': _NS_PER_S,
+}
+
 
 @total_ordering
 class Duration:
@@ -164,6 +175,23 @@ class Timestamp:
     def from_ms(cls, ms: int) -> Timestamp:
         """Create a timestamp from milliseconds since the epoch."""
         return cls(ns=ms * _NS_PER_MS)
+
+    @classmethod
+    def from_unit(cls, value: int, *, unit: str | None) -> Timestamp:
+        """Create a timestamp from an integer count of ``unit`` since the epoch.
+
+        Supports ``'ns'``, ``'us'``/``'µs'``, ``'ms'``, and ``'s'``. Raises
+        ``ValueError`` for any other ``unit`` (including ``None``). The strict
+        check prevents wire-format misinterpretation -- a microsecond value
+        treated as nanoseconds would silently map recent times into early 1970.
+        """
+        scale = _NS_PER_UNIT.get(unit)
+        if scale is None:
+            raise ValueError(
+                f"Unsupported time unit {unit!r}; expected one of "
+                f"{sorted(_NS_PER_UNIT)}"
+            )
+        return cls(ns=int(value) * scale)
 
     @classmethod
     def from_scipp(cls, var: Any) -> Timestamp:

--- a/src/ess/livedata/core/timestamp.py
+++ b/src/ess/livedata/core/timestamp.py
@@ -176,9 +176,10 @@ class Timestamp:
         microseconds treated as nanoseconds would silently map recent times
         into early 1970 -- surfaces as a hard error.
 
-        Numpy ``uint64`` values must be cast to ``int`` by the caller since
-        scipp does not support unsigned integers; standard ns-epoch values
-        fit comfortably in ``int64`` (until ~year 2262).
+        Numpy ``uint64`` values are accepted: the internal ``int`` cast yields
+        a Python ``int`` that scipp can ingest as ``int64`` (which scipp does
+        support, unlike ``uint64``). Standard ns-epoch values fit comfortably
+        in ``int64`` (until ~year 2262).
         """
         import scipp as sc
 

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -183,7 +183,7 @@ def _extract_reference_time(
             data = np.asarray(var.data)
             if data.size == 0 or data.dtype not in (np.int64, np.uint64):
                 return None
-            return Timestamp.from_unit(int(data[-1]), unit=var.unit)
+            return Timestamp.from_unit(data[-1], unit=var.unit)
     return None
 
 

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -168,15 +168,22 @@ def _extract_reference_time(
     Mirrors the ev44 convention of using ``reference_time[-1]`` as the message
     timestamp, providing data-derived timestamps for consistent batching.
 
-    Only int64 and uint64 arrays are accepted. Smaller integer types (e.g.,
-    int32) cannot represent nanosecond-epoch timestamps without overflow and
-    are silently ignored, falling back to the top-level ``timestamp_ns``.
+    Returns ``None`` to fall back to the top-level ``timestamp_ns`` if no usable
+    ``reference_time`` is present (empty array, or dtype too small to represent
+    a nanosecond-epoch value -- int32 wraps every ~2 seconds).
+
+    Delegates unit handling to :meth:`Timestamp.from_unit`, which raises
+    ``ValueError`` on unsupported units. The integer payload of
+    ``reference_time`` is unit-bearing, so silent reinterpretation must be
+    avoided -- treating microseconds as nanoseconds maps recent times into
+    early 1970.
     """
     for var in variables:
         if var.name == 'reference_time':
             data = np.asarray(var.data)
-            if data.size > 0 and data.dtype in (np.int64, np.uint64):
-                return Timestamp.from_ns(int(data[-1]))
+            if data.size == 0 or data.dtype not in (np.int64, np.uint64):
+                return None
+            return Timestamp.from_unit(int(data[-1]), unit=var.unit)
     return None
 
 

--- a/tests/core/timestamp_test.py
+++ b/tests/core/timestamp_test.py
@@ -141,6 +141,24 @@ class TestTimestampFactory:
         ts = Timestamp.from_ms(1500)
         assert ts.to_ns() == 1_500_000_000
 
+    @pytest.mark.parametrize(
+        ("unit", "value", "expected_ns"),
+        [
+            ("ns", 42, 42),
+            ("us", 5, 5_000),
+            ("µs", 5, 5_000),
+            ("ms", 7, 7_000_000),
+            ("s", 3, 3_000_000_000),
+        ],
+    )
+    def test_from_unit_supported(self, unit: str, value: int, expected_ns: int) -> None:
+        assert Timestamp.from_unit(value, unit=unit).to_ns() == expected_ns
+
+    @pytest.mark.parametrize("unit", [None, "", "counts", "minutes", "datetime64[ns]"])
+    def test_from_unit_unsupported_raises(self, unit: str | None) -> None:
+        with pytest.raises(ValueError, match="Unsupported time unit"):
+            Timestamp.from_unit(1, unit=unit)
+
     def test_to_seconds(self):
         ts = Timestamp.from_ns(1_500_000_000)
         assert ts.to_seconds() == 1.5

--- a/tests/core/timestamp_test.py
+++ b/tests/core/timestamp_test.py
@@ -160,9 +160,9 @@ class TestTimestampFactory:
     def test_from_unit_handles_uint64_numpy_value(self) -> None:
         import numpy as np
 
-        # scipp rejects uint64 dtype; the caller-side ``int`` cast is what
-        # makes this work. ns-since-epoch in 2023 (~1.7e18) fits in int64.
-        ts = Timestamp.from_unit(int(np.uint64(1_700_000_000_000_000_000)), unit='ns')
+        # scipp rejects uint64 dtype directly; ``from_unit`` must cast
+        # internally. ns-since-epoch in 2023 (~1.7e18) fits in int64.
+        ts = Timestamp.from_unit(np.uint64(1_700_000_000_000_000_000), unit='ns')
         assert ts.to_datetime().year == 2023
 
     @pytest.mark.parametrize("unit", [None, "", "counts", "datetime64[ns]"])

--- a/tests/core/timestamp_test.py
+++ b/tests/core/timestamp_test.py
@@ -149,12 +149,23 @@ class TestTimestampFactory:
             ("µs", 5, 5_000),
             ("ms", 7, 7_000_000),
             ("s", 3, 3_000_000_000),
+            # Long-form UDUNITS spellings flow through scipp's unit parser.
+            ("nanosecond", 42, 42),
+            ("second", 3, 3_000_000_000),
         ],
     )
     def test_from_unit_supported(self, unit: str, value: int, expected_ns: int) -> None:
         assert Timestamp.from_unit(value, unit=unit).to_ns() == expected_ns
 
-    @pytest.mark.parametrize("unit", [None, "", "counts", "minutes", "datetime64[ns]"])
+    def test_from_unit_handles_uint64_numpy_value(self) -> None:
+        import numpy as np
+
+        # scipp rejects uint64 dtype; the caller-side ``int`` cast is what
+        # makes this work. ns-since-epoch in 2023 (~1.7e18) fits in int64.
+        ts = Timestamp.from_unit(int(np.uint64(1_700_000_000_000_000_000)), unit='ns')
+        assert ts.to_datetime().year == 2023
+
+    @pytest.mark.parametrize("unit", [None, "", "counts", "datetime64[ns]"])
     def test_from_unit_unsupported_raises(self, unit: str | None) -> None:
         with pytest.raises(ValueError, match="Unsupported time unit"):
             Timestamp.from_unit(1, unit=unit)

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -387,7 +387,7 @@ class TestKafkaToDa00Adapter:
 
         assert result.timestamp == Timestamp.from_ns(expected_ns)
 
-    @pytest.mark.parametrize("unit", ["datetime64[ns]", "", "counts", "minutes", None])
+    @pytest.mark.parametrize("unit", ["datetime64[ns]", "", "counts", None])
     def test_raises_on_unsupported_reference_time_unit(self, unit: str | None) -> None:
         # Silent reinterpretation of an unknown unit as ns risks mapping recent
         # times into 1970; reject so the producer bug surfaces in the logs.

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -355,6 +355,62 @@ class TestKafkaToDa00Adapter:
 
         assert result.timestamp == Timestamp.from_ns(5678)
 
+    @pytest.mark.parametrize(
+        ("unit", "expected_ns"),
+        [
+            ("ns", 3000),
+            ("us", 3000 * 1_000),
+            ("µs", 3000 * 1_000),
+            ("ms", 3000 * 1_000_000),
+            ("s", 3000 * 1_000_000_000),
+        ],
+    )
+    def test_converts_supported_units_to_ns(self, unit: str, expected_ns: int) -> None:
+        da00_msg = dataarray_da00.serialise_da00(
+            source_name="instrument",
+            timestamp_ns=5678,
+            data=[
+                dataarray_da00.Variable(
+                    name="signal", data=np.array([1.0]), unit="counts"
+                ),
+                dataarray_da00.Variable(
+                    name="reference_time",
+                    data=np.array([1000, 2000, 3000], dtype=np.int64),
+                    axes=["frame"],
+                    unit=unit,
+                ),
+            ],
+        )
+        message = FakeKafkaMessage(value=da00_msg, topic="instrument")
+        adapter = KafkaToDa00Adapter(stream_kind=StreamKind.MONITOR_COUNTS)
+        result = adapter.adapt(message)
+
+        assert result.timestamp == Timestamp.from_ns(expected_ns)
+
+    @pytest.mark.parametrize("unit", ["datetime64[ns]", "", "counts", "minutes", None])
+    def test_raises_on_unsupported_reference_time_unit(self, unit: str | None) -> None:
+        # Silent reinterpretation of an unknown unit as ns risks mapping recent
+        # times into 1970; reject so the producer bug surfaces in the logs.
+        da00_msg = dataarray_da00.serialise_da00(
+            source_name="instrument",
+            timestamp_ns=5678,
+            data=[
+                dataarray_da00.Variable(
+                    name="signal", data=np.array([1.0]), unit="counts"
+                ),
+                dataarray_da00.Variable(
+                    name="reference_time",
+                    data=np.array([1000, 2000, 3000], dtype=np.int64),
+                    axes=["frame"],
+                    unit=unit,
+                ),
+            ],
+        )
+        message = FakeKafkaMessage(value=da00_msg, topic="instrument")
+        adapter = KafkaToDa00Adapter(stream_kind=StreamKind.MONITOR_COUNTS)
+        with pytest.raises(ValueError, match="Unsupported time unit"):
+            adapter.adapt(message)
+
     def test_adapter_with_stream_mapping(self) -> None:
         message = FakeKafkaMessage(value=make_serialized_da00(), topic="instrument")
         adapter = KafkaToDa00Adapter(


### PR DESCRIPTION
`_extract_reference_time` in the da00 message adapter passed the integer payload of a `reference_time` variable straight to `Timestamp.from_ns`, ignoring `Variable.unit`. In production we only observed `unit='ns'`, but this PR **fixes the latent bug** if this ever changes.

Adds `Timestamp.from_unit(value, *, unit)`, which delegates to scipp's unit machinery and so accepts any UDUNITS-compatible time unit (short forms `ns`/`us`/`µs`/`ms`/`s`, long forms `nanosecond`/`second`/…). Dimensionless, `None`, or non-time units are surfaced as `ValueError`. The adapter delegates to it, so wrong-unit messages now fail loudly in the consumer log instead of becoming 1970 timestamps downstream.

scipp does not support `uint64`, but the caller-side `int()` cast in the adapter handles the unsigned-int wire case; ns-epoch values fit comfortably in `int64` (until ~year 2262).

ev44 is structurally immune (its flatbuffer schema fixes `reference_time` as int64 with no unit field), matching the observation that ev44 timestamps in production were correct.