### PR TITLE
Disable autoreload in production dashboard, drop dead WSGI server property

### DIFF
--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -276,21 +276,6 @@ class DashboardBase(ServiceBase, ABC):
             """
         ]
 
-    @property
-    def server(self):
-        """Get the Panel server for WSGI deployment."""
-        return pn.serve(
-            self.create_layout,
-            port=self._port,
-            show=False,
-            autoreload=False,
-            dev=self._dev,
-            basic_auth=self._basic_auth_password,
-            cookie_secret=self._basic_auth_cookie_secret,
-            login_template=_LOGIN_TEMPLATE,
-            logout_template=_LOGOUT_TEMPLATE,
-        )
-
     def _start_impl(self) -> None:
         """Start the dashboard service."""
         self._services.start()
@@ -305,7 +290,7 @@ class DashboardBase(ServiceBase, ABC):
                 self.create_layout,
                 port=self._port,
                 show=False,
-                autoreload=True,
+                autoreload=self._dev,
                 dev=self._dev,
                 basic_auth=self._basic_auth_password,
                 cookie_secret=self._basic_auth_cookie_secret,


### PR DESCRIPTION
## Summary

`Dashboard.run_forever` — the live production entry point — started Panel's server with `autoreload=True`, installing a periodic source-file watcher. py-spy profiling of the healthy Bifrost production dashboard showed this `_check_file` watcher consuming small baseline CPU on the server IOLoop, with no benefit in a deployed service. Autoreload is now tied to the dev flag (`autoreload=self._dev`), so it is active only for local development and off in production.

While here, the sibling `server` property is removed. It was a WSGI entry-point hook (`application = _app.server`) for gunicorn deployment. gunicorn and the `*_wsgi.py` modules were removed previously, leaving the property orphaned with no remaining call sites in the codebase. Removing it also eliminates the near-duplicate `pn.serve(...)` call whose divergent `autoreload` value was the root of this issue.

Fixes #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
