### PR TITLE
Hoist plot styling out of the per-tick render path

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -5,9 +5,9 @@
 from __future__ import annotations
 
 import weakref
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 import holoviews as hv
 import numpy as np
@@ -185,6 +185,16 @@ def _identity(x: str) -> str:
     return x
 
 
+def _typed_opts(element_types: Iterable[type], **options: Any) -> list[hv.Options]:
+    """Build per-element-type ``Options`` for declaring style once on a DynamicMap.
+
+    ``responsive`` and most plot options are invalid on ``Layout``, so styling
+    hoisted onto a DynamicMap must be keyed to concrete leaf element types rather
+    than applied generically.
+    """
+    return [getattr(hv.opts, t.__name__)(**options) for t in element_types]
+
+
 @dataclass(frozen=True)
 class TitleResolver:
     """Resolves raw source and output names to human-readable display titles.
@@ -283,12 +293,17 @@ class DefaultPresenter(PresenterBase):
     """
 
     def present(self, pipe: hv.streams.Pipe) -> hv.DynamicMap:
-        """Create a DynamicMap that passes through pre-computed elements."""
+        """Create a DynamicMap that passes through pre-computed elements.
+
+        Static styling is applied once on the DynamicMap (see
+        :meth:`Plotter._style_opts`) rather than per element on every tick.
+        """
 
         def passthrough(data):
             return data
 
-        return hv.DynamicMap(passthrough, streams=[pipe], cache_size=1)
+        dmap = hv.DynamicMap(passthrough, streams=[pipe], cache_size=1)
+        return dmap.opts(*self._plotter._style_opts())
 
 
 class StaticPresenter(PresenterBase):
@@ -587,29 +602,23 @@ class Plotter:
             self._range_targets = {}
             plots = [
                 hv.Text(0.5, 0.5, f"Error: {e}").opts(
-                    text_align='center', text_baseline='middle'
+                    text_align='center', text_baseline='middle', **self._sizing_opts
                 )
             ]
 
         if len(plots) == 0:
             plots = [
                 hv.Text(0.5, 0.5, 'No data').opts(
-                    text_align='center', text_baseline='middle'
+                    text_align='center', text_baseline='middle', **self._sizing_opts
                 )
             ]
 
-        plots = [self._apply_generic_options(p) for p in plots]
-
         if self.layout_params.combine_mode == 'overlay':
-            result = hv.Overlay(plots).opts(shared_axes=True)
+            result = hv.Overlay(plots)
         elif len(plots) == 1:
             result = plots[0]
         else:
-            result = (
-                hv.Layout(plots)
-                .opts(shared_axes=False)
-                .cols(self.layout_params.layout_columns)
-            )
+            result = hv.Layout(plots).cols(self.layout_params.layout_columns)
 
         # Add time interval and lag indicator as plot title
         time_info = _compute_time_info(data)
