### PR TITLE
Cell titlebar: rename, add-layer, toolbar toggle, and freshness indicator

### DIFF
--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -29,7 +29,7 @@ from .plot_params import (
     PlotDisplayParams1d,
     PlotDisplayParams2d,
 )
-from .plots import ImagePlotter, LinePlotter, PresenterBase, TitleResolver
+from .plots import ImagePlotter, LinePlotter, PresenterBase, TimeBounds, TitleResolver
 from .range_hook import Axis, RangeTargets
 
 
@@ -256,6 +256,11 @@ class CorrelationHistogramPlotter:
     def get_cached_state(self) -> Any | None:
         """Get the last computed state from the renderer."""
         return self._renderer.get_cached_state()
+
+    @property
+    def time_bounds(self) -> TimeBounds | None:
+        """Time bounds of the most recently computed data (from the renderer)."""
+        return self._renderer.time_bounds
 
     def has_cached_state(self) -> bool:
         """Check if the renderer has computed state."""

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -203,10 +203,14 @@ class PlotCell:
     The plots are placed in the given row and col of a :py:class:`PlotGrid`, spanning
     the given number of rows and columns. A cell can contain multiple layers that
     are composed via hv.Overlay.
+
+    ``user_title`` is an optional user-defined cell title shown in the cell
+    titlebar. When ``None`` the titlebar shows a title derived from the layers.
     """
 
     geometry: CellGeometry
     layers: list[Layer]
+    user_title: str | None = None
 
 
 @dataclass
@@ -616,7 +620,12 @@ class PlotOrchestrator:
         self._notify_grid_created(new_grid_id)
         return new_grid_id
 
-    def add_cell(self, grid_id: GridId, geometry: CellGeometry) -> CellId:
+    def add_cell(
+        self,
+        grid_id: GridId,
+        geometry: CellGeometry,
+        user_title: str | None = None,
+    ) -> CellId:
         """
         Add an empty cell to a grid.
 
@@ -628,6 +637,8 @@ class PlotOrchestrator:
             ID of the grid to add the cell to.
         geometry
             Cell geometry (position and size in the grid).
+        user_title
+            Optional user-defined title for the cell.
 
         Returns
         -------
@@ -635,7 +646,7 @@ class PlotOrchestrator:
             ID of the added cell.
         """
         cell_id = CellId(uuid4())
-        cell = PlotCell(geometry=geometry, layers=[])
+        cell = PlotCell(geometry=geometry, layers=[], user_title=user_title)
         grid = self._grids[grid_id]
         grid.cells[cell_id] = cell
         self._cell_to_grid[cell_id] = grid_id
@@ -658,6 +669,25 @@ class PlotOrchestrator:
 
         self._persist_to_store()
         self._notify_cell_removed(grid_id, cell_id, cell)
+
+    def set_cell_title(self, cell_id: CellId, title: str | None) -> None:
+        """
+        Set or clear the user-defined title of a cell.
+
+        Parameters
+        ----------
+        cell_id
+            ID of the cell to rename.
+        title
+            New user-defined title, or ``None``/empty to clear it and fall back
+            to the derived title.
+        """
+        grid_id = self._cell_to_grid[cell_id]
+        cell = self._grids[grid_id].cells[cell_id]
+        cell.user_title = title or None
+        self._persist_to_store()
+        self._logger.info('Set cell %s title to %r', cell_id, cell.user_title)
+        self._notify_cell_updated(grid_id, cell_id, cell)
 
     def get_layer_config(self, layer_id: LayerId) -> PlotConfig:
         """
@@ -1204,7 +1234,11 @@ class PlotOrchestrator:
         if not layers:
             return None
 
-        return PlotCell(geometry=geometry, layers=layers)
+        return PlotCell(
+            geometry=geometry,
+            layers=layers,
+            user_title=cell_data.get('user_title'),
+        )
 
     def _parse_raw_layer(self, layer_data: dict[str, Any]) -> Layer | None:
         """
@@ -1361,18 +1395,7 @@ class PlotOrchestrator:
             'title': grid.title,
             'nrows': grid.nrows,
             'ncols': grid.ncols,
-            'cells': [
-                {
-                    'geometry': {
-                        'row': cell.geometry.row,
-                        'col': cell.geometry.col,
-                        'row_span': cell.geometry.row_span,
-                        'col_span': cell.geometry.col_span,
-                    },
-                    'layers': [self._serialize_layer(layer) for layer in cell.layers],
-                }
-                for cell in grid.cells.values()
-            ],
+            'cells': [self._serialize_cell(cell) for cell in grid.cells.values()],
         }
         if not grid.enabled:
             result['enabled'] = False
@@ -1389,6 +1412,21 @@ class PlotOrchestrator:
             runtime identity handles with no cross-session significance.
         """
         return [self.serialize_grid(grid_id) for grid_id in self._grids]
+
+    def _serialize_cell(self, cell: PlotCell) -> dict[str, Any]:
+        """Serialize a single cell to dict format."""
+        result: dict[str, Any] = {
+            'geometry': {
+                'row': cell.geometry.row,
+                'col': cell.geometry.col,
+                'row_span': cell.geometry.row_span,
+                'col_span': cell.geometry.col_span,
+            },
+            'layers': [self._serialize_layer(layer) for layer in cell.layers],
+        }
+        if cell.user_title is not None:
+            result['user_title'] = cell.user_title
+        return result
 
     def _serialize_layer(self, layer: Layer) -> dict[str, Any]:
         """Serialize a single layer to dict format."""
@@ -1425,7 +1463,9 @@ class PlotOrchestrator:
             for spec in specs:
                 grid_id = self.add_grid(spec.title, spec.nrows, spec.ncols)
                 for cell in spec.cells:
-                    cell_id = self.add_cell(grid_id, cell.geometry)
+                    cell_id = self.add_cell(
+                        grid_id, cell.geometry, user_title=cell.user_title
+                    )
                     for layer in cell.layers:
                         self.add_layer(cell_id, layer.config)
                 if not spec.enabled:

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -732,7 +732,12 @@ class Plotter:
         store for every element on every tick. Subclasses extend this with opts
         for their leaf element types; the base provides the container-level opts.
         """
-        return [hv.opts.Overlay(shared_axes=True), hv.opts.Layout(shared_axes=False)]
+        # title='' stops Bokeh promoting a single overlaid element's label to the
+        # plot title when there is no legend to carry it.
+        return [
+            hv.opts.Overlay(shared_axes=True, title=''),
+            hv.opts.Layout(shared_axes=False),
+        ]
 
     def plot(
         self, data: sc.DataArray, data_key: ResultKey, *, label: str = '', **kwargs
@@ -1300,6 +1305,11 @@ class Overlay1DPlotter(Plotter):
         data = plot_data
         use_histogram = actual_mode == 'histogram'
 
+        # A single slice needs no label: a lone labelled element renders its
+        # label as the plot title, whereas labels only earn their keep as legend
+        # entries distinguishing multiple overlaid slices.
+        label_slices = slice_size > 1
+
         elements: list[hv.Element] = []
         for i in range(slice_size):
             slice_data = data[slice_dim, i]
@@ -1311,7 +1321,7 @@ class Overlay1DPlotter(Plotter):
             color_idx = int(coord_val) % len(self._colors)
             color = self._colors[color_idx]
 
-            curve_label = f"{slice_dim}={coord_val}"
+            curve_label = f"{slice_dim}={coord_val}" if label_slices else ''
             converter = HvConverter1d(
                 slice_data, value_label=output_display_name, dim_label=dim_label
             )

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -320,46 +320,74 @@ class StaticPresenter(PresenterBase):
         return pipe.data
 
 
-def _compute_time_info(data: dict[str, sc.DataArray]) -> str | None:
-    """
-    Compute time interval and lag from start_time/end_time coordinates.
+@dataclass(frozen=True)
+class TimeBounds:
+    """Data-time bounds backing the freshness/lag indicator.
 
-    Returns a formatted string like "12:34:56 - 12:35:02 (Lag: 2.3s)" or None
-    if no timing coordinates are found. Uses the earliest start_time and
-    latest end_time across all DataArrays to show the full data range.
-    Lag is computed from the earliest end_time (oldest data) to show worst-case
-    staleness.
+    ``min_end`` is the end time of the oldest data, giving worst-case staleness.
+    ``min_start`` and ``max_end`` bound the full data range and are present only
+    when start times exist on the data.
     """
-    now_ns = Timestamp.now()
+
+    min_end: Timestamp
+    min_start: Timestamp | None = None
+    max_end: Timestamp | None = None
+
+    def lag_seconds(self, now: Timestamp | None = None) -> float:
+        """Seconds between the oldest data's end time and ``now`` (max lag)."""
+        now = Timestamp.now() if now is None else now
+        return (now - self.min_end).to_seconds()
+
+
+def _compute_time_bounds(data: dict[str, sc.DataArray]) -> TimeBounds | None:
+    """
+    Extract time bounds from start_time/end_time coordinates.
+
+    Returns the earliest start_time, the earliest end_time (oldest data, for
+    worst-case lag), and the latest end_time across all DataArrays. Returns None
+    if no end_time coordinate is found.
+    """
     min_start: Timestamp | None = None
     min_end: Timestamp | None = None
     max_end: Timestamp | None = None
 
     for da in data.values():
         if 'start_time' in da.coords:
-            start_ns = Timestamp.from_scipp(da.coords['start_time'])
-            if min_start is None or start_ns < min_start:
-                min_start = start_ns
+            start = Timestamp.from_scipp(da.coords['start_time'])
+            min_start = start if min_start is None else min(min_start, start)
         if 'end_time' in da.coords:
-            end_ns = Timestamp.from_scipp(da.coords['end_time'])
-            if min_end is None or end_ns < min_end:
-                min_end = end_ns
-            if max_end is None or end_ns > max_end:
-                max_end = end_ns
+            end = Timestamp.from_scipp(da.coords['end_time'])
+            min_end = end if min_end is None else min(min_end, end)
+            max_end = end if max_end is None else max(max_end, end)
 
     if min_end is None:
         return None
+    return TimeBounds(min_end=min_end, min_start=min_start, max_end=max_end)
 
-    # Use min_end for lag (oldest data = maximum lag)
-    lag_s = (now_ns - min_end).to_seconds()
 
-    if min_start is not None and max_end is not None:
-        start_str = format_time_ns_local(min_start)
-        end_str = format_time_ns_local(max_end)
+def merge_time_bounds(bounds: Iterable[TimeBounds | None]) -> TimeBounds | None:
+    """Combine bounds across layers: earliest start, oldest end, latest end."""
+    present = [b for b in bounds if b is not None]
+    if not present:
+        return None
+    starts = [b.min_start for b in present if b.min_start is not None]
+    ends = [b.max_end for b in present if b.max_end is not None]
+    return TimeBounds(
+        min_end=min(b.min_end for b in present),
+        min_start=min(starts) if starts else None,
+        max_end=max(ends) if ends else None,
+    )
+
+
+def format_time_info(bounds: TimeBounds, now: Timestamp | None = None) -> str:
+    """Format time bounds as a range + lag string, e.g. "12:34:56 (Lag: 2.3s)"."""
+    now = Timestamp.now() if now is None else now
+    lag_s = bounds.lag_seconds(now)
+    if bounds.min_start is not None and bounds.max_end is not None:
+        start_str = format_time_ns_local(bounds.min_start)
+        end_str = format_time_ns_local(bounds.max_end)
         return f'{start_str} - {end_str} (Lag: {lag_s:.1f}s)'
-    else:
-        end_str = format_time_ns_local(min_end)
-        return f'{end_str} (Lag: {lag_s:.1f}s)'
+    return f'{format_time_ns_local(bounds.min_end)} (Lag: {lag_s:.1f}s)'
 
 
 class Plotter:
@@ -393,6 +421,7 @@ class Plotter:
         """
         self._normalize_to_rate = normalize_to_rate
         self._cached_state: Any | None = None
+        self._time_bounds: TimeBounds | None = None
         self._range_targets: dict[ResultKey, RangeTargets] = {}
         self._presenters: weakref.WeakSet[PresenterBase] = weakref.WeakSet()
         self.layout_params = layout_params or LayoutParams()
@@ -620,11 +649,9 @@ class Plotter:
         else:
             result = hv.Layout(plots).cols(self.layout_params.layout_columns)
 
-        # Add time interval and lag indicator as plot title
-        time_info = _compute_time_info(data)
-        if time_info is not None:
-            result = result.opts(title=time_info, fontsize={'title': '10pt'})
-
+        # Time bounds drive the cell titlebar's freshness indicator; they are
+        # kept off the plot title to avoid minting an OptionTree entry per tick.
+        self._time_bounds = _compute_time_bounds(data)
         self._set_cached_state(result)
 
     def create_presenter(self, *, owner: Plotter | None = None) -> PresenterBase:
@@ -669,6 +696,11 @@ class Plotter:
     def get_cached_state(self) -> Any | None:
         """Get the last computed state, or None if not yet computed."""
         return self._cached_state
+
+    @property
+    def time_bounds(self) -> TimeBounds | None:
+        """Time bounds of the most recently computed data, or None if absent."""
+        return self._time_bounds
 
     def has_cached_state(self) -> bool:
         """Check if state has been computed."""

--- a/src/ess/livedata/dashboard/static_plots.py
+++ b/src/ess/livedata/dashboard/static_plots.py
@@ -110,6 +110,11 @@ class StaticPlotter(ABC):
         """Get the last computed state, or None if not yet computed."""
         return self._cached_state
 
+    @property
+    def time_bounds(self) -> None:
+        """Static plots carry no time data, so they never contribute lag."""
+        return None
+
     def has_cached_state(self) -> bool:
         """Check if state has been computed."""
         return self._cached_state is not None

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -1,0 +1,769 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""
+CellWidget - Per-session view of a single plot cell.
+
+A cell is one position in a plot grid. Its widget bundles a titlebar (cell
+title, rename, per-cell add-layer, toolbar toggle, freshness/lag pill), a
+stack of per-layer toolbars, and a content area showing either the composed
+plot or a status placeholder.
+
+All per-session, per-cell state lives here (autoscale controller, freshness
+pane, per-layer time panes, toolbar-visibility toggle), so ``PlotGridTabs``
+holds a single ``dict[CellId, CellWidget]`` and delegates updates and
+disposal to the widget.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+import holoviews as hv
+import panel as pn
+import structlog
+
+from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
+from ess.livedata.core.timestamp import Timestamp
+
+from ..cell_autoscale import CellAutoscaleController, build_controller_from_layers
+from ..data_roles import PRIMARY
+from ..format_utils import extract_error_summary
+from ..frame_aspect import make_frame_aspect_hook_from_config
+from ..plot_data_service import LayerState, LayerStateMachine, PlotDataService
+from ..plot_orchestrator import (
+    CellId,
+    DataSourceConfig,
+    LayerId,
+    PlotCell,
+    PlotConfig,
+    PlotOrchestrator,
+)
+from ..plot_params import PlotAspectType, StretchMode
+from ..plots import TimeBounds, format_time_info, merge_time_bounds
+from ..plotting_controller import PlottingController
+from ..save_filename import build_save_filename_from_cell, make_save_filename_hook
+from ..session_layer import SessionLayer
+from .plot_grid import GridCellStyles
+from .plot_widgets import (
+    create_cell_titlebar,
+    create_layer_toolbar,
+    derive_cell_title,
+    get_plot_cell_display_info,
+    get_workflow_display_info,
+)
+from .styles import Colors, FreshnessPill, StatusColors
+
+logger = structlog.get_logger(__name__)
+
+
+def _get_sizing_mode(config: PlotConfig) -> str:
+    """Extract Panel sizing_mode from plot configuration.
+
+    Parameters
+    ----------
+    config:
+        Plot configuration containing plotter params.
+
+    Returns
+    -------
+    :
+        Panel sizing_mode string ('stretch_both', 'stretch_width', or 'stretch_height').
+    """
+    params = config.params
+    if hasattr(params, 'plot_aspect'):
+        aspect = params.plot_aspect
+        if aspect.aspect_type == PlotAspectType.free:
+            return 'stretch_both'
+        if aspect.stretch_mode == StretchMode.width:
+            return 'stretch_width'
+        return 'stretch_height'
+    return 'stretch_both'
+
+
+def _freshness_band(lag_seconds: float) -> tuple[str, str, str]:
+    """Return the ``(background, text, dot)`` pill colors for a lag in seconds."""
+    if lag_seconds < FreshnessPill.FRESH_MAX_SECONDS:
+        return FreshnessPill.FRESH
+    if lag_seconds < FreshnessPill.STALE_MAX_SECONDS:
+        return FreshnessPill.STALE
+    return FreshnessPill.OLD
+
+
+def _format_lag_short(lag_seconds: float) -> str:
+    """Compact lag label, e.g. "2.3s", "41s", "3m"."""
+    if lag_seconds < 10:
+        return f'{lag_seconds:.1f}s'
+    if lag_seconds < 60:
+        return f'{lag_seconds:.0f}s'
+    return f'{lag_seconds / 60:.0f}m'
+
+
+def format_freshness_html(lag_seconds: float | None, tooltip: str = '') -> str:
+    """Render the titlebar freshness/lag pill, color-banded by staleness.
+
+    Parameters
+    ----------
+    lag_seconds:
+        Data lag in seconds, or None to render nothing (no timing data).
+    tooltip:
+        Full time-range text shown on hover (the pill itself shows only the
+        compact lag).
+    """
+    if lag_seconds is None:
+        return ''
+    background, text_color, dot_color = _freshness_band(lag_seconds)
+    pill_style = (
+        f'display:inline-flex;align-items:center;gap:5px;height:20px;'
+        f'padding:0 8px;border-radius:10px;font-size:11px;'
+        f'font-variant-numeric:tabular-nums;white-space:nowrap;'
+        f'background:{background};color:{text_color};'
+    )
+    dot_style = (
+        f'width:7px;height:7px;border-radius:50%;flex:none;background:{dot_color};'
+    )
+    if tooltip:
+        from html import escape
+
+        title_attr = f' title="{escape(tooltip)}"'
+    else:
+        title_attr = ''
+    return (
+        f'<span style="{pill_style}"{title_attr}>'
+        f'<span style="{dot_style}"></span>{_format_lag_short(lag_seconds)}</span>'
+    )
+
+
+def create_freshness_pane() -> pn.pane.HTML:
+    """Create the titlebar freshness/lag pane, updated in place via ``.object``.
+
+    Content sizes to the pill; ``align='center'`` (``align-self:center``)
+    vertically centers it against the title and buttons in the row.
+    """
+    return pn.pane.HTML(
+        '',
+        align='center',
+        margin=(0, 6),
+        styles={'flex': '0 0 auto'},
+    )
+
+
+def format_layer_time_html(text: str) -> str:
+    """Render a per-layer time-range/lag label (muted, tabular nums)."""
+    if not text:
+        return ''
+    style = (
+        f'font-size:11px;color:{Colors.TEXT_MUTED};white-space:nowrap;'
+        'font-variant-numeric:tabular-nums;'
+    )
+    return f'<span style="{style}">{text}</span>'
+
+
+def create_layer_time_pane() -> pn.pane.HTML:
+    """Create a per-layer time-range pane, updated in place via ``.object``.
+
+    Placed on its own line below the layer title/buttons row; indented and
+    pulled up close to the title so it visually belongs to it.
+    """
+    return pn.pane.HTML(
+        '',
+        align='start',
+        margin=(-4, 6, 0, 14),
+        styles={'flex': '0 0 auto'},
+    )
+
+
+@dataclass(frozen=True)
+class CellDeps:
+    """Shared, session-stable dependencies for building cell widgets.
+
+    Bundled once by ``PlotGridTabs`` so each ``CellWidget`` stays a thin view.
+    ``session_layers`` is the session's shared layer render-state registry
+    (owned by the poll loop, read here when composing plots); the callbacks
+    route modal interactions back to the owning ``PlotGridTabs`` (which holds
+    the shared modal container).
+    """
+
+    orchestrator: PlotOrchestrator
+    workflow_registry: Mapping[WorkflowId, WorkflowSpec]
+    plotting_controller: PlottingController
+    plot_data_service: PlotDataService
+    session_layers: dict[LayerId, SessionLayer]
+    on_edit_title: Callable[[CellId, str, bool], None]
+    on_add_layer: Callable[[CellId], None]
+    on_reconfigure_layer: Callable[[LayerId], None]
+
+
+class CellWidget:
+    """
+    Per-session widget for a single plot cell.
+
+    Builds a Panel ``Column`` with a titlebar, a (toggleable) column of
+    per-layer toolbars, and a content area showing the composed plot or a
+    status placeholder. Owns the cell's autoscale controller and the panes
+    updated in place by the poll loop (titlebar freshness pill, per-layer
+    time-range labels).
+
+    Parameters
+    ----------
+    cell_id
+        ID of the cell.
+    cell
+        Plot cell configuration with all layers.
+    deps
+        Shared dependencies (services and modal callbacks).
+    toolbars_visible
+        Initial visibility of the per-layer toolbars. Preserved across cell
+        rebuilds by the owner so the user's toggle survives version polling.
+    """
+
+    def __init__(
+        self,
+        cell_id: CellId,
+        cell: PlotCell,
+        deps: CellDeps,
+        *,
+        toolbars_visible: bool,
+    ) -> None:
+        self._cell_id = cell_id
+        self._cell = cell
+        self._deps = deps
+        self._toolbars_shown = toolbars_visible
+        self._autoscale_controller: CellAutoscaleController | None = None
+        self._freshness_pane = create_freshness_pane()
+        self._layer_time_panes: dict[LayerId, pn.pane.HTML] = {}
+        # Composing builds the autoscale controller as a side effect.
+        self._plot = self._compose_plot()
+        self._view = self._build()
+
+    @property
+    def view(self) -> pn.Column:
+        """The Panel widget for this cell."""
+        return self._view
+
+    @property
+    def has_plot(self) -> bool:
+        """Whether the cell currently shows a composed plot (vs. placeholder)."""
+        return self._plot is not None
+
+    @property
+    def toolbars_shown(self) -> bool:
+        """Whether the per-layer toolbars are currently revealed."""
+        return self._toolbars_shown
+
+    @property
+    def freshness_pane(self) -> pn.pane.HTML:
+        """The titlebar freshness/lag pill pane."""
+        return self._freshness_pane
+
+    @property
+    def layer_time_panes(self) -> dict[LayerId, pn.pane.HTML]:
+        """The per-layer time-range panes, keyed by layer ID."""
+        return self._layer_time_panes
+
+    @property
+    def autoscale_controller(self) -> CellAutoscaleController | None:
+        """The cell's autoscale controller, if any layer drives autoscale."""
+        return self._autoscale_controller
+
+    def update_freshness(self, bounds_list: list[TimeBounds | None]) -> None:
+        """Update the titlebar freshness pane from the layers' time bounds."""
+        merged = merge_time_bounds(bounds_list)
+        if merged is None:
+            html = ''
+        else:
+            now = Timestamp.now()
+            html = format_freshness_html(
+                merged.lag_seconds(now), tooltip=format_time_info(merged, now=now)
+            )
+        if self._freshness_pane.object != html:
+            self._freshness_pane.object = html
+
+    def update_layer_time(self, layer_id: LayerId, bounds: TimeBounds | None) -> None:
+        """Update a layer toolbar's time-range pane from its time bounds."""
+        pane = self._layer_time_panes.get(layer_id)
+        if pane is None:
+            return
+        text = format_time_info(bounds) if bounds is not None else ''
+        html = format_layer_time_html(text)
+        if pane.object != html:
+            pane.object = html
+
+    def dispose(self) -> None:
+        """Dispose the autoscale controller, breaking its reference cycle.
+
+        Calling ``dispose()`` breaks the controller → Bokeh-tool →
+        on_change-callback → controller reference cycle so long sessions
+        don't accumulate detached controllers after cell rebuilds/removals.
+        """
+        if self._autoscale_controller is not None:
+            self._autoscale_controller.dispose()
+            self._autoscale_controller = None
+
+    def _layer_states(self) -> dict[LayerId, LayerStateMachine]:
+        """Get layer states from PlotDataService for all layers in the cell."""
+        result: dict[LayerId, LayerStateMachine] = {}
+        for layer in self._cell.layers:
+            state = self._deps.plot_data_service.get(layer.layer_id)
+            if state is None:
+                raise RuntimeError(
+                    f"Layer {layer.layer_id} has no state in PlotDataService. "
+                    "This indicates a bug: layers should be registered before "
+                    "widgets are notified."
+                )
+            result[layer.layer_id] = state
+        return result
+
+    def _build(self) -> pn.Column:
+        """Assemble the cell widget: titlebar, layer toolbars, and content."""
+        layer_states = self._layer_states()
+
+        # Per-layer toolbars, wrapped in a column the titlebar toggle can hide.
+        layer_toolbars = self._build_layer_toolbars(layer_states)
+        layers_column = pn.Column(
+            *layer_toolbars,
+            sizing_mode='stretch_width',
+            margin=0,
+            visible=self._toolbars_shown,
+        )
+        titlebar = self._build_titlebar(layers_column)
+
+        # Create content area (placeholder or plot)
+        if self._plot is not None:
+            content = self._build_plot_content(self._plot)
+            border = None
+            bg_color = None
+        else:
+            content = self._build_placeholder(layer_states)
+            # Check if any layer has an error
+            has_error = any(
+                state.error_message is not None for state in layer_states.values()
+            )
+            if has_error:
+                bg_color = '#ffe6e6'
+                border = f'2px solid {StatusColors.ERROR}'
+            else:
+                bg_color = Colors.BG_LIGHT
+                border = f'2px dashed {Colors.BORDER}'
+
+        styles = {}
+        if bg_color:
+            styles['background-color'] = bg_color
+        if border:
+            styles['border'] = border
+
+        return pn.Column(
+            titlebar,
+            layers_column,
+            content,
+            sizing_mode='stretch_both',
+            styles=styles,
+            margin=GridCellStyles.CELL_MARGIN,
+        )
+
+    def _build_titlebar(self, layers_column: pn.Column) -> pn.Row:
+        """
+        Create the cell-level titlebar (title, add layer, rename, toolbar toggle).
+
+        Parameters
+        ----------
+        layers_column
+            The column wrapping the per-layer toolbars, whose visibility the
+            toggle button controls.
+        """
+        cell = self._cell
+        has_user_title = cell.user_title is not None
+        title = (
+            cell.user_title
+            if has_user_title
+            else derive_cell_title(
+                cell,
+                self._deps.workflow_registry,
+                get_source_title=self._deps.orchestrator.get_source_title,
+            )
+        )
+
+        # Union of overlay suggestions across all layers, excluding plotters
+        # already present in the cell. Each suggestion remembers the source
+        # layer's config so the overlay inherits the right workflow/sources.
+        existing_plotter_names = {layer.config.plot_name for layer in cell.layers}
+        overlay_specs: list[tuple[str, str, str]] = []
+        overlay_sources: dict[tuple[str, str], PlotConfig] = {}
+        for layer in cell.layers:
+            for spec in self._available_overlays(layer.config):
+                output_name, plotter_name, _ = spec
+                key = (output_name, plotter_name)
+                if plotter_name in existing_plotter_names or key in overlay_sources:
+                    continue
+                overlay_sources[key] = layer.config
+                overlay_specs.append(spec)
+
+        def on_edit_title() -> None:
+            self._deps.on_edit_title(self._cell_id, title, has_user_title)
+
+        def on_toggle_toolbars(visible: bool) -> None:
+            self._toolbars_shown = visible
+            layers_column.visible = visible
+
+        def on_add() -> None:
+            self._deps.on_add_layer(self._cell_id)
+
+        def on_overlay(view_name: str, plotter_name: str) -> None:
+            source_config = overlay_sources[(view_name, plotter_name)]
+            self._create_overlay_layer(source_config, view_name, plotter_name)
+
+        return create_cell_titlebar(
+            title=title,
+            has_user_title=has_user_title,
+            on_edit_title_callback=on_edit_title,
+            toolbars_visible=self._toolbars_shown,
+            on_toggle_toolbars_callback=on_toggle_toolbars,
+            freshness_pane=self._freshness_pane,
+            on_add_callback=on_add,
+            on_overlay_selected=on_overlay,
+            available_overlays=overlay_specs,
+        )
+
+    def _available_overlays(self, config: PlotConfig) -> list[tuple[str, str, str]]:
+        """
+        Get available overlay suggestions for a layer based on its configuration.
+
+        Returns
+        -------
+        :
+            List of (output_name, plotter_name, plotter_title) tuples.
+            Returns empty list if overlays are not applicable.
+        """
+        # Skip for static overlays (no workflow)
+        if config.is_static():
+            return []
+
+        # Get workflow spec
+        workflow_spec = self._deps.workflow_registry.get(config.workflow_id)
+        if workflow_spec is None:
+            return []
+
+        return self._deps.plotting_controller.get_available_overlays(
+            workflow_spec, config.plot_name
+        )
+
+    def _create_overlay_layer(
+        self,
+        base_config: PlotConfig,
+        view_name: str,
+        plotter_name: str,
+    ) -> None:
+        """
+        Create an overlay layer inheriting configuration from a base layer.
+
+        Parameters
+        ----------
+        base_config
+            Configuration of the base layer (e.g., image layer).
+        view_name
+            Name of the output view for the overlay (e.g., 'roi_rectangle').
+        plotter_name
+            Name of the plotter to use for the overlay.
+        """
+        # Get default params for the plotter
+        spec = self._deps.plotting_controller.get_spec(plotter_name)
+        params = spec.params() if spec.params else None
+
+        # Create PlotConfig inheriting workflow/sources from base layer
+        overlay_config = PlotConfig(
+            data_sources={
+                PRIMARY: DataSourceConfig(
+                    workflow_id=base_config.workflow_id,
+                    source_names=list(base_config.source_names),
+                    view_name=view_name,
+                )
+            },
+            plot_name=plotter_name,
+            params=params,
+        )
+
+        self._deps.orchestrator.add_layer(self._cell_id, overlay_config)
+
+    def _build_layer_toolbars(
+        self,
+        layer_states: dict[LayerId, LayerStateMachine],
+    ) -> list[pn.Row | pn.Column]:
+        """
+        Create per-layer toolbars (title + gear/close) for all layers in the cell.
+
+        Parameters
+        ----------
+        layer_states
+            Per-layer runtime state from PlotDataService.
+
+        Returns
+        -------
+        :
+            List of toolbar widgets, one per layer.
+        """
+        toolbars = []
+        for layer in self._cell.layers:
+            layer_id = layer.layer_id
+            config = layer.config
+            state = layer_states[layer_id]
+
+            # Get display info for this layer
+            title, description = get_plot_cell_display_info(
+                config,
+                self._deps.workflow_registry,
+                get_source_title=self._deps.orchestrator.get_source_title,
+            )
+
+            # Add state info to description using explicit state enum
+            stopped = False
+            match state.state:
+                case LayerState.ERROR:
+                    description = f"{description}\n\nError: {state.error_message}"
+                case LayerState.STOPPED:
+                    stopped = True
+                    description = f"{description}\n\nStatus: Workflow ended"
+                case LayerState.WAITING_FOR_DATA:
+                    description = f"{description}\n\nStatus: Waiting for data..."
+                case LayerState.WAITING_FOR_JOB:
+                    description = f"{description}\n\nStatus: Waiting for workflow"
+                case LayerState.READY:
+                    pass  # No extra description for ready state
+
+            def make_close_callback(lid: LayerId) -> Callable[[], None]:
+                def on_close() -> None:
+                    self._deps.orchestrator.remove_layer(lid)
+
+                return on_close
+
+            def make_gear_callback(lid: LayerId) -> Callable[[], None]:
+                def on_gear() -> None:
+                    self._deps.on_reconfigure_layer(lid)
+
+                return on_gear
+
+            time_pane = create_layer_time_pane()
+            self._layer_time_panes[layer_id] = time_pane
+
+            toolbar = create_layer_toolbar(
+                on_gear_callback=make_gear_callback(layer_id),
+                on_close_callback=make_close_callback(layer_id),
+                title=title,
+                description=description,
+                stopped=stopped,
+                time_pane=time_pane,
+            )
+            toolbars.append(toolbar)
+
+        return toolbars
+
+    def _build_placeholder(
+        self,
+        layer_states: dict[LayerId, LayerStateMachine],
+    ) -> pn.pane.Markdown:
+        """
+        Create placeholder content showing layer status.
+
+        Parameters
+        ----------
+        layer_states
+            Per-layer runtime state from PlotDataService.
+
+        Returns
+        -------
+        :
+            Markdown pane showing status for all layers.
+        """
+        # Build status info for each layer
+        status_lines = []
+        for layer in self._cell.layers:
+            config = layer.config
+            state = layer_states[layer.layer_id]
+
+            workflow_title, output_title = get_workflow_display_info(
+                self._deps.workflow_registry, config.workflow_id, config.view_name
+            )
+
+            # Determine status from explicit state enum
+            match state.state:
+                case LayerState.ERROR:
+                    error_text = state.error_message or "Unknown error"
+                    status = f"Error: {extract_error_summary(error_text)}"
+                    text_color = StatusColors.ERROR
+                case LayerState.STOPPED:
+                    status = "Workflow ended"
+                    text_color = Colors.TEXT
+                case LayerState.WAITING_FOR_DATA:
+                    status = "Waiting for data..."
+                    text_color = Colors.TEXT_MUTED
+                case LayerState.WAITING_FOR_JOB:
+                    status = "Waiting for workflow..."
+                    text_color = Colors.TEXT_MUTED
+                case LayerState.READY:
+                    # Defensive: READY should have displayable plot and not
+                    # reach placeholder. Log if this happens.
+                    logger.warning(
+                        "Layer %s in READY state but showing placeholder",
+                        layer.layer_id,
+                    )
+                    status = "Ready (loading...)"
+                    text_color = Colors.TEXT_MUTED
+
+            status_lines.append(
+                f"**{workflow_title} → {output_title}**: "
+                f"<span style='color: {text_color}'>{status}</span>"
+            )
+
+        content = "\n\n".join(status_lines)
+
+        return pn.pane.Markdown(
+            content,
+            styles={'text-align': 'left', 'padding': '20px'},
+        )
+
+    def _build_plot_content(
+        self,
+        plot: hv.DynamicMap | hv.Element | hv.Overlay,
+    ) -> pn.pane.HoloViews:
+        """
+        Create plot content widget.
+
+        Parameters
+        ----------
+        plot
+            The composed plot.
+
+        Returns
+        -------
+        :
+            HoloViews pane containing the plot.
+        """
+        # Use sizing mode from first layer (they should be consistent for overlay)
+        if self._cell.layers:
+            sizing_mode = _get_sizing_mode(self._cell.layers[0].config)
+        else:
+            sizing_mode = 'stretch_both'
+
+        # Use .layout to preserve widgets for DynamicMaps with kdims.
+        # When pn.pane.HoloViews wraps a DynamicMap with kdims, it generates
+        # widgets. However, these widgets don't render when the pane is placed
+        # in a Panel layout (Tabs, Column, etc.). The .layout property contains
+        # both the plot and widgets, which renders correctly in layouts.
+        # See: https://github.com/holoviz/panel/issues/5628
+        #
+        # CRITICAL: Use linked_axes=False to prevent unintended axis linking (#607)
+        #
+        # Problem: By default, Panel's HoloViews pane links axes across different
+        # plots based on their axis labels (e.g., all plots with 'x' and 'y' axes
+        # get linked). For detector panels in different grid cells, this is unwanted:
+        # - Different detector panels have independent spatial coordinates
+        # - Zooming one panel shouldn't affect others
+        # - Each panel needs independent autoscaling
+        #
+        # Previous workarounds and why they failed:
+        # - shared_axes=False (HoloViews): Breaks dynamic features that rely on
+        #   shared axis infrastructure
+        # - Wrapping in hv.Layout: Prevents multi-layer composition with hv.Overlay,
+        #   which was needed for the layer system (#606)
+        #
+        # Solution: linked_axes=False on the Panel pane
+        # - Disables Panel's cross-plot axis linking while preserving HoloViews
+        #   features (autoscaling, dynamic updates)
+        # - Allows proper multi-layer composition via hv.Overlay
+        # - Each grid cell's plot remains independent
+        plot_pane_wrapper = pn.pane.HoloViews(
+            plot, sizing_mode=sizing_mode, linked_axes=False
+        )
+        return plot_pane_wrapper.layout
+
+    def _compose_plot(self) -> hv.DynamicMap | hv.Element | None:
+        """
+        Compose the cell's plot from session-local DynamicMaps or static elements.
+
+        Ensures session components exist when data is available. Sets a
+        descriptive SaveTool filename on the result so that browser "Save"
+        downloads get a meaningful name, and builds the cell's autoscale
+        controller as a side effect.
+
+        Returns
+        -------
+        :
+            Composed plot from session DMaps/elements, or None if none available.
+        """
+        plots = []
+        has_layout = False
+        cell_plotters: list = []
+        for layer in self._cell.layers:
+            layer_id = layer.layer_id
+            session_layer = self._deps.session_layers.get(layer_id)
+            if session_layer is None:
+                continue
+
+            # Ensure components exist if data is now available
+            state = self._deps.plot_data_service.get(layer_id)
+            if state is not None:
+                session_layer.ensure_components(state)
+                # Static overlays (vlines/hlines/rectangles) are not Plotters
+                # and carry no autoscale axes; exclude them from the controller.
+                if state.plotter is not None and not layer.config.is_static():
+                    cell_plotters.append(state.plotter)
+
+            dmap = session_layer.dmap
+            if dmap is not None:
+                # Check the DynamicMap's resolved type (set after Bokeh
+                # renders it) and the plotter's cached state.  Either
+                # being a Layout means hooks must be skipped.
+                if isinstance(dmap, hv.DynamicMap) and dmap.type is hv.Layout:
+                    has_layout = True
+                elif (
+                    state is not None
+                    and state.plotter is not None
+                    and isinstance(state.plotter.get_cached_state(), hv.Layout)
+                ):
+                    has_layout = True
+                plots.append(dmap)
+
+        if not plots:
+            return None
+
+        result: hv.DynamicMap | hv.Element
+        if len(plots) == 1:
+            result = plots[0]
+        else:
+            # Collate so hooks survive for any number of DynamicMap layers.
+            # Without collation, HoloViews drops overlay-level opts (including
+            # hooks) when an Overlay contains 3+ DynamicMaps.  Collating first
+            # produces a single DynamicMap whose outputs are plain Overlays;
+            # opts applied afterwards land on the OverlayPlot and persist.
+            result = hv.Overlay(plots).collate()
+
+        # Skip hooks for Layouts — each sub-figure has its own SaveTool,
+        # so a single cell-level filename is not meaningful.
+        if has_layout:
+            return result
+
+        hooks: list = []
+        filename = build_save_filename_from_cell(
+            self._cell,
+            self._deps.workflow_registry,
+            self._deps.orchestrator.get_source_title,
+        )
+        if filename is not None:
+            hooks.append(make_save_filename_hook(filename))
+        if self._cell.layers:
+            params = self._cell.layers[0].config.params
+            if hasattr(params, 'plot_aspect'):
+                aspect_hook = make_frame_aspect_hook_from_config(params.plot_aspect)
+                if aspect_hook is not None:
+                    hooks.append(aspect_hook)
+        # Fresh controller on every cell rebuild: keeps tools and toggle state
+        # local to this session's Bokeh document. The previous cell widget's
+        # controller is disposed by the owner after the swap, breaking its
+        # on_change reference cycle (would otherwise leak across the session).
+        controller = build_controller_from_layers(cell_plotters)
+        if controller is not None:
+            self._autoscale_controller = controller
+            hooks.append(controller.make_hook())
+        if hooks:
+            result = result.opts(hooks=hooks)
+
+        return result

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -81,11 +81,17 @@ def _get_sizing_mode(config: PlotConfig) -> str:
     return 'stretch_both'
 
 
