### PR TITLE
Show data age in freshness pill; demote pipeline lag to detail

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -80,3 +80,19 @@ Python constants rather than CSS variables for centralized color management.
 ## Avoiding flicker
 
 Make sure all widget-updates that touch more than a single widget (or a single widget multiple times) use `pn.io.hold()`.
+
+### Native tooltips on re-rendering panes
+
+A native HTML `title=` tooltip baked into a `pn.pane.HTML` string is torn down
+every time `pane.object` is reassigned — Panel replaces the pane's inner DOM, so
+the browser drops any open hover tooltip. This makes hover tooltips unworkable on
+any element whose content updates frequently (e.g. a live freshness/lag readout
+updating per data frame at ~1 Hz): the tooltip flickers once per update.
+
+Guarding the write (`if pane.object != html`) only helps if the rendered string is
+genuinely piecewise-constant. Live values (timestamps, sub-second lag) defeat it.
+
+For detail that must accompany a live-updating element, put it in a separate
+*visible* label (e.g. a toolbar row) that can redraw freely, not a hover tooltip.
+Encode continuously-changing signals as discrete bands (color/border) so the HTML
+stays constant between threshold crossings.

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -326,17 +326,31 @@ class TimeBounds:
 
     ``min_end`` is the end time of the oldest data, giving worst-case staleness.
     ``min_start`` and ``max_end`` bound the full data range and are present only
-    when start times exist on the data.
+    when start times exist on the data. ``created_at`` is the wall-clock instant
+    these bounds were computed, anchoring the two distinct freshness measures:
+    pipeline lag (frozen at compute time) and idle time (grows against the wall
+    clock between data arrivals).
     """
 
     min_end: Timestamp
+    created_at: Timestamp
     min_start: Timestamp | None = None
     max_end: Timestamp | None = None
 
-    def lag_seconds(self, now: Timestamp | None = None) -> float:
-        """Seconds between the oldest data's end time and ``now`` (max lag)."""
+    def lag_seconds(self) -> float:
+        """Pipeline latency: oldest data's end time to when it was plotted.
+
+        Frozen at compute time -- does not grow while the stream is idle.
+        """
+        return (self.created_at - self.min_end).to_seconds()
+
+    def idle_seconds(self, now: Timestamp | None = None) -> float:
+        """Wall-clock seconds since these bounds were computed (stream idle).
+
+        Grows between data arrivals, so a stalled stream visibly ages.
+        """
         now = Timestamp.now() if now is None else now
-        return (now - self.min_end).to_seconds()
+        return (now - self.created_at).to_seconds()
 
 
 def _compute_time_bounds(data: dict[str, sc.DataArray]) -> TimeBounds | None:
@@ -362,11 +376,20 @@ def _compute_time_bounds(data: dict[str, sc.DataArray]) -> TimeBounds | None:
 
     if min_end is None:
         return None
-    return TimeBounds(min_end=min_end, min_start=min_start, max_end=max_end)
+    return TimeBounds(
+        min_end=min_end,
+        created_at=Timestamp.now(),
+        min_start=min_start,
+        max_end=max_end,
+    )
 
 
 def merge_time_bounds(bounds: Iterable[TimeBounds | None]) -> TimeBounds | None:
-    """Combine bounds across layers: earliest start, oldest end, latest end."""
+    """Combine bounds across layers: earliest start, oldest end, latest end.
+
+    ``created_at`` takes the earliest across layers so idle time reflects the
+    most stale layer (worst-case staleness).
+    """
     present = [b for b in bounds if b is not None]
     if not present:
         return None
@@ -374,15 +397,18 @@ def merge_time_bounds(bounds: Iterable[TimeBounds | None]) -> TimeBounds | None:
     ends = [b.max_end for b in present if b.max_end is not None]
     return TimeBounds(
         min_end=min(b.min_end for b in present),
+        created_at=min(b.created_at for b in present),
         min_start=min(starts) if starts else None,
         max_end=max(ends) if ends else None,
     )
 
 
