### PR TITLE
Update logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE)
 
-# ESSlivedata
+# ![esslivedata]
+
+[esslivedata]: https://raw.githubusercontent.com/scipp/esslivedata/master/docs/_static/logo.svg
 
 ## About
 

--- a/docs/_static/logo-dark.svg
+++ b/docs/_static/logo-dark.svg
@@ -1,193 +1,41 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="300"
-   height="90"
-   viewBox="0 0 300 90"
-   version="1.1"
-   id="svg11"
-   sodipodi:docname="logo.svg"
-   inkscape:export-filename="logo.svg"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview11"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1" />
-  <defs
-     id="defs1" />
-  <g
-     id="g2">
-    <path
-       d="M 21,36 H 263"
-       stroke-width="3"
-       stroke="#5e6100"
-       stroke-linecap="round"
-       id="path1" />
-    <path
-       d="M 173.58,36 H 263"
-       stroke-width="3"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path2" />
-  </g>
-  <g
-     id="g3">
-    <path
-       d="m 12.649,73.366 c 1.037,0 1.83,-0.854 1.83,-1.647 v -0.488 c 1.83,0.793 5.063,1.708 8.052,1.708 9.211,0 13.298,-6.893 13.298,-16.104 0,-8.296 -4.331,-13.42 -10.675,-13.42 -4.087,0 -7.991,1.708 -10.614,4.697 V 33.167 c 0,-1.037 -0.915,-1.708 -1.83,-1.708 -1.037,0 -1.952,0.671 -1.952,1.708 v 38.43 c 0,0.976 0.915,1.769 1.891,1.769 z m 9.394,-4.087 c -3.233,0 -6.405,-1.037 -7.503,-1.525 V 55.493 c 0,-4.575 4.636,-8.235 10.553,-8.235 4.209,0 7.076,3.416 7.076,9.577 0,7.503 -2.684,12.444 -10.126,12.444 z m 34.586991,4.087 c 3.721,0 7.93,-1.952 10.065,-4.392 0.244,-0.305 0.488,-0.793 0.488,-1.22 0,-1.037 -0.793,-1.83 -1.83,-1.83 -0.488,0 -0.976,0.244 -1.22,0.61 -1.647,1.769 -4.88,3.294 -7.564,3.294 -4.697,0 -8.235,-2.013 -10.309,-5.917 l 18.91,-10.797 c 1.037,-0.61 1.464,-1.281 1.464,-1.952 0,-2.684 -3.599,-8.235 -11.468,-8.235 -8.296,0 -13.725,7.503 -13.725,15.799 0,7.869 5.978,14.64 15.189,14.64 z m -11.529,-12.871 c -0.122,-0.732 -0.122,-1.281 -0.122,-1.952 0.122,-6.649 4.27,-12.017 10.248,-12.017 4.209,0 6.527,1.464 7.625,4.148 z m 48.921962,13.359 c 1.098,0 1.891,-0.915 1.891,-2.013 V 45.428 c -1.037,-0.488 -4.819,-2.501 -9.272,-2.501 -9.455,0 -14.64,9.272 -14.64,17.263 0,7.869 4.941,13.176 11.529,13.176 3.233,0 6.466,-1.403 8.601,-3.233 v 1.708 c 0,1.098 0.61,2.013 1.891,2.013 z m -10.492,-4.087 c -4.453,0 -7.625,-3.721 -7.625,-9.699 0,-7.808 4.758,-13.542 10.858,-13.542 1.952,0 4.331,0.732 5.429,1.22 l -0.244,18.483 c -1.403,1.403 -4.88,3.538 -8.418,3.538 z m 23.850937,3.599 c 1.037,0 1.891,-0.854 1.891,-1.83 v -9.089 c 0,-4.758 0.549,-6.832 2.745,-9.943 2.135,-2.989 5.307,-5.978 8.296,-5.978 3.294,0 4.697,2.135 4.697,7.259 v 17.751 c 0,0.976 0.915,1.83 1.952,1.83 1.098,0 1.891,-0.854 1.891,-1.83 V 57.75 c 0,-7.015 6.1,-11.224 9.455,-11.224 3.111,0 4.819,2.074 4.819,7.259 v 17.751 c 0,0.976 0.854,1.83 1.891,1.83 1.037,0 1.952,-0.854 1.952,-1.83 V 54.212 c 0,-8.174 -3.538,-11.285 -8.174,-11.285 -3.294,0 -7.259,1.83 -10.37,6.893 -1.159,-5.49 -4.636,-6.893 -7.625,-6.893 -4.148,0 -8.845,3.599 -11.529,8.906 v -7.015 c 0,-0.976 -0.793,-1.891 -1.891,-1.891 -1.037,0 -1.952,0.915 -1.952,1.891 v 26.718 c 0,0.976 0.915,1.83 1.952,1.83 z"
-       id="text2"
-       style="font-size:61px;font-family:'Comic Neue';fill:#5e6100"
-       aria-label="beam" />
-    <path
-       d="m 158.54801,73.366 c 1.403,0 2.928,-1.22 2.928,-2.745 v -35.38 c 0,-1.586 -1.403,-2.867 -2.928,-2.867 -1.708,0 -2.928,1.281 -2.928,2.867 v 35.38 c 0,1.525 1.403,2.745 2.928,2.745 z m 14.76187,-33.001 c 1.647,0 2.867,-1.22 2.928,-2.867 l 0.061,-2.318 c 0.061,-1.464 -1.342,-2.928 -2.867,-2.928 -1.525,0 -2.867,1.281 -2.928,2.867 l -0.061,2.257 c -0.061,1.586 1.342,2.989 2.867,2.989 z m -0.305,33.001 c 1.586,0 2.989,-1.342 2.989,-2.989 l 0.305,-24.278 c 0,-1.647 -1.281,-2.989 -2.989,-2.989 -1.586,0 -2.989,1.342 -2.989,2.989 l -0.305,24.278 c 0,1.647 1.342,2.989 2.989,2.989 z m 14.76189,0 c 1.586,0 2.928,-1.281 2.928,-2.867 l -0.061,-8.967 c 0,-2.989 0.732,-5.307 2.135,-7.686 1.586,-2.501 4.27,-5.307 7.137,-5.307 2.135,0 2.989,1.769 2.989,5.612 v 16.348 c 0,1.586 1.403,2.867 2.928,2.867 1.647,0 2.928,-1.281 2.928,-2.867 V 59.153 c 0,-6.161 4.026,-10.614 7.564,-10.614 2.318,0 3.294,1.891 3.294,5.612 v 16.348 c 0,1.586 1.342,2.867 2.928,2.867 1.525,0 2.928,-1.281 2.928,-2.867 V 54.517 c 0,-7.991 -3.294,-11.59 -8.174,-11.59 -4.087,0 -7.198,2.379 -9.516,5.856 -1.098,-4.026 -3.843,-5.856 -7.015,-5.856 -4.148,0 -7.564,2.44 -10.065,7.198 v -4.27 c 0,-1.525 -1.281,-2.928 -2.928,-2.928 -1.525,0 -2.928,1.403 -2.928,2.928 v 24.644 c 0,1.586 1.403,2.867 2.928,2.867 z m 58.80397,0 c 3.782,0 7.991,-2.013 10.187,-4.514 0.488,-0.549 0.732,-1.098 0.732,-1.83 0,-1.586 -1.22,-2.745 -2.867,-2.745 -0.793,0 -1.464,0.427 -2.013,0.976 -1.342,1.403 -3.355,2.623 -6.039,2.623 -3.477,0 -6.71,-1.403 -7.869,-3.965 l 16.348,-9.394 c 1.281,-0.732 1.891,-1.83 1.891,-2.806 0,-2.867 -3.66,-8.784 -11.712,-8.784 -8.357,0 -13.786,7.503 -13.786,15.128 0,9.577 6.527,15.311 15.128,15.311 z m -9.577,-14.518 c 0,-0.854 0,-1.281 0.122,-2.196 0.488,-4.514 3.782,-8.235 8.54,-8.235 2.379,0 4.27,0.854 5.246,2.562 z"
-       id="text3"
-       style="font-weight:bold;font-size:61px;font-family:'Comic Neue';fill:#a3a800"
-       aria-label="lime" />
-  </g>
-  <g
-     id="g10">
-    <path
-       d="M 264,36 244.94744,25"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path3" />
-    <circle
-       cx="251.55492"
-       cy="23.55492"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-9.21534"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle3" />
-    <path
-       d="M 264,36 258.30598,14.749632"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path4" />
-    <circle
-       cx="264"
-       cy="18.4"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-11.9799"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle4" />
-    <circle
-       cx="255.2"
-       cy="20.757954"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-16.5876"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle5" />
-    <path
-       d="M 264,36 275,16.947441"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path5" />
-    <circle
-       cx="276.44507"
-       cy="23.55492"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-14.7445"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle6" />
-    <circle
-       cx="268.55521"
-       cy="18.999706"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-19.3522"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle7" />
-    <path
-       d="m 264,36 21.25037,-5.694019"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path7" />
-    <circle
-       cx="281.60001"
-       cy="36"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-17.5091"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle8" />
-    <circle
-       cx="279.24203"
-       cy="27.200001"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-0"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle9" />
-    <path
-       d="m 264,36 19.05256,11"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path9" />
-    <circle
-       cx="281.00031"
-       cy="40.555214"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-2.7646"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle10" />
-  </g>
-  <g
-     id="g11"
-     inkscape:export-filename="g11.svg"
-     inkscape:export-xdpi="96"
-     inkscape:export-ydpi="96">
-    <circle
-       cx="264"
-       cy="36"
-       r="22"
-       stroke-dasharray="69.115, 69.115"
-       stroke-dashoffset="-80.6342"
-       stroke-width="5"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle11" />
-  </g>
-</svg>
+<?xml version='1.0' encoding='utf-8'?>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="320" height="90" viewBox="0 0 320 90">
+<svg:defs>
+<svg:path d="M6,73 L87.60000000000001,73" opacity="1" id="d0" />
+<svg:path d="M87.60000000000001,73 L171.75,73" opacity="1" id="d1" />
+<svg:path d="M171.75,73 L272,73" opacity="1" id="d2" />
+</svg:defs>
+<svg:g>
+<svg:path d="M22,36 L280,36" stroke-width="3" stroke="#5E6100" stroke-linecap="round" />
+<svg:path d="M110.25,36 L280,36" stroke-width="3" stroke="#A3A800" stroke-linecap="round" />
+</svg:g>
+<svg:g>
+<svg:text font-size="61" text-anchor="start" font-family="Comic Neue" font-weight="normal" fill="#5E6100"><svg:textPath xlink:href="#d0" startOffset="0">
+<svg:tspan dy="0em">ess</svg:tspan>
+</svg:textPath></svg:text>
+<svg:text font-size="61" text-anchor="start" font-family="Comic Neue" font-weight="bold" fill="#A3A800"><svg:textPath xlink:href="#d1" startOffset="0">
+<svg:tspan dy="0em">live</svg:tspan>
+</svg:textPath></svg:text>
+<svg:text font-size="61" text-anchor="start" font-family="Comic Neue" font-weight="normal" fill="#5E6100"><svg:textPath xlink:href="#d2" startOffset="0">
+<svg:tspan dy="0em">data</svg:tspan>
+</svg:textPath></svg:text>
+</svg:g>
+<svg:g>
+<svg:path d="M281,36 L260.2153903091735,24.000000000000007" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="267.42354980121826" cy="22.423549801218286" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-10.05309649148734" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:path d="M281,36 L274.7883429175395,12.81778016906236" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="281.0" cy="16.799999999999997" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-13.069025438933542" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:circle cx="271.4" cy="19.372312247338773" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-18.09557368467721" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:path d="M281,36 L293.0,15.215390309173465" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="294.5764501987817" cy="22.42354980121827" r="3.84" stroke-dasharray="3.0159289474461994 21.11150263212341" stroke-dashoffset="-16.084954386379742" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:circle cx="285.96932566596837" cy="17.454224135249884" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-21.111502632123408" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:path d="M281,36 L304.18221983093764,29.788342917539502" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="300.2" cy="35.99999999999999" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-19.10088333382594" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:circle cx="297.62768775266125" cy="26.400000000000006" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-0.0" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:path d="M281,36 L301.7846096908265,47.999999999999986" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="299.5457758647501" cy="40.96932566596839" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-3.015928947446201" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+</svg:g>
+<svg:g>
+<svg:circle cx="281" cy="36" r="24" stroke-dasharray="75.39822368615503 75.39822368615503" stroke-dashoffset="-87.96459430051422" stroke-width="5" stroke="#A3A800" stroke-linecap="round" fill="none" />
+</svg:g>
+</svg:svg>

