### PR TITLE
Fix autoscale hook failure on datetime axes

### DIFF
--- a/src/ess/livedata/dashboard/range_hook.py
+++ b/src/ess/livedata/dashboard/range_hook.py
@@ -14,8 +14,26 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+import numpy as np
+
 Axis = Literal['x', 'y', 'c']
 RangeTargets = dict[Axis, tuple[float, float]]
+
+
+def _coerce_to(value: float, reference: Any) -> Any:
+    """Coerce a float target to ``reference``'s type for assignment.
+
+    Bokeh stores datetime axis ranges as ``np.datetime64`` (matching the unit
+    of the source coord). Range targets are computed in float space (epoch
+    counts for datetime coords; see ``plots._finite_min_max``), so on a
+    datetime axis a raw float would mix incompatible numpy dtypes -- both the
+    ordering comparison below and Bokeh's range patch raise a ``UFuncTypeError``
+    ('less_equal' loop missing for datetime64/float). Cast back to a datetime64
+    of the same unit so the value round-trips and stays comparable.
+    """
+    if isinstance(reference, np.datetime64):
+        return np.datetime64(round(value), np.datetime_data(reference)[0])
+    return value
 
 
 def _ordered_write(
@@ -31,6 +49,8 @@ def _ordered_write(
     first.
     """
     current_hi = getattr(model, hi_attr, None)
+    lo = _coerce_to(lo, current_hi)
+    hi = _coerce_to(hi, current_hi)
     write_hi_first = current_hi is None or hi >= current_hi
     if write_hi_first:
         setattr(model, hi_attr, hi)

--- a/tests/dashboard/range_hook_test.py
+++ b/tests/dashboard/range_hook_test.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
 from ess.livedata.dashboard.range_hook import RangeHandles
 
 
@@ -140,6 +142,23 @@ def test_write_avoids_inverted_range_downward() -> None:
         else:
             seen_end = value
         assert seen_start <= seen_end, f"inverted: start={seen_start} end={seen_end}"
+
+
+def test_write_datetime_axis_coerces_float_targets() -> None:
+    """Bokeh stores datetime ranges as ``np.datetime64``; range targets are
+    floats (epoch counts). The float must be cast back to a datetime64 of the
+    handle's unit so neither the ordering comparison nor Bokeh's range patch
+    mixes datetime64/float (which raises ``UFuncTypeError``)."""
+    lo_dt = np.datetime64('2026-06-17T11:52:00', 'ns')
+    hi_dt = np.datetime64('2026-06-17T11:52:04', 'ns')
+    handle = _StubRange(start=lo_dt, end=hi_dt)
+    target_lo = float(np.datetime64('2026-06-17T11:52:01', 'ns').astype('int64'))
+    target_hi = float(np.datetime64('2026-06-17T11:52:03', 'ns').astype('int64'))
+
+    assert RangeHandles.write(_StubPlot(x_range=handle), 'x', target_lo, target_hi)
+
+    assert handle.start == np.datetime64('2026-06-17T11:52:01', 'ns')
+    assert handle.end == np.datetime64('2026-06-17T11:52:03', 'ns')
 
 
 def test_write_color_mapper_avoids_inversion() -> None:


### PR DESCRIPTION
## Problem

The dashboard logs were flooded with warnings (~44/min on bifrost, across all timeseries plots):

```
Plotting hook <function CellAutoscaleController.make_hook.<locals>.hook ...> could not be applied:
 ufunc 'less_equal' did not contain a loop with signature matching types (DateTime64DType, _PyFloatDType)
```

As a side effect, autoscale-x silently never applied on datetime-axis (timeseries) plots.

## Cause

The per-cell autoscale controller computes axis range targets as floats — for a datetime coord that is an epoch count (via `plots._finite_min_max`'s `float(values.min())`). Bokeh, however, stores a datetime axis's `Range1d` as `np.datetime64`. Writing a float target then hit `hi >= current_hi` with `float` vs `datetime64`, which dispatches to a `less_equal` ufunc loop that does not exist, raising `UFuncTypeError`. HoloViews caught the hook exception and logged the warning on every render.

## Fix

Coerce float targets back to a `datetime64` of the handle's unit at the write boundary, leaving the float padding math unchanged. The coercion keys off the handle's current value type, so it applies only to datetime axes and is a no-op for numeric x/y/colour ranges.