@@ -682,9 +691,16 @@ class Plotter:
         """
         return iter(self._range_targets.items())
 
-    def _apply_generic_options(self, plot_element: hv.Element) -> hv.Element:
-        """Apply generic options like aspect ratio to a plot element."""
-        return plot_element.opts(**self._sizing_opts)
+    def _style_opts(self) -> list[hv.Options]:
+        """Static HoloViews opts applied once on the presenter's DynamicMap.
+
+        Hoisting styling here keeps ``compute()`` a pure data->element transform:
+        the per-tick build emits bare elements and styling is declared once at
+        render time, rather than minting an entry in the process-global option
+        store for every element on every tick. Subclasses extend this with opts
+        for their leaf element types; the base provides the container-level opts.
+        """
+        return [hv.opts.Overlay(shared_axes=True), hv.opts.Layout(shared_axes=False)]
 
     def plot(
         self, data: sc.DataArray, data_key: ResultKey, *, label: str = '', **kwargs
@@ -715,6 +731,15 @@ _LINE1D_ELEMENT: dict[str, type] = {
     'histogram': hv.Histogram,
 }
 _LINE1D_HISTOGRAM_FALLBACK = 'line'
+# Every leaf element type a 1-D line plot may render (base modes plus error
+# displays), for declaring style opts once on the DynamicMap.
+_LINE1D_LEAF_ELEMENTS: tuple[type, ...] = (
+    hv.Curve,
+    hv.Scatter,
+    hv.Histogram,
+    hv.ErrorBars,
+    hv.Spread,
+)
 
 
 def _resolve_line1d_mode(
@@ -907,10 +932,8 @@ class LinePlotter(Plotter):
         converter = HvConverter1d(
             da, value_label=output_display_name, dim_label=dim_label
         )
-        opts = dict(self._base_opts)
-
         base_method = getattr(converter, _LINE1D_BASE_METHOD[mode])
-        base = base_method(label=label).opts(**opts)
+        base = base_method(label=label)
 
         if da.variances is not None and self._errors != 'none':
             if mode == 'histogram':
@@ -921,13 +944,15 @@ class LinePlotter(Plotter):
                     dim_label=dim_label,
                 )
             error_method = getattr(converter, _LINE1D_ERROR_METHOD[self._errors])
-            error_element = error_method(label=label).opts(**opts, **self._sizing_opts)
-            # Apply sizing opts to child elements individually. Bokeh needs
-            # responsive/aspect on each element to size the figure correctly;
-            # applying them only to the composite Overlay is not sufficient.
-            return base.opts(**self._sizing_opts) * error_element
+            return base * error_method(label=label)
 
         return base
+
+    def _style_opts(self) -> list[hv.Options]:
+        return [
+            *_typed_opts(_LINE1D_LEAF_ELEMENTS, **self._base_opts, **self._sizing_opts),
+            *super()._style_opts(),
+        ]
 
 
 class ImagePlotter(Plotter):
@@ -1025,11 +1050,19 @@ class ImagePlotter(Plotter):
         if targets:
             self._range_targets[data_key] = targets
 
-        opts = dict(self._base_opts)
-        # Set explicit clim for log scale when data is all NaN to avoid HoloViews error
+        # base_opts are declared once in _style_opts(); only the data-dependent clim
+        # guard (log scale with all-NaN data) must be set per element here.
         if use_log_scale and (clim := self._get_log_scale_clim(plot_data)) is not None:
-            opts['clim'] = clim
-        return histogram.opts(**opts)
+            return histogram.opts(clim=clim)
+        return histogram
+
+    def _style_opts(self) -> list[hv.Options]:
+        return [
+            *_typed_opts(
+                (hv.Image, hv.QuadMesh), **self._base_opts, **self._sizing_opts
+            ),
+            *super()._style_opts(),
+        ]
 
 
 class BarsPlotter(Plotter):
@@ -1055,6 +1088,12 @@ class BarsPlotter(Plotter):
         """
         super().__init__(**kwargs)
         self._horizontal = horizontal
+        self._bars_opts: dict[str, Any] = {
+            'invert_axes': horizontal,
+            'show_legend': False,
+            'toolbar': None,
+            'yrotation' if horizontal else 'xrotation': 45 if horizontal else 25,
+        }
 
     @classmethod
     def from_params(cls, params: PlotParamsBars):
@@ -1087,18 +1126,18 @@ class BarsPlotter(Plotter):
         vdim = hv.Dimension(
             data_key.output_name or 'values', label=vdim_label, unit=unit
         )
