### PR TITLE
Fix shipped grid templates broken since namespace drop (26.5.0)

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/bragg_peak_monitor.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/bragg_peak_monitor.yaml
@@ -12,7 +12,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        workflow_id: bifrost/monitor_histogram/1
         view_name: total_in_range
         source_names:
         - bragg_peak_monitor
@@ -28,7 +28,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        workflow_id: bifrost/monitor_histogram/1
         view_name: histogram
         source_names:
         - bragg_peak_monitor
@@ -46,7 +46,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        workflow_id: bifrost/monitor_histogram/1
         view_name: total_counts
         source_names:
         - bragg_peak_monitor
@@ -62,7 +62,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        workflow_id: bifrost/monitor_histogram/1
         view_name: histogram
         source_names:
         - bragg_peak_monitor

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/detectors.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/detectors.yaml
@@ -12,7 +12,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/detector_data/unified_detector_view/1
+        workflow_id: bifrost/unified_detector_view/1
         view_name: image
         source_names:
         - unified_detector
@@ -24,7 +24,7 @@ cells:
         mode: latest
   - data_sources:
       primary:
-        workflow_id: static/static_overlay/geometric/1
+        workflow_id: static/geometric/1
         view_name: Triplet bounds
         source_names: []
     plot_name: rectangles
@@ -44,7 +44,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/data_reduction/detector_ratemeter/1
+        workflow_id: bifrost/detector_ratemeter/1
         view_name: detector_region_counts
         source_names:
         - unified_detector
@@ -62,7 +62,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/data_reduction/detector_ratemeter/1
+        workflow_id: bifrost/detector_ratemeter/1
         view_name: detector_region_counts
         source_names:
         - unified_detector

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/monitors.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/monitors.yaml
@@ -12,7 +12,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        workflow_id: bifrost/monitor_histogram/1
         view_name: histogram
         source_names:
         - 090_frame_1
@@ -33,7 +33,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        workflow_id: bifrost/monitor_histogram/1
         view_name: histogram
         source_names:
         - 090_frame_1
@@ -55,7 +55,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/monitor_data/monitor_histogram/1
+        workflow_id: bifrost/monitor_histogram/1
         view_name: histogram
         source_names:
         - 090_frame_1

--- a/src/ess/livedata/config/instruments/bifrost/grid_templates/spectrum_view.yaml
+++ b/src/ess/livedata/config/instruments/bifrost/grid_templates/spectrum_view.yaml
@@ -12,7 +12,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: bifrost/detector_data/unified_detector_view/1
+        workflow_id: bifrost/unified_detector_view/1
         view_name: spectrum_view
         source_names:
         - unified_detector

--- a/src/ess/livedata/config/instruments/dummy/grid_templates/detector_overview.yaml
+++ b/src/ess/livedata/config/instruments/dummy/grid_templates/detector_overview.yaml
@@ -13,7 +13,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: dummy/detector_data/area_panel_xy/1
+        workflow_id: dummy/area_panel_xy/1
         view_name: image
         source_names:
         - area_panel
@@ -45,7 +45,7 @@ cells:
   layers:
   - data_sources:
       primary:
-        workflow_id: dummy/detector_data/panel_0_xy/1
+        workflow_id: dummy/panel_0_xy/1
         view_name: image
         source_names:
         - panel_0

--- a/tests/config/grid_template_test.py
+++ b/tests/config/grid_template_test.py
@@ -188,3 +188,20 @@ class TestLoadRawGridTemplates:
         assert 'col' in geometry
         assert 'row_span' in geometry
         assert 'col_span' in geometry
+
+    @pytest.mark.parametrize('instrument', ['bifrost', 'dummy'])
+    def test_shipped_template_workflow_ids_parse(self, instrument):
+        """Every workflow_id in a shipped template parses as a WorkflowId.
+
+        Guards against the templates drifting out of sync with the
+        WorkflowId string format and silently disappearing from the
+        UI dropdown when ``_parse_single_spec`` catches the resulting
+        ``ValueError``.
+        """
+        templates = load_raw_grid_templates(instrument)
+        assert templates, f'no templates shipped for instrument {instrument!r}'
+        for template in templates:
+            for cell in template['cells']:
+                for layer in cell['layers']:
+                    for ds in layer['data_sources'].values():
+                        WorkflowId.from_string(ds['workflow_id'])


### PR DESCRIPTION
The bifrost and dummy grid templates have shipped with obsolete 4-part `workflow_id` strings (`instrument/group/name/version`) since `42837b33` dropped the namespace from `WorkflowId` identity. `WorkflowId.from_string` raises on them, `_parse_single_spec` catches the `ValueError`, and every affected template silently disappears from the dashboard's Template dropdown. Shipped broken in 26.5.0.

Rewrites every `workflow_id:` line in shipped templates to the 3-part form, plus a regression test that parses every `workflow_id` in every shipped template.

Out of scope: `_parse_single_spec` swallowing template errors at startup is also worth revisiting -- fail-fast on a misconfigured template would have surfaced this in CI or first-boot.

## Test plan

- [x] Bifrost dashboard: open the Template dropdown, confirm Detectors, Monitors, Spectrum View, and Bragg Peak Monitor are present.
- [x] Apply each template, confirm cells subscribe and render without errors in the browser console / backend logs.
- [x] Dummy dashboard: open Template dropdown, confirm Detectors template is present and applies.