--- a/docs/_static/logo.svg
+++ b/docs/_static/logo.svg
@@ -1,193 +1,41 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="300"
-   height="90"
-   viewBox="0 0 300 90"
-   version="1.1"
-   id="svg11"
-   sodipodi:docname="logo.svg"
-   inkscape:export-filename="logo.svg"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview11"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1" />
-  <defs
-     id="defs1" />
-  <g
-     id="g2">
-    <path
-       d="M 21,36 H 263"
-       stroke-width="3"
-       stroke="#5e6100"
-       stroke-linecap="round"
-       id="path1" />
-    <path
-       d="M 173.58,36 H 263"
-       stroke-width="3"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path2" />
-  </g>
-  <g
-     id="g3">
-    <path
-       d="m 12.649,73.366 c 1.037,0 1.83,-0.854 1.83,-1.647 v -0.488 c 1.83,0.793 5.063,1.708 8.052,1.708 9.211,0 13.298,-6.893 13.298,-16.104 0,-8.296 -4.331,-13.42 -10.675,-13.42 -4.087,0 -7.991,1.708 -10.614,4.697 V 33.167 c 0,-1.037 -0.915,-1.708 -1.83,-1.708 -1.037,0 -1.952,0.671 -1.952,1.708 v 38.43 c 0,0.976 0.915,1.769 1.891,1.769 z m 9.394,-4.087 c -3.233,0 -6.405,-1.037 -7.503,-1.525 V 55.493 c 0,-4.575 4.636,-8.235 10.553,-8.235 4.209,0 7.076,3.416 7.076,9.577 0,7.503 -2.684,12.444 -10.126,12.444 z m 34.586991,4.087 c 3.721,0 7.93,-1.952 10.065,-4.392 0.244,-0.305 0.488,-0.793 0.488,-1.22 0,-1.037 -0.793,-1.83 -1.83,-1.83 -0.488,0 -0.976,0.244 -1.22,0.61 -1.647,1.769 -4.88,3.294 -7.564,3.294 -4.697,0 -8.235,-2.013 -10.309,-5.917 l 18.91,-10.797 c 1.037,-0.61 1.464,-1.281 1.464,-1.952 0,-2.684 -3.599,-8.235 -11.468,-8.235 -8.296,0 -13.725,7.503 -13.725,15.799 0,7.869 5.978,14.64 15.189,14.64 z m -11.529,-12.871 c -0.122,-0.732 -0.122,-1.281 -0.122,-1.952 0.122,-6.649 4.27,-12.017 10.248,-12.017 4.209,0 6.527,1.464 7.625,4.148 z m 48.921962,13.359 c 1.098,0 1.891,-0.915 1.891,-2.013 V 45.428 c -1.037,-0.488 -4.819,-2.501 -9.272,-2.501 -9.455,0 -14.64,9.272 -14.64,17.263 0,7.869 4.941,13.176 11.529,13.176 3.233,0 6.466,-1.403 8.601,-3.233 v 1.708 c 0,1.098 0.61,2.013 1.891,2.013 z m -10.492,-4.087 c -4.453,0 -7.625,-3.721 -7.625,-9.699 0,-7.808 4.758,-13.542 10.858,-13.542 1.952,0 4.331,0.732 5.429,1.22 l -0.244,18.483 c -1.403,1.403 -4.88,3.538 -8.418,3.538 z m 23.850937,3.599 c 1.037,0 1.891,-0.854 1.891,-1.83 v -9.089 c 0,-4.758 0.549,-6.832 2.745,-9.943 2.135,-2.989 5.307,-5.978 8.296,-5.978 3.294,0 4.697,2.135 4.697,7.259 v 17.751 c 0,0.976 0.915,1.83 1.952,1.83 1.098,0 1.891,-0.854 1.891,-1.83 V 57.75 c 0,-7.015 6.1,-11.224 9.455,-11.224 3.111,0 4.819,2.074 4.819,7.259 v 17.751 c 0,0.976 0.854,1.83 1.891,1.83 1.037,0 1.952,-0.854 1.952,-1.83 V 54.212 c 0,-8.174 -3.538,-11.285 -8.174,-11.285 -3.294,0 -7.259,1.83 -10.37,6.893 -1.159,-5.49 -4.636,-6.893 -7.625,-6.893 -4.148,0 -8.845,3.599 -11.529,8.906 v -7.015 c 0,-0.976 -0.793,-1.891 -1.891,-1.891 -1.037,0 -1.952,0.915 -1.952,1.891 v 26.718 c 0,0.976 0.915,1.83 1.952,1.83 z"
-       id="text2"
-       style="font-size:61px;font-family:'Comic Neue';fill:#5e6100"
-       aria-label="beam" />
-    <path
-       d="m 158.54801,73.366 c 1.403,0 2.928,-1.22 2.928,-2.745 v -35.38 c 0,-1.586 -1.403,-2.867 -2.928,-2.867 -1.708,0 -2.928,1.281 -2.928,2.867 v 35.38 c 0,1.525 1.403,2.745 2.928,2.745 z m 14.76187,-33.001 c 1.647,0 2.867,-1.22 2.928,-2.867 l 0.061,-2.318 c 0.061,-1.464 -1.342,-2.928 -2.867,-2.928 -1.525,0 -2.867,1.281 -2.928,2.867 l -0.061,2.257 c -0.061,1.586 1.342,2.989 2.867,2.989 z m -0.305,33.001 c 1.586,0 2.989,-1.342 2.989,-2.989 l 0.305,-24.278 c 0,-1.647 -1.281,-2.989 -2.989,-2.989 -1.586,0 -2.989,1.342 -2.989,2.989 l -0.305,24.278 c 0,1.647 1.342,2.989 2.989,2.989 z m 14.76189,0 c 1.586,0 2.928,-1.281 2.928,-2.867 l -0.061,-8.967 c 0,-2.989 0.732,-5.307 2.135,-7.686 1.586,-2.501 4.27,-5.307 7.137,-5.307 2.135,0 2.989,1.769 2.989,5.612 v 16.348 c 0,1.586 1.403,2.867 2.928,2.867 1.647,0 2.928,-1.281 2.928,-2.867 V 59.153 c 0,-6.161 4.026,-10.614 7.564,-10.614 2.318,0 3.294,1.891 3.294,5.612 v 16.348 c 0,1.586 1.342,2.867 2.928,2.867 1.525,0 2.928,-1.281 2.928,-2.867 V 54.517 c 0,-7.991 -3.294,-11.59 -8.174,-11.59 -4.087,0 -7.198,2.379 -9.516,5.856 -1.098,-4.026 -3.843,-5.856 -7.015,-5.856 -4.148,0 -7.564,2.44 -10.065,7.198 v -4.27 c 0,-1.525 -1.281,-2.928 -2.928,-2.928 -1.525,0 -2.928,1.403 -2.928,2.928 v 24.644 c 0,1.586 1.403,2.867 2.928,2.867 z m 58.80397,0 c 3.782,0 7.991,-2.013 10.187,-4.514 0.488,-0.549 0.732,-1.098 0.732,-1.83 0,-1.586 -1.22,-2.745 -2.867,-2.745 -0.793,0 -1.464,0.427 -2.013,0.976 -1.342,1.403 -3.355,2.623 -6.039,2.623 -3.477,0 -6.71,-1.403 -7.869,-3.965 l 16.348,-9.394 c 1.281,-0.732 1.891,-1.83 1.891,-2.806 0,-2.867 -3.66,-8.784 -11.712,-8.784 -8.357,0 -13.786,7.503 -13.786,15.128 0,9.577 6.527,15.311 15.128,15.311 z m -9.577,-14.518 c 0,-0.854 0,-1.281 0.122,-2.196 0.488,-4.514 3.782,-8.235 8.54,-8.235 2.379,0 4.27,0.854 5.246,2.562 z"
-       id="text3"
-       style="font-weight:bold;font-size:61px;font-family:'Comic Neue';fill:#a3a800"
-       aria-label="lime" />
-  </g>
-  <g
-     id="g10">
-    <path
-       d="M 264,36 244.94744,25"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path3" />
-    <circle
-       cx="251.55492"
-       cy="23.55492"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-9.21534"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle3" />
-    <path
-       d="M 264,36 258.30598,14.749632"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path4" />
-    <circle
-       cx="264"
-       cy="18.4"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-11.9799"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle4" />
-    <circle
-       cx="255.2"
-       cy="20.757954"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-16.5876"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle5" />
-    <path
-       d="M 264,36 275,16.947441"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path5" />
-    <circle
-       cx="276.44507"
-       cy="23.55492"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-14.7445"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle6" />
-    <circle
-       cx="268.55521"
-       cy="18.999706"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-19.3522"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle7" />
-    <path
-       d="m 264,36 21.25037,-5.694019"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path7" />
-    <circle
-       cx="281.60001"
-       cy="36"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-17.5091"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle8" />
-    <circle
-       cx="279.24203"
-       cy="27.200001"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-0"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle9" />
-    <path
-       d="m 264,36 19.05256,11"
-       stroke-width="4"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       id="path9" />
-    <circle
-       cx="281.00031"
-       cy="40.555214"
-       r="3.52"
-       stroke-dasharray="2.7646, 19.3522"
-       stroke-dashoffset="-2.7646"
-       stroke-width="2"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle10" />
-  </g>
-  <g
-     id="g11"
-     inkscape:export-filename="g11.svg"
-     inkscape:export-xdpi="96"
-     inkscape:export-ydpi="96">
-    <circle
-       cx="264"
-       cy="36"
-       r="22"
-       stroke-dasharray="69.115, 69.115"
-       stroke-dashoffset="-80.6342"
-       stroke-width="5"
-       stroke="#a3a800"
-       stroke-linecap="round"
-       fill="none"
-       id="circle11" />
-  </g>
-</svg>
+<?xml version='1.0' encoding='utf-8'?>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="320" height="90" viewBox="0 0 320 90">
+<svg:defs>
+<svg:path d="M6,73 L87.60000000000001,73" opacity="1" id="d0" />
+<svg:path d="M87.60000000000001,73 L171.75,73" opacity="1" id="d1" />
+<svg:path d="M171.75,73 L272,73" opacity="1" id="d2" />
+</svg:defs>
+<svg:g>
+<svg:path d="M22,36 L280,36" stroke-width="3" stroke="#5E6100" stroke-linecap="round" />
+<svg:path d="M110.25,36 L280,36" stroke-width="3" stroke="#A3A800" stroke-linecap="round" />
+</svg:g>
+<svg:g>
+<svg:text font-size="61" text-anchor="start" font-family="Comic Neue" font-weight="normal" fill="#5E6100"><svg:textPath xlink:href="#d0" startOffset="0">
+<svg:tspan dy="0em">ess</svg:tspan>
+</svg:textPath></svg:text>
+<svg:text font-size="61" text-anchor="start" font-family="Comic Neue" font-weight="bold" fill="#A3A800"><svg:textPath xlink:href="#d1" startOffset="0">
+<svg:tspan dy="0em">live</svg:tspan>
+</svg:textPath></svg:text>
+<svg:text font-size="61" text-anchor="start" font-family="Comic Neue" font-weight="normal" fill="#5E6100"><svg:textPath xlink:href="#d2" startOffset="0">
+<svg:tspan dy="0em">data</svg:tspan>
+</svg:textPath></svg:text>
+</svg:g>
+<svg:g>
+<svg:path d="M281,36 L260.2153903091735,24.000000000000007" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="267.42354980121826" cy="22.423549801218286" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-10.05309649148734" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:path d="M281,36 L274.7883429175395,12.81778016906236" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="281.0" cy="16.799999999999997" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-13.069025438933542" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:circle cx="271.4" cy="19.372312247338773" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-18.09557368467721" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:path d="M281,36 L293.0,15.215390309173465" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="294.5764501987817" cy="22.42354980121827" r="3.84" stroke-dasharray="3.0159289474461994 21.11150263212341" stroke-dashoffset="-16.084954386379742" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:circle cx="285.96932566596837" cy="17.454224135249884" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-21.111502632123408" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:path d="M281,36 L304.18221983093764,29.788342917539502" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="300.2" cy="35.99999999999999" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-19.10088333382594" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:circle cx="297.62768775266125" cy="26.400000000000006" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-0.0" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+<svg:path d="M281,36 L301.7846096908265,47.999999999999986" stroke-width="4" stroke="#A3A800" stroke-linecap="round" />
+<svg:circle cx="299.5457758647501" cy="40.96932566596839" r="3.84" stroke-dasharray="3.015928947446201 21.111502632123408" stroke-dashoffset="-3.015928947446201" stroke-width="2" stroke="#A3A800" stroke-linecap="round" fill="none" />
+</svg:g>
+<svg:g>
+<svg:circle cx="281" cy="36" r="24" stroke-dasharray="75.39822368615503 75.39822368615503" stroke-dashoffset="-87.96459430051422" stroke-width="5" stroke="#A3A800" stroke-linecap="round" fill="none" />
+</svg:g>
+</svg:svg>