+# Lag thresholds in seconds (now minus the oldest data's end time) that
+# classify data freshness for the titlebar pill.
+_FRESH_MAX_SECONDS = 5.0
+_STALE_MAX_SECONDS = 30.0
+
+
 def _freshness_band(lag_seconds: float) -> tuple[str, str, str]:
     """Return the ``(background, text, dot)`` pill colors for a lag in seconds."""
-    if lag_seconds < FreshnessPill.FRESH_MAX_SECONDS:
+    if lag_seconds < _FRESH_MAX_SECONDS:
         return FreshnessPill.FRESH
-    if lag_seconds < FreshnessPill.STALE_MAX_SECONDS:
+    if lag_seconds < _STALE_MAX_SECONDS:
         return FreshnessPill.STALE
     return FreshnessPill.OLD
 

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -44,7 +44,7 @@ from ..session_layer import SessionLayer
 from .plot_grid import GridCellStyles
 from .plot_widgets import (
     create_cell_titlebar,
-    create_layer_toolbar,
+    create_layer_info_row,
     derive_cell_title,
     get_plot_cell_display_info,
     get_workflow_display_info,
@@ -384,6 +384,18 @@ class CellWidget:
             )
         )
 
+        configure_layers = [
+            (
+                layer.layer_id,
+                get_plot_cell_display_info(
+                    layer.config,
+                    self._deps.workflow_registry,
+                    get_source_title=self._deps.orchestrator.get_source_title,
+                )[0],
+            )
+            for layer in cell.layers
+        ]
+
         def on_edit_title() -> None:
             self._deps.on_edit_title(self._cell_id, title, has_user_title)
 
@@ -395,6 +407,8 @@ class CellWidget:
             title=title,
             has_user_title=has_user_title,
             on_edit_title_callback=on_edit_title,
+            configure_layers=configure_layers,
+            on_configure_layer=self._deps.on_reconfigure_layer,
             toolbars_visible=self._toolbars_shown,
             on_toggle_toolbars_callback=on_toggle_toolbars,
             freshness_pane=self._freshness_pane,
@@ -405,7 +419,7 @@ class CellWidget:
         layer_states: dict[LayerId, LayerStateMachine],
     ) -> list[pn.Row | pn.Column]:
         """
-        Create per-layer toolbars (title + gear/close) for all layers in the cell.
+        Create per-layer info rows (title + time range) for the cell's layers.
 
         Parameters
         ----------
@@ -415,9 +429,9 @@ class CellWidget:
         Returns
         -------
         :
-            List of toolbar widgets, one per layer.
+            List of info-row widgets, one per layer.
         """
-        toolbars = []
+        rows = []
         for layer in self._cell.layers:
             layer_id = layer.layer_id
             config = layer.config
@@ -445,25 +459,19 @@ class CellWidget:
                 case LayerState.READY:
                     pass  # No extra description for ready state
 
-            def make_gear_callback(lid: LayerId) -> Callable[[], None]:
-                def on_gear() -> None:
-                    self._deps.on_reconfigure_layer(lid)
-
-                return on_gear
-
             time_pane = create_layer_time_pane()
             self._layer_time_panes[layer_id] = time_pane
 