-        bars = hv.Bars(
+        return hv.Bars(
             [(bar_label, value)],
             kdims=['source'],
             vdims=[vdim],
             label=label,
         )
-        opts = {'invert_axes': self._horizontal, 'show_legend': False, 'toolbar': None}
-        if self._horizontal:
-            opts['yrotation'] = 45
-        else:
-            opts['xrotation'] = 25
-        return cast(hv.Bars, bars.opts(**opts))
+
+    def _style_opts(self) -> list[hv.Options]:
+        return [
+            hv.opts.Bars(**self._bars_opts, **self._sizing_opts),
+            *super()._style_opts(),
+        ]
 
 
 class Overlay1DPlotter(Plotter):
@@ -1211,7 +1250,7 @@ class Overlay1DPlotter(Plotter):
         slice_size = data.sizes[slice_dim]
 
         if slice_size == 0:
-            return hv.Curve([]).opts(**self._base_opts)
+            return hv.Curve([])
 
         actual_mode, plot_data = _resolve_line1d_mode(
             self._mode, data, dim=data.dims[1]
@@ -1245,7 +1284,7 @@ class Overlay1DPlotter(Plotter):
                 slice_data, value_label=output_display_name, dim_label=dim_label
             )
             base_method = getattr(converter, _LINE1D_BASE_METHOD[actual_mode])
-            base = base_method(label=curve_label).opts(color=color, **self._base_opts)
+            base = base_method(label=curve_label).opts(color=color)
 
             if slice_data.variances is not None and self._errors != 'none':
                 if use_histogram:
@@ -1261,16 +1300,19 @@ class Overlay1DPlotter(Plotter):
                         mid, value_label=output_display_name, dim_label=dim_label
                     )
                 error_method = getattr(converter, _LINE1D_ERROR_METHOD[self._errors])
-                error_el = error_method(label=curve_label).opts(
-                    color=color,
-                    **self._base_opts,
-                    **self._sizing_opts,
-                )
-                elements.append(base.opts(**self._sizing_opts))
+                error_el = error_method(label=curve_label).opts(color=color)
+                elements.append(base)
                 elements.append(error_el)
             else:
-                elements.append(base.opts(**self._sizing_opts))
+                elements.append(base)
 
         if len(elements) == 1:
             return elements[0]
-        return hv.Overlay(elements).opts(shared_axes=True)
+        return hv.Overlay(elements)
+
+    def _style_opts(self) -> list[hv.Options]:
+        # Per-slice ``color`` stays on the elements in plot(); the rest is static.
+        return [
+            *_typed_opts(_LINE1D_LEAF_ELEMENTS, **self._base_opts, **self._sizing_opts),
+            *super()._style_opts(),
+        ]

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -296,14 +296,14 @@ class DefaultPresenter(PresenterBase):
         """Create a DynamicMap that passes through pre-computed elements.
 
         Static styling is applied once on the DynamicMap (see
-        :meth:`Plotter._style_opts`) rather than per element on every tick.
+        :meth:`Plotter.style_opts`) rather than per element on every tick.
         """
 
         def passthrough(data):
             return data
 
         dmap = hv.DynamicMap(passthrough, streams=[pipe], cache_size=1)
-        return dmap.opts(*self._plotter._style_opts())
+        return dmap.opts(*self._plotter.style_opts())
 
 
 class StaticPresenter(PresenterBase):
@@ -691,7 +691,7 @@ class Plotter:
         """
         return iter(self._range_targets.items())
 
-    def _style_opts(self) -> list[hv.Options]:
+    def style_opts(self) -> list[hv.Options]:
         """Static HoloViews opts applied once on the presenter's DynamicMap.
 
         Hoisting styling here keeps ``compute()`` a pure data->element transform:
@@ -948,10 +948,10 @@ class LinePlotter(Plotter):
 
         return base
 
-    def _style_opts(self) -> list[hv.Options]:
+    def style_opts(self) -> list[hv.Options]:
         return [
             *_typed_opts(_LINE1D_LEAF_ELEMENTS, **self._base_opts, **self._sizing_opts),
-            *super()._style_opts(),
+            *super().style_opts(),
         ]
 
 
@@ -1050,18 +1050,18 @@ class ImagePlotter(Plotter):
         if targets:
             self._range_targets[data_key] = targets
 