--- a/resources/draw_logo.py
+++ b/resources/draw_logo.py
@@ -1,24 +1,29 @@
 # This script for drawing logo is one-time used, but it is kept here for reference.
 # To run this script, you may need to install
 # a python package ``drawsvg`` and a font ``Comic Neue``.
-import drawsvg as dvg
+from drawsvg import Group, Line, Text, ArcLine, Drawing
 
 LIME_DARK = '#5E6100'
 LIME_LIGHT = '#A3A800'
+ORIGINAL_WIDTH = 300
+NEW_WIDTH = 320
 
 
-def write_text(*, x: int, y: int, width: int = 256) -> dvg.Group:
-    split_x = x + width * 0.57
-    transparent_line_1 = dvg.Line(x, y, split_x, y, opacity=0)
-    transparent_line_2 = dvg.Line(split_x, y, width, y, opacity=0)
+def write_text(*, x: int, y: int, width: int = 256) -> Group:
+    split_1 = x + width * 0.32 * ORIGINAL_WIDTH/NEW_WIDTH
+    split_2 = x + width * 0.65 * ORIGINAL_WIDTH/NEW_WIDTH
+    transparent_line_1 = Line(x, y, split_1, y, opacity=1)
+    transparent_line_2 = Line(split_1, y, split_2, y, opacity=1)
+    transparent_line_3 = Line(split_2, y, width, y, opacity=1)
     text_recipes = [
-        ('beam', LIME_DARK, 'normal', transparent_line_1),
-        ('lime', LIME_LIGHT, 'bold', transparent_line_2),
+        ('ess', LIME_DARK, 'normal', transparent_line_1),
+        ('live', LIME_LIGHT, 'bold', transparent_line_2),
+        ('data', LIME_DARK, 'normal', transparent_line_3),
     ]
     texts = [
-        dvg.Text(
+        Text(
             text,
-            font_size=int((width / 4) * 0.958),
+            font_size=int((width / 4 * ORIGINAL_WIDTH/NEW_WIDTH) * 0.958),
             path=path,
             text_anchor='start',
             font_family='Comic Neue',
@@ -27,11 +32,11 @@ def write_text(*, x: int, y: int, width: int = 256) -> dvg.Group:
         )
         for text, color, weight, path in text_recipes
     ]
-    return dvg.Group(texts)
+    return Group(texts)
 
 
-def draw_beam(*, start_x: int = 0, y: int, width: int) -> dvg.Group:
-    beam_beam = dvg.Line(
+def draw_beam(*, start_x: int = 0, y: int, width: int) -> Group:
+    beam_beam = Line(
         start_x,
         y,
         start_x + width,
@@ -40,8 +45,8 @@ def draw_beam(*, start_x: int = 0, y: int, width: int) -> dvg.Group:
         stroke=LIME_DARK,
         stroke_linecap="round",
     )
-    lime_beam = dvg.Line(
-        (start_x + width) * 0.66,
+    lime_beam = Line(
+        (start_x + width) * 0.42 * ORIGINAL_WIDTH/NEW_WIDTH,
         y,
         start_x + width,
         y,
@@ -49,10 +54,10 @@ def draw_beam(*, start_x: int = 0, y: int, width: int) -> dvg.Group:
         stroke=LIME_LIGHT,
         stroke_linecap="round",
     )
-    return dvg.Group([beam_beam, lime_beam])
+    return Group([beam_beam, lime_beam])
 
 
-def draw_lime_splits(cx: int, cy: int, radius: int) -> dvg.Group:
+def draw_lime_splits(cx: int, cy: int, radius: int) -> Group:
     import numpy as np
 
     start = np.pi + (np.pi / 6)
@@ -63,7 +68,7 @@ def draw_lime_splits(cx: int, cy: int, radius: int) -> dvg.Group:
         x, y = center + (np.array([np.cos(cur_theta), np.sin(cur_theta)]) * radius)
 
         lime_splits.append(
-            dvg.Line(
+            Line(
                 cx, cy, x, y, stroke_width=4, stroke=LIME_LIGHT, stroke_linecap="round"
             )
         )
@@ -77,7 +82,7 @@ def draw_lime_splits(cx: int, cy: int, radius: int) -> dvg.Group:
                 * (radius * 0.8)
             )
             lime_splits.append(
-                dvg.ArcLine(
+                ArcLine(
                     np.cos(cur_theta + np.pi / 12) * arc_rotation_r + cx,
                     np.sin(cur_theta + np.pi / 12) * arc_rotation_r + cy,
                     radius * 0.16,
@@ -97,7 +102,7 @@ def draw_lime_splits(cx: int, cy: int, radius: int) -> dvg.Group:
                 * (radius * 0.8)
             )
             lime_splits.append(
-                dvg.ArcLine(
+                ArcLine(
                     little_arc_x,
                     little_arc_y,
                     radius * 0.16,
@@ -110,13 +115,13 @@ def draw_lime_splits(cx: int, cy: int, radius: int) -> dvg.Group:
                 )
             )
 
-    return dvg.Group(lime_splits)
+    return Group(lime_splits)
 
 
-def draw_lime_arc(cx: int, cy: int, radius: int) -> dvg.Group:
-    return dvg.Group(
+def draw_lime_arc(cx: int, cy: int, radius: int) -> Group:
+    return Group(
         [
-            dvg.ArcLine(
+            ArcLine(
                 cx,
                 cy,
                 radius,
@@ -132,9 +137,9 @@ def draw_lime_arc(cx: int, cy: int, radius: int) -> dvg.Group:
 
 
 if __name__ == '__main__':
-    total_width = 300
-    total_height = int(total_width * 0.3)
-    d = dvg.Drawing(total_width, total_height, origin='top-left')
+    total_width = NEW_WIDTH
+    total_height = int(total_width * 0.3 * ORIGINAL_WIDTH/NEW_WIDTH)
+    d = Drawing(total_width, total_height, origin='top-left')
     # Draw text
     text_width = int(total_width * 0.85)
 

--- a/resources/draw_logo.py
+++ b/resources/draw_logo.py
@@ -1,7 +1,7 @@
 # This script for drawing logo is one-time used, but it is kept here for reference.
 # To run this script, you may need to install
 # a python package ``drawsvg`` and a font ``Comic Neue``.
-from drawsvg import Group, Line, Text, ArcLine, Drawing
+from drawsvg import ArcLine, Drawing, Group, Line, Text
 
 LIME_DARK = '#5E6100'
 LIME_LIGHT = '#A3A800'
@@ -10,8 +10,8 @@ NEW_WIDTH = 320
 
 
 def write_text(*, x: int, y: int, width: int = 256) -> Group:
-    split_1 = x + width * 0.32 * ORIGINAL_WIDTH/NEW_WIDTH
-    split_2 = x + width * 0.65 * ORIGINAL_WIDTH/NEW_WIDTH
+    split_1 = x + width * 0.32 * ORIGINAL_WIDTH / NEW_WIDTH
+    split_2 = x + width * 0.65 * ORIGINAL_WIDTH / NEW_WIDTH
     transparent_line_1 = Line(x, y, split_1, y, opacity=1)
     transparent_line_2 = Line(split_1, y, split_2, y, opacity=1)
     transparent_line_3 = Line(split_2, y, width, y, opacity=1)
@@ -23,7 +23,7 @@ def write_text(*, x: int, y: int, width: int = 256) -> Group:
     texts = [
         Text(
             text,
-            font_size=int((width / 4 * ORIGINAL_WIDTH/NEW_WIDTH) * 0.958),
+            font_size=int((width / 4 * ORIGINAL_WIDTH / NEW_WIDTH) * 0.958),
             path=path,
             text_anchor='start',
             font_family='Comic Neue',
@@ -46,7 +46,7 @@ def draw_beam(*, start_x: int = 0, y: int, width: int) -> Group:
         stroke_linecap="round",
     )
     lime_beam = Line(
-        (start_x + width) * 0.42 * ORIGINAL_WIDTH/NEW_WIDTH,
+        (start_x + width) * 0.42 * ORIGINAL_WIDTH / NEW_WIDTH,
         y,
         start_x + width,
         y,
@@ -138,7 +138,7 @@ def draw_lime_arc(cx: int, cy: int, radius: int) -> Group:
 
 if __name__ == '__main__':
     total_width = NEW_WIDTH
-    total_height = int(total_width * 0.3 * ORIGINAL_WIDTH/NEW_WIDTH)
+    total_height = int(total_width * 0.3 * ORIGINAL_WIDTH / NEW_WIDTH)
     d = Drawing(total_width, total_height, origin='top-left')
     # Draw text
     text_width = int(total_width * 0.85)


### PR DESCRIPTION
The logo for `esslivedata` reads "beamlime" despite the package rename in [September 2025](https://github.com/scipp/esslivedata/commit/1a700baeee7ce6df2b241500468f67f927b5537b)

This PR replaces the logo with a variation in the same theme:
![esslivedata](https://raw.githubusercontent.com/g5t/esslivedata/update-logo/docs/_static/logo.svg)

The logo generation script has been modified to make this new logo, and it will be rendered in the `README.md` preview if/when the new svgs in `docs/_static` are merged into the main branch.