-            toolbar = create_layer_toolbar(
-                on_gear_callback=make_gear_callback(layer_id),
-                title=title,
-                description=description,
-                stopped=stopped,
-                time_pane=time_pane,
+            rows.append(
+                create_layer_info_row(
+                    title=title,
+                    description=description,
+                    stopped=stopped,
+                    time_pane=time_pane,
+                )
             )
-            toolbars.append(toolbar)
 
-        return toolbars
+        return rows
 
     def _build_placeholder(
         self,

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -27,13 +27,11 @@ from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
 from ess.livedata.core.timestamp import Timestamp
 
 from ..cell_autoscale import CellAutoscaleController, build_controller_from_layers
-from ..data_roles import PRIMARY
 from ..format_utils import extract_error_summary
 from ..frame_aspect import make_frame_aspect_hook_from_config
 from ..plot_data_service import LayerState, LayerStateMachine, PlotDataService
 from ..plot_orchestrator import (
     CellId,
-    DataSourceConfig,
     LayerId,
     PlotCell,
     PlotConfig,
@@ -41,7 +39,6 @@ from ..plot_orchestrator import (
 )
 from ..plot_params import PlotAspectType, StretchMode
 from ..plots import TimeBounds, format_time_info, merge_time_bounds
-from ..plotting_controller import PlottingController
 from ..save_filename import build_save_filename_from_cell, make_save_filename_hook
 from ..session_layer import SessionLayer
 from .plot_grid import GridCellStyles
@@ -192,11 +189,9 @@ class CellDeps:
 
     orchestrator: PlotOrchestrator
     workflow_registry: Mapping[WorkflowId, WorkflowSpec]
-    plotting_controller: PlottingController
     plot_data_service: PlotDataService
     session_layers: dict[LayerId, SessionLayer]
     on_edit_title: Callable[[CellId, str, bool], None]
-    on_add_layer: Callable[[CellId], None]
     on_reconfigure_layer: Callable[[LayerId], None]
 
 
@@ -389,34 +384,12 @@ class CellWidget:
             )
         )
 
-        # Union of overlay suggestions across all layers, excluding plotters
-        # already present in the cell. Each suggestion remembers the source
-        # layer's config so the overlay inherits the right workflow/sources.
-        existing_plotter_names = {layer.config.plot_name for layer in cell.layers}
-        overlay_specs: list[tuple[str, str, str]] = []
-        overlay_sources: dict[tuple[str, str], PlotConfig] = {}
-        for layer in cell.layers:
-            for spec in self._available_overlays(layer.config):
-                output_name, plotter_name, _ = spec
-                key = (output_name, plotter_name)
-                if plotter_name in existing_plotter_names or key in overlay_sources:
-                    continue
-                overlay_sources[key] = layer.config
-                overlay_specs.append(spec)
-
         def on_edit_title() -> None:
             self._deps.on_edit_title(self._cell_id, title, has_user_title)
 
         def on_toggle_toolbars(visible: bool) -> None:
             self._toolbars_shown = visible
             layers_column.visible = visible
-
-        def on_add() -> None:
-            self._deps.on_add_layer(self._cell_id)
-
-        def on_overlay(view_name: str, plotter_name: str) -> None:
-            source_config = overlay_sources[(view_name, plotter_name)]
-            self._create_overlay_layer(source_config, view_name, plotter_name)
 
         return create_cell_titlebar(
             title=title,
@@ -425,70 +398,7 @@ class CellWidget:
             toolbars_visible=self._toolbars_shown,
             on_toggle_toolbars_callback=on_toggle_toolbars,
             freshness_pane=self._freshness_pane,
-            on_add_callback=on_add,
-            on_overlay_selected=on_overlay,
-            available_overlays=overlay_specs,
         )
-
-    def _available_overlays(self, config: PlotConfig) -> list[tuple[str, str, str]]:
-        """
-        Get available overlay suggestions for a layer based on its configuration.
-
-        Returns
-        -------
-        :
-            List of (output_name, plotter_name, plotter_title) tuples.
-            Returns empty list if overlays are not applicable.
-        """
-        # Skip for static overlays (no workflow)
-        if config.is_static():
-            return []
-
-        # Get workflow spec
-        workflow_spec = self._deps.workflow_registry.get(config.workflow_id)
-        if workflow_spec is None:
-            return []
-
-        return self._deps.plotting_controller.get_available_overlays(
-            workflow_spec, config.plot_name
-        )
-
-    def _create_overlay_layer(
-        self,
-        base_config: PlotConfig,
-        view_name: str,
-        plotter_name: str,
-    ) -> None:
-        """
-        Create an overlay layer inheriting configuration from a base layer.
-
-        Parameters
-        ----------
-        base_config
-            Configuration of the base layer (e.g., image layer).
-        view_name
-            Name of the output view for the overlay (e.g., 'roi_rectangle').
-        plotter_name
-            Name of the plotter to use for the overlay.
-        """
-        # Get default params for the plotter
-        spec = self._deps.plotting_controller.get_spec(plotter_name)
-        params = spec.params() if spec.params else None
-
-        # Create PlotConfig inheriting workflow/sources from base layer
-        overlay_config = PlotConfig(
-            data_sources={
-                PRIMARY: DataSourceConfig(
-                    workflow_id=base_config.workflow_id,
-                    source_names=list(base_config.source_names),
-                    view_name=view_name,
-                )
-            },
-            plot_name=plotter_name,
-            params=params,
-        )
-
-        self._deps.orchestrator.add_layer(self._cell_id, overlay_config)
 
     def _build_layer_toolbars(
         self,
@@ -535,12 +445,6 @@ class CellWidget:
                 case LayerState.READY:
                     pass  # No extra description for ready state
 
-            def make_close_callback(lid: LayerId) -> Callable[[], None]:
-                def on_close() -> None:
-                    self._deps.orchestrator.remove_layer(lid)
-
-                return on_close
-
             def make_gear_callback(lid: LayerId) -> Callable[[], None]:
                 def on_gear() -> None:
                     self._deps.on_reconfigure_layer(lid)
@@ -552,7 +456,6 @@ class CellWidget:
 
             toolbar = create_layer_toolbar(
                 on_gear_callback=make_gear_callback(layer_id),
-                on_close_callback=make_close_callback(layer_id),
                 title=title,
                 description=description,
                 stopped=stopped,

--- a/src/ess/livedata/dashboard/widgets/cell_properties_modal.py
+++ b/src/ess/livedata/dashboard/widgets/cell_properties_modal.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""
+Cell-properties modal: rename a cell and edit its layer composition.
+
+Opened from the cell titlebar's edit (pencil) button. Rename is the only field
+saved on "Save"; add/remove act immediately, so the modal doubles as the cell's
+layer-composition editor:
+
+- a cell-level "Add layer…" button hands off to the plot config modal (a new,
+  independent layer);
+- each layer row has a ``+`` offering overlays derived from that layer (added in
+  place, keeping the modal open) and an ``x`` to remove it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+import panel as pn
+
+from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
+
+from ..data_roles import PRIMARY
+from ..plot_orchestrator import (
+    CellId,
+    DataSourceConfig,
+    LayerId,
+    PlotConfig,
+    PlotOrchestrator,
+)
+from ..plotting_controller import PlottingController
+from .buttons import ButtonStyles, create_tool_button
+from .plot_widgets import (
+    create_overlay_add_button,
+    get_plot_cell_display_info,
+    overlay_suggestions_for_layer,
+)
+
+
+class CellPropertiesModal:
+    """
+    Modal for renaming a cell and editing its layers.
+
+    Builds a ``pn.Modal`` (exposed as :attr:`modal`) for the owner to place in
+    its shared modal container and :meth:`show`. The two outward interactions
+    are passed as callbacks: ``on_add_layer`` hands the "Add layer…" flow back
+    to the owner (which opens the plot config modal in the shared container),
+    and ``on_close`` tears down the container on Save/Cancel/remove-last.
+
+    Parameters
+    ----------
+    orchestrator:
+        Orchestrator owning the cell; mutated directly by add/remove/rename.
+    workflow_registry:
+        Registry mapping workflow IDs to specs, for layer display titles.
+    plotting_controller:
+        Controller providing overlay suggestions and plotter specs.
+    cell_id:
+        ID of the cell to edit.
+    current_title:
+        The currently displayed title (user-defined or derived).
+    has_user_title:
+        Whether ``current_title`` is user-defined; if not, the input starts
+        empty so the placeholder hints at the derived fallback.
+    on_add_layer:
+        Invoked with the cell ID to open the add-layer config modal. The
+        properties modal closes itself first (the owner reuses the container).
+    on_close:
+        Invoked to tear down the shared container after the modal closes.
+    """
+
+    def __init__(
+        self,
+        *,
+        orchestrator: PlotOrchestrator,
+        workflow_registry: Mapping[WorkflowId, WorkflowSpec],
+        plotting_controller: PlottingController,
+        cell_id: CellId,
+        current_title: str,
+        has_user_title: bool,
+        on_add_layer: Callable[[CellId], None],
+        on_close: Callable[[], None],
+    ) -> None:
+        self._orchestrator = orchestrator
+        self._workflow_registry = workflow_registry
+        self._plotting_controller = plotting_controller
+        self._cell_id = cell_id
+        self._on_add_layer = on_add_layer
+        self._on_close = on_close
+        self._cell = orchestrator.get_cell(cell_id)
+        self._done = False
+
+        self._text = pn.widgets.TextInput(
+            value=current_title if has_user_title else '',
+            label='Cell title',
+            placeholder='Leave empty to use the derived title',
+            sizing_mode='stretch_width',
+        )
+        self._layers_col = pn.Column(sizing_mode='stretch_width')
+        self.modal = self._build()
+        self._render_layers()
+
+    def show(self) -> None:
+        """Open the modal."""
+        self.modal.open = True
+
+    def _build(self) -> pn.Modal:
+        add_layer_button = pn.widgets.Button(name='Add layer…', button_type='default')
+        add_layer_button.on_click(lambda _: self._on_add())
+        save_button = pn.widgets.Button(name='Save', button_type='primary')
+        save_button.on_click(lambda _: self._finish(save=True))
+        cancel_button = pn.widgets.Button(name='Cancel')
+        cancel_button.on_click(lambda _: self._finish(save=False))
+
+        modal = pn.Modal(
+            pn.Column(
+                pn.pane.Markdown('### Cell properties', margin=(0, 0, 5, 0)),
+                pn.pane.Markdown('#### Header', margin=(0, 0, 0, 0)),
+                self._text,
+                pn.pane.Markdown('#### Layers', margin=(10, 0, 0, 0)),
+                pn.Row(add_layer_button, pn.Spacer(sizing_mode='stretch_width')),
+                self._layers_col,
+                pn.Row(
+                    pn.Spacer(sizing_mode='stretch_width'),
+                    cancel_button,
+                    save_button,
+                    margin=(10, 0, 0, 0),
+                ),
+                sizing_mode='stretch_width',
+            ),
+            margin=20,
+            width=480,
+        )
+        # Closing via the X button or ESC cancels.
+        modal.param.watch(
+            lambda event: None if event.new else self._finish(save=False), 'open'
+        )
+        return modal
+
+    def _persist_title(self) -> None:
+        new_title = (self._text.value_input or '').strip() or None
+        self._orchestrator.set_cell_title(self._cell_id, new_title)
+
+    def _close(self) -> None:
+        self._done = True
+        self.modal.open = False
+        self._on_close()
+
+    def _finish(self, *, save: bool) -> None:
+        if self._done:
+            return
+        if save:
+            self._persist_title()
+        self._close()
+
+    def _on_add(self) -> None:
+        if self._done:
+            return
+        self._persist_title()
+        # Hand off to the owner's add-layer flow, which reuses the container.
+        self._done = True
+        self.modal.open = False
+        self._on_add_layer(self._cell_id)
+
+    def _on_remove(self, layer_id: LayerId) -> None:
+        # ``remove_layer`` mutates the shared ``cell.layers`` in place, and
+        # removes the whole cell once its last layer is gone.
+        self._orchestrator.remove_layer(layer_id)
+        if not self._cell.layers:
+            self._close()
+        else:
+            # Per-layer overlay suggestions depend on the remaining layers.
+            self._render_layers()
+
+    def _on_add_overlay(
+        self, view_name: str, plotter_name: str, base_config: PlotConfig
+    ) -> None:
+        if self._done:
+            return
+        # Add in place and keep the modal open so several overlays can be added
+        # in one session; the new layer appears as its own row.
+        self._add_overlay_layer(base_config, view_name, plotter_name)
+        self._render_layers()
+
+    def _add_overlay_layer(
+        self, base_config: PlotConfig, view_name: str, plotter_name: str
+    ) -> None:
+        spec = self._plotting_controller.get_spec(plotter_name)
+        params = spec.params() if spec.params else None
+        overlay_config = PlotConfig(
+            data_sources={
+                PRIMARY: DataSourceConfig(
+                    workflow_id=base_config.workflow_id,
+                    source_names=list(base_config.source_names),
+                    view_name=view_name,
+                )
+            },
+            plot_name=plotter_name,
+            params=params,
+        )
+        self._orchestrator.add_layer(self._cell_id, overlay_config)
+
+    def _render_layers(self) -> None:
+        existing = frozenset(layer.config.plot_name for layer in self._cell.layers)
+        rows: list = []
+        for layer in self._cell.layers:
+            title, _ = get_plot_cell_display_info(
+                layer.config,
+                self._workflow_registry,
+                get_source_title=self._orchestrator.get_source_title,
+            )
+            controls: list = []
+            overlays = overlay_suggestions_for_layer(
+                layer.config,
+                existing,
+                self._workflow_registry,
+                self._plotting_controller,
+            )
+            if overlays:
+                controls.append(
+                    create_overlay_add_button(
+                        overlays=overlays,
+                        on_overlay_selected=(
+                            lambda v, p, b=layer.config: self._on_add_overlay(v, p, b)
+                        ),
+                    )
+                )
+            controls.append(
+                create_tool_button(
+                    icon_name='x',
+                    button_color=ButtonStyles.DANGER_RED,
+                    hover_color=ButtonStyles.DANGER_HOVER,
+                    on_click_callback=lambda lid=layer.layer_id: self._on_remove(lid),
+                )
+            )
+            title_pane = pn.pane.HTML(
+                title,
+                sizing_mode='stretch_width',
+                align='center',
+                styles={'overflow': 'hidden'},
+            )
+            rows.append(pn.Row(title_pane, *controls, sizing_mode='stretch_width'))
+        self._layers_col[:] = rows

--- a/src/ess/livedata/dashboard/widgets/icons.py
+++ b/src/ess/livedata/dashboard/widgets/icons.py
@@ -132,30 +132,13 @@ _ICONS: dict[str, str] = {
     ),
     # Check (confirm)
     'check': _svg('<path d="M5 12l5 5l10 -10"/>'),
-    # Adjustments/sliders (layer controls visible)
-    'adjustments': _svg(
-        '<path d="M4 10a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
-        '<path d="M6 4v4"/>'
-        '<path d="M6 12v8"/>'
-        '<path d="M10 16a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
-        '<path d="M12 4v10"/>'
-        '<path d="M12 18v2"/>'
-        '<path d="M16 7a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
-        '<path d="M18 4v1"/>'
-        '<path d="M18 9v11"/>'
-    ),
-    # Adjustments off (layer controls hidden): sliders with a diagonal strike
-    'adjustments-off': _svg(
-        '<path d="M4 10a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
-        '<path d="M6 4v4"/>'
-        '<path d="M6 12v8"/>'
-        '<path d="M10 16a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
-        '<path d="M12 4v10"/>'
-        '<path d="M12 18v2"/>'
-        '<path d="M16 7a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
-        '<path d="M18 4v1"/>'
-        '<path d="M18 9v11"/>'
-        '<path d="M3 3l18 18"/>'
+    # Stack (single layer): layer toolbars hidden
+    'stack': _svg('<path d="M12 6l-8 4l8 4l8 -4l-8 -4"/><path d="M4 14l8 4l8 -4"/>'),
+    # Stack-2 (multiple layers): layer toolbars shown
+    'stack-2': _svg(
+        '<path d="M12 4l-8 4l8 4l8 -4l-8 -4"/>'
+        '<path d="M4 12l8 4l8 -4"/>'
+        '<path d="M4 16l8 4l8 -4"/>'
     ),
     # Trash/delete
     'trash': _svg(
@@ -233,12 +216,12 @@ def get_icon(name: str) -> str:
     Parameters
     ----------
     name:
-        Icon name. Available icons: adjustments, adjustments-off,
+        Icon name. Available icons:
         arrows-minimize, autoscale-c, autoscale-c-on, autoscale-x,
         autoscale-x-on, autoscale-y, autoscale-y-on, backspace, check,
         chevron-down, chevron-right, chevron-up, download, eye, eye-off, pencil,
-        player-pause, player-play, player-stop, plus, refresh, settings, trash,
-        x.
+        player-pause, player-play, player-stop, plus, refresh, settings, stack,
+        stack-2, trash, x.
 
     Returns
     -------

--- a/src/ess/livedata/dashboard/widgets/icons.py
+++ b/src/ess/livedata/dashboard/widgets/icons.py
@@ -130,6 +130,33 @@ _ICONS: dict[str, str] = {
         '-.18c3.6 0 6.6 2 9 6c-.666 1.11 -1.379 2.067 -2.138 2.87"/>'
         '<path d="M3 3l18 18"/>'
     ),
+    # Check (confirm)
+    'check': _svg('<path d="M5 12l5 5l10 -10"/>'),
+    # Adjustments/sliders (layer controls visible)
+    'adjustments': _svg(
+        '<path d="M4 10a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
+        '<path d="M6 4v4"/>'
+        '<path d="M6 12v8"/>'
+        '<path d="M10 16a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
+        '<path d="M12 4v10"/>'
+        '<path d="M12 18v2"/>'
+        '<path d="M16 7a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
+        '<path d="M18 4v1"/>'
+        '<path d="M18 9v11"/>'
+    ),
+    # Adjustments off (layer controls hidden): sliders with a diagonal strike
+    'adjustments-off': _svg(
+        '<path d="M4 10a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
+        '<path d="M6 4v4"/>'
+        '<path d="M6 12v8"/>'
+        '<path d="M10 16a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
+        '<path d="M12 4v10"/>'
+        '<path d="M12 18v2"/>'
+        '<path d="M16 7a2 2 0 1 0 4 0a2 2 0 0 0 -4 0"/>'
+        '<path d="M18 4v1"/>'
+        '<path d="M18 9v11"/>'
+        '<path d="M3 3l18 18"/>'
+    ),
     # Trash/delete
     'trash': _svg(
         '<path d="M4 7l16 0"/>'
@@ -206,11 +233,12 @@ def get_icon(name: str) -> str:
     Parameters
     ----------
     name:
-        Icon name. Available icons: arrows-minimize, autoscale-c,
-        autoscale-c-on, autoscale-x, autoscale-x-on, autoscale-y,
-        autoscale-y-on, backspace, chevron-down, chevron-right, chevron-up,
-        download, eye, eye-off, pencil, player-pause, player-play, player-stop,
-        plus, refresh, settings, trash, x.
+        Icon name. Available icons: adjustments, adjustments-off,
+        arrows-minimize, autoscale-c, autoscale-c-on, autoscale-x,
+        autoscale-x-on, autoscale-y, autoscale-y-on, backspace, check,
+        chevron-down, chevron-right, chevron-up, download, eye, eye-off, pencil,
+        player-pause, player-play, player-stop, plus, refresh, settings, trash,
+        x.
 
     Returns
     -------

--- a/src/ess/livedata/dashboard/widgets/plot_grid_manager.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_manager.py
@@ -703,7 +703,9 @@ class PlotGridManager:
             cells_to_add = ()
 
         for cell in cells_to_add:
-            cell_id = self._orchestrator.add_cell(grid_id, cell.geometry)
+            cell_id = self._orchestrator.add_cell(
+                grid_id, cell.geometry, user_title=cell.user_title
+            )
             for layer in cell.layers:
                 self._orchestrator.add_layer(cell_id, layer.config)
 
@@ -939,7 +941,9 @@ class PlotGridManager:
         )
 
         for cell in cells_to_add:
-            cell_id = self._orchestrator.add_cell(new_grid_id, cell.geometry)
+            cell_id = self._orchestrator.add_cell(
+                new_grid_id, cell.geometry, user_title=cell.user_title
+            )
             for layer in cell.layers:
                 self._orchestrator.add_layer(cell_id, layer.config)
 
@@ -954,7 +958,9 @@ class PlotGridManager:
         grid_id = self._orchestrator.add_grid(title=title, nrows=nrows, ncols=ncols)
 
         for cell in cells_to_add:
-            cell_id = self._orchestrator.add_cell(grid_id, cell.geometry)
+            cell_id = self._orchestrator.add_cell(
+                grid_id, cell.geometry, user_title=cell.user_title
+            )
             for layer in cell.layers:
                 self._orchestrator.add_layer(cell_id, layer.config)
 

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -508,12 +508,14 @@ class PlotGridTabs:
             name='Cell title',
             value=current_title if has_user_title else '',
             placeholder='Leave empty to use the derived title',
+            description='Leave empty to use the derived title.',
             sizing_mode='stretch_width',
         )
         save_button = pn.widgets.Button(name='Save', button_type='primary')
         cancel_button = pn.widgets.Button(name='Cancel')
         modal = pn.Modal(
             pn.Column(
+                pn.pane.Markdown('### Configure cell', margin=(0, 0, 5, 0)),
                 text,
                 pn.Row(
                     pn.Spacer(sizing_mode='stretch_width'),
@@ -522,7 +524,7 @@ class PlotGridTabs:
                 ),
                 sizing_mode='stretch_width',
             ),
-            name='Rename cell',
+            name='Configure cell',
             margin=20,
             width=420,
         )

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -17,12 +17,10 @@ import structlog
 
 from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
 
-from ..data_roles import PRIMARY
 from ..plot_data_service import PlotDataService
 from ..plot_orchestrator import (
     CellGeometry,
     CellId,
-    DataSourceConfig,
     GridId,
     LayerId,
     PlotCell,
@@ -34,16 +32,11 @@ from ..plot_orchestrator import (
 from ..plots import TimeBounds
 from ..session_layer import SessionLayer
 from ..session_updater import SessionUpdater
-from .buttons import ButtonStyles, create_tool_button
 from .cell import CellDeps, CellWidget
+from .cell_properties_modal import CellPropertiesModal
 from .plot_config_modal import PlotConfigModal
 from .plot_grid import PlotGrid
 from .plot_grid_manager import PlotGridManager
-from .plot_widgets import (
-    create_overlay_add_button,
-    get_plot_cell_display_info,
-    overlay_suggestions_for_layer,
-)
 from .styles import Colors
 
 logger = structlog.get_logger(__name__)
@@ -448,53 +441,11 @@ class PlotGridTabs:
         self._current_modal = None
         self._modal_container.clear()
 
-    def _add_overlay_layer(
-        self,
-        cell_id: CellId,
-        base_config: PlotConfig,
-        view_name: str,
-        plotter_name: str,
-    ) -> None:
-        """
-        Add an overlay layer inheriting workflow/sources from a base layer.
-
-        Parameters
-        ----------
-        cell_id
-            ID of the cell to add the overlay to.
-        base_config
-            Configuration of the base layer the overlay derives from.
-        view_name
-            Name of the output view for the overlay (e.g., 'roi_rectangle').
-        plotter_name
-            Name of the plotter to use for the overlay.
-        """
-        spec = self._plotting_controller.get_spec(plotter_name)
-        params = spec.params() if spec.params else None
-        overlay_config = PlotConfig(
-            data_sources={
-                PRIMARY: DataSourceConfig(
-                    workflow_id=base_config.workflow_id,
-                    source_names=list(base_config.source_names),
-                    view_name=view_name,
-                )
-            },
-            plot_name=plotter_name,
-            params=params,
-        )
-        self._orchestrator.add_layer(cell_id, overlay_config)
-
     def _show_cell_properties_modal(
         self, cell_id: CellId, current_title: str, has_user_title: bool
     ) -> None:
         """
-        Show the cell-properties modal: rename, add layer, and remove layers.
-
-        Rename is the only field saved on "Save"; add/remove act immediately so
-        the modal doubles as the cell's layer-composition editor. Add layer and
-        add overlay persist any pending title edit, then hand off to the plot
-        config modal (add layer) or add the overlay directly (overlays use
-        plotter defaults).
+        Show the cell-properties modal (rename, add layer, remove layers).
 
         Parameters
         ----------
@@ -506,136 +457,19 @@ class PlotGridTabs:
             Whether ``current_title`` is user-defined; if not, the input starts
             empty so the placeholder hints at the derived fallback.
         """
-        cell = self._orchestrator.get_cell(cell_id)
-        text = pn.widgets.TextInput(
-            value=current_title if has_user_title else '',
-            placeholder='Leave empty to use the derived title',
-            description='Leave empty to use the derived title.',
-            sizing_mode='stretch_width',
+        modal = CellPropertiesModal(
+            orchestrator=self._orchestrator,
+            workflow_registry=self._workflow_registry,
+            plotting_controller=self._plotting_controller,
+            cell_id=cell_id,
+            current_title=current_title,
+            has_user_title=has_user_title,
+            on_add_layer=self._on_add_layer,
+            on_close=self._cleanup_modal,
         )
-        layers_col = pn.Column(sizing_mode='stretch_width')
-        add_layer_button = pn.widgets.Button(name='Add layer…', button_type='default')
-        save_button = pn.widgets.Button(name='Save', button_type='primary')
-        cancel_button = pn.widgets.Button(name='Cancel')
-        heading_margin = (10, 0, 0, 0)
-        modal = pn.Modal(
-            pn.Column(
-                pn.pane.Markdown('### Cell properties', margin=(0, 0, 5, 0)),
-                pn.pane.Markdown('#### Header', margin=(0, 0, 0, 0)),
-                text,
-                pn.pane.Markdown('#### Layers', margin=heading_margin),
-                pn.Row(add_layer_button, pn.Spacer(sizing_mode='stretch_width')),
-                layers_col,
-                pn.Row(
-                    pn.Spacer(sizing_mode='stretch_width'),
-                    cancel_button,
-                    save_button,
-                    margin=(10, 0, 0, 0),
-                ),
-                sizing_mode='stretch_width',
-            ),
-            margin=20,
-            width=480,
-        )
-        done = {'v': False}
-
-        def persist_title() -> None:
-            new_title = (text.value_input or '').strip() or None
-            self._orchestrator.set_cell_title(cell_id, new_title)
-
-        def close() -> None:
-            done['v'] = True
-            modal.open = False
-            self._modal_container.clear()
-
-        def finish(*, save: bool) -> None:
-            if done['v']:
-                return
-            if save:
-                persist_title()
-            close()
-
-        def on_remove(layer_id: LayerId) -> None:
-            # ``remove_layer`` mutates the shared ``cell.layers`` in place, and
-            # removes the whole cell once its last layer is gone.
-            self._orchestrator.remove_layer(layer_id)
-            if not cell.layers:
-                close()
-            else:
-                # Per-layer overlay suggestions depend on the remaining layers.
-                render_layers()
-
-        def on_add() -> None:
-            if done['v']:
-                return
-            persist_title()
-            close()
-            self._on_add_layer(cell_id)
-
-        def on_add_overlay(
-            view_name: str, plotter_name: str, base_config: PlotConfig
-        ) -> None:
-            if done['v']:
-                return
-            # Add in place and keep the modal open so several overlays can be
-            # added in one session; the new layer appears as its own row.
-            self._add_overlay_layer(cell_id, base_config, view_name, plotter_name)
-            render_layers()
-
-        def render_layers() -> None:
-            existing = frozenset(layer.config.plot_name for layer in cell.layers)
-            rows: list = []
-            for layer in cell.layers:
-                title, _ = get_plot_cell_display_info(
-                    layer.config,
-                    self._workflow_registry,
-                    get_source_title=self._orchestrator.get_source_title,
-                )
-                controls: list = []
-                overlays = overlay_suggestions_for_layer(
-                    layer.config,
-                    existing,
-                    self._workflow_registry,
-                    self._plotting_controller,
-                )
-                if overlays:
-                    controls.append(
-                        create_overlay_add_button(
-                            overlays=overlays,
-                            on_overlay_selected=(
-                                lambda v, p, b=layer.config: on_add_overlay(v, p, b)
-                            ),
-                        )
-                    )
-                controls.append(
-                    create_tool_button(
-                        icon_name='x',
-                        button_color=ButtonStyles.DANGER_RED,
-                        hover_color=ButtonStyles.DANGER_HOVER,
-                        on_click_callback=lambda lid=layer.layer_id: on_remove(lid),
-                    )
-                )
-                title_pane = pn.pane.HTML(
-                    title,
-                    sizing_mode='stretch_width',
-                    align='center',
-                    styles={'overflow': 'hidden'},
-                )
-                rows.append(pn.Row(title_pane, *controls, sizing_mode='stretch_width'))
-            layers_col[:] = rows
-
-        add_layer_button.on_click(lambda _: on_add())
-        render_layers()
-        save_button.on_click(lambda _: finish(save=True))
-        cancel_button.on_click(lambda _: finish(save=False))
-        # Closing via the X button or ESC cancels.
-        modal.param.watch(
-            lambda event: None if event.new else finish(save=False), 'open'
-        )
-
         self._modal_container.clear()
-        self._modal_container.append(modal)
-        modal.open = True
+        self._modal_container.append(modal.modal)
+        modal.show()
 
     def _on_cell_updated(
         self,

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -43,7 +43,9 @@ from .plot_config_modal import PlotConfigModal
 from .plot_grid import GridCellStyles, PlotGrid
 from .plot_grid_manager import PlotGridManager
 from .plot_widgets import (
-    create_cell_toolbar,
+    create_cell_titlebar,
+    create_layer_toolbar,
+    derive_cell_title,
     get_plot_cell_display_info,
     get_workflow_display_info,
 )
@@ -146,6 +148,13 @@ class PlotGridTabs:
 
         # Per-session layer state: version tracking and optional render components.
         self._session_layers: dict[LayerId, SessionLayer] = {}
+
+        # Per-session, per-cell display preference: cells whose layer toolbars
+        # are shown. Layer toolbars are hidden by default; this set tracks the
+        # cells the user has revealed. Purely local UI state (not persisted, not
+        # cross-session); re-applied on cell rebuild so it survives version
+        # polling.
+        self._toolbars_shown: set[CellId] = set()
 
         # Per-session, per-cell autoscale controllers. Lifetime tracks the
         # cell composition: each rebuild creates a fresh controller whose
@@ -462,6 +471,67 @@ class PlotGridTabs:
         self._current_modal = None
         self._modal_container.clear()
 
+    def _show_rename_modal(
+        self, cell_id: CellId, current_title: str, has_user_title: bool
+    ) -> None:
+        """
+        Show a small modal to set or clear the user-defined cell title.
+
+        Parameters
+        ----------
+        cell_id
+            ID of the cell to rename.
+        current_title
+            The currently displayed title (user-defined or derived).
+        has_user_title
+            Whether ``current_title`` is user-defined; if not, the input starts
+            empty so the placeholder hints at the derived fallback.
+        """
+        text = pn.widgets.TextInput(
+            name='Cell title',
+            value=current_title if has_user_title else '',
+            placeholder='Leave empty to use the derived title',
+            sizing_mode='stretch_width',
+        )
+        save_button = pn.widgets.Button(name='Save', button_type='primary')
+        cancel_button = pn.widgets.Button(name='Cancel')
+        modal = pn.Modal(
+            pn.Column(
+                text,
+                pn.Row(
+                    pn.Spacer(sizing_mode='stretch_width'),
+                    cancel_button,
+                    save_button,
+                ),
+                sizing_mode='stretch_width',
+            ),
+            name='Rename cell',
+            margin=20,
+            width=420,
+        )
+        done = {'v': False}
+
+        def finish(*, save: bool) -> None:
+            if done['v']:
+                return
+            done['v'] = True
+            if save:
+                new_title = (text.value_input or '').strip() or None
+                self._orchestrator.set_cell_title(cell_id, new_title)
+            modal.open = False
+            self._modal_container.clear()
+
+        save_button.on_click(lambda _: finish(save=True))
+        cancel_button.on_click(lambda _: finish(save=False))
+        # Closing via the X button or ESC cancels.
+        modal.param.watch(
+            lambda event: None if event.new else finish(save=False), 'open'
+        )
+
+        self._modal_container.clear()
+        self._modal_container.append(modal)
+        modal.open = True
+
     def _on_cell_updated(
         self,
         *,
@@ -619,8 +689,15 @@ class PlotGridTabs:
         # Get layer states from PlotDataService
         layer_states = self._get_layer_states(cell)
 
-        # Create toolbars for all layers
-        toolbars = self._create_layer_toolbars(cell_id, cell, layer_states)
+        # Per-layer toolbars, wrapped in a column the titlebar toggle can hide.
+        layer_toolbars = self._create_layer_toolbars(cell, layer_states)
+        layers_column = pn.Column(
+            *layer_toolbars,
+            sizing_mode='stretch_width',
+            margin=0,
+            visible=cell_id in self._toolbars_shown,
+        )
+        titlebar = self._create_cell_titlebar(cell_id, cell, layers_column)
 
         # Create content area (placeholder or plot)
         if plot is not None:
@@ -647,7 +724,8 @@ class PlotGridTabs:
             styles['border'] = border
 
         return pn.Column(
-            *toolbars,
+            titlebar,
+            layers_column,
             content,
             sizing_mode='stretch_both',
             styles=styles,
@@ -724,19 +802,94 @@ class PlotGridTabs:
 
         self._orchestrator.add_layer(cell_id, overlay_config)
 
-    def _create_layer_toolbars(
+    def _create_cell_titlebar(
         self,
         cell_id: CellId,
         cell: PlotCell,
-        layer_states: dict[LayerId, LayerStateMachine],
-    ) -> list[pn.Row]:
+        layers_column: pn.Column,
+    ) -> pn.Row:
         """
-        Create toolbars for all layers in a cell.
+        Create the cell-level titlebar (title, add layer, rename, toolbar toggle).
 
         Parameters
         ----------
         cell_id
             ID of the cell.
+        cell
+            Plot cell with layers.
+        layers_column
+            The column wrapping the per-layer toolbars, whose visibility the
+            toggle button controls.
+
+        Returns
+        -------
+        :
+            Titlebar Row widget.
+        """
+        has_user_title = cell.user_title is not None
+        title = (
+            cell.user_title
+            if has_user_title
+            else derive_cell_title(
+                cell,
+                self._workflow_registry,
+                get_source_title=self._orchestrator.get_source_title,
+            )
+        )
+
+        # Union of overlay suggestions across all layers, excluding plotters
+        # already present in the cell. Each suggestion remembers the source
+        # layer's config so the overlay inherits the right workflow/sources.
+        existing_plotter_names = {layer.config.plot_name for layer in cell.layers}
+        overlay_specs: list[tuple[str, str, str]] = []
+        overlay_sources: dict[tuple[str, str], PlotConfig] = {}
+        for layer in cell.layers:
+            for spec in self._get_available_overlays_for_layer(layer.config):
+                output_name, plotter_name, _ = spec
+                key = (output_name, plotter_name)
+                if plotter_name in existing_plotter_names or key in overlay_sources:
+                    continue
+                overlay_sources[key] = layer.config
+                overlay_specs.append(spec)
+
+        def on_edit_title() -> None:
+            self._show_rename_modal(cell_id, title, has_user_title)
+
+        def on_toggle_toolbars(visible: bool) -> None:
+            if visible:
+                self._toolbars_shown.add(cell_id)
+            else:
+                self._toolbars_shown.discard(cell_id)
+            layers_column.visible = visible
+
+        def on_add() -> None:
+            self._on_add_layer(cell_id)
+
+        def on_overlay(view_name: str, plotter_name: str) -> None:
+            source_config = overlay_sources[(view_name, plotter_name)]
+            self._create_overlay_layer(cell_id, source_config, view_name, plotter_name)
+
+        return create_cell_titlebar(
+            title=title,
+            has_user_title=has_user_title,
+            on_edit_title_callback=on_edit_title,
+            toolbars_visible=cell_id in self._toolbars_shown,
+            on_toggle_toolbars_callback=on_toggle_toolbars,
+            on_add_callback=on_add,
+            on_overlay_selected=on_overlay,
+            available_overlays=overlay_specs,
+        )
+
+    def _create_layer_toolbars(
+        self,
+        cell: PlotCell,
+        layer_states: dict[LayerId, LayerStateMachine],
+    ) -> list[pn.Row]:
+        """
+        Create per-layer toolbars (title + gear/close) for all layers in a cell.
+
+        Parameters
+        ----------
         cell
             Plot cell with layers.
         layer_states
@@ -747,9 +900,6 @@ class PlotGridTabs:
         :
             List of toolbar widgets, one per layer.
         """
-        # Collect existing plotter names to filter already-added overlays
-        existing_plotter_names = {layer.config.plot_name for layer in cell.layers}
-
         toolbars = []
         for layer in cell.layers:
             layer_id = layer.layer_id
@@ -778,15 +928,6 @@ class PlotGridTabs:
                 case LayerState.READY:
                     pass  # No extra description for ready state
 
-            # Get available overlays, excluding those already present in the cell
-            available_overlays = [
-                overlay
-                for overlay in self._get_available_overlays_for_layer(config)
-                if overlay[1]
-                not in existing_plotter_names  # overlay[1] is plotter_name
-            ]
-
-            # Create callbacks that capture layer_id / cell_id / config
             def make_close_callback(lid: LayerId) -> Callable[[], None]:
                 def on_close() -> None:
                     self._orchestrator.remove_layer(lid)
@@ -799,26 +940,9 @@ class PlotGridTabs:
 
                 return on_gear
 
-            def make_add_callback(cid: CellId) -> Callable[[], None]:
-                def on_add() -> None:
-                    self._on_add_layer(cid)
-
-                return on_add
-
-            def make_overlay_callback(
-                cid: CellId, cfg: PlotConfig
-            ) -> Callable[[str, str], None]:
-                def on_overlay(view_name: str, plotter_name: str) -> None:
-                    self._create_overlay_layer(cid, cfg, view_name, plotter_name)
-
-                return on_overlay
-
-            toolbar = create_cell_toolbar(
+            toolbar = create_layer_toolbar(
                 on_gear_callback=make_gear_callback(layer_id),
                 on_close_callback=make_close_callback(layer_id),
-                on_add_callback=make_add_callback(cell_id),
-                on_overlay_selected=make_overlay_callback(cell_id, config),
-                available_overlays=available_overlays,
                 title=title,
                 description=description,
                 stopped=stopped,

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -908,7 +908,7 @@ class PlotGridTabs:
         self,
         cell: PlotCell,
         layer_states: dict[LayerId, LayerStateMachine],
-    ) -> list[pn.Row]:
+    ) -> list[pn.Row | pn.Column]:
         """
         Create per-layer toolbars (title + gear/close) for all layers in a cell.
 

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -17,6 +17,7 @@ import panel as pn
 import structlog
 
 from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
+from ess.livedata.core.timestamp import Timestamp
 
 from ..cell_autoscale import CellAutoscaleController, build_controller_from_layers
 from ..data_roles import PRIMARY
@@ -36,6 +37,7 @@ from ..plot_orchestrator import (
     SubscriptionId,
 )
 from ..plot_params import PlotAspectType, StretchMode
+from ..plots import TimeBounds, format_time_info, merge_time_bounds
 from ..save_filename import build_save_filename_from_cell, make_save_filename_hook
 from ..session_layer import SessionLayer
 from ..session_updater import SessionUpdater
@@ -44,8 +46,12 @@ from .plot_grid import GridCellStyles, PlotGrid
 from .plot_grid_manager import PlotGridManager
 from .plot_widgets import (
     create_cell_titlebar,
+    create_freshness_pane,
+    create_layer_time_pane,
     create_layer_toolbar,
     derive_cell_title,
+    format_freshness_html,
+    format_layer_time_html,
     get_plot_cell_display_info,
     get_workflow_display_info,
 )
@@ -162,6 +168,17 @@ class PlotGridTabs:
         # previous controller (with its now-detached tools) is garbage
         # collected. Cleaned up when the cell goes away or its layers do.
         self._session_autoscale_controllers: dict[CellId, CellAutoscaleController] = {}
+
+        # Per-session, per-cell freshness/lag indicator panes in the titlebar.
+        # Updated in place via ``.object`` on each poll where new data arrived,
+        # keeping the lag display off the HoloViews plot title. Recreated on cell
+        # rebuild; swept when the cell goes away.
+        self._cell_freshness_panes: dict[CellId, pn.pane.HTML] = {}
+
+        # Per-session, per-layer time-range panes in the layer toolbars (revealed
+        # by the toolbar-visibility toggle). Updated in place via ``.object``;
+        # recreated on cell rebuild, swept when the layer goes away.
+        self._layer_time_panes: dict[LayerId, pn.pane.HTML] = {}
 
         # Determine number of static tabs for stylesheet
         static_tab_count = 3 if system_status_widget else 2
@@ -622,6 +639,9 @@ class PlotGridTabs:
         for cid in list(self._session_autoscale_controllers):
             if cid not in active_cell_ids:
                 self._drop_autoscale_controller(cid)
+        for cid in list(self._cell_freshness_panes):
+            if cid not in active_cell_ids:
+                del self._cell_freshness_panes[cid]
 
     def _drop_autoscale_controller(self, cell_id: CellId) -> None:
         """Pop the controller for ``cell_id`` and dispose it (if any).
@@ -869,12 +889,16 @@ class PlotGridTabs:
             source_config = overlay_sources[(view_name, plotter_name)]
             self._create_overlay_layer(cell_id, source_config, view_name, plotter_name)
 
+        freshness_pane = create_freshness_pane()
+        self._cell_freshness_panes[cell_id] = freshness_pane
+
         return create_cell_titlebar(
             title=title,
             has_user_title=has_user_title,
             on_edit_title_callback=on_edit_title,
             toolbars_visible=cell_id in self._toolbars_shown,
             on_toggle_toolbars_callback=on_toggle_toolbars,
+            freshness_pane=freshness_pane,
             on_add_callback=on_add,
             on_overlay_selected=on_overlay,
             available_overlays=overlay_specs,
@@ -940,12 +964,16 @@ class PlotGridTabs:
 
                 return on_gear
 
+            time_pane = create_layer_time_pane()
+            self._layer_time_panes[layer_id] = time_pane
+
             toolbar = create_layer_toolbar(
                 on_gear_callback=make_gear_callback(layer_id),
                 on_close_callback=make_close_callback(layer_id),
                 title=title,
                 description=description,
                 stopped=stopped,
+                time_pane=time_pane,
             )
             toolbars.append(toolbar)
 
@@ -1198,6 +1226,11 @@ class PlotGridTabs:
         cells_to_rebuild: dict[CellId, tuple[PlotCell, PlotGrid]] = {}
         versions_to_apply: dict[LayerId, int] = {}
         seen_layer_ids: set[LayerId] = set()
+        # Per-layer time bounds for active-grid cells, to drive the freshness
+        # indicator (per cell) and the per-layer time-range panes. Collected
+        # here to avoid a second pass over the states.
+        cell_time_bounds: dict[CellId, list[TimeBounds | None]] = {}
+        layer_time_bounds: dict[LayerId, TimeBounds | None] = {}
         active_grid_id = self._get_active_grid_id()
 
         for grid_id, plot_grid in self._grid_widgets.items():
@@ -1222,6 +1255,15 @@ class PlotGridTabs:
                         )
                         continue
 
+                    if is_active:
+                        bounds = (
+                            state.plotter.time_bounds
+                            if state.plotter is not None
+                            else None
+                        )
+                        cell_time_bounds.setdefault(cell_id, []).append(bounds)
+                        layer_time_bounds[layer_id] = bounds
+
                     # Get or create session layer for version tracking
                     session_layer = self._session_layers.get(layer_id)
                     if session_layer is None:
@@ -1243,6 +1285,9 @@ class PlotGridTabs:
         for layer_id in list(self._session_layers.keys()):
             if layer_id not in seen_layer_ids:
                 del self._session_layers[layer_id]
+        for layer_id in list(self._layer_time_panes):
+            if layer_id not in seen_layer_ids:
+                del self._layer_time_panes[layer_id]
 
         # Rebuild affected cells.
         # Defer insertion to allow Bokeh to process any pending model updates
@@ -1264,6 +1309,45 @@ class PlotGridTabs:
                     sl = self._session_layers.get(layer.layer_id)
                     if sl is not None:
                         sl.last_seen_version = versions_to_apply[layer.layer_id]
+
+        # Refresh the freshness/lag indicator for active-grid cells. Runs after
+        # rebuilds so cells recreated this poll update their fresh pane handle.
+        # Lag is recomputed against the current wall clock every poll, so a
+        # stalled stream visibly grows stale rather than freezing.
+        for cell_id, bounds_list in cell_time_bounds.items():
+            self._update_freshness_pane(cell_id, bounds_list)
+        for layer_id, bounds in layer_time_bounds.items():
+            self._update_layer_time_pane(layer_id, bounds)
+
+    def _update_freshness_pane(
+        self, cell_id: CellId, bounds_list: list[TimeBounds | None]
+    ) -> None:
+        """Update a cell's titlebar freshness pane from its layers' time bounds."""
+        pane = self._cell_freshness_panes.get(cell_id)
+        if pane is None:
+            return
+        merged = merge_time_bounds(bounds_list)
+        if merged is None:
+            html = ''
+        else:
+            now = Timestamp.now()
+            html = format_freshness_html(
+                merged.lag_seconds(now), tooltip=format_time_info(merged, now=now)
+            )
+        if pane.object != html:
+            pane.object = html
+
+    def _update_layer_time_pane(
+        self, layer_id: LayerId, bounds: TimeBounds | None
+    ) -> None:
+        """Update a layer toolbar's time-range pane from its time bounds."""
+        pane = self._layer_time_panes.get(layer_id)
+        if pane is None:
+            return
+        text = format_time_info(bounds) if bounds is not None else ''
+        html = format_layer_time_html(text)
+        if pane.object != html:
+            pane.object = html
 
     def shutdown(self) -> None:
         """Unsubscribe from lifecycle events and clean up session state."""

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -17,10 +17,12 @@ import structlog
 
 from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
 
+from ..data_roles import PRIMARY
 from ..plot_data_service import PlotDataService
 from ..plot_orchestrator import (
     CellGeometry,
     CellId,
+    DataSourceConfig,
     GridId,
     LayerId,
     PlotCell,
@@ -32,10 +34,16 @@ from ..plot_orchestrator import (
 from ..plots import TimeBounds
 from ..session_layer import SessionLayer
 from ..session_updater import SessionUpdater
+from .buttons import ButtonStyles, create_tool_button
 from .cell import CellDeps, CellWidget
 from .plot_config_modal import PlotConfigModal
 from .plot_grid import PlotGrid
 from .plot_grid_manager import PlotGridManager
+from .plot_widgets import (
+    create_overlay_add_button,
+    get_plot_cell_display_info,
+    overlay_suggestions_for_layer,
+)
 from .styles import Colors
 
 logger = structlog.get_logger(__name__)
@@ -126,11 +134,9 @@ class PlotGridTabs:
         self._cell_deps = CellDeps(
             orchestrator=plot_orchestrator,
             workflow_registry=self._workflow_registry,
-            plotting_controller=plotting_controller,
             plot_data_service=plot_data_service,
             session_layers=self._session_layers,
-            on_edit_title=self._show_rename_modal,
-            on_add_layer=self._on_add_layer,
+            on_edit_title=self._show_cell_properties_modal,
             on_reconfigure_layer=self._on_reconfigure_layer,
         )
 
@@ -383,7 +389,7 @@ class PlotGridTabs:
 
     def _on_add_layer(self, cell_id: CellId) -> None:
         """
-        Handle add layer request from plus button.
+        Handle add layer request from the cell-properties modal.
 
         Shows the PlotConfigModal to configure the new layer, then adds it
         to the cell in the orchestrator on success.
@@ -442,58 +448,184 @@ class PlotGridTabs:
         self._current_modal = None
         self._modal_container.clear()
 
-    def _show_rename_modal(
-        self, cell_id: CellId, current_title: str, has_user_title: bool
+    def _add_overlay_layer(
+        self,
+        cell_id: CellId,
+        base_config: PlotConfig,
+        view_name: str,
+        plotter_name: str,
     ) -> None:
         """
-        Show a small modal to set or clear the user-defined cell title.
+        Add an overlay layer inheriting workflow/sources from a base layer.
 
         Parameters
         ----------
         cell_id
-            ID of the cell to rename.
+            ID of the cell to add the overlay to.
+        base_config
+            Configuration of the base layer the overlay derives from.
+        view_name
+            Name of the output view for the overlay (e.g., 'roi_rectangle').
+        plotter_name
+            Name of the plotter to use for the overlay.
+        """
+        spec = self._plotting_controller.get_spec(plotter_name)
+        params = spec.params() if spec.params else None
+        overlay_config = PlotConfig(
+            data_sources={
+                PRIMARY: DataSourceConfig(
+                    workflow_id=base_config.workflow_id,
+                    source_names=list(base_config.source_names),
+                    view_name=view_name,
+                )
+            },
+            plot_name=plotter_name,
+            params=params,
+        )
+        self._orchestrator.add_layer(cell_id, overlay_config)
+
+    def _show_cell_properties_modal(
+        self, cell_id: CellId, current_title: str, has_user_title: bool
+    ) -> None:
+        """
+        Show the cell-properties modal: rename, add layer, and remove layers.
+
+        Rename is the only field saved on "Save"; add/remove act immediately so
+        the modal doubles as the cell's layer-composition editor. Add layer and
+        add overlay persist any pending title edit, then hand off to the plot
+        config modal (add layer) or add the overlay directly (overlays use
+        plotter defaults).
+
+        Parameters
+        ----------
+        cell_id
+            ID of the cell to edit.
         current_title
             The currently displayed title (user-defined or derived).
         has_user_title
             Whether ``current_title`` is user-defined; if not, the input starts
             empty so the placeholder hints at the derived fallback.
         """
+        cell = self._orchestrator.get_cell(cell_id)
         text = pn.widgets.TextInput(
-            name='Cell title',
             value=current_title if has_user_title else '',
             placeholder='Leave empty to use the derived title',
             description='Leave empty to use the derived title.',
             sizing_mode='stretch_width',
         )
+        layers_col = pn.Column(sizing_mode='stretch_width')
+        add_layer_button = pn.widgets.Button(name='Add layer…', button_type='default')
         save_button = pn.widgets.Button(name='Save', button_type='primary')
         cancel_button = pn.widgets.Button(name='Cancel')
+        heading_margin = (10, 0, 0, 0)
         modal = pn.Modal(
             pn.Column(
-                pn.pane.Markdown('### Configure cell', margin=(0, 0, 5, 0)),
+                pn.pane.Markdown('### Cell properties', margin=(0, 0, 5, 0)),
+                pn.pane.Markdown('#### Header', margin=(0, 0, 0, 0)),
                 text,
+                pn.pane.Markdown('#### Layers', margin=heading_margin),
+                pn.Row(add_layer_button, pn.Spacer(sizing_mode='stretch_width')),
+                layers_col,
                 pn.Row(
                     pn.Spacer(sizing_mode='stretch_width'),
                     cancel_button,
                     save_button,
+                    margin=(10, 0, 0, 0),
                 ),
                 sizing_mode='stretch_width',
             ),
-            name='Configure cell',
             margin=20,
-            width=420,
+            width=480,
         )
         done = {'v': False}
+
+        def persist_title() -> None:
+            new_title = (text.value_input or '').strip() or None
+            self._orchestrator.set_cell_title(cell_id, new_title)
+
+        def close() -> None:
+            done['v'] = True
+            modal.open = False
+            self._modal_container.clear()
 
         def finish(*, save: bool) -> None:
             if done['v']:
                 return
-            done['v'] = True
             if save:
-                new_title = (text.value_input or '').strip() or None
-                self._orchestrator.set_cell_title(cell_id, new_title)
-            modal.open = False
-            self._modal_container.clear()
+                persist_title()
+            close()
 
+        def on_remove(layer_id: LayerId) -> None:
+            # ``remove_layer`` mutates the shared ``cell.layers`` in place, and
+            # removes the whole cell once its last layer is gone.
+            self._orchestrator.remove_layer(layer_id)
+            if not cell.layers:
+                close()
+            else:
+                # Per-layer overlay suggestions depend on the remaining layers.
+                render_layers()
+
+        def on_add() -> None:
+            if done['v']:
+                return
+            persist_title()
+            close()
+            self._on_add_layer(cell_id)
+
+        def on_add_overlay(
+            view_name: str, plotter_name: str, base_config: PlotConfig
+        ) -> None:
+            if done['v']:
+                return
+            # Add in place and keep the modal open so several overlays can be
+            # added in one session; the new layer appears as its own row.
+            self._add_overlay_layer(cell_id, base_config, view_name, plotter_name)
+            render_layers()
+
+        def render_layers() -> None:
+            existing = frozenset(layer.config.plot_name for layer in cell.layers)
+            rows: list = []
+            for layer in cell.layers:
+                title, _ = get_plot_cell_display_info(
+                    layer.config,
+                    self._workflow_registry,
+                    get_source_title=self._orchestrator.get_source_title,
+                )
+                controls: list = []
+                overlays = overlay_suggestions_for_layer(
+                    layer.config,
+                    existing,
+                    self._workflow_registry,
+                    self._plotting_controller,
+                )
+                if overlays:
+                    controls.append(
+                        create_overlay_add_button(
+                            overlays=overlays,
+                            on_overlay_selected=(
+                                lambda v, p, b=layer.config: on_add_overlay(v, p, b)
+                            ),
+                        )
+                    )
+                controls.append(
+                    create_tool_button(
+                        icon_name='x',
+                        button_color=ButtonStyles.DANGER_RED,
+                        hover_color=ButtonStyles.DANGER_HOVER,
+                        on_click_callback=lambda lid=layer.layer_id: on_remove(lid),
+                    )
+                )
+                title_pane = pn.pane.HTML(
+                    title,
+                    sizing_mode='stretch_width',
+                    align='center',
+                    styles={'overflow': 'hidden'},
+                )
+                rows.append(pn.Row(title_pane, *controls, sizing_mode='stretch_width'))
+            layers_col[:] = rows
+
+        add_layer_button.on_click(lambda _: on_add())
+        render_layers()
         save_button.on_click(lambda _: finish(save=True))
         cancel_button.on_click(lambda _: finish(save=False))
         # Closing via the X button or ESC cancels.

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -12,22 +12,15 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from contextlib import nullcontext
 
-import holoviews as hv
 import panel as pn
 import structlog
 
 from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
-from ess.livedata.core.timestamp import Timestamp
 
-from ..cell_autoscale import CellAutoscaleController, build_controller_from_layers
-from ..data_roles import PRIMARY
-from ..format_utils import extract_error_summary
-from ..frame_aspect import make_frame_aspect_hook_from_config
-from ..plot_data_service import LayerState, LayerStateMachine, PlotDataService
+from ..plot_data_service import PlotDataService
 from ..plot_orchestrator import (
     CellGeometry,
     CellId,
-    DataSourceConfig,
     GridId,
     LayerId,
     PlotCell,
@@ -36,26 +29,14 @@ from ..plot_orchestrator import (
     PlotOrchestrator,
     SubscriptionId,
 )
-from ..plot_params import PlotAspectType, StretchMode
-from ..plots import TimeBounds, format_time_info, merge_time_bounds
-from ..save_filename import build_save_filename_from_cell, make_save_filename_hook
+from ..plots import TimeBounds
 from ..session_layer import SessionLayer
 from ..session_updater import SessionUpdater
+from .cell import CellDeps, CellWidget
 from .plot_config_modal import PlotConfigModal
-from .plot_grid import GridCellStyles, PlotGrid
+from .plot_grid import PlotGrid
 from .plot_grid_manager import PlotGridManager
-from .plot_widgets import (
-    create_cell_titlebar,
-    create_freshness_pane,
-    create_layer_time_pane,
-    create_layer_toolbar,
-    derive_cell_title,
-    format_freshness_html,
-    format_layer_time_html,
-    get_plot_cell_display_info,
-    get_workflow_display_info,
-)
-from .styles import Colors, StatusColors
+from .styles import Colors
 
 logger = structlog.get_logger(__name__)
 
@@ -79,30 +60,6 @@ class _BatchedTabs(pn.Tabs):
         freeze = doc.models.freeze() if doc is not None else nullcontext()
         with pn.io.hold(), freeze:
             super()._update_active(*events)
-
-
-def _get_sizing_mode(config: PlotConfig) -> str:
-    """Extract Panel sizing_mode from plot configuration.
-
-    Parameters
-    ----------
-    config:
-        Plot configuration containing plotter params.
-
-    Returns
-    -------
-    :
-        Panel sizing_mode string ('stretch_both', 'stretch_width', or 'stretch_height').
-    """
-    params = config.params
-    if hasattr(params, 'plot_aspect'):
-        aspect = params.plot_aspect
-        if aspect.aspect_type == PlotAspectType.free:
-            return 'stretch_both'
-        if aspect.stretch_mode == StretchMode.width:
-            return 'stretch_width'
-        return 'stretch_height'
-    return 'stretch_both'
 
 
 class PlotGridTabs:
@@ -152,33 +109,30 @@ class PlotGridTabs:
         # Track grid widgets (insertion order determines tab position)
         self._grid_widgets: dict[GridId, PlotGrid] = {}
 
-        # Per-session layer state: version tracking and optional render components.
+        # Per-session layer state: version tracking and optional render
+        # components. Owned by the poll loop; read by CellWidgets when composing
+        # plots (shared via CellDeps).
         self._session_layers: dict[LayerId, SessionLayer] = {}
 
-        # Per-session, per-cell display preference: cells whose layer toolbars
-        # are shown. Layer toolbars are hidden by default; this set tracks the
-        # cells the user has revealed. Purely local UI state (not persisted, not
-        # cross-session); re-applied on cell rebuild so it survives version
-        # polling.
-        self._toolbars_shown: set[CellId] = set()
+        # Per-session cell widgets, keyed by CellId. Each owns its titlebar,
+        # per-layer toolbars, content, autoscale controller, and the panes
+        # updated in place by the poll loop (freshness pill, layer time labels).
+        # Rebuilt on cell/layer changes; disposed when the cell goes away.
+        self._cells: dict[CellId, CellWidget] = {}
 
-        # Per-session, per-cell autoscale controllers. Lifetime tracks the
-        # cell composition: each rebuild creates a fresh controller whose
-        # ``CustomAction`` tools live in this session's Bokeh document; the
-        # previous controller (with its now-detached tools) is garbage
-        # collected. Cleaned up when the cell goes away or its layers do.
-        self._session_autoscale_controllers: dict[CellId, CellAutoscaleController] = {}
-
-        # Per-session, per-cell freshness/lag indicator panes in the titlebar.
-        # Updated in place via ``.object`` on each poll where new data arrived,
-        # keeping the lag display off the HoloViews plot title. Recreated on cell
-        # rebuild; swept when the cell goes away.
-        self._cell_freshness_panes: dict[CellId, pn.pane.HTML] = {}
-
-        # Per-session, per-layer time-range panes in the layer toolbars (revealed
-        # by the toolbar-visibility toggle). Updated in place via ``.object``;
-        # recreated on cell rebuild, swept when the layer goes away.
-        self._layer_time_panes: dict[LayerId, pn.pane.HTML] = {}
+        # Shared dependencies handed to every CellWidget. Built once; the
+        # callbacks route modal interactions back here (modal container lives
+        # at this level). Created after the dependencies above are set.
+        self._cell_deps = CellDeps(
+            orchestrator=plot_orchestrator,
+            workflow_registry=self._workflow_registry,
+            plotting_controller=plotting_controller,
+            plot_data_service=plot_data_service,
+            session_layers=self._session_layers,
+            on_edit_title=self._show_rename_modal,
+            on_add_layer=self._on_add_layer,
+            on_reconfigure_layer=self._on_reconfigure_layer,
+        )
 
         # Determine number of static tabs for stylesheet
         static_tab_count = 3 if system_status_widget else 2
@@ -580,18 +534,16 @@ class PlotGridTabs:
         if plot_grid is None:
             return
 
-        # Get session-local composed plot if data is available.
-        # Note: When config changes, update_layer_config() creates a new layer_id.
-        # The old layer_id is orphaned and cleaned up by update_pipes().
-        # New layer_ids have no cache, so fresh components are created naturally.
-        session_plot = self._get_session_composed_plot(cell_id, cell)
-
-        # Create widget with toolbars and content
-        widget = self._create_cell_widget(cell_id, cell, session_plot)
-
+        # Build the cell widget. Composing its plot creates fresh session
+        # components: when config changes, update_layer_config() creates a new
+        # layer_id; the old one is orphaned and cleaned up by update_pipes(),
+        # and new layer_ids have no cache, so components are created naturally.
+        #
         # Note: SessionLayer.create() already records state.version in
         # last_seen_version, so _poll_for_plot_updates won't trigger
         # redundant rebuilds.
+        cell_widget = self._build_cell(cell_id, cell)
+        view = cell_widget.view
 
         # Defer insertion for plots to allow Panel to update layout sizing.
         # When a workflow is already running with data, subscribing triggers
@@ -600,13 +552,13 @@ class PlotGridTabs:
         # collapsed/default size before the grid container is properly sized,
         # resulting in "glitched" rendering. Deferring to the next event loop
         # iteration allows Panel to process layout updates first.
-        if session_plot is not None:
+        if cell_widget.has_plot:
             pn.state.execute(
-                lambda g=cell.geometry: plot_grid.insert_widget_at(g, widget)
+                lambda g=cell.geometry: plot_grid.insert_widget_at(g, view)
             )
         else:
             # Status widgets can be inserted immediately
-            plot_grid.insert_widget_at(cell.geometry, widget)
+            plot_grid.insert_widget_at(cell.geometry, view)
 
     def _on_cell_removed(self, grid_id: GridId, geometry: CellGeometry) -> None:
         """
@@ -628,9 +580,9 @@ class PlotGridTabs:
         # Remove widget at explicit position
         plot_grid.remove_widget_at(geometry)
 
-        # Drop any per-session autoscale controller for the removed cell.
-        # The geometry → cell_id mapping isn't tracked here, so we sweep
-        # controllers whose CellId no longer matches any active cell.
+        # Drop the cell widget for the removed cell, disposing its autoscale
+        # controller. The geometry → cell_id mapping isn't tracked here, so we
+        # sweep widgets whose CellId no longer matches any active cell.
         active_cell_ids: set[CellId] = set()
         for grid_config in (
             self._orchestrator.peek_grid(gid) for gid in self._grid_widgets
@@ -638,573 +590,26 @@ class PlotGridTabs:
             if grid_config is None:
                 continue
             active_cell_ids.update(grid_config.cells.keys())
-        for cid in list(self._session_autoscale_controllers):
+        for cid in list(self._cells):
             if cid not in active_cell_ids:
-                self._drop_autoscale_controller(cid)
-        for cid in list(self._cell_freshness_panes):
-            if cid not in active_cell_ids:
-                del self._cell_freshness_panes[cid]
+                self._cells.pop(cid).dispose()
 
-    def _drop_autoscale_controller(self, cell_id: CellId) -> None:
-        """Pop the controller for ``cell_id`` and dispose it (if any).
+    def _build_cell(self, cell_id: CellId, cell: PlotCell) -> CellWidget:
+        """Build (or rebuild) the session widget for a cell.
 
-        Calling ``dispose()`` breaks the controller → Bokeh-tool →
-        on_change-callback → controller reference cycle so long sessions
-        don't accumulate detached controllers after cell rebuilds/removals.
+        Preserves the per-layer toolbar visibility toggle across rebuilds and
+        disposes the previous widget's autoscale controller (breaking its
+        on_change reference cycle) once the replacement is in place.
         """
-        controller = self._session_autoscale_controllers.pop(cell_id, None)
-        if controller is not None:
-            controller.dispose()
-
-    def _get_layer_states(self, cell: PlotCell) -> dict[LayerId, LayerStateMachine]:
-        """
-        Get layer states from PlotDataService for all layers in a cell.
-
-        Parameters
-        ----------
-        cell
-            Plot cell with layers.
-
-        Returns
-        -------
-        :
-            Dict mapping layer IDs to their state.
-        """
-        result: dict[LayerId, LayerStateMachine] = {}
-        for layer in cell.layers:
-            state = self._plot_data_service.get(layer.layer_id)
-            if state is None:
-                raise RuntimeError(
-                    f"Layer {layer.layer_id} has no state in PlotDataService. "
-                    "This indicates a bug: layers should be registered before "
-                    "widgets are notified."
-                )
-            result[layer.layer_id] = state
-        return result
-
-    def _create_cell_widget(
-        self,
-        cell_id: CellId,
-        cell: PlotCell,
-        plot: hv.DynamicMap | hv.Element | hv.Overlay | None,
-    ) -> pn.Column:
-        """
-        Create a cell widget with per-layer toolbars and content area.
-
-        The widget has a stable toolbar section (one toolbar per layer) and
-        a content area that shows either a placeholder or the composed plot.
-
-        Parameters
-        ----------
-        cell_id
-            ID of the cell.
-        cell
-            Plot cell configuration with all layers.
-        plot
-            The composed plot, or None if no layers have data yet.
-
-        Returns
-        -------
-        :
-            Panel widget with toolbars and content.
-        """
-        # Get layer states from PlotDataService
-        layer_states = self._get_layer_states(cell)
-
-        # Per-layer toolbars, wrapped in a column the titlebar toggle can hide.
-        layer_toolbars = self._create_layer_toolbars(cell, layer_states)
-        layers_column = pn.Column(
-            *layer_toolbars,
-            sizing_mode='stretch_width',
-            margin=0,
-            visible=cell_id in self._toolbars_shown,
+        previous = self._cells.get(cell_id)
+        toolbars_visible = previous.toolbars_shown if previous is not None else False
+        cell_widget = CellWidget(
+            cell_id, cell, self._cell_deps, toolbars_visible=toolbars_visible
         )
-        titlebar = self._create_cell_titlebar(cell_id, cell, layers_column)
-
-        # Create content area (placeholder or plot)
-        if plot is not None:
-            content = self._create_plot_content(cell, plot)
-            border = None
-            bg_color = None
-        else:
-            content = self._create_placeholder_content(cell, layer_states)
-            # Check if any layer has an error
-            has_error = any(
-                state.error_message is not None for state in layer_states.values()
-            )
-            if has_error:
-                bg_color = '#ffe6e6'
-                border = f'2px solid {StatusColors.ERROR}'
-            else:
-                bg_color = Colors.BG_LIGHT
-                border = f'2px dashed {Colors.BORDER}'
-
-        styles = {}
-        if bg_color:
-            styles['background-color'] = bg_color
-        if border:
-            styles['border'] = border
-
-        return pn.Column(
-            titlebar,
-            layers_column,
-            content,
-            sizing_mode='stretch_both',
-            styles=styles,
-            margin=GridCellStyles.CELL_MARGIN,
-        )
-
-    def _get_available_overlays_for_layer(
-        self, config: PlotConfig
-    ) -> list[tuple[str, str, str]]:
-        """
-        Get available overlay suggestions for a layer based on its configuration.
-
-        Parameters
-        ----------
-        config
-            Layer's plot configuration.
-
-        Returns
-        -------
-        :
-            List of (output_name, plotter_name, plotter_title) tuples.
-            Returns empty list if overlays are not applicable.
-        """
-        # Skip for static overlays (no workflow)
-        if config.is_static():
-            return []
-
-        # Get workflow spec
-        workflow_spec = self._workflow_registry.get(config.workflow_id)
-        if workflow_spec is None:
-            return []
-
-        return self._plotting_controller.get_available_overlays(
-            workflow_spec, config.plot_name
-        )
-
-    def _create_overlay_layer(
-        self,
-        cell_id: CellId,
-        base_config: PlotConfig,
-        view_name: str,
-        plotter_name: str,
-    ) -> None:
-        """
-        Create an overlay layer inheriting configuration from a base layer.
-
-        Parameters
-        ----------
-        cell_id
-            ID of the cell to add the overlay to.
-        base_config
-            Configuration of the base layer (e.g., image layer).
-        view_name
-            Name of the output view for the overlay (e.g., 'roi_rectangle').
-        plotter_name
-            Name of the plotter to use for the overlay.
-        """
-        # Get default params for the plotter
-        spec = self._plotting_controller.get_spec(plotter_name)
-        params = spec.params() if spec.params else None
-
-        # Create PlotConfig inheriting workflow/sources from base layer
-        overlay_config = PlotConfig(
-            data_sources={
-                PRIMARY: DataSourceConfig(
-                    workflow_id=base_config.workflow_id,
-                    source_names=list(base_config.source_names),
-                    view_name=view_name,
-                )
-            },
-            plot_name=plotter_name,
-            params=params,
-        )
-
-        self._orchestrator.add_layer(cell_id, overlay_config)
-
-    def _create_cell_titlebar(
-        self,
-        cell_id: CellId,
-        cell: PlotCell,
-        layers_column: pn.Column,
-    ) -> pn.Row:
-        """
-        Create the cell-level titlebar (title, add layer, rename, toolbar toggle).
-
-        Parameters
-        ----------
-        cell_id
-            ID of the cell.
-        cell
-            Plot cell with layers.
-        layers_column
-            The column wrapping the per-layer toolbars, whose visibility the
-            toggle button controls.
-
-        Returns
-        -------
-        :
-            Titlebar Row widget.
-        """
-        has_user_title = cell.user_title is not None
-        title = (
-            cell.user_title
-            if has_user_title
-            else derive_cell_title(
-                cell,
-                self._workflow_registry,
-                get_source_title=self._orchestrator.get_source_title,
-            )
-        )
-
-        # Union of overlay suggestions across all layers, excluding plotters
-        # already present in the cell. Each suggestion remembers the source
-        # layer's config so the overlay inherits the right workflow/sources.
-        existing_plotter_names = {layer.config.plot_name for layer in cell.layers}
-        overlay_specs: list[tuple[str, str, str]] = []
-        overlay_sources: dict[tuple[str, str], PlotConfig] = {}
-        for layer in cell.layers:
-            for spec in self._get_available_overlays_for_layer(layer.config):
-                output_name, plotter_name, _ = spec
-                key = (output_name, plotter_name)
-                if plotter_name in existing_plotter_names or key in overlay_sources:
-                    continue
-                overlay_sources[key] = layer.config
-                overlay_specs.append(spec)
-
-        def on_edit_title() -> None:
-            self._show_rename_modal(cell_id, title, has_user_title)
-
-        def on_toggle_toolbars(visible: bool) -> None:
-            if visible:
-                self._toolbars_shown.add(cell_id)
-            else:
-                self._toolbars_shown.discard(cell_id)
-            layers_column.visible = visible
-
-        def on_add() -> None:
-            self._on_add_layer(cell_id)
-
-        def on_overlay(view_name: str, plotter_name: str) -> None:
-            source_config = overlay_sources[(view_name, plotter_name)]
-            self._create_overlay_layer(cell_id, source_config, view_name, plotter_name)
-
-        freshness_pane = create_freshness_pane()
-        self._cell_freshness_panes[cell_id] = freshness_pane
-
-        return create_cell_titlebar(
-            title=title,
-            has_user_title=has_user_title,
-            on_edit_title_callback=on_edit_title,
-            toolbars_visible=cell_id in self._toolbars_shown,
-            on_toggle_toolbars_callback=on_toggle_toolbars,
-            freshness_pane=freshness_pane,
-            on_add_callback=on_add,
-            on_overlay_selected=on_overlay,
-            available_overlays=overlay_specs,
-        )
-
-    def _create_layer_toolbars(
-        self,
-        cell: PlotCell,
-        layer_states: dict[LayerId, LayerStateMachine],
-    ) -> list[pn.Row | pn.Column]:
-        """
-        Create per-layer toolbars (title + gear/close) for all layers in a cell.
-
-        Parameters
-        ----------
-        cell
-            Plot cell with layers.
-        layer_states
-            Per-layer runtime state from PlotDataService.
-
-        Returns
-        -------
-        :
-            List of toolbar widgets, one per layer.
-        """
-        toolbars = []
-        for layer in cell.layers:
-            layer_id = layer.layer_id
-            config = layer.config
-            state = layer_states[layer_id]
-
-            # Get display info for this layer
-            title, description = get_plot_cell_display_info(
-                config,
-                self._workflow_registry,
-                get_source_title=self._orchestrator.get_source_title,
-            )
-
-            # Add state info to description using explicit state enum
-            stopped = False
-            match state.state:
-                case LayerState.ERROR:
-                    description = f"{description}\n\nError: {state.error_message}"
-                case LayerState.STOPPED:
-                    stopped = True
-                    description = f"{description}\n\nStatus: Workflow ended"
-                case LayerState.WAITING_FOR_DATA:
-                    description = f"{description}\n\nStatus: Waiting for data..."
-                case LayerState.WAITING_FOR_JOB:
-                    description = f"{description}\n\nStatus: Waiting for workflow"
-                case LayerState.READY:
-                    pass  # No extra description for ready state
-
-            def make_close_callback(lid: LayerId) -> Callable[[], None]:
-                def on_close() -> None:
-                    self._orchestrator.remove_layer(lid)
-
-                return on_close
-
-            def make_gear_callback(lid: LayerId) -> Callable[[], None]:
-                def on_gear() -> None:
-                    self._on_reconfigure_layer(lid)
-
-                return on_gear
-
-            time_pane = create_layer_time_pane()
-            self._layer_time_panes[layer_id] = time_pane
-
-            toolbar = create_layer_toolbar(
-                on_gear_callback=make_gear_callback(layer_id),
-                on_close_callback=make_close_callback(layer_id),
-                title=title,
-                description=description,
-                stopped=stopped,
-                time_pane=time_pane,
-            )
-            toolbars.append(toolbar)
-
-        return toolbars
-
-    def _create_placeholder_content(
-        self,
-        cell: PlotCell,
-        layer_states: dict[LayerId, LayerStateMachine],
-    ) -> pn.pane.Markdown:
-        """
-        Create placeholder content showing layer status.
-
-        Parameters
-        ----------
-        cell
-            Plot cell with layers.
-        layer_states
-            Per-layer runtime state from PlotDataService.
-
-        Returns
-        -------
-        :
-            Markdown pane showing status for all layers.
-        """
-        # Build status info for each layer
-        status_lines = []
-        for layer in cell.layers:
-            config = layer.config
-            state = layer_states[layer.layer_id]
-
-            workflow_title, output_title = get_workflow_display_info(
-                self._workflow_registry, config.workflow_id, config.view_name
-            )
-
-            # Determine status from explicit state enum
-            match state.state:
-                case LayerState.ERROR:
-                    error_text = state.error_message or "Unknown error"
-                    status = f"Error: {extract_error_summary(error_text)}"
-                    text_color = StatusColors.ERROR
-                case LayerState.STOPPED:
-                    status = "Workflow ended"
-                    text_color = Colors.TEXT
-                case LayerState.WAITING_FOR_DATA:
-                    status = "Waiting for data..."
-                    text_color = Colors.TEXT_MUTED
-                case LayerState.WAITING_FOR_JOB:
-                    status = "Waiting for workflow..."
-                    text_color = Colors.TEXT_MUTED
-                case LayerState.READY:
-                    # Defensive: READY should have displayable plot and not
-                    # reach placeholder. Log if this happens.
-                    logger.warning(
-                        "Layer %s in READY state but showing placeholder",
-                        layer.layer_id,
-                    )
-                    status = "Ready (loading...)"
-                    text_color = Colors.TEXT_MUTED
-
-            status_lines.append(
-                f"**{workflow_title} → {output_title}**: "
-                f"<span style='color: {text_color}'>{status}</span>"
-            )
-
-        content = "\n\n".join(status_lines)
-
-        return pn.pane.Markdown(
-            content,
-            styles={'text-align': 'left', 'padding': '20px'},
-        )
-
-    def _create_plot_content(
-        self,
-        cell: PlotCell,
-        plot: hv.DynamicMap | hv.Element | hv.Overlay,
-    ) -> pn.pane.HoloViews:
-        """
-        Create plot content widget.
-
-        Parameters
-        ----------
-        cell
-            Plot cell with layers.
-        plot
-            The composed plot.
-
-        Returns
-        -------
-        :
-            HoloViews pane containing the plot.
-        """
-        # Use sizing mode from first layer (they should be consistent for overlay)
-        if cell.layers:
-            sizing_mode = _get_sizing_mode(cell.layers[0].config)
-        else:
-            sizing_mode = 'stretch_both'
-
-        # Use .layout to preserve widgets for DynamicMaps with kdims.
-        # When pn.pane.HoloViews wraps a DynamicMap with kdims, it generates
-        # widgets. However, these widgets don't render when the pane is placed
-        # in a Panel layout (Tabs, Column, etc.). The .layout property contains
-        # both the plot and widgets, which renders correctly in layouts.
-        # See: https://github.com/holoviz/panel/issues/5628
-        #
-        # CRITICAL: Use linked_axes=False to prevent unintended axis linking (#607)
-        #
-        # Problem: By default, Panel's HoloViews pane links axes across different
-        # plots based on their axis labels (e.g., all plots with 'x' and 'y' axes
-        # get linked). For detector panels in different grid cells, this is unwanted:
-        # - Different detector panels have independent spatial coordinates
-        # - Zooming one panel shouldn't affect others
-        # - Each panel needs independent autoscaling
-        #
-        # Previous workarounds and why they failed:
-        # - shared_axes=False (HoloViews): Breaks dynamic features that rely on
-        #   shared axis infrastructure
-        # - Wrapping in hv.Layout: Prevents multi-layer composition with hv.Overlay,
-        #   which was needed for the layer system (#606)
-        #
-        # Solution: linked_axes=False on the Panel pane
-        # - Disables Panel's cross-plot axis linking while preserving HoloViews
-        #   features (autoscaling, dynamic updates)
-        # - Allows proper multi-layer composition via hv.Overlay
-        # - Each grid cell's plot remains independent
-        plot_pane_wrapper = pn.pane.HoloViews(
-            plot, sizing_mode=sizing_mode, linked_axes=False
-        )
-        return plot_pane_wrapper.layout
-
-    def _get_session_composed_plot(
-        self, cell_id: CellId, cell: PlotCell
-    ) -> hv.DynamicMap | hv.Element | None:
-        """
-        Get composed plot from session-local DynamicMaps or static elements.
-
-        Ensures session components exist when data is available.
-        Sets a descriptive SaveTool filename on the result so that
-        browser "Save" downloads get a meaningful name.
-
-        Parameters
-        ----------
-        cell
-            The plot cell with layers.
-
-        Returns
-        -------
-        :
-            Composed plot from session DMaps/elements, or None if none available.
-        """
-        plots = []
-        has_layout = False
-        cell_plotters: list = []
-        for layer in cell.layers:
-            layer_id = layer.layer_id
-            session_layer = self._session_layers.get(layer_id)
-            if session_layer is None:
-                continue
-
-            # Ensure components exist if data is now available
-            state = self._plot_data_service.get(layer_id)
-            if state is not None:
-                session_layer.ensure_components(state)
-                # Static overlays (vlines/hlines/rectangles) are not Plotters
-                # and carry no autoscale axes; exclude them from the controller.
-                if state.plotter is not None and not layer.config.is_static():
-                    cell_plotters.append(state.plotter)
-
-            dmap = session_layer.dmap
-            if dmap is not None:
-                # Check the DynamicMap's resolved type (set after Bokeh
-                # renders it) and the plotter's cached state.  Either
-                # being a Layout means hooks must be skipped.
-                if isinstance(dmap, hv.DynamicMap) and dmap.type is hv.Layout:
-                    has_layout = True
-                elif (
-                    state is not None
-                    and state.plotter is not None
-                    and isinstance(state.plotter.get_cached_state(), hv.Layout)
-                ):
-                    has_layout = True
-                plots.append(dmap)
-
-        if not plots:
-            self._drop_autoscale_controller(cell_id)
-            return None
-
-        result: hv.DynamicMap | hv.Element
-        if len(plots) == 1:
-            result = plots[0]
-        else:
-            # Collate so hooks survive for any number of DynamicMap layers.
-            # Without collation, HoloViews drops overlay-level opts (including
-            # hooks) when an Overlay contains 3+ DynamicMaps.  Collating first
-            # produces a single DynamicMap whose outputs are plain Overlays;
-            # opts applied afterwards land on the OverlayPlot and persist.
-            result = hv.Overlay(plots).collate()
-
-        # Skip hooks for Layouts — each sub-figure has its own SaveTool,
-        # so a single cell-level filename is not meaningful.
-        if has_layout:
-            self._drop_autoscale_controller(cell_id)
-        else:
-            hooks: list = []
-            filename = build_save_filename_from_cell(
-                cell, self._workflow_registry, self._orchestrator.get_source_title
-            )
-            if filename is not None:
-                hooks.append(make_save_filename_hook(filename))
-            if cell.layers:
-                params = cell.layers[0].config.params
-                if hasattr(params, 'plot_aspect'):
-                    aspect_hook = make_frame_aspect_hook_from_config(params.plot_aspect)
-                    if aspect_hook is not None:
-                        hooks.append(aspect_hook)
-            # Fresh controller on every cell rebuild: keeps tools and
-            # toggle state local to this session's Bokeh document. Dispose
-            # any prior controller for this cell first to break its
-            # on_change reference cycle (would otherwise leak across the
-            # session lifetime).
-            self._drop_autoscale_controller(cell_id)
-            controller = build_controller_from_layers(cell_plotters)
-            if controller is not None:
-                self._session_autoscale_controllers[cell_id] = controller
-                hooks.append(controller.make_hook())
-            if hooks:
-                result = result.opts(hooks=hooks)
-
-        return result
+        self._cells[cell_id] = cell_widget
+        if previous is not None:
+            previous.dispose()
+        return cell_widget
 
     def _poll_for_plot_updates(self) -> None:
         """
@@ -1228,11 +633,9 @@ class PlotGridTabs:
         cells_to_rebuild: dict[CellId, tuple[PlotCell, PlotGrid]] = {}
         versions_to_apply: dict[LayerId, int] = {}
         seen_layer_ids: set[LayerId] = set()
-        # Per-layer time bounds for active-grid cells, to drive the freshness
-        # indicator (per cell) and the per-layer time-range panes. Collected
-        # here to avoid a second pass over the states.
-        cell_time_bounds: dict[CellId, list[TimeBounds | None]] = {}
-        layer_time_bounds: dict[LayerId, TimeBounds | None] = {}
+        # Per-cell, per-layer time bounds for active-grid cells, driving the
+        # titlebar freshness pill (merged) and the per-layer time-range panes.
+        active_cell_bounds: dict[CellId, dict[LayerId, TimeBounds | None]] = {}
         active_grid_id = self._get_active_grid_id()
 
         for grid_id, plot_grid in self._grid_widgets.items():
@@ -1263,8 +666,7 @@ class PlotGridTabs:
                             if state.plotter is not None
                             else None
                         )
-                        cell_time_bounds.setdefault(cell_id, []).append(bounds)
-                        layer_time_bounds[layer_id] = bounds
+                        active_cell_bounds.setdefault(cell_id, {})[layer_id] = bounds
 
                     # Get or create session layer for version tracking
                     session_layer = self._session_layers.get(layer_id)
@@ -1283,13 +685,12 @@ class PlotGridTabs:
                             cells_to_rebuild[cell_id] = (cell, plot_grid)
                             versions_to_apply[layer_id] = state.version
 
-        # Clean up orphaned session layers (removed from orchestrator)
+        # Clean up orphaned session layers (removed from orchestrator). Per-cell
+        # widget state (freshness/time panes, autoscale) is swept on cell rebuild
+        # or removal, so only the global layer registry needs explicit cleanup.
         for layer_id in list(self._session_layers.keys()):
             if layer_id not in seen_layer_ids:
                 del self._session_layers[layer_id]
-        for layer_id in list(self._layer_time_panes):
-            if layer_id not in seen_layer_ids:
-                del self._layer_time_panes[layer_id]
 
         # Rebuild affected cells.
         # Defer insertion to allow Bokeh to process any pending model updates
@@ -1297,12 +698,9 @@ class PlotGridTabs:
         # race with DynamicMap updates, causing KeyError when Panel tries to
         # access removed models.
         for cell_id, (cell, plot_grid) in cells_to_rebuild.items():
-            session_plot = self._get_session_composed_plot(cell_id, cell)
-            widget = self._create_cell_widget(cell_id, cell, session_plot)
+            view = self._build_cell(cell_id, cell).view
             pn.state.execute(
-                lambda g=cell.geometry, w=widget, pg=plot_grid: pg.insert_widget_at(
-                    g, w
-                )
+                lambda g=cell.geometry, w=view, pg=plot_grid: pg.insert_widget_at(g, w)
             )
             # Bump versions only after successful rebuild — if the rebuild
             # raised, the version stays stale so the next poll retries.
@@ -1316,40 +714,13 @@ class PlotGridTabs:
         # rebuilds so cells recreated this poll update their fresh pane handle.
         # Lag is recomputed against the current wall clock every poll, so a
         # stalled stream visibly grows stale rather than freezing.
-        for cell_id, bounds_list in cell_time_bounds.items():
-            self._update_freshness_pane(cell_id, bounds_list)
-        for layer_id, bounds in layer_time_bounds.items():
-            self._update_layer_time_pane(layer_id, bounds)
-
-    def _update_freshness_pane(
-        self, cell_id: CellId, bounds_list: list[TimeBounds | None]
-    ) -> None:
-        """Update a cell's titlebar freshness pane from its layers' time bounds."""
-        pane = self._cell_freshness_panes.get(cell_id)
-        if pane is None:
-            return
-        merged = merge_time_bounds(bounds_list)
-        if merged is None:
-            html = ''
-        else:
-            now = Timestamp.now()
-            html = format_freshness_html(
-                merged.lag_seconds(now), tooltip=format_time_info(merged, now=now)
-            )
-        if pane.object != html:
-            pane.object = html
-
-    def _update_layer_time_pane(
-        self, layer_id: LayerId, bounds: TimeBounds | None
-    ) -> None:
-        """Update a layer toolbar's time-range pane from its time bounds."""
-        pane = self._layer_time_panes.get(layer_id)
-        if pane is None:
-            return
-        text = format_time_info(bounds) if bounds is not None else ''
-        html = format_layer_time_html(text)
-        if pane.object != html:
-            pane.object = html
+        for cell_id, per_layer in active_cell_bounds.items():
+            cell_widget = self._cells.get(cell_id)
+            if cell_widget is None:
+                continue
+            cell_widget.update_freshness(list(per_layer.values()))
+            for layer_id, bounds in per_layer.items():
+                cell_widget.update_layer_time(layer_id, bounds)
 
     def shutdown(self) -> None:
         """Unsubscribe from lifecycle events and clean up session state."""
@@ -1357,8 +728,9 @@ class PlotGridTabs:
             self._orchestrator.unsubscribe_from_lifecycle(self._subscription_id)
             self._subscription_id = None
         self._session_layers.clear()
-        for cid in list(self._session_autoscale_controllers):
-            self._drop_autoscale_controller(cid)
+        for cell_widget in self._cells.values():
+            cell_widget.dispose()
+        self._cells.clear()
         self._grid_manager.shutdown()
 
     @property

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -656,29 +656,17 @@ def derive_cell_title(
     """
     Derive a default cell title from its layers.
 
-    Static layers (decorative overlays) are excluded from the derivation; they
-    never drive or break the title. The title is built from the non-static
-    layers as ``Workflow &rarr; Output (Source, window)``, where each segment is
-    shown only when it resolves to a single concrete value across all layers. A
-    varying output, source, or window is omitted rather than summarised: a bare
-    count (``2 outputs``, ``3 sources``) adds nothing a default title can act
-    on, and the per-source/per-output breakdown is already visible in the plot.
+    Deliberately minimal: the title is the first non-static layer's workflow
+    title, plus ``" (Source)"`` when the cell's layers reference a single source
+    (a single source is otherwise not shown by plot labels). Output names and
+    window info are omitted -- base-workflow output names (``Image``,
+    ``Histogram``) are implied by the workflow, window/freshness lives in the
+    titlebar indicator, and per-source breakdown is visible in the plot. When
+    this default is too coarse (e.g. distinct reduction outputs sharing a
+    workflow), the user sets an explicit cell title.
 
-    The ``" (+N more)"`` suffix is not a layer count: it corrects titles that
-    would otherwise read as single-layer. A shared output keeps the ``&rarr;
-    Output`` segment, so the dropped varying source/window makes a multi-layer
-    cell render identically to a single layer -- the suffix flips that bit. A
-    varying output drops the segment entirely, a shape only a composite can
-    produce, so no suffix is added there. ``N`` counts data layers only; static
-    overlays are never reflected in the title.
-
-    Special cases:
-
-    - No non-static layers: an empty cell yields ``''``; a cell with only static
-      overlays uses the first static layer's title.
-    - Multiple distinct workflows cannot merge into a single ``Workflow &rarr;
-      ...`` shape, so the first non-static layer's full title is used, suffixed
-      with ``" (+N more)"`` for the remaining layers.
+    Static layers (decorative overlays) are excluded. A cell with only static
+    overlays uses the first static layer's title; an empty cell yields ``''``.
 
     Parameters
     ----------
@@ -703,44 +691,13 @@ def derive_cell_title(
         )
         return title
 
-    if len({layer.config.workflow_id for layer in layers}) > 1:
-        first_title, _ = get_plot_cell_display_info(
-            layers[0].config, workflow_registry, get_source_title
-        )
-        return f'{first_title} (+{len(layers) - 1} more)'
+    workflow_title, _ = get_workflow_display_info(
+        workflow_registry, layers[0].config.workflow_id, None
+    )
 
-    workflow_id = layers[0].config.workflow_id
-    workflow_title, _ = get_workflow_display_info(workflow_registry, workflow_id, None)
-
-    title = workflow_title
-    output_shown = False
-    views = {layer.config.view_name for layer in layers}
-    if len(views) == 1:
-        _, output_title = get_workflow_display_info(
-            workflow_registry, workflow_id, next(iter(views))
-        )
-        if output_title:
-            title = f'{workflow_title} &rarr; {output_title}'
-            output_shown = True
-
-    details = []
     sources = {s for layer in layers for s in layer.config.source_names}
     if len(sources) == 1:
         source = next(iter(sources))
-        details.append(get_source_title(source) if get_source_title else source)
-
-    windows = {_format_window_info(layer.config.params) for layer in layers}
-    if len(windows) == 1 and (window_info := next(iter(windows))):
-        details.append(window_info)
-
-    if details:
-        title = f'{title} ({", ".join(details)})'
-
-    # A shared output keeps the "&rarr; Output" segment, so the dropped varying
-    # source/window makes a multi-layer cell render identically to a single
-    # layer. Flag the extra layers so the two are distinguishable. When the
-    # output varies the segment is absent, which already marks the cell as a
-    # composite, so no suffix is needed there.
-    if output_shown and len(layers) > 1:
-        title = f'{title} (+{len(layers) - 1} more)'
-    return title
+        source_title = get_source_title(source) if get_source_title else source
+        return f'{workflow_title} ({source_title})'
+    return workflow_title

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -249,7 +249,7 @@ def _create_toolbar_visibility_button(
     """Adjustments button toggling per-layer toolbar visibility for a cell."""
 
     def _icon(shown: bool) -> str:
-        return get_icon('adjustments' if shown else 'adjustments-off')
+        return get_icon('stack-2' if shown else 'stack')
 
     def _tip(shown: bool) -> str:
         return 'Hide layer toolbars' if shown else 'Show layer toolbars'

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -645,9 +645,9 @@ def derive_cell_title(
     Derive a default cell title from its layers.
 
     Uses the source title when a single source is shared across all non-static
-    layers (the common monitoring case). Otherwise falls back to the single
-    layer's display title, or a generic ``"N layers"`` placeholder for
-    multi-layer cells the user is expected to rename.
+    layers (the common monitoring case). Otherwise falls back to the first
+    layer's display title, suffixed with ``" (+N more layers)"`` for
+    multi-layer cells.
 
     Parameters
     ----------
@@ -678,10 +678,12 @@ def derive_cell_title(
             source = next(iter(common))
             return get_source_title(source) if get_source_title else source
 
+    first_title, _ = get_plot_cell_display_info(
+        layers[0].config, workflow_registry, get_source_title
+    )
     if len(layers) == 1:
-        title, _ = get_plot_cell_display_info(
-            layers[0].config, workflow_registry, get_source_title
-        )
-        return title
+        return first_title
 
-    return f'{len(layers)} layers'
+    extra = len(layers) - 1
+    suffix = 'layer' if extra == 1 else 'layers'
+    return f'{first_title} (+{extra} more {suffix})'

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -16,7 +16,7 @@ from .icons import get_icon
 from .styles import Colors, HoverColors, StatusColors
 
 if TYPE_CHECKING:
-    from ..plot_orchestrator import PlotConfig
+    from ..plot_orchestrator import PlotCell, PlotConfig
 
 
 _ADD_LAYER_ITEM = 'Add layer...'
@@ -102,26 +102,21 @@ def _create_add_button_or_menu(
     return menu_button
 
 
-def create_cell_toolbar(
+def create_layer_toolbar(
     *,
     on_gear_callback: Callable[[], None],
     on_close_callback: Callable[[], None],
-    on_add_callback: Callable[[], None] | None = None,
-    on_overlay_selected: Callable[[str, str], None] | None = None,
-    available_overlays: list[tuple[str, str, str]] | None = None,
     title: str | None = None,
     description: str | None = None,
     stopped: bool = False,
 ) -> pn.Row:
     """
-    Create a toolbar row containing title and buttons for plot cells.
+    Create a per-layer toolbar row with title and gear/close buttons.
 
     The toolbar displays an optional title on the left (with tooltip for
-    description) and gear/add/close buttons on the right, using flexbox layout
-    to avoid overlap with Bokeh's plot toolbar.
-
-    When overlay suggestions are available, the add button becomes a dropdown
-    menu with "Add layer..." (opens modal) and direct overlay options.
+    description) and gear/close buttons on the right, using flexbox layout
+    to avoid overlap with Bokeh's plot toolbar. Cell-level actions (add layer,
+    rename, toolbar visibility) live on the cell titlebar, not here.
 
     Parameters
     ----------
@@ -129,19 +124,6 @@ def create_cell_toolbar(
         Callback function to invoke when the gear button is clicked.
     on_close_callback:
         Callback function to invoke when the close button is clicked.
-    on_add_callback:
-        Optional callback to invoke when the add button is clicked.
-        If None, the add button is not shown. This allows the toolbar to be
-        used in contexts where adding layers doesn't make sense (e.g., read-only
-        views, cells with layer limits, or special cell types).
-    on_overlay_selected:
-        Optional callback when an overlay is selected from dropdown.
-        Called with (output_name, plotter_name). Required if available_overlays
-        is provided.
-    available_overlays:
-        Optional list of (output_name, plotter_name, plotter_title) tuples
-        representing available overlay options for this layer. If provided,
-        the add button becomes a dropdown menu.
     title:
         Optional title text to display on the left side of the toolbar.
     description:
@@ -160,15 +142,6 @@ def create_cell_toolbar(
         hover_color=ButtonStyles.PRIMARY_HOVER,
         on_click_callback=on_gear_callback,
     )
-
-    add_button: pn.widgets.Button | pn.widgets.MenuButton | None = None
-    if on_add_callback is not None:
-        add_button = _create_add_button_or_menu(
-            on_add_callback=on_add_callback,
-            on_overlay_selected=on_overlay_selected,
-            available_overlays=available_overlays,
-        )
-
     close_button = create_tool_button(
         icon_name='x',
         button_color=ButtonStyles.DANGER_RED,
@@ -208,10 +181,6 @@ def create_cell_toolbar(
             left_items.append(tooltip_icon)
 
     margin = ButtonStyles.CELL_MARGIN
-    right_buttons = [gear_button]
-    if add_button is not None:
-        right_buttons.append(add_button)
-    right_buttons.append(close_button)
 
     # Add border when workflow is stopped
     styles = {}
@@ -222,12 +191,159 @@ def create_cell_toolbar(
     return pn.Row(
         *left_items,
         pn.Spacer(sizing_mode='stretch_width'),
-        *right_buttons,
+        gear_button,
+        close_button,
         sizing_mode='stretch_width',
         height=ButtonStyles.TOOL_BUTTON_SIZE,
         margin=(margin, margin, margin, margin),
         align='end',
         styles=styles,
+    )
+
+
+def _cell_title_html(title: str, has_user_title: bool) -> str:
+    """Render the cell title span; derived titles are muted and italic.
+
+    User-defined titles are free text and HTML-escaped. Derived titles come
+    from display-info helpers and may contain HTML entities (e.g. ``&rarr;``),
+    so they are rendered as-is.
+    """
+    if has_user_title:
+        from html import escape
+
+        style = f'font-size:12.5px;font-weight:600;color:{Colors.TEXT_DARK};'
+        title = escape(title)
+    else:
+        style = f'font-size:12.5px;color:{Colors.TEXT_MUTED};font-style:italic;'
+    return (
+        f'<span style="{style}white-space:nowrap;overflow:hidden;'
+        f'text-overflow:ellipsis;display:block;">{title}</span>'
+    )
+
+
+def _create_toolbar_visibility_button(
+    *,
+    visible: bool,
+    on_toggle: Callable[[bool], None],
+) -> pn.widgets.Button:
+    """Adjustments button toggling per-layer toolbar visibility for a cell."""
+
+    def _icon(shown: bool) -> str:
+        return get_icon('adjustments' if shown else 'adjustments-off')
+
+    def _tip(shown: bool) -> str:
+        return 'Hide layer toolbars' if shown else 'Show layer toolbars'
+
+    button = pn.widgets.Button(
+        label='',
+        icon=_icon(visible),
+        icon_size='1.5em',
+        width=ButtonStyles.TOOL_BUTTON_SIZE,
+        height=ButtonStyles.TOOL_BUTTON_SIZE,
+        color='light',
+        sizing_mode='fixed',
+        margin=0,
+        description=_tip(visible),
+        stylesheets=create_tool_button_stylesheet(Colors.TEXT_MUTED, HoverColors.MUTED),
+    )
+    state = {'visible': visible}
+
+    def _toggle(_) -> None:
+        state['visible'] = not state['visible']
+        button.icon = _icon(state['visible'])
+        button.description = _tip(state['visible'])
+        on_toggle(state['visible'])
+
+    button.on_click(_toggle)
+    return button
+
+
+def create_cell_titlebar(
+    *,
+    title: str,
+    has_user_title: bool,
+    on_edit_title_callback: Callable[[], None],
+    toolbars_visible: bool,
+    on_toggle_toolbars_callback: Callable[[bool], None],
+    on_add_callback: Callable[[], None] | None = None,
+    on_overlay_selected: Callable[[str, str], None] | None = None,
+    available_overlays: list[tuple[str, str, str]] | None = None,
+) -> pn.Row:
+    """
+    Create the cell-level titlebar shown above the per-layer toolbars.
+
+    The titlebar holds the cell title on the left and cell-level actions on the
+    right: add layer (with overlay suggestions), edit title (opens a modal), and
+    a toggle that hides/shows the per-layer toolbars.
+
+    Parameters
+    ----------
+    title:
+        Title to display. Either the user-defined title or a derived one.
+    has_user_title:
+        Whether ``title`` is user-defined (styled prominently) or derived
+        (styled muted/italic as a placeholder).
+    on_edit_title_callback:
+        Invoked when the edit (pencil) button is clicked; opens the rename modal.
+    toolbars_visible:
+        Current visibility of the per-layer toolbars; sets the toggle icon.
+    on_toggle_toolbars_callback:
+        Invoked with the new visibility state when the toggle is clicked.
+    on_add_callback:
+        Optional callback to add a layer (opens modal). If None, no add button.
+    on_overlay_selected:
+        Optional callback when an overlay suggestion is selected, called with
+        (output_name, plotter_name).
+    available_overlays:
+        Optional list of (output_name, plotter_name, plotter_title) tuples; if
+        provided the add button becomes a dropdown menu.
+
+    Returns
+    -------
+    :
+        Panel Row widget containing the cell titlebar.
+    """
+    title_pane = pn.pane.HTML(
+        _cell_title_html(title, has_user_title),
+        sizing_mode='stretch_width',
+        margin=(0, 4),
+        styles={'overflow': 'hidden', 'min-width': '0'},
+    )
+
+    edit_button = create_tool_button(
+        icon_name='pencil',
+        button_color=Colors.TEXT_MUTED,
+        hover_color=HoverColors.MUTED,
+        on_click_callback=on_edit_title_callback,
+    )
+    toggle_button = _create_toolbar_visibility_button(
+        visible=toolbars_visible,
+        on_toggle=on_toggle_toolbars_callback,
+    )
+
+    right_buttons: list = []
+    if on_add_callback is not None:
+        right_buttons.append(
+            _create_add_button_or_menu(
+                on_add_callback=on_add_callback,
+                on_overlay_selected=on_overlay_selected,
+                available_overlays=available_overlays,
+            )
+        )
+    right_buttons.extend([edit_button, toggle_button])
+
+    margin = ButtonStyles.CELL_MARGIN
+    return pn.Row(
+        title_pane,
+        *right_buttons,
+        sizing_mode='stretch_width',
+        min_height=ButtonStyles.TOOL_BUTTON_SIZE,
+        align='center',
+        margin=(margin, margin, 0, margin),
+        styles={
+            'background-color': Colors.BG_LIGHT,
+            'border-bottom': f'1px solid {Colors.BORDER}',
+        },
     )
 
 
@@ -408,3 +524,54 @@ def get_plot_cell_display_info(
     description = '\n'.join(description_parts)
 
     return title, description
+
+
+def derive_cell_title(
+    cell: PlotCell,
+    workflow_registry: Mapping[WorkflowId, WorkflowSpec],
+    get_source_title: Callable[[str], str] | None = None,
+) -> str:
+    """
+    Derive a default cell title from its layers.
+
+    Uses the source title when a single source is shared across all non-static
+    layers (the common monitoring case). Otherwise falls back to the single
+    layer's display title, or a generic ``"N layers"`` placeholder for
+    multi-layer cells the user is expected to rename.
+
+    Parameters
+    ----------
+    cell:
+        The plot cell.
+    workflow_registry:
+        Registry mapping workflow IDs to their specifications.
+    get_source_title:
+        Optional function to get display title for a source name.
+
+    Returns
+    -------
+    :
+        Derived title string.
+    """
+    layers = cell.layers
+    if not layers:
+        return ''
+
+    source_sets = [
+        set(layer.config.source_names)
+        for layer in layers
+        if not layer.config.is_static()
+    ]
+    if source_sets:
+        common = set.intersection(*source_sets)
+        if len(common) == 1:
+            source = next(iter(common))
+            return get_source_title(source) if get_source_title else source
+
+    if len(layers) == 1:
+        title, _ = get_plot_cell_display_info(
+            layers[0].config, workflow_registry, get_source_title
+        )
+        return title
+
+    return f'{len(layers)} layers'

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -656,10 +656,29 @@ def derive_cell_title(
     """
     Derive a default cell title from its layers.
 
-    Uses the source title when a single source is shared across all non-static
-    layers (the common monitoring case). Otherwise falls back to the first
-    layer's display title, suffixed with ``" (+N more layers)"`` for
-    multi-layer cells.
+    Static layers (decorative overlays) are excluded from the derivation; they
+    never drive or break the title. The title is built from the non-static
+    layers as ``Workflow &rarr; Output (Source, window)``, where each segment is
+    shown only when it resolves to a single concrete value across all layers. A
+    varying output, source, or window is omitted rather than summarised: a bare
+    count (``2 outputs``, ``3 sources``) adds nothing a default title can act
+    on, and the per-source/per-output breakdown is already visible in the plot.
+
+    The ``" (+N more)"`` suffix is not a layer count: it corrects titles that
+    would otherwise read as single-layer. A shared output keeps the ``&rarr;
+    Output`` segment, so the dropped varying source/window makes a multi-layer
+    cell render identically to a single layer -- the suffix flips that bit. A
+    varying output drops the segment entirely, a shape only a composite can
+    produce, so no suffix is added there. ``N`` counts data layers only; static
+    overlays are never reflected in the title.
+
+    Special cases:
+
+    - No non-static layers: an empty cell yields ``''``; a cell with only static
+      overlays uses the first static layer's title.
+    - Multiple distinct workflows cannot merge into a single ``Workflow &rarr;
+      ...`` shape, so the first non-static layer's full title is used, suffixed
+      with ``" (+N more)"`` for the remaining layers.
 
     Parameters
     ----------
@@ -675,27 +694,53 @@ def derive_cell_title(
     :
         Derived title string.
     """
-    layers = cell.layers
+    layers = [layer for layer in cell.layers if not layer.config.is_static()]
     if not layers:
-        return ''
+        if not cell.layers:
+            return ''
+        title, _ = get_plot_cell_display_info(
+            cell.layers[0].config, workflow_registry, get_source_title
+        )
+        return title
 
-    source_sets = [
-        set(layer.config.source_names)
-        for layer in layers
-        if not layer.config.is_static()
-    ]
-    if source_sets:
-        common = set.intersection(*source_sets)
-        if len(common) == 1:
-            source = next(iter(common))
-            return get_source_title(source) if get_source_title else source
+    if len({layer.config.workflow_id for layer in layers}) > 1:
+        first_title, _ = get_plot_cell_display_info(
+            layers[0].config, workflow_registry, get_source_title
+        )
+        return f'{first_title} (+{len(layers) - 1} more)'
 
-    first_title, _ = get_plot_cell_display_info(
-        layers[0].config, workflow_registry, get_source_title
-    )
-    if len(layers) == 1:
-        return first_title
+    workflow_id = layers[0].config.workflow_id
+    workflow_title, _ = get_workflow_display_info(workflow_registry, workflow_id, None)
 
-    extra = len(layers) - 1
-    suffix = 'layer' if extra == 1 else 'layers'
-    return f'{first_title} (+{extra} more {suffix})'
+    title = workflow_title
+    output_shown = False
+    views = {layer.config.view_name for layer in layers}
+    if len(views) == 1:
+        _, output_title = get_workflow_display_info(
+            workflow_registry, workflow_id, next(iter(views))
+        )
+        if output_title:
+            title = f'{workflow_title} &rarr; {output_title}'
+            output_shown = True
+
+    details = []
+    sources = {s for layer in layers for s in layer.config.source_names}
+    if len(sources) == 1:
+        source = next(iter(sources))
+        details.append(get_source_title(source) if get_source_title else source)
+
+    windows = {_format_window_info(layer.config.params) for layer in layers}
+    if len(windows) == 1 and (window_info := next(iter(windows))):
+        details.append(window_info)
+
+    if details:
+        title = f'{title} ({", ".join(details)})'
+
+    # A shared output keeps the "&rarr; Output" segment, so the dropped varying
+    # source/window makes a multi-layer cell render identically to a single
+    # layer. Flag the extra layers so the two are distinguishable. When the
+    # output varies the segment is absent, which already marks the cell as a
+    # composite, so no suffix is needed there.
+    if output_shown and len(layers) > 1:
+        title = f'{title} (+{len(layers) - 1} more)'
+    return title

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -13,7 +13,7 @@ from ...config.workflow_spec import WorkflowId, WorkflowSpec
 from ..plot_params import WindowMode
 from .buttons import ButtonStyles, create_tool_button, create_tool_button_stylesheet
 from .icons import get_icon
-from .styles import Colors, HoverColors, StatusColors
+from .styles import Colors, FreshnessPill, HoverColors, StatusColors
 
 if TYPE_CHECKING:
     from ..plot_orchestrator import PlotCell, PlotConfig
@@ -109,6 +109,7 @@ def create_layer_toolbar(
     title: str | None = None,
     description: str | None = None,
     stopped: bool = False,
+    time_pane: pn.pane.HTML | None = None,
 ) -> pn.Row:
     """
     Create a per-layer toolbar row with title and gear/close buttons.
@@ -130,6 +131,9 @@ def create_layer_toolbar(
         Optional description shown as tooltip when hovering over the title.
     stopped:
         If True, adds a visual indicator (border) showing workflow has ended.
+    time_pane:
+        Optional pane showing this layer's data time range/lag, placed right of
+        the title and updated in place by the caller.
 
     Returns
     -------
@@ -188,9 +192,12 @@ def create_layer_toolbar(
         styles['border'] = f'2px solid {Colors.TEXT}'
         styles['border-radius'] = '4px'
 
+    middle: list = [time_pane] if time_pane is not None else []
+
     return pn.Row(
         *left_items,
         pn.Spacer(sizing_mode='stretch_width'),
+        *middle,
         gear_button,
         close_button,
         sizing_mode='stretch_width',
@@ -216,8 +223,101 @@ def _cell_title_html(title: str, has_user_title: bool) -> str:
     else:
         style = f'font-size:12.5px;color:{Colors.TEXT_MUTED};font-style:italic;'
     return (
-        f'<span style="{style}white-space:nowrap;overflow:hidden;'
+        f'<span style="{style}line-height:{ButtonStyles.TOOL_BUTTON_SIZE}px;'
+        f'white-space:nowrap;overflow:hidden;'
         f'text-overflow:ellipsis;display:block;">{title}</span>'
+    )
+
+
+def _freshness_band(lag_seconds: float) -> tuple[str, str, str]:
+    """Return the ``(background, text, dot)`` pill colors for a lag in seconds."""
+    if lag_seconds < FreshnessPill.FRESH_MAX_SECONDS:
+        return FreshnessPill.FRESH
+    if lag_seconds < FreshnessPill.STALE_MAX_SECONDS:
+        return FreshnessPill.STALE
+    return FreshnessPill.OLD
+
+
+def _format_lag_short(lag_seconds: float) -> str:
+    """Compact lag label, e.g. "2.3s", "41s", "3m"."""
+    if lag_seconds < 10:
+        return f'{lag_seconds:.1f}s'
+    if lag_seconds < 60:
+        return f'{lag_seconds:.0f}s'
+    return f'{lag_seconds / 60:.0f}m'
+
+
+def format_freshness_html(lag_seconds: float | None, tooltip: str = '') -> str:
+    """Render the titlebar freshness/lag pill, color-banded by staleness.
+
+    Parameters
+    ----------
+    lag_seconds:
+        Data lag in seconds, or None to render nothing (no timing data).
+    tooltip:
+        Full time-range text shown on hover (the pill itself shows only the
+        compact lag).
+    """
+    if lag_seconds is None:
+        return ''
+    background, text_color, dot_color = _freshness_band(lag_seconds)
+    pill_style = (
+        f'display:inline-flex;align-items:center;gap:5px;height:20px;'
+        f'padding:0 8px;border-radius:10px;font-size:11px;'
+        f'font-variant-numeric:tabular-nums;white-space:nowrap;'
+        f'background:{background};color:{text_color};'
+    )
+    dot_style = (
+        f'width:7px;height:7px;border-radius:50%;flex:none;background:{dot_color};'
+    )
+    if tooltip:
+        from html import escape
+
+        title_attr = f' title="{escape(tooltip)}"'
+    else:
+        title_attr = ''
+    return (
+        f'<span style="{pill_style}"{title_attr}>'
+        f'<span style="{dot_style}"></span>{_format_lag_short(lag_seconds)}</span>'
+    )
+
+
+def create_freshness_pane() -> pn.pane.HTML:
+    """Create the titlebar freshness/lag pane, updated in place via ``.object``.
+
+    Content sizes to the pill; ``align='center'`` (``align-self:center``)
+    vertically centers it against the title and buttons in the row.
+    """
+    return pn.pane.HTML(
+        '',
+        align='center',
+        margin=(0, 6),
+        styles={'flex': '0 0 auto'},
+    )
+
+
+def format_layer_time_html(text: str) -> str:
+    """Render a per-layer time-range/lag label (muted, tabular nums)."""
+    if not text:
+        return ''
+    style = (
+        f'font-size:11px;color:{Colors.TEXT_MUTED};white-space:nowrap;'
+        'font-variant-numeric:tabular-nums;'
+    )
+    return f'<span style="{style}">{text}</span>'
+
+
+def create_layer_time_pane() -> pn.pane.HTML:
+    """Create a per-layer time-range pane, updated in place via ``.object``.
+
+    Content sizes to the text; ``align='center'`` (``align-self:center``)
+    vertically centers it against the layer title and buttons in the row.
+    """
+    return pn.pane.HTML(
+        '',
+        align='center',
+        margin=(0, 6),
+        styles={'flex': '0 0 auto'},
     )
 
 
@@ -265,6 +365,7 @@ def create_cell_titlebar(
     on_edit_title_callback: Callable[[], None],
     toolbars_visible: bool,
     on_toggle_toolbars_callback: Callable[[bool], None],
+    freshness_pane: pn.pane.HTML | None = None,
     on_add_callback: Callable[[], None] | None = None,
     on_overlay_selected: Callable[[str, str], None] | None = None,
     available_overlays: list[tuple[str, str, str]] | None = None,
@@ -289,6 +390,9 @@ def create_cell_titlebar(
         Current visibility of the per-layer toolbars; sets the toggle icon.
     on_toggle_toolbars_callback:
         Invoked with the new visibility state when the toggle is clicked.
+    freshness_pane:
+        Optional pane showing the data freshness/lag indicator, placed between
+        the title and the action buttons. Updated in place by the caller.
     on_add_callback:
         Optional callback to add a layer (opens modal). If None, no add button.
     on_overlay_selected:
@@ -306,6 +410,7 @@ def create_cell_titlebar(
     title_pane = pn.pane.HTML(
         _cell_title_html(title, has_user_title),
         sizing_mode='stretch_width',
+        height=ButtonStyles.TOOL_BUTTON_SIZE,
         margin=(0, 4),
         styles={'overflow': 'hidden', 'min-width': '0'},
     )
@@ -332,8 +437,13 @@ def create_cell_titlebar(
         )
     right_buttons.extend([edit_button, toggle_button])
 
+    # Freshness pill sits at the far left; the stretch title fills the middle and
+    # pushes the action buttons to the right.
+    left: list = [freshness_pane] if freshness_pane is not None else []
+
     margin = ButtonStyles.CELL_MARGIN
     return pn.Row(
+        *left,
         title_pane,
         *right_buttons,
         sizing_mode='stretch_width',
@@ -396,10 +506,10 @@ def _format_window_info(params) -> str:
     Format window parameters into a human-readable string.
 
     Only ``since_start`` produces a label here. For window mode the actual time
-    range comes from the data and is displayed by ``_compute_time_info`` at
-    render time; the configured ``window_duration_seconds`` is a target, not a
-    truth, so showing it in the static title would lie when backend cadence
-    exceeds the requested lookback.
+    range comes from the data and is shown by the titlebar freshness indicator
+    (see ``_compute_time_bounds``); the configured ``window_duration_seconds`` is
+    a target, not a truth, so showing it in the static title would lie when
+    backend cadence exceeds the requested lookback.
     """
     window = getattr(params, 'window', None)
     if window is None:

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -17,55 +17,83 @@ from .styles import Colors, HoverColors, StatusColors
 
 if TYPE_CHECKING:
     from ..plot_orchestrator import PlotCell, PlotConfig
+    from ..plotting_controller import PlottingController
 
 
-_ADD_LAYER_ITEM = 'Add layer...'
+def _available_overlays_for_config(
+    config: PlotConfig,
+    workflow_registry: Mapping[WorkflowId, WorkflowSpec],
+    plotting_controller: PlottingController,
+) -> list[tuple[str, str, str]]:
+    """Overlay suggestions for a single layer: ``(view, plotter, title)``."""
+    if config.is_static():
+        return []
+    workflow_spec = workflow_registry.get(config.workflow_id)
+    if workflow_spec is None:
+        return []
+    return plotting_controller.get_available_overlays(workflow_spec, config.plot_name)
 
 
-def _create_add_button_or_menu(
-    *,
-    on_add_callback: Callable[[], None],
-    on_overlay_selected: Callable[[str, str], None] | None = None,
-    available_overlays: list[tuple[str, str, str]] | None = None,
-) -> pn.widgets.Button | pn.widgets.MenuButton:
+def overlay_suggestions_for_layer(
+    config: PlotConfig,
+    existing_plotters: frozenset[str],
+    workflow_registry: Mapping[WorkflowId, WorkflowSpec],
+    plotting_controller: PlottingController,
+) -> list[tuple[str, str, str]]:
     """
-    Create either a simple add button or a dropdown menu with overlay options.
+    Overlay suggestions derived from one layer, minus plotters already present.
 
-    Parameters
-    ----------
-    on_add_callback:
-        Callback when "Add layer..." is selected (opens modal).
-    on_overlay_selected:
-        Callback when an overlay is selected: (output_name, plotter_name).
-    available_overlays:
-        List of (output_name, plotter_name, plotter_title) tuples.
+    Overlays inherit the layer's workflow/sources, so a suggestion is offered
+    per base layer. Plotters already present anywhere in the cell are excluded
+    to avoid suggesting a duplicate.
 
     Returns
     -------
     :
-        Button widget or MenuButton with overlay options.
+        List of ``(view_name, plotter_name, plotter_title)`` tuples.
+    """
+    return [
+        (view_name, plotter_name, title)
+        for view_name, plotter_name, title in _available_overlays_for_config(
+            config, workflow_registry, plotting_controller
+        )
+        if plotter_name not in existing_plotters
+    ]
+
+
+def create_overlay_add_button(
+    *,
+    overlays: list[tuple[str, str, str]],
+    on_overlay_selected: Callable[[str, str], None],
+) -> pn.widgets.MenuButton:
+    """
+    Create a ``+`` dropdown adding an overlay derived from a layer.
+
+    The dropdown lists the overlay titles (always a menu, even for a single
+    suggestion, so the choice is always labeled). Callers build this only when
+    ``overlays`` is non-empty.
+
+    Parameters
+    ----------
+    overlays:
+        ``(view_name, plotter_name, plotter_title)`` tuples for the layer.
+    on_overlay_selected:
+        Callback when an overlay is chosen: ``(view_name, plotter_name)``.
+
+    Returns
+    -------
+    :
+        MenuButton listing the overlay suggestions.
     """
     button_color = StatusColors.SUCCESS
     hover_color = HoverColors.SUCCESS
 
-    if not available_overlays or on_overlay_selected is None:
-        # No overlays available - use simple button
-        return create_tool_button(
-            icon_name='plus',
-            button_color=button_color,
-            hover_color=hover_color,
-            on_click_callback=on_add_callback,
-        )
-
-    # Build menu items: "Add layer..." followed by overlay suggestions
-    items = [_ADD_LAYER_ITEM]
+    items: list[str] = []
     overlay_map: dict[str, tuple[str, str]] = {}
+    for view_name, plotter_name, title in overlays:
+        items.append(title)
+        overlay_map[title] = (view_name, plotter_name)
 
-    for output_name, plotter_name, plotter_title in available_overlays:
-        items.append(plotter_title)
-        overlay_map[plotter_title] = (output_name, plotter_name)
-
-    # Use shared button stylesheet + menu-specific styling
     stylesheets = create_tool_button_stylesheet(button_color, hover_color)
     stylesheets.append(
         """
@@ -76,7 +104,6 @@ def _create_add_button_or_menu(
         }
         """
     )
-
     menu_button = pn.widgets.MenuButton(
         label='',
         items=items,
@@ -91,12 +118,9 @@ def _create_add_button_or_menu(
     )
 
     def on_menu_click(event: pn.param.parameterized.Event) -> None:
-        selected = event.new
-        if selected == _ADD_LAYER_ITEM:
-            on_add_callback()
-        elif selected in overlay_map:
-            output_name, plotter_name = overlay_map[selected]
-            on_overlay_selected(output_name, plotter_name)
+        if event.new in overlay_map:
+            view_name, plotter_name = overlay_map[event.new]
+            on_overlay_selected(view_name, plotter_name)
 
     menu_button.on_click(on_menu_click)
     return menu_button
@@ -105,28 +129,26 @@ def _create_add_button_or_menu(
 def create_layer_toolbar(
     *,
     on_gear_callback: Callable[[], None],
-    on_close_callback: Callable[[], None],
     title: str | None = None,
     description: str | None = None,
     stopped: bool = False,
     time_pane: pn.pane.HTML | None = None,
 ) -> pn.Row | pn.Column:
     """
-    Create a per-layer toolbar with title and gear/close buttons.
+    Create a per-layer toolbar with title and a gear button.
 
     The toolbar displays an optional title on the left (with tooltip for
-    description) and gear/close buttons on the right, using flexbox layout
+    description) and a gear button on the right, using flexbox layout
     to avoid overlap with Bokeh's plot toolbar. When a ``time_pane`` is given
     it is placed on its own line below, so the time info does not compete with
-    the title for horizontal space. Cell-level actions (add layer, rename,
-    toolbar visibility) live on the cell titlebar, not here.
+    the title for horizontal space. Cell-level actions (add/remove layer,
+    rename, toolbar visibility) live on the cell titlebar and properties modal,
+    not here.
 
     Parameters
     ----------
     on_gear_callback:
         Callback function to invoke when the gear button is clicked.
-    on_close_callback:
-        Callback function to invoke when the close button is clicked.
     title:
         Optional title text to display on the left side of the toolbar.
     description:
@@ -147,12 +169,6 @@ def create_layer_toolbar(
         button_color=ButtonStyles.PRIMARY_BLUE,
         hover_color=ButtonStyles.PRIMARY_HOVER,
         on_click_callback=on_gear_callback,
-    )
-    close_button = create_tool_button(
-        icon_name='x',
-        button_color=ButtonStyles.DANGER_RED,
-        hover_color=ButtonStyles.DANGER_HOVER,
-        on_click_callback=on_close_callback,
     )
 
     # Build left content: title and optional tooltip icon
@@ -198,7 +214,6 @@ def create_layer_toolbar(
         *left_items,
         pn.Spacer(sizing_mode='stretch_width'),
         gear_button,
-        close_button,
         sizing_mode='stretch_width',
         height=ButtonStyles.TOOL_BUTTON_SIZE,
         align='end',
@@ -286,15 +301,12 @@ def create_cell_titlebar(
     toolbars_visible: bool,
     on_toggle_toolbars_callback: Callable[[bool], None],
     freshness_pane: pn.pane.HTML | None = None,
-    on_add_callback: Callable[[], None] | None = None,
-    on_overlay_selected: Callable[[str, str], None] | None = None,
-    available_overlays: list[tuple[str, str, str]] | None = None,
 ) -> pn.Row:
     """
     Create the cell-level titlebar shown above the per-layer toolbars.
 
     The titlebar holds the cell title on the left and cell-level actions on the
-    right: add layer (with overlay suggestions), edit title (opens a modal), and
+    right: edit cell properties (opens a modal for rename/add/remove layer) and
     a toggle that hides/shows the per-layer toolbars.
 
     Parameters
@@ -305,7 +317,8 @@ def create_cell_titlebar(
         Whether ``title`` is user-defined (styled prominently) or derived
         (styled muted/italic as a placeholder).
     on_edit_title_callback:
-        Invoked when the edit (pencil) button is clicked; opens the rename modal.
+        Invoked when the edit (pencil) button is clicked; opens the cell
+        properties modal.
     toolbars_visible:
         Current visibility of the per-layer toolbars; sets the toggle icon.
     on_toggle_toolbars_callback:
@@ -313,14 +326,6 @@ def create_cell_titlebar(
     freshness_pane:
         Optional pane showing the data freshness/lag indicator, placed between
         the title and the action buttons. Updated in place by the caller.
-    on_add_callback:
-        Optional callback to add a layer (opens modal). If None, no add button.
-    on_overlay_selected:
-        Optional callback when an overlay suggestion is selected, called with
-        (output_name, plotter_name).
-    available_overlays:
-        Optional list of (output_name, plotter_name, plotter_title) tuples; if
-        provided the add button becomes a dropdown menu.
 
     Returns
     -------
@@ -346,16 +351,7 @@ def create_cell_titlebar(
         on_toggle=on_toggle_toolbars_callback,
     )
 
-    right_buttons: list = []
-    if on_add_callback is not None:
-        right_buttons.append(
-            _create_add_button_or_menu(
-                on_add_callback=on_add_callback,
-                on_overlay_selected=on_overlay_selected,
-                available_overlays=available_overlays,
-            )
-        )
-    right_buttons.extend([edit_button, toggle_button])
+    right_buttons: list = [edit_button, toggle_button]
 
     # Freshness pill sits at the far left; the stretch title fills the middle and
     # pushes the action buttons to the right.

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -110,14 +110,16 @@ def create_layer_toolbar(
     description: str | None = None,
     stopped: bool = False,
     time_pane: pn.pane.HTML | None = None,
-) -> pn.Row:
+) -> pn.Row | pn.Column:
     """
-    Create a per-layer toolbar row with title and gear/close buttons.
+    Create a per-layer toolbar with title and gear/close buttons.
 
     The toolbar displays an optional title on the left (with tooltip for
     description) and gear/close buttons on the right, using flexbox layout
-    to avoid overlap with Bokeh's plot toolbar. Cell-level actions (add layer,
-    rename, toolbar visibility) live on the cell titlebar, not here.
+    to avoid overlap with Bokeh's plot toolbar. When a ``time_pane`` is given
+    it is placed on its own line below, so the time info does not compete with
+    the title for horizontal space. Cell-level actions (add layer, rename,
+    toolbar visibility) live on the cell titlebar, not here.
 
     Parameters
     ----------
@@ -192,18 +194,28 @@ def create_layer_toolbar(
         styles['border'] = f'2px solid {Colors.TEXT}'
         styles['border-radius'] = '4px'
 
-    middle: list = [time_pane] if time_pane is not None else []
-
-    return pn.Row(
+    button_row = pn.Row(
         *left_items,
         pn.Spacer(sizing_mode='stretch_width'),
-        *middle,
         gear_button,
         close_button,
         sizing_mode='stretch_width',
         height=ButtonStyles.TOOL_BUTTON_SIZE,
-        margin=(margin, margin, margin, margin),
         align='end',
+    )
+
+    if time_pane is None:
+        button_row.margin = (margin, margin, margin, margin)
+        button_row.styles = styles
+        return button_row
+
+    # Time info goes on its own line below the title/buttons row to avoid
+    # competing with the title for horizontal space.
+    return pn.Column(
+        button_row,
+        time_pane,
+        sizing_mode='stretch_width',
+        margin=(margin, margin, margin, margin),
         styles=styles,
     )
 
@@ -310,13 +322,13 @@ def format_layer_time_html(text: str) -> str:
 def create_layer_time_pane() -> pn.pane.HTML:
     """Create a per-layer time-range pane, updated in place via ``.object``.
 
-    Content sizes to the text; ``align='center'`` (``align-self:center``)
-    vertically centers it against the layer title and buttons in the row.
+    Placed on its own line below the layer title/buttons row; indented and
+    pulled up close to the title so it visually belongs to it.
     """
     return pn.pane.HTML(
         '',
-        align='center',
-        margin=(0, 6),
+        align='start',
+        margin=(-4, 6, 0, 14),
         styles={'flex': '0 0 auto'},
     )
 

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import html
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,7 @@ from .icons import get_icon
 from .styles import Colors, HoverColors, StatusColors
 
 if TYPE_CHECKING:
+    from ..plot_data_service import LayerId
     from ..plot_orchestrator import PlotCell, PlotConfig
     from ..plotting_controller import PlottingController
 
@@ -126,51 +128,39 @@ def create_overlay_add_button(
     return menu_button
 
 
-def create_layer_toolbar(
+def create_layer_info_row(
     *,
-    on_gear_callback: Callable[[], None],
     title: str | None = None,
     description: str | None = None,
     stopped: bool = False,
     time_pane: pn.pane.HTML | None = None,
 ) -> pn.Row | pn.Column:
     """
-    Create a per-layer toolbar with title and a gear button.
+    Create a per-layer info row showing the layer title and its time range.
 
-    The toolbar displays an optional title on the left (with tooltip for
-    description) and a gear button on the right, using flexbox layout
-    to avoid overlap with Bokeh's plot toolbar. When a ``time_pane`` is given
-    it is placed on its own line below, so the time info does not compete with
-    the title for horizontal space. Cell-level actions (add/remove layer,
-    rename, toolbar visibility) live on the cell titlebar and properties modal,
-    not here.
+    Purely informational: it shows the layer title (with a tooltip for the
+    description) and, when a ``time_pane`` is given, the layer's data time
+    range on its own line below. Layer configuration lives on the cell titlebar
+    gear; add/remove and rename live on the cell properties modal — no controls
+    are placed here.
 
     Parameters
     ----------
-    on_gear_callback:
-        Callback function to invoke when the gear button is clicked.
     title:
-        Optional title text to display on the left side of the toolbar.
+        Optional title text to display on the left side of the row.
     description:
         Optional description shown as tooltip when hovering over the title.
     stopped:
         If True, adds a visual indicator (border) showing workflow has ended.
     time_pane:
-        Optional pane showing this layer's data time range/lag, placed right of
-        the title and updated in place by the caller.
+        Optional pane showing this layer's data time range/lag, placed on its
+        own line below the title and updated in place by the caller.
 
     Returns
     -------
     :
-        Panel Row widget containing the toolbar.
+        Panel Row (or Column when a time pane is given) for one layer.
     """
-    gear_button = create_tool_button(
-        icon_name='settings',
-        button_color=ButtonStyles.PRIMARY_BLUE,
-        hover_color=ButtonStyles.PRIMARY_HOVER,
-        on_click_callback=on_gear_callback,
-    )
-
     # Build left content: title and optional tooltip icon
     left_items: list = []
     if title:
@@ -210,24 +200,23 @@ def create_layer_toolbar(
         styles['border'] = f'2px solid {Colors.TEXT}'
         styles['border-radius'] = '4px'
 
-    button_row = pn.Row(
+    title_row = pn.Row(
         *left_items,
         pn.Spacer(sizing_mode='stretch_width'),
-        gear_button,
         sizing_mode='stretch_width',
         height=ButtonStyles.TOOL_BUTTON_SIZE,
         align='end',
     )
 
     if time_pane is None:
-        button_row.margin = (margin, margin, margin, margin)
-        button_row.styles = styles
-        return button_row
+        title_row.margin = (margin, margin, margin, margin)
+        title_row.styles = styles
+        return title_row
 
-    # Time info goes on its own line below the title/buttons row to avoid
-    # competing with the title for horizontal space.
+    # Time info goes on its own line below the title row to avoid competing
+    # with the title for horizontal space.
     return pn.Column(
-        button_row,
+        title_row,
         time_pane,
         sizing_mode='stretch_width',
         margin=(margin, margin, margin, margin),
@@ -261,13 +250,13 @@ def _create_toolbar_visibility_button(
     visible: bool,
     on_toggle: Callable[[bool], None],
 ) -> pn.widgets.Button:
-    """Adjustments button toggling per-layer toolbar visibility for a cell."""
+    """Adjustments button toggling per-layer info-row visibility for a cell."""
 
     def _icon(shown: bool) -> str:
         return get_icon('stack-2' if shown else 'stack')
 
     def _tip(shown: bool) -> str:
-        return 'Hide layer toolbars' if shown else 'Show layer toolbars'
+        return 'Hide layer details' if shown else 'Show layer details'
 
     button = pn.widgets.Button(
         label='',
@@ -293,21 +282,101 @@ def _create_toolbar_visibility_button(
     return button
 
 
+def _create_configure_button_or_menu(
+    *,
+    layers: list[tuple[LayerId, str]],
+    on_configure: Callable[[LayerId], None],
+) -> pn.widgets.Button | pn.widgets.MenuButton:
+    """
+    Gear button (single layer) or menu picking which layer to configure.
+
+    For a single-layer cell the gear configures that layer directly. For
+    multiple layers it becomes a dropdown listing the layer titles, routing the
+    selection to ``on_configure`` with the chosen layer's ID.
+
+    Parameters
+    ----------
+    layers:
+        ``(layer_id, title)`` pairs for the cell's layers, in display order.
+    on_configure:
+        Callback invoked with the layer ID to configure.
+    """
+    button_color = Colors.TEXT_MUTED
+    hover_color = HoverColors.MUTED
+
+    if len(layers) == 1:
+        layer_id = layers[0][0]
+        return create_tool_button(
+            icon_name='settings',
+            button_color=button_color,
+            hover_color=hover_color,
+            on_click_callback=lambda: on_configure(layer_id),
+        )
+
+    # Titles carry HTML entities (e.g. '&rarr;'); unescape for plain menu
+    # labels and disambiguate duplicates so the label->layer map stays 1:1.
+    items: list[str] = []
+    label_map: dict[str, LayerId] = {}
+    for layer_id, title in layers:
+        label = html.unescape(title)
+        if label in label_map:
+            suffix = 2
+            while f'{label} ({suffix})' in label_map:
+                suffix += 1
+            label = f'{label} ({suffix})'
+        items.append(label)
+        label_map[label] = layer_id
+
+    stylesheets = create_tool_button_stylesheet(button_color, hover_color)
+    stylesheets.append(
+        """
+        .bk-menu {
+            min-width: 200px !important;
+            right: 0 !important;
+            left: auto !important;
+        }
+        """
+    )
+    menu_button = pn.widgets.MenuButton(
+        label='',
+        items=items,
+        icon=get_icon('settings'),
+        icon_size='1.5em',
+        width=ButtonStyles.TOOL_BUTTON_SIZE,
+        height=ButtonStyles.TOOL_BUTTON_SIZE,
+        color='light',
+        sizing_mode='fixed',
+        margin=0,
+        stylesheets=stylesheets,
+    )
+
+    def on_menu_click(event: pn.param.parameterized.Event) -> None:
+        if event.new in label_map:
+            on_configure(label_map[event.new])
+
+    menu_button.on_click(on_menu_click)
+    return menu_button
+
+
 def create_cell_titlebar(
     *,
     title: str,
     has_user_title: bool,
     on_edit_title_callback: Callable[[], None],
+    configure_layers: list[tuple[LayerId, str]],
+    on_configure_layer: Callable[[LayerId], None],
     toolbars_visible: bool,
     on_toggle_toolbars_callback: Callable[[bool], None],
     freshness_pane: pn.pane.HTML | None = None,
 ) -> pn.Row:
     """
-    Create the cell-level titlebar shown above the per-layer toolbars.
+    Create the cell-level titlebar shown above the per-layer info rows.
 
     The titlebar holds the cell title on the left and cell-level actions on the
-    right: edit cell properties (opens a modal for rename/add/remove layer) and
-    a toggle that hides/shows the per-layer toolbars.
+    right: a gear that configures a layer (directly for one layer, via a layer
+    picker for several), edit cell properties (opens a modal for
+    rename/add/remove layer), and a toggle that hides/shows the per-layer info
+    rows.
 
     Parameters
     ----------
@@ -319,8 +388,13 @@ def create_cell_titlebar(
     on_edit_title_callback:
         Invoked when the edit (pencil) button is clicked; opens the cell
         properties modal.
+    configure_layers:
+        ``(layer_id, title)`` pairs for the cell's layers, driving the gear
+        button/menu.
+    on_configure_layer:
+        Invoked with a layer ID when the gear (or a layer menu entry) is chosen.
     toolbars_visible:
-        Current visibility of the per-layer toolbars; sets the toggle icon.
+        Current visibility of the per-layer info rows; sets the toggle icon.
     on_toggle_toolbars_callback:
         Invoked with the new visibility state when the toggle is clicked.
     freshness_pane:
@@ -340,6 +414,10 @@ def create_cell_titlebar(
         styles={'overflow': 'hidden', 'min-width': '0'},
     )
 
+    gear_button = _create_configure_button_or_menu(
+        layers=configure_layers,
+        on_configure=on_configure_layer,
+    )
     edit_button = create_tool_button(
         icon_name='pencil',
         button_color=Colors.TEXT_MUTED,
@@ -351,7 +429,7 @@ def create_cell_titlebar(
         on_toggle=on_toggle_toolbars_callback,
     )
 
-    right_buttons: list = [edit_button, toggle_button]
+    right_buttons: list = [gear_button, edit_button, toggle_button]
 
     # Freshness pill sits at the far left; the stretch title fills the middle and
     # pushes the action buttons to the right.

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -13,7 +13,7 @@ from ...config.workflow_spec import WorkflowId, WorkflowSpec
 from ..plot_params import WindowMode
 from .buttons import ButtonStyles, create_tool_button, create_tool_button_stylesheet
 from .icons import get_icon
-from .styles import Colors, FreshnessPill, HoverColors, StatusColors
+from .styles import Colors, HoverColors, StatusColors
 
 if TYPE_CHECKING:
     from ..plot_orchestrator import PlotCell, PlotConfig
@@ -238,98 +238,6 @@ def _cell_title_html(title: str, has_user_title: bool) -> str:
         f'<span style="{style}line-height:{ButtonStyles.TOOL_BUTTON_SIZE}px;'
         f'white-space:nowrap;overflow:hidden;'
         f'text-overflow:ellipsis;display:block;">{title}</span>'
-    )
-
-
-def _freshness_band(lag_seconds: float) -> tuple[str, str, str]:
-    """Return the ``(background, text, dot)`` pill colors for a lag in seconds."""
-    if lag_seconds < FreshnessPill.FRESH_MAX_SECONDS:
-        return FreshnessPill.FRESH
-    if lag_seconds < FreshnessPill.STALE_MAX_SECONDS:
-        return FreshnessPill.STALE
-    return FreshnessPill.OLD
-
-
-def _format_lag_short(lag_seconds: float) -> str:
-    """Compact lag label, e.g. "2.3s", "41s", "3m"."""
-    if lag_seconds < 10:
-        return f'{lag_seconds:.1f}s'
-    if lag_seconds < 60:
-        return f'{lag_seconds:.0f}s'
-    return f'{lag_seconds / 60:.0f}m'
-
-
-def format_freshness_html(lag_seconds: float | None, tooltip: str = '') -> str:
-    """Render the titlebar freshness/lag pill, color-banded by staleness.
-
-    Parameters
-    ----------
-    lag_seconds:
-        Data lag in seconds, or None to render nothing (no timing data).
-    tooltip:
-        Full time-range text shown on hover (the pill itself shows only the
-        compact lag).
-    """
-    if lag_seconds is None:
-        return ''
-    background, text_color, dot_color = _freshness_band(lag_seconds)
-    pill_style = (
-        f'display:inline-flex;align-items:center;gap:5px;height:20px;'
-        f'padding:0 8px;border-radius:10px;font-size:11px;'
-        f'font-variant-numeric:tabular-nums;white-space:nowrap;'
-        f'background:{background};color:{text_color};'
-    )
-    dot_style = (
-        f'width:7px;height:7px;border-radius:50%;flex:none;background:{dot_color};'
-    )
-    if tooltip:
-        from html import escape
-
-        title_attr = f' title="{escape(tooltip)}"'
-    else:
-        title_attr = ''
-    return (
-        f'<span style="{pill_style}"{title_attr}>'
-        f'<span style="{dot_style}"></span>{_format_lag_short(lag_seconds)}</span>'
-    )
-
-
-def create_freshness_pane() -> pn.pane.HTML:
-    """Create the titlebar freshness/lag pane, updated in place via ``.object``.
-
-    Content sizes to the pill; ``align='center'`` (``align-self:center``)
-    vertically centers it against the title and buttons in the row.
-    """
-    return pn.pane.HTML(
-        '',
-        align='center',
-        margin=(0, 6),
-        styles={'flex': '0 0 auto'},
-    )
-
-
-def format_layer_time_html(text: str) -> str:
-    """Render a per-layer time-range/lag label (muted, tabular nums)."""
-    if not text:
-        return ''
-    style = (
-        f'font-size:11px;color:{Colors.TEXT_MUTED};white-space:nowrap;'
-        'font-variant-numeric:tabular-nums;'
-    )
-    return f'<span style="{style}">{text}</span>'
-
-
-def create_layer_time_pane() -> pn.pane.HTML:
-    """Create a per-layer time-range pane, updated in place via ``.object``.
-
-    Placed on its own line below the layer title/buttons row; indented and
-    pulled up close to the title so it visually belongs to it.
-    """
-    return pn.pane.HTML(
-        '',
-        align='start',
-        margin=(-4, 6, 0, 14),
-        styles={'flex': '0 0 auto'},
     )
 
 

--- a/src/ess/livedata/dashboard/widgets/styles.py
+++ b/src/ess/livedata/dashboard/widgets/styles.py
@@ -45,16 +45,12 @@ class Colors:
 class FreshnessPill:
     """Color bands for the titlebar freshness/lag pill, by data staleness.
 
-    Each band is ``(background, text, dot)``. Thresholds are in seconds of lag
-    (now minus the oldest data's end time).
+    Each band is ``(background, text, dot)``.
     """
 
     FRESH = ("rgba(40, 167, 69, 0.16)", "#1e7e34", StatusColors.SUCCESS)
     STALE = ("rgba(255, 193, 7, 0.18)", "#946c00", StatusColors.WARNING)
     OLD = ("rgba(220, 53, 69, 0.16)", "#b21f2d", StatusColors.ERROR)
-
-    FRESH_MAX_SECONDS = 5.0
-    STALE_MAX_SECONDS = 30.0
 
 
 class ErrorBox:

--- a/src/ess/livedata/dashboard/widgets/styles.py
+++ b/src/ess/livedata/dashboard/widgets/styles.py
@@ -42,6 +42,21 @@ class Colors:
     TAB_ACTIVE_BG = "#e8f4f8"
 
 
+class FreshnessPill:
+    """Color bands for the titlebar freshness/lag pill, by data staleness.
+
+    Each band is ``(background, text, dot)``. Thresholds are in seconds of lag
+    (now minus the oldest data's end time).
+    """
+
+    FRESH = ("rgba(40, 167, 69, 0.16)", "#1e7e34", StatusColors.SUCCESS)
+    STALE = ("rgba(255, 193, 7, 0.18)", "#946c00", StatusColors.WARNING)
+    OLD = ("rgba(220, 53, 69, 0.16)", "#b21f2d", StatusColors.ERROR)
+
+    FRESH_MAX_SECONDS = 5.0
+    STALE_MAX_SECONDS = 30.0
+
+
 class ErrorBox:
     """Colors for error alert boxes (Bootstrap-style danger alert)."""
 

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -2198,6 +2198,90 @@ class TestSetGridEnabled:
         assert 'enabled' not in data
 
 
+class TestCellTitle:
+    """Tests for user-defined cell titles."""
+
+    def test_add_cell_defaults_to_no_user_title(self, plot_orchestrator):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = plot_orchestrator.add_cell(grid_id, DEFAULT_GEOMETRY)
+        assert plot_orchestrator.get_cell(cell_id).user_title is None
+
+    def test_add_cell_with_user_title(self, plot_orchestrator):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = plot_orchestrator.add_cell(
+            grid_id, DEFAULT_GEOMETRY, user_title='My cell'
+        )
+        assert plot_orchestrator.get_cell(cell_id).user_title == 'My cell'
+
+    def test_set_cell_title_updates(self, plot_orchestrator, workflow_id):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator,
+            grid_id,
+            DEFAULT_GEOMETRY,
+            make_plot_config(workflow_id),
+        )
+        plot_orchestrator.set_cell_title(cell_id, 'Renamed')
+        assert plot_orchestrator.get_cell(cell_id).user_title == 'Renamed'
+
+    def test_set_cell_title_empty_clears(self, plot_orchestrator):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = plot_orchestrator.add_cell(grid_id, DEFAULT_GEOMETRY, user_title='X')
+        plot_orchestrator.set_cell_title(cell_id, '')
+        assert plot_orchestrator.get_cell(cell_id).user_title is None
+
+    def test_set_cell_title_notifies_cell_updated(self, plot_orchestrator, workflow_id):
+        callback = CallbackCapture()
+        plot_orchestrator.subscribe_to_lifecycle(on_cell_updated=callback)
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator,
+            grid_id,
+            DEFAULT_GEOMETRY,
+            make_plot_config(workflow_id),
+        )
+        before = callback.call_count
+        plot_orchestrator.set_cell_title(cell_id, 'Renamed')
+        assert callback.call_count == before + 1
+        assert callback.call_args[1]['cell'].user_title == 'Renamed'
+
+    def test_user_title_serialized_when_set(self, plot_orchestrator, workflow_id):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator,
+            grid_id,
+            DEFAULT_GEOMETRY,
+            make_plot_config(workflow_id),
+        )
+        plot_orchestrator.set_cell_title(cell_id, 'Saved title')
+        data = plot_orchestrator.serialize_grid(grid_id)
+        assert data['cells'][0]['user_title'] == 'Saved title'
+
+    def test_user_title_omitted_when_none(self, plot_orchestrator, workflow_id):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        add_cell_with_layer(
+            plot_orchestrator,
+            grid_id,
+            DEFAULT_GEOMETRY,
+            make_plot_config(workflow_id),
+        )
+        data = plot_orchestrator.serialize_grid(grid_id)
+        assert 'user_title' not in data['cells'][0]
+
+    def test_user_title_round_trips_through_parse(self, plot_orchestrator, workflow_id):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator,
+            grid_id,
+            DEFAULT_GEOMETRY,
+            make_plot_config(workflow_id),
+        )
+        plot_orchestrator.set_cell_title(cell_id, 'Round trip')
+        data = plot_orchestrator.serialize_grid(grid_id)
+        parsed = plot_orchestrator.parse_raw_cell(data['cells'][0])
+        assert parsed.user_title == 'Round trip'
+
+
 class TestReplaceGrid:
     """Tests for grid replacement functionality."""
 

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1369,6 +1369,8 @@ class TestOverlay1DPlotter:
         result = overlay_plotter.plot(data, data_key)
         # Single curve, not wrapped in Overlay
         assert isinstance(result, hv.Curve)
+        # No label: a lone labelled element would render its label as the title.
+        assert result.label == ''
 
     def test_empty_first_dim_returns_empty_curve(
         self, overlay_plotter, data_2d_empty_first_dim, data_key

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -12,6 +12,7 @@ from bokeh.models import GlyphRenderer
 from holoviews.plotting.bokeh import BokehRenderer
 
 from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
+from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.dashboard import plots
 from ess.livedata.dashboard.plot_params import (
     ErrorDisplay,
@@ -1653,7 +1654,7 @@ class TestLagIndicator:
         )
 
     def test_time_info_shown_when_coords_present(self, data_key):
-        """Test that time interval and lag are shown in title."""
+        """Time interval and lag are exposed via the plotter's time bounds."""
         import time
 
         now_ns = time.time_ns()
@@ -1671,12 +1672,8 @@ class TestLagIndicator:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({'primary': {data_key: data}})
-        result = plotter.get_cached_state()
 
-        # Check that title contains time range and lag
-        opts = hv.Store.lookup_options('bokeh', result, 'plot').kwargs
-        assert 'title' in opts
-        title = opts['title']
+        title = plots.format_time_info(plotter.time_bounds)
         # Should contain time range separator and lag
         assert ' - ' in title  # hyphen between times
         assert 'Lag:' in title
@@ -1684,7 +1681,7 @@ class TestLagIndicator:
         assert '1.' in title or '2.' in title
 
     def test_no_lag_title_when_end_time_absent(self, data_key):
-        """Test that no lag title is added when end_time coord is absent."""
+        """No time bounds are produced when the end_time coord is absent."""
         data = sc.DataArray(
             data=sc.array(dims=['x'], values=[1.0, 2.0, 3.0]),
             coords={'x': sc.array(dims=['x'], values=[0.0, 1.0, 2.0])},
@@ -1692,12 +1689,8 @@ class TestLagIndicator:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({'primary': {data_key: data}})
-        result = plotter.get_cached_state()
 
-        # Check that no title is set (or title doesn't contain Lag)
-        opts = hv.Store.lookup_options('bokeh', result, 'plot').kwargs
-        title = opts.get('title', '')
-        assert 'Lag:' not in title
+        assert plotter.time_bounds is None
 
     def test_lag_uses_maximum_across_multiple_sources(self):
         """Test that lag shows the maximum (oldest data) when multiple sources."""
@@ -1742,14 +1735,70 @@ class TestLagIndicator:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({'primary': {data_key1: data1, data_key2: data2}})
-        result = plotter.get_cached_state()
 
-        # Check that lag is approximately 5 seconds (the older data)
-        opts = hv.Store.lookup_options('bokeh', result, 'plot').kwargs
-        assert 'title' in opts
-        assert 'Lag:' in opts['title']
+        title = plots.format_time_info(plotter.time_bounds)
+        assert 'Lag:' in title
         # Should show ~5 seconds, not ~1 second (using oldest end_time)
-        assert '5.' in opts['title'] or '6.' in opts['title']
+        assert '5.' in title or '6.' in title
+
+
+class TestTimeBounds:
+    """Tests for time-bounds merging and formatting helpers."""
+
+    @staticmethod
+    def _ts(ns: int) -> Timestamp:
+        return Timestamp.from_ns(ns)
+
+    def test_merge_returns_none_for_all_none(self) -> None:
+        assert plots.merge_time_bounds([None, None]) is None
+
+    def test_merge_returns_none_for_empty(self) -> None:
+        assert plots.merge_time_bounds([]) is None
+
+    def test_merge_takes_oldest_end_for_lag(self) -> None:
+        a = plots.TimeBounds(min_end=self._ts(100), max_end=self._ts(100))
+        b = plots.TimeBounds(min_end=self._ts(50), max_end=self._ts(80))
+        merged = plots.merge_time_bounds([a, b])
+        assert merged.min_end == self._ts(50)
+
+    def test_merge_spans_full_range(self) -> None:
+        a = plots.TimeBounds(
+            min_end=self._ts(100), min_start=self._ts(90), max_end=self._ts(110)
+        )
+        b = plots.TimeBounds(
+            min_end=self._ts(50), min_start=self._ts(40), max_end=self._ts(60)
+        )
+        merged = plots.merge_time_bounds([a, b, None])
+        assert merged.min_start == self._ts(40)
+        assert merged.min_end == self._ts(50)
+        assert merged.max_end == self._ts(110)
+
+    def test_merge_drops_missing_start(self) -> None:
+        a = plots.TimeBounds(min_end=self._ts(100))  # no start/max_end
+        b = plots.TimeBounds(
+            min_end=self._ts(50), min_start=self._ts(40), max_end=self._ts(60)
+        )
+        merged = plots.merge_time_bounds([a, b])
+        assert merged.min_start == self._ts(40)
+        assert merged.max_end == self._ts(60)
+
+    def test_format_with_range_shows_interval(self) -> None:
+        now = self._ts(int(10e9))
+        bounds = plots.TimeBounds(
+            min_end=self._ts(int(8e9)),
+            min_start=self._ts(int(7e9)),
+            max_end=self._ts(int(9e9)),
+        )
+        text = plots.format_time_info(bounds, now=now)
+        assert ' - ' in text
+        assert 'Lag: 2.0s' in text
+
+    def test_format_without_range_shows_single_time(self) -> None:
+        now = self._ts(int(10e9))
+        bounds = plots.TimeBounds(min_end=self._ts(int(7e9)))
+        text = plots.format_time_info(bounds, now=now)
+        assert ' - ' not in text
+        assert 'Lag: 3.0s' in text
 
 
 class TestTwoStageArchitecture:

--- a/tests/dashboard/time_info_test.py
+++ b/tests/dashboard/time_info_test.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """
-Tests for time-interval display in plot titles.
+Tests for the time-interval freshness indicator.
 
-These tests verify that the time information shown in plot titles is factual,
-i.e., it reflects the actual time range of the data being displayed.
+These tests verify that the time information exposed by a plotter (and shown in
+the cell titlebar) is factual, i.e., it reflects the actual time range of the
+data being displayed.
 
 The tests simulate the end-to-end flow: buffered data → extractor → plotter.
 Extractors are responsible for setting correct start_time/end_time coords
@@ -44,10 +45,10 @@ def data_key(workflow_id):
     return ResultKey(workflow_id=workflow_id, job_id=job_id, output_name='test_result')
 
 
-def _extract_title(result) -> str:
-    """Extract title from a HoloViews plot result."""
-    opts = hv.Store.lookup_options('bokeh', result, 'plot').kwargs
-    return opts.get('title', '')
+def _time_info(plotter) -> str:
+    """Format the plotter's freshness/lag indicator, or '' if no time bounds."""
+    bounds = plotter.time_bounds
+    return plots.format_time_info(bounds) if bounds is not None else ''
 
 
 def _parse_time_range_from_title(title: str) -> tuple[str, str] | None:
@@ -108,9 +109,7 @@ class TestTimeseriesTimeInfo:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({'primary': {data_key: extracted_data}})
-        result = plotter.get_cached_state()
-
-        title = _extract_title(result)
+        title = _time_info(plotter)
         assert 'Lag:' in title
         lag_seconds = _extract_lag_seconds(title)
 
@@ -148,9 +147,7 @@ class TestTimeseriesTimeInfo:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({'primary': {data_key: extracted_data}})
-        result = plotter.get_cached_state()
-
-        title = _extract_title(result)
+        title = _time_info(plotter)
         # Extractor computes min/max of start_time/end_time
         assert 'Lag:' in title
         lag_seconds = _extract_lag_seconds(title)
@@ -193,9 +190,7 @@ class TestWindowedTimeInfo:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({'primary': {data_key: extracted_data}})
-        result = plotter.get_cached_state()
-
-        title = _extract_title(result)
+        title = _time_info(plotter)
         assert 'Lag:' in title
         lag_seconds = _extract_lag_seconds(title)
 
@@ -223,9 +218,7 @@ class TestTimeInfoBaseline:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({'primary': {data_key: data}})
-        result = plotter.get_cached_state()
-
-        title = _extract_title(result)
+        title = _time_info(plotter)
         assert 'Lag:' in title
         lag_seconds = _extract_lag_seconds(title)
         assert 0.5 < lag_seconds < 3.0
@@ -243,9 +236,7 @@ class TestTimeInfoEdgeCases:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({data_key: data})
-        result = plotter.get_cached_state()
-
-        title = _extract_title(result)
+        title = _time_info(plotter)
         assert 'Lag:' not in title
 
     def test_time_dimension_without_coords_does_not_crash(self, data_key):
@@ -263,5 +254,4 @@ class TestTimeInfoEdgeCases:
 
         plotter = plots.LinePlotter.from_params(PlotParams1d())
         plotter.compute({'primary': {data_key: data}})  # Should not raise
-        result = plotter.get_cached_state()
-        assert isinstance(_extract_title(result), str)
+        assert plotter.time_bounds is None

--- a/tests/dashboard/widgets/cell_test.py
+++ b/tests/dashboard/widgets/cell_test.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from ess.livedata.dashboard.widgets.cell import (
+    format_freshness_html,
+    format_layer_time_html,
+)
+from ess.livedata.dashboard.widgets.styles import FreshnessPill
+
+
+class TestFreshnessPill:
+    def test_none_renders_nothing(self) -> None:
+        assert format_freshness_html(None) == ''
+
+    def test_fresh_band_colors_and_label(self) -> None:
+        html = format_freshness_html(2.3)
+        assert FreshnessPill.FRESH[0] in html  # background
+        assert '2.3s' in html
+        assert 'border-radius' in html
+
+    def test_stale_band(self) -> None:
+        html = format_freshness_html(12.0)
+        assert FreshnessPill.STALE[0] in html
+        assert '12s' in html
+
+    def test_old_band(self) -> None:
+        html = format_freshness_html(41.0)
+        assert FreshnessPill.OLD[0] in html
+        assert '41s' in html
+
+    def test_minutes_for_large_lag(self) -> None:
+        assert '3m' in format_freshness_html(200.0)
+
+    def test_tooltip_is_html_escaped(self) -> None:
+        html = format_freshness_html(2.0, tooltip='12:00 <range>')
+        assert 'title="12:00 &lt;range&gt;"' in html
+
+
+class TestLayerTimeHtml:
+    def test_empty_renders_nothing(self) -> None:
+        assert format_layer_time_html('') == ''
+
+    def test_wraps_text_in_muted_span(self) -> None:
+        html = format_layer_time_html('14:35:01 - 14:35:07 (Lag: 2.3s)')
+        assert '14:35:01 - 14:35:07 (Lag: 2.3s)' in html
+        assert '<span' in html

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -232,12 +232,12 @@ class TestPollHandlesLayoutPlotters:
         assert new_version != version_after_first_poll
 
         # Inject a transient failure into the rebuild path
-        original = plot_grid_tabs._get_session_composed_plot
+        original = plot_grid_tabs._build_cell
 
         def _raise(cell_id, cell):
             raise RuntimeError("injected failure")
 
-        plot_grid_tabs._get_session_composed_plot = _raise
+        plot_grid_tabs._build_cell = _raise
         try:
             try:
                 plot_grid_tabs._poll_for_plot_updates()
@@ -247,7 +247,7 @@ class TestPollHandlesLayoutPlotters:
             session_layer = plot_grid_tabs._session_layers[layer_id]
             assert session_layer.last_seen_version != new_version
         finally:
-            plot_grid_tabs._get_session_composed_plot = original
+            plot_grid_tabs._build_cell = original
 
 
 class TestFreshnessIndicator:
@@ -275,14 +275,18 @@ class TestFreshnessIndicator:
 
         plot_grid_tabs._poll_for_plot_updates()
 
-        panes = list(plot_grid_tabs._cell_freshness_panes.values())
+        panes = [cw.freshness_pane for cw in plot_grid_tabs._cells.values()]
         assert len(panes) == 1
         # Pill styling present, with the full range in the hover tooltip.
         assert 'border-radius' in panes[0].object
         assert 'Lag:' in panes[0].object
 
         # The per-layer time pane shows the full range + lag.
-        layer_panes = list(plot_grid_tabs._layer_time_panes.values())
+        layer_panes = [
+            pane
+            for cw in plot_grid_tabs._cells.values()
+            for pane in cw.layer_time_panes.values()
+        ]
         assert len(layer_panes) == 1
         assert 'Lag:' in layer_panes[0].object
 
@@ -336,10 +340,11 @@ class TestFreshnessIndicator:
 
         plot_grid_tabs._poll_for_plot_updates()
 
-        assert 'Lag:' in plot_grid_tabs._layer_time_panes[l1].object
-        assert 'Lag:' in plot_grid_tabs._layer_time_panes[l2].object
+        cell_widget = plot_grid_tabs._cells[cell_id]
+        assert 'Lag:' in cell_widget.layer_time_panes[l1].object
+        assert 'Lag:' in cell_widget.layer_time_panes[l2].object
         # The cell pill must still show with two layers.
-        pill_panes = list(plot_grid_tabs._cell_freshness_panes.values())
+        pill_panes = [cw.freshness_pane for cw in plot_grid_tabs._cells.values()]
         assert len(pill_panes) == 1
         assert 'border-radius' in pill_panes[0].object
 
@@ -355,5 +360,5 @@ class TestFreshnessIndicator:
 
         plot_grid_tabs._poll_for_plot_updates()
 
-        for pane in plot_grid_tabs._cell_freshness_panes.values():
-            assert pane.object in ('', None)
+        for cell_widget in plot_grid_tabs._cells.values():
+            assert cell_widget.freshness_pane.object in ('', None)

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -46,12 +46,17 @@ hv.extension('bokeh')
 class FakePlotter:
     """Minimal plotter whose cached state can be set to any HoloViews object."""
 
-    def __init__(self, cached_state=None):
+    def __init__(self, cached_state=None, time_bounds=None):
         self._cached_state = cached_state
+        self._time_bounds = time_bounds
         self._presenters: list[FakePresenter] = []
 
     def get_cached_state(self):
         return self._cached_state
+
+    @property
+    def time_bounds(self):
+        return self._time_bounds
 
     def has_cached_state(self):
         return self._cached_state is not None
@@ -243,3 +248,112 @@ class TestPollHandlesLayoutPlotters:
             assert session_layer.last_seen_version != new_version
         finally:
             plot_grid_tabs._get_session_composed_plot = original
+
+
+class TestFreshnessIndicator:
+    """The titlebar freshness pane reflects the plotter's time bounds."""
+
+    def test_poll_populates_freshness_pane(
+        self, plot_orchestrator, plot_data_service, plot_grid_tabs
+    ):
+        """A poll on the active grid fills the cell's freshness pane with lag."""
+        import time
+
+        from ess.livedata.core.timestamp import Timestamp
+        from ess.livedata.dashboard.plots import TimeBounds
+
+        now_ns = time.time_ns()
+        bounds = TimeBounds(
+            min_end=Timestamp.from_ns(now_ns - int(2e9)),
+            min_start=Timestamp.from_ns(now_ns - int(3e9)),
+            max_end=Timestamp.from_ns(now_ns - int(1e9)),
+        )
+        plotter = FakePlotter(cached_state=_make_layout(), time_bounds=bounds)
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+        _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
+
+        plot_grid_tabs._poll_for_plot_updates()
+
+        panes = list(plot_grid_tabs._cell_freshness_panes.values())
+        assert len(panes) == 1
+        # Pill styling present, with the full range in the hover tooltip.
+        assert 'border-radius' in panes[0].object
+        assert 'Lag:' in panes[0].object
+
+        # The per-layer time pane shows the full range + lag.
+        layer_panes = list(plot_grid_tabs._layer_time_panes.values())
+        assert len(layer_panes) == 1
+        assert 'Lag:' in layer_panes[0].object
+
+    def test_multilayer_each_layer_pane_populated(
+        self, plot_orchestrator, plot_data_service, plot_grid_tabs
+    ):
+        """Both layers in a multi-layer cell get their time pane populated."""
+        import time
+
+        from ess.livedata.core.timestamp import Timestamp
+        from ess.livedata.dashboard.plots import TimeBounds
+
+        now_ns = time.time_ns()
+        bounds = TimeBounds(
+            min_end=Timestamp.from_ns(now_ns - int(2e9)),
+            min_start=Timestamp.from_ns(now_ns - int(3e9)),
+            max_end=Timestamp.from_ns(now_ns - int(1e9)),
+        )
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+
+        cell_id = CellId(uuid4())
+        l1, l2 = LayerId(uuid4()), LayerId(uuid4())
+
+        def cfg(view):
+            return PlotConfig(
+                data_sources={
+                    'primary': DataSourceConfig(
+                        workflow_id=WorkflowId(instrument='test', name='wf', version=1),
+                        source_names=['src'],
+                        view_name=view,
+                    )
+                },
+                plot_name='image',
+                params=_Params(),
+            )
+
+        cell = PlotCell(
+            geometry=CellGeometry(row=0, col=0, row_span=1, col_span=1),
+            layers=[
+                Layer(layer_id=l1, config=cfg('a')),
+                Layer(layer_id=l2, config=cfg('b')),
+            ],
+        )
+        plot_orchestrator.peek_grid(grid_id).cells[cell_id] = cell
+        for lid in (l1, l2):
+            plot_data_service.job_started(
+                lid, FakePlotter(cached_state=_make_layout(), time_bounds=bounds)
+            )
+            plot_data_service.data_arrived(lid)
+
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert 'Lag:' in plot_grid_tabs._layer_time_panes[l1].object
+        assert 'Lag:' in plot_grid_tabs._layer_time_panes[l2].object
+        # The cell pill must still show with two layers.
+        pill_panes = list(plot_grid_tabs._cell_freshness_panes.values())
+        assert len(pill_panes) == 1
+        assert 'border-radius' in pill_panes[0].object
+
+    def test_hidden_grid_does_not_update_freshness(
+        self, plot_orchestrator, plot_data_service, plot_grid_tabs
+    ):
+        """Freshness is only refreshed for the active grid tab."""
+        plotter = FakePlotter(cached_state=_make_layout(), time_bounds=None)
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        # Leave a non-plot static tab active so the grid is hidden.
+        plot_grid_tabs.tabs.active = 0
+        _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
+
+        plot_grid_tabs._poll_for_plot_updates()
+
+        for pane in plot_grid_tabs._cell_freshness_panes.values():
+            assert pane.object in ('', None)

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -678,11 +678,11 @@ class TestComposeMixedLayers:
             plot_grid_tabs._session_layers[layer.layer_id] = session_layer
 
         cell_id = CellId(uuid4())
-        result = plot_grid_tabs._get_session_composed_plot(cell_id, cell)
+        cell_widget = plot_grid_tabs._build_cell(cell_id, cell)
 
-        assert result is not None
+        assert cell_widget.has_plot
         # The dynamic layer still drives autoscale; controller was built.
-        assert cell_id in plot_grid_tabs._session_autoscale_controllers
+        assert cell_widget.autoscale_controller is not None
 
 
 class TestDisabledGridTabs:

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -224,15 +224,15 @@ class TestDeriveCellTitle:
         )
         return {wf: spec}
 
-    def test_single_layer_uses_full_display_title(self) -> None:
+    def test_single_layer_single_source(self) -> None:
         wf = self._wf()
         cell = PlotCell(geometry=_GEO, layers=[_make_layer(wf, ['Front Right'])])
         assert (
             derive_cell_title(cell, self._registry(wf))
-            == 'Detector XY Projection &rarr; Image (Front Right)'
+            == 'Detector XY Projection (Front Right)'
         )
 
-    def test_shared_workflow_and_source_varying_output_drops_output(self) -> None:
+    def test_output_name_is_not_shown(self) -> None:
         wf = self._wf()
         cell = PlotCell(
             geometry=_GEO,
@@ -241,24 +241,10 @@ class TestDeriveCellTitle:
                 _make_layer(wf, ['Front Right'], view_name='roi'),
             ],
         )
-        assert (
-            derive_cell_title(cell, self._registry(wf))
-            == 'Detector XY Projection (Front Right)'
-        )
-
-    def test_shared_output_multi_layer_flags_extra_layers(self) -> None:
-        wf = self._wf()
-        cell = PlotCell(
-            geometry=_GEO,
-            layers=[
-                _make_layer(wf, ['Front Right'], view_name='image'),
-                _make_layer(wf, ['Front Right'], view_name='image'),
-            ],
-        )
-        assert (
-            derive_cell_title(cell, self._registry(wf))
-            == 'Detector XY Projection &rarr; Image (Front Right) (+1 more)'
-        )
+        title = derive_cell_title(cell, self._registry(wf))
+        assert title == 'Detector XY Projection (Front Right)'
+        assert 'Image' not in title
+        assert 'ROI' not in title
 
     def test_source_title_callback_applied(self) -> None:
         wf = self._wf()
@@ -266,39 +252,22 @@ class TestDeriveCellTitle:
         title = derive_cell_title(
             cell, self._registry(wf), get_source_title=lambda s: f'Title:{s}'
         )
-        assert title == 'Detector XY Projection &rarr; Image (Title:s1)'
+        assert title == 'Detector XY Projection (Title:s1)'
 
-    def test_varying_source_is_dropped(self) -> None:
+    def test_multiple_sources_drop_source(self) -> None:
         wf = self._wf()
         cell = PlotCell(
             geometry=_GEO,
             layers=[_make_layer(wf, ['s1']), _make_layer(wf, ['s2'])],
         )
-        assert (
-            derive_cell_title(cell, self._registry(wf))
-            == 'Detector XY Projection &rarr; Image (+1 more)'
-        )
+        assert derive_cell_title(cell, self._registry(wf)) == 'Detector XY Projection'
 
     def test_single_layer_multi_source_drops_source(self) -> None:
         wf = self._wf()
         cell = PlotCell(geometry=_GEO, layers=[_make_layer(wf, ['s1', 's2'])])
-        title = derive_cell_title(cell, self._registry(wf))
-        assert title == 'Detector XY Projection &rarr; Image'
-        assert 'sources' not in title
+        assert derive_cell_title(cell, self._registry(wf)) == 'Detector XY Projection'
 
-    def test_shared_window_is_shown(self) -> None:
-        wf = self._wf()
-        params = _FakeParams(window=WindowParams(mode=WindowMode.since_start))
-        cell = PlotCell(
-            geometry=_GEO,
-            layers=[_make_layer(wf, ['Front Right'], params=params)],
-        )
-        assert (
-            derive_cell_title(cell, self._registry(wf))
-            == 'Detector XY Projection &rarr; Image (Front Right, since run start)'
-        )
-
-    def test_multiple_workflows_fall_back_to_first_layer(self) -> None:
+    def test_uses_first_layer_workflow_title(self) -> None:
         wf_a = self._wf('a')
         wf_b = self._wf('b')
         registry = {**self._registry(wf_a), **self._registry(wf_b)}
@@ -306,8 +275,8 @@ class TestDeriveCellTitle:
             geometry=_GEO,
             layers=[_make_layer(wf_a, ['Front Right']), _make_layer(wf_b, ['s2'])],
         )
-        first_title, _ = get_plot_cell_display_info(cell.layers[0].config, registry)
-        assert derive_cell_title(cell, registry) == f'{first_title} (+1 more)'
+        # Different sources across layers -> source dropped, first workflow used.
+        assert derive_cell_title(cell, registry) == 'Detector XY Projection'
 
     def test_static_layers_excluded_from_derivation(self) -> None:
         wf = self._wf()
@@ -317,7 +286,7 @@ class TestDeriveCellTitle:
         )
         assert (
             derive_cell_title(cell, self._registry(wf))
-            == 'Detector XY Projection &rarr; Image (Front Right)'
+            == 'Detector XY Projection (Front Right)'
         )
 
     def test_only_static_layers_uses_first_static_title(self) -> None:

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -22,11 +22,8 @@ from ess.livedata.dashboard.plot_params import WindowMode, WindowParams
 from ess.livedata.dashboard.widgets.plot_widgets import (
     _format_window_info,
     derive_cell_title,
-    format_freshness_html,
-    format_layer_time_html,
     get_plot_cell_display_info,
 )
-from ess.livedata.dashboard.widgets.styles import FreshnessPill
 
 
 class _FakeParams(pydantic.BaseModel):
@@ -296,41 +293,3 @@ class TestDeriveCellTitle:
     def test_empty_cell_returns_empty(self) -> None:
         cell = PlotCell(geometry=_GEO, layers=[])
         assert derive_cell_title(cell, {}) == ''
-
-
-class TestFreshnessPill:
-    def test_none_renders_nothing(self) -> None:
-        assert format_freshness_html(None) == ''
-
-    def test_fresh_band_colors_and_label(self) -> None:
-        html = format_freshness_html(2.3)
-        assert FreshnessPill.FRESH[0] in html  # background
-        assert '2.3s' in html
-        assert 'border-radius' in html
-
-    def test_stale_band(self) -> None:
-        html = format_freshness_html(12.0)
-        assert FreshnessPill.STALE[0] in html
-        assert '12s' in html
-
-    def test_old_band(self) -> None:
-        html = format_freshness_html(41.0)
-        assert FreshnessPill.OLD[0] in html
-        assert '41s' in html
-
-    def test_minutes_for_large_lag(self) -> None:
-        assert '3m' in format_freshness_html(200.0)
-
-    def test_tooltip_is_html_escaped(self) -> None:
-        html = format_freshness_html(2.0, tooltip='12:00 <range>')
-        assert 'title="12:00 &lt;range&gt;"' in html
-
-
-class TestLayerTimeHtml:
-    def test_empty_renders_nothing(self) -> None:
-        assert format_layer_time_html('') == ''
-
-    def test_wraps_text_in_muted_span(self) -> None:
-        html = format_layer_time_html('14:35:01 - 14:35:07 (Lag: 2.3s)')
-        assert '14:35:01 - 14:35:07 (Lag: 2.3s)' in html
-        assert '<span' in html

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -22,8 +22,11 @@ from ess.livedata.dashboard.plot_params import WindowMode, WindowParams
 from ess.livedata.dashboard.widgets.plot_widgets import (
     _format_window_info,
     derive_cell_title,
+    format_freshness_html,
+    format_layer_time_html,
     get_plot_cell_display_info,
 )
+from ess.livedata.dashboard.widgets.styles import FreshnessPill
 
 
 class _FakeParams(pydantic.BaseModel):
@@ -208,3 +211,41 @@ class TestDeriveCellTitle:
     def test_empty_cell_returns_empty(self) -> None:
         cell = PlotCell(geometry=_GEO, layers=[])
         assert derive_cell_title(cell, {}) == ''
+
+
+class TestFreshnessPill:
+    def test_none_renders_nothing(self) -> None:
+        assert format_freshness_html(None) == ''
+
+    def test_fresh_band_colors_and_label(self) -> None:
+        html = format_freshness_html(2.3)
+        assert FreshnessPill.FRESH[0] in html  # background
+        assert '2.3s' in html
+        assert 'border-radius' in html
+
+    def test_stale_band(self) -> None:
+        html = format_freshness_html(12.0)
+        assert FreshnessPill.STALE[0] in html
+        assert '12s' in html
+
+    def test_old_band(self) -> None:
+        html = format_freshness_html(41.0)
+        assert FreshnessPill.OLD[0] in html
+        assert '41s' in html
+
+    def test_minutes_for_large_lag(self) -> None:
+        assert '3m' in format_freshness_html(200.0)
+
+    def test_tooltip_is_html_escaped(self) -> None:
+        html = format_freshness_html(2.0, tooltip='12:00 <range>')
+        assert 'title="12:00 &lt;range&gt;"' in html
+
+
+class TestLayerTimeHtml:
+    def test_empty_renders_nothing(self) -> None:
+        assert format_layer_time_html('') == ''
+
+    def test_wraps_text_in_muted_span(self) -> None:
+        html = format_layer_time_html('14:35:01 - 14:35:07 (Lag: 2.3s)')
+        assert '14:35:01 - 14:35:07 (Lag: 2.3s)' in html
+        assert '<span' in html

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -150,7 +150,9 @@ class TestGetPlotCellDisplayInfo:
 _GEO = CellGeometry(row=0, col=0, row_span=1, col_span=1)
 
 
-def _make_layer(workflow_id, source_names, view_name='result', plot_name='lines'):
+def _make_layer(
+    workflow_id, source_names, view_name='image', plot_name='lines', params=None
+):
     from uuid import uuid4
 
     config = PlotConfig(
@@ -162,65 +164,165 @@ def _make_layer(workflow_id, source_names, view_name='result', plot_name='lines'
             )
         },
         plot_name=plot_name,
+        params=params if params is not None else _FakeParams(),
+    )
+    return Layer(layer_id=LayerId(uuid4()), config=config)
+
+
+def _make_static_layer(name, plot_name='rectangle'):
+    """A static overlay: single primary source with empty source_names."""
+    from uuid import uuid4
+
+    config = PlotConfig(
+        data_sources={
+            PRIMARY: DataSourceConfig(
+                workflow_id=WorkflowId(instrument='test', name='static', version=1),
+                source_names=[],
+                view_name=name,
+            )
+        },
+        plot_name=plot_name,
         params=_FakeParams(),
     )
     return Layer(layer_id=LayerId(uuid4()), config=config)
 
 
+class _XYOutputs(WorkflowOutputsBase):
+    image: sc.DataArray = pydantic.Field(
+        default_factory=lambda: sc.DataArray(
+            sc.zeros(dims=['x'], shape=[0], unit='counts'),
+            coords={'x': sc.arange('x', 0, unit='m')},
+        ),
+        title='Image',
+    )
+    roi: sc.DataArray = pydantic.Field(
+        default_factory=lambda: sc.DataArray(
+            sc.zeros(dims=['x'], shape=[0], unit='counts'),
+            coords={'x': sc.arange('x', 0, unit='m')},
+        ),
+        title='ROI',
+    )
+
+
 class TestDeriveCellTitle:
     @staticmethod
-    def _wf():
-        return WorkflowId(instrument='test', name='wf', version=1)
+    def _wf(name='wf'):
+        return WorkflowId(instrument='test', name=name, version=1)
 
-    def test_shared_single_source_uses_source_title(self) -> None:
+    @staticmethod
+    def _registry(wf):
+        spec = WorkflowSpec(
+            instrument='test',
+            name=wf.name,
+            version=1,
+            title='Detector XY Projection',
+            description='D',
+            outputs=_XYOutputs,
+            params=None,
+            source_names=['Front Right'],
+            group=REDUCTION,
+        )
+        return {wf: spec}
+
+    def test_single_layer_uses_full_display_title(self) -> None:
+        wf = self._wf()
+        cell = PlotCell(geometry=_GEO, layers=[_make_layer(wf, ['Front Right'])])
+        assert (
+            derive_cell_title(cell, self._registry(wf))
+            == 'Detector XY Projection &rarr; Image (Front Right)'
+        )
+
+    def test_shared_workflow_and_source_varying_output_drops_output(self) -> None:
         wf = self._wf()
         cell = PlotCell(
             geometry=_GEO,
-            layers=[_make_layer(wf, ['s1']), _make_layer(wf, ['s1'])],
+            layers=[
+                _make_layer(wf, ['Front Right'], view_name='image'),
+                _make_layer(wf, ['Front Right'], view_name='roi'),
+            ],
         )
-        title = derive_cell_title(cell, {}, get_source_title=lambda s: f'Title:{s}')
-        assert title == 'Title:s1'
+        assert (
+            derive_cell_title(cell, self._registry(wf))
+            == 'Detector XY Projection (Front Right)'
+        )
 
-    def test_shared_common_among_multi_source_layers(self) -> None:
+    def test_shared_output_multi_layer_flags_extra_layers(self) -> None:
         wf = self._wf()
         cell = PlotCell(
             geometry=_GEO,
-            layers=[_make_layer(wf, ['s1', 's2']), _make_layer(wf, ['s1', 's3'])],
+            layers=[
+                _make_layer(wf, ['Front Right'], view_name='image'),
+                _make_layer(wf, ['Front Right'], view_name='image'),
+            ],
         )
-        assert derive_cell_title(cell, {}) == 's1'
+        assert (
+            derive_cell_title(cell, self._registry(wf))
+            == 'Detector XY Projection &rarr; Image (Front Right) (+1 more)'
+        )
 
-    def test_single_layer_single_source_uses_source(self) -> None:
-        cell = PlotCell(geometry=_GEO, layers=[_make_layer(self._wf(), ['s1'])])
-        assert derive_cell_title(cell, {}) == 's1'
+    def test_source_title_callback_applied(self) -> None:
+        wf = self._wf()
+        cell = PlotCell(geometry=_GEO, layers=[_make_layer(wf, ['s1'])])
+        title = derive_cell_title(
+            cell, self._registry(wf), get_source_title=lambda s: f'Title:{s}'
+        )
+        assert title == 'Detector XY Projection &rarr; Image (Title:s1)'
 
-    def test_disjoint_sources_multi_layer_uses_first_layer_title(self) -> None:
+    def test_varying_source_is_dropped(self) -> None:
         wf = self._wf()
         cell = PlotCell(
             geometry=_GEO,
             layers=[_make_layer(wf, ['s1']), _make_layer(wf, ['s2'])],
         )
-        first_title, _ = get_plot_cell_display_info(cell.layers[0].config, {})
-        assert derive_cell_title(cell, {}) == f'{first_title} (+1 more layer)'
+        assert (
+            derive_cell_title(cell, self._registry(wf))
+            == 'Detector XY Projection &rarr; Image (+1 more)'
+        )
 
-    def test_three_disjoint_layers_pluralizes_suffix(self) -> None:
+    def test_single_layer_multi_source_drops_source(self) -> None:
+        wf = self._wf()
+        cell = PlotCell(geometry=_GEO, layers=[_make_layer(wf, ['s1', 's2'])])
+        title = derive_cell_title(cell, self._registry(wf))
+        assert title == 'Detector XY Projection &rarr; Image'
+        assert 'sources' not in title
+
+    def test_shared_window_is_shown(self) -> None:
+        wf = self._wf()
+        params = _FakeParams(window=WindowParams(mode=WindowMode.since_start))
+        cell = PlotCell(
+            geometry=_GEO,
+            layers=[_make_layer(wf, ['Front Right'], params=params)],
+        )
+        assert (
+            derive_cell_title(cell, self._registry(wf))
+            == 'Detector XY Projection &rarr; Image (Front Right, since run start)'
+        )
+
+    def test_multiple_workflows_fall_back_to_first_layer(self) -> None:
+        wf_a = self._wf('a')
+        wf_b = self._wf('b')
+        registry = {**self._registry(wf_a), **self._registry(wf_b)}
+        cell = PlotCell(
+            geometry=_GEO,
+            layers=[_make_layer(wf_a, ['Front Right']), _make_layer(wf_b, ['s2'])],
+        )
+        first_title, _ = get_plot_cell_display_info(cell.layers[0].config, registry)
+        assert derive_cell_title(cell, registry) == f'{first_title} (+1 more)'
+
+    def test_static_layers_excluded_from_derivation(self) -> None:
         wf = self._wf()
         cell = PlotCell(
             geometry=_GEO,
-            layers=[
-                _make_layer(wf, ['s1']),
-                _make_layer(wf, ['s2']),
-                _make_layer(wf, ['s3']),
-            ],
+            layers=[_make_layer(wf, ['Front Right']), _make_static_layer('Box')],
         )
-        first_title, _ = get_plot_cell_display_info(cell.layers[0].config, {})
-        assert derive_cell_title(cell, {}) == f'{first_title} (+2 more layers)'
+        assert (
+            derive_cell_title(cell, self._registry(wf))
+            == 'Detector XY Projection &rarr; Image (Front Right)'
+        )
 
-    def test_single_layer_multi_source_falls_back_to_display_title(self) -> None:
-        cell = PlotCell(
-            geometry=_GEO,
-            layers=[_make_layer(self._wf(), ['s1', 's2'], view_name='current')],
-        )
-        assert '2 sources' in derive_cell_title(cell, {})
+    def test_only_static_layers_uses_first_static_title(self) -> None:
+        cell = PlotCell(geometry=_GEO, layers=[_make_static_layer('Box')])
+        assert derive_cell_title(cell, {}) == 'Rectangle &rarr; Box'
 
     def test_empty_cell_returns_empty(self) -> None:
         cell = PlotCell(geometry=_GEO, layers=[])

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -193,13 +193,27 @@ class TestDeriveCellTitle:
         cell = PlotCell(geometry=_GEO, layers=[_make_layer(self._wf(), ['s1'])])
         assert derive_cell_title(cell, {}) == 's1'
 
-    def test_disjoint_sources_multi_layer_falls_back_to_count(self) -> None:
+    def test_disjoint_sources_multi_layer_uses_first_layer_title(self) -> None:
         wf = self._wf()
         cell = PlotCell(
             geometry=_GEO,
             layers=[_make_layer(wf, ['s1']), _make_layer(wf, ['s2'])],
         )
-        assert derive_cell_title(cell, {}) == '2 layers'
+        first_title, _ = get_plot_cell_display_info(cell.layers[0].config, {})
+        assert derive_cell_title(cell, {}) == f'{first_title} (+1 more layer)'
+
+    def test_three_disjoint_layers_pluralizes_suffix(self) -> None:
+        wf = self._wf()
+        cell = PlotCell(
+            geometry=_GEO,
+            layers=[
+                _make_layer(wf, ['s1']),
+                _make_layer(wf, ['s2']),
+                _make_layer(wf, ['s3']),
+            ],
+        )
+        first_title, _ = get_plot_cell_display_info(cell.layers[0].config, {})
+        assert derive_cell_title(cell, {}) == f'{first_title} (+2 more layers)'
 
     def test_single_layer_multi_source_falls_back_to_display_title(self) -> None:
         cell = PlotCell(

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -10,10 +10,18 @@ from ess.livedata.config.workflow_spec import (
     WorkflowSpec,
 )
 from ess.livedata.dashboard.data_roles import PRIMARY
-from ess.livedata.dashboard.plot_orchestrator import DataSourceConfig, PlotConfig
+from ess.livedata.dashboard.plot_orchestrator import (
+    CellGeometry,
+    DataSourceConfig,
+    Layer,
+    LayerId,
+    PlotCell,
+    PlotConfig,
+)
 from ess.livedata.dashboard.plot_params import WindowMode, WindowParams
 from ess.livedata.dashboard.widgets.plot_widgets import (
     _format_window_info,
+    derive_cell_title,
     get_plot_cell_display_info,
 )
 
@@ -134,3 +142,69 @@ class TestGetPlotCellDisplayInfo:
 
         title, _ = get_plot_cell_display_info(config, registry)
         assert 'since run start' in title
+
+
+_GEO = CellGeometry(row=0, col=0, row_span=1, col_span=1)
+
+
+def _make_layer(workflow_id, source_names, view_name='result', plot_name='lines'):
+    from uuid import uuid4
+
+    config = PlotConfig(
+        data_sources={
+            PRIMARY: DataSourceConfig(
+                workflow_id=workflow_id,
+                source_names=source_names,
+                view_name=view_name,
+            )
+        },
+        plot_name=plot_name,
+        params=_FakeParams(),
+    )
+    return Layer(layer_id=LayerId(uuid4()), config=config)
+
+
+class TestDeriveCellTitle:
+    @staticmethod
+    def _wf():
+        return WorkflowId(instrument='test', name='wf', version=1)
+
+    def test_shared_single_source_uses_source_title(self) -> None:
+        wf = self._wf()
+        cell = PlotCell(
+            geometry=_GEO,
+            layers=[_make_layer(wf, ['s1']), _make_layer(wf, ['s1'])],
+        )
+        title = derive_cell_title(cell, {}, get_source_title=lambda s: f'Title:{s}')
+        assert title == 'Title:s1'
+
+    def test_shared_common_among_multi_source_layers(self) -> None:
+        wf = self._wf()
+        cell = PlotCell(
+            geometry=_GEO,
+            layers=[_make_layer(wf, ['s1', 's2']), _make_layer(wf, ['s1', 's3'])],
+        )
+        assert derive_cell_title(cell, {}) == 's1'
+
+    def test_single_layer_single_source_uses_source(self) -> None:
+        cell = PlotCell(geometry=_GEO, layers=[_make_layer(self._wf(), ['s1'])])
+        assert derive_cell_title(cell, {}) == 's1'
+
+    def test_disjoint_sources_multi_layer_falls_back_to_count(self) -> None:
+        wf = self._wf()
+        cell = PlotCell(
+            geometry=_GEO,
+            layers=[_make_layer(wf, ['s1']), _make_layer(wf, ['s2'])],
+        )
+        assert derive_cell_title(cell, {}) == '2 layers'
+
+    def test_single_layer_multi_source_falls_back_to_display_title(self) -> None:
+        cell = PlotCell(
+            geometry=_GEO,
+            layers=[_make_layer(self._wf(), ['s1', 's2'], view_name='current')],
+        )
+        assert '2 sources' in derive_cell_title(cell, {})
+
+    def test_empty_cell_returns_empty(self) -> None:
+        cell = PlotCell(geometry=_GEO, layers=[])
+        assert derive_cell_title(cell, {}) == ''


### PR DESCRIPTION
## Motivation

Each plot layer carried its own toolbar. With two layers this is fine, but ROI-style plots routinely need three to five layers (image, readback, request, ...), and the stacked toolbars consume a large share of the cell's vertical space. At the same time, cell-level chrome (a title, add-layer) had no natural home and was either missing or duplicated per layer, and the lag/time indicator lived inside the HoloViews plot title — which both ate plot space and was expensive, minting a fresh `OptionTree` on every tick via `result.opts(title=...)`. Last but not least, the lag/time indicated was actually only visible in single-layer plots as composing layers using `hv.Overlay` hid the plot titles.

## What changed

### UI Examples

Collapsed details (default):
<img width="1009" height="1777" alt="screenshot-2026-06-04T13:45:08" src="https://github.com/user-attachments/assets/2b5864fa-1f4f-4cf1-9e66-948671a59f65" />
Cell config modal:
<img width="978" height="735" alt="screenshot-2026-06-04T13:57:33" src="https://github.com/user-attachments/assets/9af709a0-a5b1-4d36-8c8b-9f8a058f9d31" />
Expanded:
<img width="1005" height="1768" alt="screenshot-2026-06-04T13:58:13" src="https://github.com/user-attachments/assets/b8456f8e-d6af-4ed7-a8c9-ec1f5ea9d5b5" />

### Description

A new cell-level titlebar sits above the per-layer toolbars and absorbs the cell-level chrome:

- A user-editable cell title (modal rename, persisted and propagated cross-session) with a derived default when unset.
- Add-layer consolidated into a single per-cell button whose dropdown is the union of every layer's overlay suggestions, each remembering its source layer so overlays still inherit the right workflow/sources.
- A toggle that hides/shows the per-layer toolbars. Toolbars are hidden by default for a compact monitoring view; the choice is per-session local state.

The lag/time indicator moves out of the plot title and into the titlebar. Plotters now expose raw `TimeBounds` from `compute()` rather than formatting a string into the title. The titlebar shows a colour-banded freshness pill (worst-case lag across the cell's layers, recomputed against the wall clock each poll, so a stalled stream visibly goes stale), and per-layer time-range rows carry the full start–end/lag detail, revealed by the toolbar-visibility toggle. Updates happen in place via `pane.object`, a single cheap property write instead of rebuilding the option store.

Per-layer toolbars are slimmed to gear + close.

## Default cell title

The derived default is deliberately minimal: the first non-static layer's workflow title, plus the source name only when the cell's layers share a single source (a lone source is otherwise not visible in the plot labels). Output names and window info are dropped.

## Tradeoffs

- **Minimal default title.** Base-workflow output names (`Image`, `Histogram`) are implied by the workflow and add noise, and window/freshness now lives in the titlebar indicator, so neither is repeated in the title. The cost is that distinct reduction outputs sharing one workflow (e.g. `I(Q)` and `I(t)`) collapse to the same default and must be told apart with an explicit title. We considered a per-output "primary output" flag to selectively surface the meaningful names, but deferred it as over-engineering: the explicit-title escape hatch already exists, and we would rather see it prove insufficient before adding spec-wide annotation machinery.
- **Toolbars hidden by default.** Optimises for the common compact monitoring view at the cost of an extra click to reach per-layer settings.

## Relation to #646

Fixes #646 — the toolbar show/hide toggle provides the expand/collapse the issue asks for. The issue's separate idea of user-defined *layer groups* (and group-aware creation flows) is not addressed here, but likely obsolete given that we have the derived-layer mechanism now.

## Test plan

- [ ] Cell titlebar renders; rename modal persists and survives a page reload / second session.
- [ ] Per-cell add-layer dropdown lists the union of layer suggestions and creates layers with the right workflow/source.
- [ ] Toolbar toggle hides/shows per-layer toolbars; state is per-session.
- [ ] Freshness pill reflects the worst-case lag and grows stale when a stream stalls.
- [ ] Default title shows `Workflow (Source)` for single-source cells and the workflow title alone otherwise.