-        # base_opts are declared once in _style_opts(); only the data-dependent clim
+        # base_opts are declared once in style_opts(); only the data-dependent clim
         # guard (log scale with all-NaN data) must be set per element here.
         if use_log_scale and (clim := self._get_log_scale_clim(plot_data)) is not None:
             return histogram.opts(clim=clim)
         return histogram
 
-    def _style_opts(self) -> list[hv.Options]:
+    def style_opts(self) -> list[hv.Options]:
         return [
             *_typed_opts(
                 (hv.Image, hv.QuadMesh), **self._base_opts, **self._sizing_opts
             ),
-            *super()._style_opts(),
+            *super().style_opts(),
         ]
 
 
@@ -1133,10 +1133,10 @@ class BarsPlotter(Plotter):
             label=label,
         )
 
-    def _style_opts(self) -> list[hv.Options]:
+    def style_opts(self) -> list[hv.Options]:
         return [
             hv.opts.Bars(**self._bars_opts, **self._sizing_opts),
-            *super()._style_opts(),
+            *super().style_opts(),
         ]
 
 
@@ -1310,9 +1310,9 @@ class Overlay1DPlotter(Plotter):
             return elements[0]
         return hv.Overlay(elements)
 
-    def _style_opts(self) -> list[hv.Options]:
+    def style_opts(self) -> list[hv.Options]:
         # Per-slice ``color`` stays on the elements in plot(); the rest is static.
         return [
             *_typed_opts(_LINE1D_LEAF_ELEMENTS, **self._base_opts, **self._sizing_opts),
-            *super()._style_opts(),
+            *super().style_opts(),
         ]

--- a/src/ess/livedata/dashboard/roi_readback_plots.py
+++ b/src/ess/livedata/dashboard/roi_readback_plots.py
@@ -135,6 +135,9 @@ class RectanglesReadbackPlotter(Plotter):
             show_legend=False,
         )
 
+    def _style_opts(self) -> list[hv.Options]:
+        return [hv.opts.Rectangles(**self._sizing_opts), *super()._style_opts()]
+
     def _to_hv_data(
         self, rois: dict[int, RectangleROI]
     ) -> list[tuple[float, float, float, float, str]]:
@@ -238,6 +241,9 @@ class PolygonsReadbackPlotter(Plotter):
             line_width=style.line_width,
             show_legend=False,
         )
+
+    def _style_opts(self) -> list[hv.Options]:
+        return [hv.opts.Polygons(**self._sizing_opts), *super()._style_opts()]
 
     def _to_hv_data(self, rois: dict[int, PolygonROI]) -> list[dict[str, Any]]:
         """

--- a/src/ess/livedata/dashboard/roi_readback_plots.py
+++ b/src/ess/livedata/dashboard/roi_readback_plots.py
@@ -135,8 +135,8 @@ class RectanglesReadbackPlotter(Plotter):
             show_legend=False,
         )
 
-    def _style_opts(self) -> list[hv.Options]:
-        return [hv.opts.Rectangles(**self._sizing_opts), *super()._style_opts()]
+    def style_opts(self) -> list[hv.Options]:
+        return [hv.opts.Rectangles(**self._sizing_opts), *super().style_opts()]
 
     def _to_hv_data(
         self, rois: dict[int, RectangleROI]
@@ -242,8 +242,8 @@ class PolygonsReadbackPlotter(Plotter):
             show_legend=False,
         )
 
-    def _style_opts(self) -> list[hv.Options]:
-        return [hv.opts.Polygons(**self._sizing_opts), *super()._style_opts()]
+    def style_opts(self) -> list[hv.Options]:
+        return [hv.opts.Polygons(**self._sizing_opts), *super().style_opts()]
 
     def _to_hv_data(self, rois: dict[int, PolygonROI]) -> list[dict[str, Any]]:
         """