-def format_time_info(bounds: TimeBounds, now: Timestamp | None = None) -> str:
-    """Format time bounds as a range + lag string, e.g. "12:34:56 (Lag: 2.3s)"."""
-    now = Timestamp.now() if now is None else now
-    lag_s = bounds.lag_seconds(now)
+def format_time_info(bounds: TimeBounds) -> str:
+    """Format time bounds as a range + lag string, e.g. "12:34:56 (Lag: 2.3s)".
+
+    ``Lag`` is the frozen pipeline latency, not wall-clock staleness.
+    """
+    lag_s = bounds.lag_seconds()
     if bounds.min_start is not None and bounds.max_end is not None:
         start_str = format_time_ns_local(bounds.min_start)
         end_str = format_time_ns_local(bounds.max_end)

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -328,8 +328,8 @@ class TimeBounds:
     ``min_start`` and ``max_end`` bound the full data range and are present only
     when start times exist on the data. ``created_at`` is the wall-clock instant
     these bounds were computed, anchoring the two distinct freshness measures:
-    pipeline lag (frozen at compute time) and idle time (grows against the wall
-    clock between data arrivals).
+    data age (``now`` minus the data's end time, the headline indicator) and
+    pipeline lag (frozen at compute time, the per-layer diagnostic detail).
     """
 
     min_end: Timestamp
@@ -337,20 +337,22 @@ class TimeBounds:
     min_start: Timestamp | None = None
     max_end: Timestamp | None = None
 
+    def age_seconds(self, now: Timestamp | None = None) -> float:
+        """Wall-clock age of the oldest displayed data (``now`` minus its end).
+
+        Recomputed against a shared ``now`` so ages are comparable across plots
+        and grow while a stream is stalled -- the headline freshness indicator.
+        """
+        now = Timestamp.now() if now is None else now
+        return (now - self.min_end).to_seconds()
+
     def lag_seconds(self) -> float:
         """Pipeline latency: oldest data's end time to when it was plotted.
 
-        Frozen at compute time -- does not grow while the stream is idle.
+        Frozen at compute time -- the reduction's processing delay, anchored to
+        each plot's own render moment and so not comparable across plots.
         """
         return (self.created_at - self.min_end).to_seconds()
-
-    def idle_seconds(self, now: Timestamp | None = None) -> float:
-        """Wall-clock seconds since these bounds were computed (stream idle).
-
-        Grows between data arrivals, so a stalled stream visibly ages.
-        """
-        now = Timestamp.now() if now is None else now
-        return (now - self.created_at).to_seconds()
 
 
 def _compute_time_bounds(data: dict[str, sc.DataArray]) -> TimeBounds | None:
@@ -387,8 +389,8 @@ def _compute_time_bounds(data: dict[str, sc.DataArray]) -> TimeBounds | None:
 def merge_time_bounds(bounds: Iterable[TimeBounds | None]) -> TimeBounds | None:
     """Combine bounds across layers: earliest start, oldest end, latest end.
 
-    ``created_at`` takes the earliest across layers so idle time reflects the
-    most stale layer (worst-case staleness).
+    ``min_end`` is the oldest across layers, so the cell's age reflects its most
+    stale layer (worst case). ``created_at`` takes the earliest to match.
     """
     present = [b for b in bounds if b is not None]
     if not present:

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -24,7 +24,6 @@ import panel as pn
 import structlog
 
 from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
-from ess.livedata.core.timestamp import Timestamp
 
 from ..cell_autoscale import CellAutoscaleController, build_controller_from_layers
 from ..format_utils import extract_error_summary
@@ -102,37 +101,49 @@ def _format_lag_short(lag_seconds: float) -> str:
     return f'{lag_seconds / 60:.0f}m'
 
 
-def format_freshness_html(lag_seconds: float | None, tooltip: str = '') -> str:
-    """Render the titlebar freshness/lag pill, color-banded by staleness.
+def format_freshness_html(
+    lag_seconds: float | None,
+    idle_seconds: float | None = None,
+) -> str:
+    """Render the titlebar freshness/lag pill on two independent channels.
+
+    The fill, text, dot, and number show pipeline ``lag_seconds`` (frozen at
+    compute time), banded by staleness. The border shows wall-clock
+    ``idle_seconds`` (time since the stream last delivered), banded the same
+    way, so a stalled stream's border visibly reddens while the lag number
+    holds at its last value.
+
+    No hover tooltip: the pill re-renders whenever its content changes (up to
+    once per data frame), which would tear down a native ``title`` tooltip on
+    every update. The full range/lag detail lives in the per-layer toolbar row
+    instead, where it can update without disturbing a hover.
 
     Parameters
     ----------
     lag_seconds:
-        Data lag in seconds, or None to render nothing (no timing data).
-    tooltip:
-        Full time-range text shown on hover (the pill itself shows only the
-        compact lag).
+        Pipeline lag in seconds, or None to render nothing (no timing data).
+    idle_seconds:
+        Wall-clock seconds since the data was computed, or None to draw no
+        border accent.
     """
     if lag_seconds is None:
         return ''
     background, text_color, dot_color = _freshness_band(lag_seconds)
+    border_color = (
+        'transparent' if idle_seconds is None else _freshness_band(idle_seconds)[2]
+    )
     pill_style = (
         f'display:inline-flex;align-items:center;gap:5px;height:20px;'
-        f'padding:0 8px;border-radius:10px;font-size:11px;'
+        f'box-sizing:border-box;padding:0 8px;border-radius:10px;font-size:11px;'
         f'font-variant-numeric:tabular-nums;white-space:nowrap;'
         f'background:{background};color:{text_color};'
+        f'border:2px solid {border_color};'
     )
     dot_style = (
         f'width:7px;height:7px;border-radius:50%;flex:none;background:{dot_color};'
     )
-    if tooltip:
-        from html import escape
-
-        title_attr = f' title="{escape(tooltip)}"'
-    else:
-        title_attr = ''
     return (
-        f'<span style="{pill_style}"{title_attr}>'
+        f'<span style="{pill_style}">'
         f'<span style="{dot_style}"></span>{_format_lag_short(lag_seconds)}</span>'
     )
 
@@ -273,9 +284,8 @@ class CellWidget:
         if merged is None:
             html = ''
         else:
-            now = Timestamp.now()
             html = format_freshness_html(
-                merged.lag_seconds(now), tooltip=format_time_info(merged, now=now)
+                merged.lag_seconds(), idle_seconds=merged.idle_seconds()
             )
         if self._freshness_pane.object != html:
             self._freshness_pane.object = html

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -77,74 +77,61 @@ def _get_sizing_mode(config: PlotConfig) -> str:
     return 'stretch_both'
 
 
-# Lag thresholds in seconds (now minus the oldest data's end time) that
-# classify data freshness for the titlebar pill.
+# Data-age thresholds in seconds (now minus the oldest data's end time) that
+# classify freshness for the titlebar pill.
 _FRESH_MAX_SECONDS = 5.0
 _STALE_MAX_SECONDS = 30.0
 
 
-def _freshness_band(lag_seconds: float) -> tuple[str, str, str]:
-    """Return the ``(background, text, dot)`` pill colors for a lag in seconds."""
-    if lag_seconds < _FRESH_MAX_SECONDS:
+def _freshness_band(age_seconds: float) -> tuple[str, str, str]:
+    """Return the ``(background, text, dot)`` pill colors for a data age."""
+    if age_seconds < _FRESH_MAX_SECONDS:
         return FreshnessPill.FRESH
-    if lag_seconds < _STALE_MAX_SECONDS:
+    if age_seconds < _STALE_MAX_SECONDS:
         return FreshnessPill.STALE
     return FreshnessPill.OLD
 
 
-def _format_lag_short(lag_seconds: float) -> str:
-    """Compact lag label, e.g. "2.3s", "41s", "3m"."""
-    if lag_seconds < 10:
-        return f'{lag_seconds:.1f}s'
-    if lag_seconds < 60:
-        return f'{lag_seconds:.0f}s'
-    return f'{lag_seconds / 60:.0f}m'
+def _format_age_short(age_seconds: float) -> str:
+    """Compact age label, e.g. "2.3s", "41s", "3m"."""
+    if age_seconds < 10:
+        return f'{age_seconds:.1f}s'
+    if age_seconds < 60:
+        return f'{age_seconds:.0f}s'
+    return f'{age_seconds / 60:.0f}m'
 
 
-def format_freshness_html(
-    lag_seconds: float | None,
-    idle_seconds: float | None = None,
-) -> str:
-    """Render the titlebar freshness/lag pill on two independent channels.
+def format_freshness_html(age_seconds: float | None) -> str:
+    """Render the titlebar freshness pill: wall-clock age of the displayed data.
 
-    The fill, text, dot, and number show pipeline ``lag_seconds`` (frozen at
-    compute time), banded by staleness. The border shows wall-clock
-    ``idle_seconds`` (time since the stream last delivered), banded the same
-    way, so a stalled stream's border visibly reddens while the lag number
-    holds at its last value.
+    Shows ``now - data_end`` for the oldest layer, color-banded by staleness.
+    Because every cell uses a shared ``now``, ages are directly comparable
+    across plots and grow visibly while a stream is stalled.
 
-    No hover tooltip: the pill re-renders whenever its content changes (up to
-    once per data frame), which would tear down a native ``title`` tooltip on
-    every update. The full range/lag detail lives in the per-layer toolbar row
-    instead, where it can update without disturbing a hover.
+    No hover tooltip: the pill re-renders as the age ticks, which would tear
+    down a native ``title`` tooltip on every update. The absolute time range and
+    the frozen pipeline lag live in the per-layer toolbar row instead.
 
     Parameters
     ----------
-    lag_seconds:
-        Pipeline lag in seconds, or None to render nothing (no timing data).
-    idle_seconds:
-        Wall-clock seconds since the data was computed, or None to draw no
-        border accent.
+    age_seconds:
+        Data age in seconds, or None to render nothing (no timing data).
     """
-    if lag_seconds is None:
+    if age_seconds is None:
         return ''
-    background, text_color, dot_color = _freshness_band(lag_seconds)
-    border_color = (
-        'transparent' if idle_seconds is None else _freshness_band(idle_seconds)[2]
-    )
+    background, text_color, dot_color = _freshness_band(age_seconds)
     pill_style = (
         f'display:inline-flex;align-items:center;gap:5px;height:20px;'
-        f'box-sizing:border-box;padding:0 8px;border-radius:10px;font-size:11px;'
+        f'padding:0 8px;border-radius:10px;font-size:11px;'
         f'font-variant-numeric:tabular-nums;white-space:nowrap;'
         f'background:{background};color:{text_color};'
-        f'border:2px solid {border_color};'
     )
     dot_style = (
         f'width:7px;height:7px;border-radius:50%;flex:none;background:{dot_color};'
     )
     return (
         f'<span style="{pill_style}">'
-        f'<span style="{dot_style}"></span>{_format_lag_short(lag_seconds)}</span>'
+        f'<span style="{dot_style}"></span>{_format_age_short(age_seconds)}</span>'
     )
 
 
@@ -279,14 +266,10 @@ class CellWidget:
         return self._autoscale_controller
 
     def update_freshness(self, bounds_list: list[TimeBounds | None]) -> None:
-        """Update the titlebar freshness pane from the layers' time bounds."""
+        """Update the titlebar freshness pane with the worst-case data age."""
         merged = merge_time_bounds(bounds_list)
-        if merged is None:
-            html = ''
-        else:
-            html = format_freshness_html(
-                merged.lag_seconds(), idle_seconds=merged.idle_seconds()
-            )
+        age = merged.age_seconds() if merged is not None else None
+        html = format_freshness_html(age)
         if self._freshness_pane.object != html:
             self._freshness_pane.object = html
 

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1767,7 +1767,7 @@ class TestTimeBounds:
         merged = plots.merge_time_bounds([a, b])
         assert merged.min_end == self._ts(50)
 
-    def test_merge_takes_earliest_created_at_for_idle(self) -> None:
+    def test_merge_takes_earliest_created_at(self) -> None:
         a = plots.TimeBounds(min_end=self._ts(100), created_at=self._ts(200))
         b = plots.TimeBounds(min_end=self._ts(50), created_at=self._ts(150))
         merged = plots.merge_time_bounds([a, b])
@@ -1809,11 +1809,11 @@ class TestTimeBounds:
         )
         assert bounds.lag_seconds() == pytest.approx(2.0)
 
