### PR TITLE
Fix error bar/band color not matching line color in LinePlotter

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -866,6 +866,7 @@ class LinePlotter(Plotter):
         self._errors = errors
         self._logx = scale_opts.x_scale == PlotScale.log
         self._logy = scale_opts.y_scale == PlotScale.log
+        self._color = hv.Cycle.default_cycles["default_colors"][0]
         self._base_opts: dict[str, Any] = {
             'logx': self._logx,
             'logy': self._logy,
@@ -998,7 +999,7 @@ class LinePlotter(Plotter):
             da, value_label=output_display_name, dim_label=dim_label
         )
         base_method = getattr(converter, _LINE1D_BASE_METHOD[mode])
-        base = base_method(label=label)
+        base = base_method(label=label).opts(color=self._color)
 
         if da.variances is not None and self._errors != 'none':
             if mode == 'histogram':
@@ -1009,7 +1010,7 @@ class LinePlotter(Plotter):
                     dim_label=dim_label,
                 )
             error_method = getattr(converter, _LINE1D_ERROR_METHOD[self._errors])
-            return base * error_method(label=label)
+            return base * error_method(label=label).opts(color=self._color)
 
         return base
 

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -597,6 +597,40 @@ class TestLinePlotter:
         assert isinstance(elements[0], hv.Histogram)
         assert isinstance(elements[1], hv.ErrorBars)
 
+    @pytest.mark.parametrize(
+        ('mode', 'errors', 'base_type', 'error_type'),
+        [
+            (Line1dRenderMode.line, ErrorDisplay.bars, hv.Curve, hv.ErrorBars),
+            (Line1dRenderMode.line, ErrorDisplay.band, hv.Curve, hv.Spread),
+            (Line1dRenderMode.points, ErrorDisplay.bars, hv.Scatter, hv.ErrorBars),
+        ],
+    )
+    def test_error_elements_match_line_color(
+        self, data_key, mode, errors, base_type, error_type
+    ):
+        params = PlotParams1d(line=Line1dParams(mode=mode, errors=errors))
+        plotter = plots.LinePlotter.from_params(params)
+        data = sc.DataArray(
+            sc.array(
+                dims=['x'],
+                values=[1.0, 2.0, 3.0],
+                variances=[0.1, 0.2, 0.3],
+                unit='counts',
+            ),
+            coords={'x': sc.array(dims=['x'], values=[10.0, 20.0, 30.0], unit='m')},
+        )
+        result = plotter.plot(data, data_key)
+        elements = list(result)
+        assert isinstance(elements[0], base_type)
+        assert isinstance(elements[1], error_type)
+        base_color = hv.Store.lookup_options('bokeh', elements[0], 'style').kwargs[
+            'color'
+        ]
+        error_color = hv.Store.lookup_options('bokeh', elements[1], 'style').kwargs[
+            'color'
+        ]
+        assert base_color == error_color
+
     def test_error_overlay_renders_responsive(self, data_key):
         """A line+error overlay renders as a responsive (stretch_both) figure."""
         params = PlotParams1d(


### PR DESCRIPTION
`LinePlotter` was creating `ErrorBars`/`Spread` elements with no explicit color, so Bokeh rendered them in its default black. `Overlay1DPlotter` already handled this correctly by applying the same cycle color to both the base element and the error element.

The fix mirrors that pattern: `LinePlotter` now stores the first default cycle color and applies it via `.opts(color=...)` to both the base element (Curve/Scatter/Histogram) and the error element. No other plotters are affected — only `LinePlotter` and `Overlay1DPlotter` render error bars, and `Overlay1DPlotter` was already correct.

A parametrized test covers all affected combinations (line+bars, line+band, points+bars).