--- a/src/ess/livedata/dashboard/slicer_plotter.py
+++ b/src/ess/livedata/dashboard/slicer_plotter.py
@@ -98,7 +98,7 @@ class SlicerPresenter(PresenterBase):
 
     def _style_opts(self) -> list[hv.Options]:
         """Static styling declared once on the DynamicMap (see
-        :meth:`Plotter._style_opts`); the data-dependent clim stays per slice."""
+        :meth:`Plotter.style_opts`); the data-dependent clim stays per slice."""
         return _typed_opts(
             (hv.Image, hv.QuadMesh), **self._base_opts, **self._sizing_opts
         )

--- a/src/ess/livedata/dashboard/slicer_plotter.py
+++ b/src/ess/livedata/dashboard/slicer_plotter.py
@@ -21,6 +21,7 @@ from .plots import (
     _hv_axis_padding,
     _normalize_to_rate,
     _pad_range,
+    _typed_opts,
 )
 from .range_hook import Axis
 from .scipp_to_holoviews import to_holoviews
@@ -84,7 +85,7 @@ class SlicerPresenter(PresenterBase):
             The `mode`, `slice_dim`, and other slider kwargs come from kdims.
             """
             if data is None or not data.data:
-                return hv.Text(0.5, 0.5, 'No data')
+                return hv.Text(0.5, 0.5, 'No data').opts(**self._sizing_opts)
 
             # Get first data item (expects single data source)
             array_data = next(iter(data.data.values()))
@@ -92,7 +93,15 @@ class SlicerPresenter(PresenterBase):
                 array_data, data.clim, mode=mode, slice_dim=slice_dim, **kwargs
             )
 