-    def test_idle_grows_against_now(self) -> None:
+    def test_age_grows_against_now(self) -> None:
         bounds = plots.TimeBounds(
             min_end=self._ts(int(8e9)), created_at=self._ts(int(10e9))
         )
-        assert bounds.idle_seconds(now=self._ts(int(25e9))) == pytest.approx(15.0)
+        assert bounds.age_seconds(now=self._ts(int(25e9))) == pytest.approx(17.0)
 
     def test_format_with_range_shows_interval(self) -> None:
         bounds = plots.TimeBounds(

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1758,17 +1758,33 @@ class TestTimeBounds:
         assert plots.merge_time_bounds([]) is None
 
     def test_merge_takes_oldest_end_for_lag(self) -> None:
-        a = plots.TimeBounds(min_end=self._ts(100), max_end=self._ts(100))
-        b = plots.TimeBounds(min_end=self._ts(50), max_end=self._ts(80))
+        a = plots.TimeBounds(
+            min_end=self._ts(100), created_at=self._ts(200), max_end=self._ts(100)
+        )
+        b = plots.TimeBounds(
+            min_end=self._ts(50), created_at=self._ts(150), max_end=self._ts(80)
+        )
         merged = plots.merge_time_bounds([a, b])
         assert merged.min_end == self._ts(50)
 
+    def test_merge_takes_earliest_created_at_for_idle(self) -> None:
+        a = plots.TimeBounds(min_end=self._ts(100), created_at=self._ts(200))
+        b = plots.TimeBounds(min_end=self._ts(50), created_at=self._ts(150))
+        merged = plots.merge_time_bounds([a, b])
+        assert merged.created_at == self._ts(150)
+
     def test_merge_spans_full_range(self) -> None:
         a = plots.TimeBounds(
-            min_end=self._ts(100), min_start=self._ts(90), max_end=self._ts(110)
+            min_end=self._ts(100),
+            created_at=self._ts(200),
+            min_start=self._ts(90),
+            max_end=self._ts(110),
         )
         b = plots.TimeBounds(
-            min_end=self._ts(50), min_start=self._ts(40), max_end=self._ts(60)
+            min_end=self._ts(50),
+            created_at=self._ts(150),
+            min_start=self._ts(40),
+            max_end=self._ts(60),
         )
         merged = plots.merge_time_bounds([a, b, None])
         assert merged.min_start == self._ts(40)
@@ -1776,29 +1792,45 @@ class TestTimeBounds:
         assert merged.max_end == self._ts(110)
 
     def test_merge_drops_missing_start(self) -> None:
-        a = plots.TimeBounds(min_end=self._ts(100))  # no start/max_end
+        a = plots.TimeBounds(min_end=self._ts(100), created_at=self._ts(200))
         b = plots.TimeBounds(
-            min_end=self._ts(50), min_start=self._ts(40), max_end=self._ts(60)
+            min_end=self._ts(50),
+            created_at=self._ts(150),
+            min_start=self._ts(40),
+            max_end=self._ts(60),
         )
         merged = plots.merge_time_bounds([a, b])
         assert merged.min_start == self._ts(40)
         assert merged.max_end == self._ts(60)
 
+    def test_lag_is_frozen_at_created_at(self) -> None:
+        bounds = plots.TimeBounds(
+            min_end=self._ts(int(8e9)), created_at=self._ts(int(10e9))
+        )
+        assert bounds.lag_seconds() == pytest.approx(2.0)
+
+    def test_idle_grows_against_now(self) -> None:
+        bounds = plots.TimeBounds(
+            min_end=self._ts(int(8e9)), created_at=self._ts(int(10e9))
+        )
+        assert bounds.idle_seconds(now=self._ts(int(25e9))) == pytest.approx(15.0)
+
     def test_format_with_range_shows_interval(self) -> None:
-        now = self._ts(int(10e9))
         bounds = plots.TimeBounds(
             min_end=self._ts(int(8e9)),
+            created_at=self._ts(int(10e9)),
             min_start=self._ts(int(7e9)),
             max_end=self._ts(int(9e9)),
         )
-        text = plots.format_time_info(bounds, now=now)
+        text = plots.format_time_info(bounds)
         assert ' - ' in text
         assert 'Lag: 2.0s' in text
 
     def test_format_without_range_shows_single_time(self) -> None:
-        now = self._ts(int(10e9))
-        bounds = plots.TimeBounds(min_end=self._ts(int(7e9)))
-        text = plots.format_time_info(bounds, now=now)
+        bounds = plots.TimeBounds(
+            min_end=self._ts(int(7e9)), created_at=self._ts(int(10e9))
+        )
+        text = plots.format_time_info(bounds)
         assert ' - ' not in text
         assert 'Lag: 3.0s' in text
 

--- a/tests/dashboard/widgets/cell_test.py
+++ b/tests/dashboard/widgets/cell_test.py
@@ -27,38 +27,13 @@ class TestFreshnessPill:
         assert FreshnessPill.OLD[0] in html
         assert '41s' in html
 
-    def test_minutes_for_large_lag(self) -> None:
+    def test_minutes_for_large_age(self) -> None:
         assert '3m' in format_freshness_html(200.0)
 
     def test_no_hover_tooltip_on_pill(self) -> None:
-        # A native title tooltip cannot survive the pill's per-frame re-renders;
-        # detail lives in the toolbar row instead.
-        assert 'title=' not in format_freshness_html(2.0, idle_seconds=2.0)
-
-    def test_idle_drives_border_independently_of_lag(self) -> None:
-        # Fresh pipeline lag, but the stream has gone idle: fill stays fresh,
-        # border reflects the stale idle band.
-        html = format_freshness_html(2.0, idle_seconds=12.0)
-        assert FreshnessPill.FRESH[0] in html  # fill banded by lag
-        assert f'2px solid {FreshnessPill.STALE[2]}' in html  # border by idle
-        assert '2.0s' in html  # number is the frozen lag, not the idle time
-
-    def test_no_idle_draws_transparent_border(self) -> None:
-        html = format_freshness_html(2.0)
-        assert '2px solid transparent' in html
-
-    def test_html_is_stable_within_a_band(self) -> None:
-        # Anti-flicker: a growing idle that stays in the same band must yield
-        # byte-identical HTML so the guarded pane write never fires (and an
-        # open hover tooltip is not torn down).
-        assert format_freshness_html(2.0, idle_seconds=1.0) == format_freshness_html(
-            2.0, idle_seconds=4.0
-        )
-
-    def test_html_changes_across_band_boundary(self) -> None:
-        assert format_freshness_html(2.0, idle_seconds=4.0) != format_freshness_html(
-            2.0, idle_seconds=12.0
-        )
+        # A native title tooltip cannot survive the pill's per-frame re-renders
+        # as the age ticks; detail lives in the toolbar row instead.
+        assert 'title=' not in format_freshness_html(2.0)
 
 
 class TestLayerTimeHtml:

--- a/tests/dashboard/widgets/cell_test.py
+++ b/tests/dashboard/widgets/cell_test.py
@@ -30,9 +30,35 @@ class TestFreshnessPill:
     def test_minutes_for_large_lag(self) -> None:
         assert '3m' in format_freshness_html(200.0)
 
-    def test_tooltip_is_html_escaped(self) -> None:
-        html = format_freshness_html(2.0, tooltip='12:00 <range>')
-        assert 'title="12:00 &lt;range&gt;"' in html
+    def test_no_hover_tooltip_on_pill(self) -> None:
+        # A native title tooltip cannot survive the pill's per-frame re-renders;
+        # detail lives in the toolbar row instead.
+        assert 'title=' not in format_freshness_html(2.0, idle_seconds=2.0)
+
+    def test_idle_drives_border_independently_of_lag(self) -> None:
+        # Fresh pipeline lag, but the stream has gone idle: fill stays fresh,
+        # border reflects the stale idle band.
+        html = format_freshness_html(2.0, idle_seconds=12.0)
+        assert FreshnessPill.FRESH[0] in html  # fill banded by lag
+        assert f'2px solid {FreshnessPill.STALE[2]}' in html  # border by idle
+        assert '2.0s' in html  # number is the frozen lag, not the idle time
+
+    def test_no_idle_draws_transparent_border(self) -> None:
+        html = format_freshness_html(2.0)
+        assert '2px solid transparent' in html
+
+    def test_html_is_stable_within_a_band(self) -> None:
+        # Anti-flicker: a growing idle that stays in the same band must yield
+        # byte-identical HTML so the guarded pane write never fires (and an
+        # open hover tooltip is not torn down).
+        assert format_freshness_html(2.0, idle_seconds=1.0) == format_freshness_html(
+            2.0, idle_seconds=4.0
+        )
+
+    def test_html_changes_across_band_boundary(self) -> None:
+        assert format_freshness_html(2.0, idle_seconds=4.0) != format_freshness_html(
+            2.0, idle_seconds=12.0
+        )
 
 
 class TestLayerTimeHtml:

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -278,9 +278,11 @@ class TestFreshnessIndicator:
 
         panes = [cw.freshness_pane for cw in plot_grid_tabs._cells.values()]
         assert len(panes) == 1
-        # Pill shows the compact frozen lag with band styling, no hover tooltip.
+        # Pill shows the compact data age with band styling, no hover tooltip.
+        # Age is computed against the poll's wall clock, so assert structure
+        # rather than an exact value.
         assert 'border-radius' in panes[0].object
-        assert '2.0s' in panes[0].object
+        assert 's</span>' in panes[0].object  # compact age label, e.g. "2.0s"
         assert 'title=' not in panes[0].object
 
         # The per-layer time pane shows the full range + lag.

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -265,6 +265,7 @@ class TestFreshnessIndicator:
         now_ns = time.time_ns()
         bounds = TimeBounds(
             min_end=Timestamp.from_ns(now_ns - int(2e9)),
+            created_at=Timestamp.from_ns(now_ns),
             min_start=Timestamp.from_ns(now_ns - int(3e9)),
             max_end=Timestamp.from_ns(now_ns - int(1e9)),
         )
@@ -277,9 +278,10 @@ class TestFreshnessIndicator:
 
         panes = [cw.freshness_pane for cw in plot_grid_tabs._cells.values()]
         assert len(panes) == 1
-        # Pill styling present, with the full range in the hover tooltip.
+        # Pill shows the compact frozen lag with band styling, no hover tooltip.
         assert 'border-radius' in panes[0].object
-        assert 'Lag:' in panes[0].object
+        assert '2.0s' in panes[0].object
+        assert 'title=' not in panes[0].object
 
         # The per-layer time pane shows the full range + lag.
         layer_panes = [
@@ -302,6 +304,7 @@ class TestFreshnessIndicator:
         now_ns = time.time_ns()
         bounds = TimeBounds(
             min_end=Timestamp.from_ns(now_ns - int(2e9)),
+            created_at=Timestamp.from_ns(now_ns),
             min_start=Timestamp.from_ns(now_ns - int(3e9)),
             max_end=Timestamp.from_ns(now_ns - int(1e9)),
         )


### PR DESCRIPTION
## Motivation

Moving the lag indicator into the cell titlebar (#960) changed it to report the wall-clock age of the displayed data (`now − data_end`), recomputed each poll, so it ticks up while a stream is stalled. That looked like a regression versus the old plot-title indicator, which froze the lag at render time. On reflection it is the right behavior: the stalled data really is getting older, and — crucially — an age measured against a shared `now` is comparable across plots and against the experiment control software's clock, whereas a per-plot frozen lag is anchored to each plot's own render moment and so cannot be compared. The original purpose of the indicator was exactly that cross-plot / cross-system correlation, not just pipeline-latency diagnosis.

## Changes

Keeps data age as the headline pill (color-banded by staleness, formatted `3s` → `1m` → `5m` so a dead stream reads as obviously stale) and demotes the frozen pipeline lag to the per-layer toolbar detail row, where it sits next to the absolute time range — the skew-free primitive for correlating with external timestamps. `TimeBounds` records `created_at` so the toolbar can still report that frozen lag, while the pill uses `age_seconds` against the poll clock.

The pill carries no native `title` tooltip. It re-renders as the age ticks (up to once per data frame), which tears down a hover tooltip on every update — flicker at the typical 1 Hz rate, and unavoidable for a hover tooltip on a live-updating element. Detail therefore lives in the toolbar row, which updates without disturbing a hover.

## Test plan

- [x] Watch a live stream: pill age stays low and green, ticking with each frame.
- [x] Stop the stream: age climbs and the band goes stale → old.
- [x] Toggle the toolbar: per-layer row shows the absolute range and frozen lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