-        return hv.DynamicMap(render, streams=[pipe], kdims=self._kdims, cache_size=1)
+        dmap = hv.DynamicMap(render, streams=[pipe], kdims=self._kdims, cache_size=1)
+        return dmap.opts(*self._style_opts())
+
+    def _style_opts(self) -> list[hv.Options]:
+        """Static styling declared once on the DynamicMap (see
+        :meth:`Plotter._style_opts`); the data-dependent clim stays per slice."""
+        return _typed_opts(
+            (hv.Image, hv.QuadMesh), **self._base_opts, **self._sizing_opts
+        )
 
     def _initialize_kdims(self, state: SlicerState) -> None:
         """
@@ -192,11 +201,12 @@ class SlicerPresenter(PresenterBase):
             plot_data = self._slice_data(data, slice_dim, kwargs)
 
         image = to_holoviews(plot_data)
-        opts: dict[str, Any] = {**self._base_opts, **self._sizing_opts}
-        # Use pre-computed clim for consistent color scale across slices
+        # base_opts/sizing are declared once on the DynamicMap (see _style_opts);
+        # only the data-dependent clim is applied per slice here for a consistent
+        # color scale across slices.
         if clim is not None:
-            opts['clim'] = clim
-        return image.opts(**opts)
+            return image.opts(clim=clim)
+        return image
 
     def _slice_data(
         self, data: sc.DataArray, slice_dim: str, kwargs: dict

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -8,6 +8,7 @@ import holoviews as hv
 import numpy as np
 import pytest
 import scipp as sc
+from bokeh.models import GlyphRenderer
 from holoviews.plotting.bokeh import BokehRenderer
 
 from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
@@ -98,6 +99,19 @@ def render_to_bokeh(hv_element):
     assert bokeh_plot is not None
     assert hasattr(bokeh_plot, 'state')
     return bokeh_plot
+
+
+def present_figure(plotter, data_dict):
+    """Render a plotter through the full compute -> present -> bokeh path.
+
+    Styling is applied on the presenter's DynamicMap rather than per element, so
+    observable style (responsive sizing, axis inversion) must be checked on the
+    rendered figure, not on the element returned by ``plot()``.
+    """
+    plotter.compute({'primary': data_dict})
+    presenter = plotter.create_presenter()
+    pipe = hv.streams.Pipe(data=plotter.get_cached_state())
+    return render_to_bokeh(presenter.present(pipe)).state
 
 
 class TestTitleResolver:
@@ -582,13 +596,8 @@ class TestLinePlotter:
         assert isinstance(elements[0], hv.Histogram)
         assert isinstance(elements[1], hv.ErrorBars)
 
-    def test_error_overlay_children_have_sizing_opts(self, data_key):
-        """Sizing opts must be on child elements, not just the overlay.
-
-        Bokeh needs responsive/aspect on individual plot elements to size the
-        figure correctly; applying them only to the composite Overlay causes
-        the plot to collapse to a small default size.
-        """
+    def test_error_overlay_renders_responsive(self, data_key):
+        """A line+error overlay renders as a responsive (stretch_both) figure."""
         params = PlotParams1d(
             line=Line1dParams(mode=Line1dRenderMode.line, errors=ErrorDisplay.bars)
         )
@@ -602,11 +611,9 @@ class TestLinePlotter:
             ),
             coords={'x': sc.array(dims=['x'], values=[10.0, 20.0, 30.0], unit='m')},
         )
-        result = plotter.plot(data, data_key)
-        assert isinstance(result, hv.Overlay)
-        for child in result:
-            opts = child.opts.get().kwargs
-            assert opts.get('responsive') is True
+        assert isinstance(plotter.plot(data, data_key), hv.Overlay)
+        fig = present_figure(plotter, {data_key: data})
+        assert fig.sizing_mode == 'stretch_both'
 
     def test_plot_uses_output_display_name_as_vdim_label(self, line_plotter, data_key):
         """Test that output_display_name is used as the vdim label."""
@@ -1225,19 +1232,20 @@ class TestBarsPlotter:
         assert vdim.label == 'I(d)'
 
     def test_vertical_bars_default(self, bars_plotter, scalar_data, data_key):
-        """Test that bars are vertical by default (invert_axes=False)."""
-        result = bars_plotter.plot(scalar_data, data_key)
-        # When invert_axes is False (default), it may not appear in options
-        opts = hv.Store.lookup_options('bokeh', result, 'plot').kwargs
-        assert opts.get('invert_axes', False) is False
+        """Test that bars are vertical by default (rendered as VBar glyphs)."""
+        fig = present_figure(bars_plotter, {data_key: scalar_data})
+        glyphs = {type(gr.glyph).__name__ for gr in fig.select({'type': GlyphRenderer})}
+        assert 'VBar' in glyphs
+        assert 'HBar' not in glyphs
 
     def test_horizontal_bars_option(
         self, horizontal_bars_plotter, scalar_data, data_key
     ):
-        """Test that horizontal option inverts axes."""
-        result = horizontal_bars_plotter.plot(scalar_data, data_key)
-        opts = hv.Store.lookup_options('bokeh', result, 'plot').kwargs
-        assert opts.get('invert_axes') is True
+        """Test that the horizontal option inverts axes (rendered as HBar glyphs)."""
+        fig = present_figure(horizontal_bars_plotter, {data_key: scalar_data})
+        glyphs = {type(gr.glyph).__name__ for gr in fig.select({'type': GlyphRenderer})}
+        assert 'HBar' in glyphs
+        assert 'VBar' not in glyphs
 
     def test_rejects_non_scalar_data(self, bars_plotter, data_key):
         """Test that BarsPlotter rejects non-0D data."""
@@ -1468,39 +1476,32 @@ class TestOverlay1DPlotter:
         for elem in result:
             assert isinstance(elem, hv.Curve), f"Expected Curve, got {type(elem)}"
 
-    def test_sizing_opts_applied_to_curves(self, data_2d_with_roi_coord, data_key):
-        """Test that sizing options are applied to individual curves."""
+    def test_renders_responsive(self, data_2d_with_roi_coord, data_key):
+        """Aspect enforcement is handled by a JS hook (frame_aspect.py), so the
+        overlay renders responsive (stretch_both) regardless of aspect type."""
         from ess.livedata.dashboard.plot_params import PlotAspect, PlotAspectType
 
-        # Aspect enforcement is handled by a JS hook (frame_aspect.py),
-        # so the plotter only sets responsive=True on the HoloViews element.
         params = PlotParams1d()
         params.plot_aspect = PlotAspect(aspect_type=PlotAspectType.square)
         plotter = plots.Overlay1DPlotter.from_params(params)
 
-        result = plotter.plot(data_2d_with_roi_coord, data_key)
+        fig = present_figure(plotter, {data_key: data_2d_with_roi_coord})
+        assert fig.sizing_mode == 'stretch_both'
+        assert fig.aspect_ratio is None
 
-        for curve in result:
-            opts = hv.Store.lookup_options('bokeh', curve, 'plot').kwargs
-            assert opts.get('responsive') is True
-
-    def test_free_aspect_applies_responsive_only(
+    def test_free_aspect_renders_responsive_without_aspect(
         self, data_2d_with_roi_coord, data_key
     ):
-        """Test that 'free' aspect applies responsive=True without aspect constraint."""
+        """'free' aspect renders responsive (stretch_both) without an aspect ratio."""
         from ess.livedata.dashboard.plot_params import PlotAspect, PlotAspectType
 
         params = PlotParams1d()
         params.plot_aspect = PlotAspect(aspect_type=PlotAspectType.free)
         plotter = plots.Overlay1DPlotter.from_params(params)
 
-        result = plotter.plot(data_2d_with_roi_coord, data_key)
-
-        # Check that responsive is set but no aspect constraint
-        for curve in result:
-            opts = hv.Store.lookup_options('bokeh', curve, 'plot').kwargs
-            assert opts.get('responsive') is True
-            assert 'aspect' not in opts or opts.get('aspect') is None
+        fig = present_figure(plotter, {data_key: data_2d_with_roi_coord})
+        assert fig.sizing_mode == 'stretch_both'
+        assert fig.aspect_ratio is None
 
     def test_plot_uses_output_display_name_as_vdim_label(
         self, overlay_plotter, data_2d_with_roi_coord, data_key


### PR DESCRIPTION
## Motivation

`Plotter.compute()` runs server-side on every data batch and applied instance-level `.opts()` to every element on every tick (per-element sizing, container `shared_axes`). Each `.opts()` call mints an entry in the process-global HoloViews option store (clone/merge, weakref-GC'd), so the build re-decided styling every frame and churned a global store every tick — work that should be declared once, not redone per frame.

## Approach

Static styling is declared once per presenter via `Plotter._style_opts()` and applied on the DynamicMap in `present()`. `compute()` now emits bare elements; `plot()` retains only genuinely data-dependent opts (per-slice `color`, the log/all-NaN `clim` guard, error/no-data text sizing). The dynamic per-tick title stays in `compute()`.

Opts are keyed to concrete leaf element types because `responsive` (and most plot options) are invalid on `Layout`, so a generic `DynamicMap.opts()` would fail whenever multiple non-overlay sources render as a grid. This also subsumes the now-obsolete requirement (false under HoloViews 1.22.1) to set `responsive` on each child rather than the container.

The slicer presenter gets the same treatment. The other custom plotters need no change: ROI-request plotters already apply styling once on their DynamicMap, correlation plotters delegate presentation to an inner line/image plotter and so are covered automatically, and static plotters compute once from params with no per-tick render path.

## Base

Built on #952 (`plot-autoscale`), whose removal of the per-tick `framewise` opt is the enabler: it lets the element opts become fully static and therefore hoistable. This PR targets that branch, not `main`.

## Test plan

Rendering equivalence was checked with a bokeh-level signature (sizing mode, axis scales, colorbars, glyph colors, titles) over every plotter, render mode, error display, color scale, and single/overlay/layout combination — identical before and after — and the hoisted opts were confirmed to persist across streaming pipe updates.

- [x] `tests/dashboard/` (1464 passed)
- [x] Manual: open the real dashboards (1D / 2D / bars / overlay / slicer, single and multi-source layout) and confirm styling and sizing are unchanged.
