### PR TITLE
Color error-bar endcaps to match the line color

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar
 import holoviews as hv
 import numpy as np
 import scipp as sc
+from bokeh.models import TeeHead
 from holoviews.core.util import range_pad
 from holoviews.plotting.util import get_axis_padding
 
@@ -807,6 +808,23 @@ _LINE1D_LEAF_ELEMENTS: tuple[type, ...] = (
 )
 
 
+def _color_error_element(el: hv.Element, color: Any) -> hv.Element:
+    """Apply ``color`` to an error element, including ``ErrorBars`` endcaps.
+
+    HoloViews maps ``color`` to the Whisker body line only; its endcaps are
+    separate ``TeeHead`` glyphs whose ``line_color`` otherwise stays black.
+    ``Spread`` (a subclass of ``ErrorBars``) renders as a filled band with no
+    endcaps, so it takes the plain ``color`` path.
+    """
+    if type(el) is hv.ErrorBars:
+        return el.opts(
+            color=color,
+            upper_head=TeeHead(line_color=color),
+            lower_head=TeeHead(line_color=color),
+        )
+    return el.opts(color=color)
+
+
 def _resolve_line1d_mode(
     mode: str, data: sc.DataArray, dim: str | None = None
 ) -> tuple[str, sc.DataArray]:
@@ -1010,7 +1028,8 @@ class LinePlotter(Plotter):
                     dim_label=dim_label,
                 )
             error_method = getattr(converter, _LINE1D_ERROR_METHOD[self._errors])
-            return base * error_method(label=label).opts(color=self._color)
+            error = _color_error_element(error_method(label=label), self._color)
+            return base * error
 
         return base
 
@@ -1371,7 +1390,7 @@ class Overlay1DPlotter(Plotter):
                         mid, value_label=output_display_name, dim_label=dim_label
                     )
                 error_method = getattr(converter, _LINE1D_ERROR_METHOD[self._errors])
-                error_el = error_method(label=curve_label).opts(color=color)
+                error_el = _color_error_element(error_method(label=curve_label), color)
                 elements.append(base)
                 elements.append(error_el)
             else:

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -1015,16 +1015,20 @@ class LinePlotter(Plotter):
         targets = self._compute_line_range_targets(data, mode)
         if targets:
             self._range_targets[data_key] = targets
-        # Overlaid lines each get a distinct cycle color so multiple sources are
-        # distinguishable; the error element is colored to match.
-        color = self._colors[plot_index % len(self._colors)]
         converter = HvConverter1d(
             da, value_label=output_display_name, dim_label=dim_label
         )
         base_method = getattr(converter, _LINE1D_BASE_METHOD[mode])
-        base = base_method(label=label).opts(color=color)
+        base = base_method(label=label)
 
         if da.variances is not None and self._errors != 'none':
+            # An error element must be colored explicitly to match its line and
+            # to color its endcaps; this picks a distinct cycle color per source
+            # but forfeits HoloViews' cross-overlay auto-cycling. Error-free lines
+            # keep no explicit color so auto-cycling still distinguishes sources
+            # across independently overlaid layers.
+            color = self._colors[plot_index % len(self._colors)]
+            base = base.opts(color=color)
             if mode == 'histogram':
                 # Error elements need midpoint coords (N values, not N+1 edges)
                 converter = HvConverter1d(

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -640,7 +640,7 @@ class Plotter:
         resolver = title_resolver or TitleResolver()
         plots: list[hv.Element] = []
         try:
-            for data_key, da in data.items():
+            for plot_index, (data_key, da) in enumerate(data.items()):
                 label = resolver.get_legend_label(
                     data_key.job_id.source_name, data_key.output_name
                 )
@@ -653,6 +653,7 @@ class Plotter:
                     source_display_name=source_display_name,
                     output_display_name=output_display_name,
                     dim_label=resolver.dim,
+                    plot_index=plot_index,
                     **kwargs,
                 )
                 plots.append(plot_element)
@@ -884,7 +885,7 @@ class LinePlotter(Plotter):
         self._errors = errors
         self._logx = scale_opts.x_scale == PlotScale.log
         self._logy = scale_opts.y_scale == PlotScale.log
-        self._color = hv.Cycle.default_cycles["default_colors"][0]
+        self._colors = hv.Cycle.default_cycles["default_colors"]
         self._base_opts: dict[str, Any] = {
             'logx': self._logx,
             'logy': self._logy,
@@ -1006,6 +1007,7 @@ class LinePlotter(Plotter):
         label: str = '',
         output_display_name: str = '',
         dim_label: Callable[[str], str] | None = None,
+        plot_index: int = 0,
         **kwargs,
     ) -> hv.Element | hv.Overlay:
         """Create a 1D plot from a scipp DataArray."""
@@ -1013,11 +1015,14 @@ class LinePlotter(Plotter):
         targets = self._compute_line_range_targets(data, mode)
         if targets:
             self._range_targets[data_key] = targets
+        # Overlaid lines each get a distinct cycle color so multiple sources are
+        # distinguishable; the error element is colored to match.
+        color = self._colors[plot_index % len(self._colors)]
         converter = HvConverter1d(
             da, value_label=output_display_name, dim_label=dim_label
         )
         base_method = getattr(converter, _LINE1D_BASE_METHOD[mode])
-        base = base_method(label=label).opts(color=self._color)
+        base = base_method(label=label).opts(color=color)
 
         if da.variances is not None and self._errors != 'none':
             if mode == 'histogram':
@@ -1028,7 +1033,7 @@ class LinePlotter(Plotter):
                     dim_label=dim_label,
                 )
             error_method = getattr(converter, _LINE1D_ERROR_METHOD[self._errors])
-            error = _color_error_element(error_method(label=label), self._color)
+            error = _color_error_element(error_method(label=label), color)
             return base * error
 
         return base

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -8,7 +8,7 @@ import holoviews as hv
 import numpy as np
 import pytest
 import scipp as sc
-from bokeh.models import GlyphRenderer
+from bokeh.models import GlyphRenderer, Whisker
 from holoviews.plotting.bokeh import BokehRenderer
 
 from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
@@ -31,6 +31,21 @@ from ess.livedata.dashboard.slicer_plotter import (
 )
 
 hv.extension('bokeh')
+
+
+def _assert_error_bar_endcaps_colored(error_bars: hv.ErrorBars, color: str) -> None:
+    """Assert the rendered Whisker body and both endcaps use ``color``.
+
+    Endcaps are separate ``TeeHead`` glyphs that default to black, so coloring
+    the Whisker body alone leaves them mismatched.
+    """
+    fig = hv.render(error_bars)
+    whiskers = fig.select(Whisker)
+    assert whiskers, "expected a Whisker glyph for ErrorBars"
+    whisker = whiskers[0]
+    assert whisker.line_color == color
+    assert whisker.upper_head.line_color == color
+    assert whisker.lower_head.line_color == color
 
 
 @pytest.fixture
@@ -630,6 +645,8 @@ class TestLinePlotter:
             'color'
         ]
         assert base_color == error_color
+        if error_type is hv.ErrorBars:
+            _assert_error_bar_endcaps_colored(elements[1], base_color)
 
     def test_error_overlay_renders_responsive(self, data_key):
         """A line+error overlay renders as a responsive (stretch_both) figure."""
@@ -1619,6 +1636,9 @@ class TestOverlay1DPlotter:
         assert isinstance(elements[1], hv.ErrorBars)
         assert isinstance(elements[2], hv.Curve)
         assert isinstance(elements[3], hv.ErrorBars)
+        for base, error in ((elements[0], elements[1]), (elements[2], elements[3])):
+            base_color = hv.Store.lookup_options('bokeh', base, 'style').kwargs['color']
+            _assert_error_bar_endcaps_colored(error, base_color)
 
     def test_error_band_with_variances(self, data_key):
         params = PlotParams1d(

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -648,6 +648,43 @@ class TestLinePlotter:
         if error_type is hv.ErrorBars:
             _assert_error_bar_endcaps_colored(elements[1], base_color)
 
+    def test_overlaid_sources_get_distinct_matching_colors(self, data_key):
+        """Each overlaid source gets a distinct color; its error bars match it."""
+        params = PlotParams1d(
+            line=Line1dParams(mode=Line1dRenderMode.line, errors=ErrorDisplay.bars)
+        )
+        plotter = plots.LinePlotter.from_params(params)
+        data = sc.DataArray(
+            sc.array(
+                dims=['x'],
+                values=[1.0, 2.0, 3.0],
+                variances=[0.1, 0.2, 0.3],
+                unit='counts',
+            ),
+            coords={'x': sc.array(dims=['x'], values=[10.0, 20.0, 30.0], unit='m')},
+        )
+        data_key2 = ResultKey(
+            workflow_id=data_key.workflow_id,
+            job_id=JobId(source_name='other_source', job_number=uuid.uuid4()),
+            output_name=data_key.output_name,
+        )
+        plotter.compute({'primary': {data_key: data, data_key2: data}})
+
+        fig = hv.render(plotter.get_cached_state())
+        line_colors = [
+            r.glyph.line_color
+            for r in fig.select(GlyphRenderer)
+            if type(r.glyph).__name__ == 'Line'
+        ]
+        assert len(line_colors) == 2
+        assert line_colors[0] != line_colors[1]
+        whiskers = fig.select(Whisker)
+        whisker_colors = {w.line_color for w in whiskers}
+        assert whisker_colors == set(line_colors)
+        for w in whiskers:
+            assert w.upper_head.line_color == w.line_color
+            assert w.lower_head.line_color == w.line_color
+
     def test_error_overlay_renders_responsive(self, data_key):
         """A line+error overlay renders as a responsive (stretch_both) figure."""
         params = PlotParams1d(

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -685,6 +685,38 @@ class TestLinePlotter:
             assert w.upper_head.line_color == w.line_color
             assert w.lower_head.line_color == w.line_color
 
+    def test_layered_error_free_lines_get_distinct_colors(self, data_key):
+        """Error-free lines from independent plotters auto-cycle when layered.
+
+        Without errors no explicit color is set, so HoloViews' cross-overlay
+        cycling distinguishes sources even across plotters composed via the
+        cell layer mechanism. (Error bars require explicit colors and therefore
+        still collide across layers; see the per-plotter coloring limitation.)
+        """
+        params = PlotParams1d(
+            line=Line1dParams(mode=Line1dRenderMode.line, errors=ErrorDisplay.none)
+        )
+        data = sc.DataArray(
+            sc.array(dims=['x'], values=[1.0, 2.0, 3.0], unit='counts'),
+            coords={'x': sc.array(dims=['x'], values=[10.0, 20.0, 30.0], unit='m')},
+        )
+        layer_a = plots.LinePlotter.from_params(params)
+        layer_a.compute({'primary': {data_key: data}})
+        layer_b = plots.LinePlotter.from_params(params)
+        layer_b.compute({'primary': {data_key: data}})
+
+        composed = hv.Overlay(
+            [layer_a.get_cached_state(), layer_b.get_cached_state()]
+        ).collate()
+        fig = hv.render(composed)
+        line_colors = [
+            r.glyph.line_color
+            for r in fig.select(GlyphRenderer)
+            if type(r.glyph).__name__ == 'Line'
+        ]
+        assert len(line_colors) == 2
+        assert line_colors[0] != line_colors[1]
+
     def test_error_overlay_renders_responsive(self, data_key):
         """A line+error overlay renders as a responsive (stretch_both) figure."""
         params = PlotParams1d(


### PR DESCRIPTION
Follow-up to #973. Two related 1D-line coloring fixes.

**Error-bar endcaps.** Setting `color` on a HoloViews `ErrorBars` element only colors the Bokeh `Whisker` body line. The endcaps are separate `TeeHead` glyphs with their own `line_color` that defaults to black, so the short horizontal caps stayed black while the vertical lines took the curve color. The fix colors the endcaps too by passing `upper_head`/`lower_head` `TeeHead` glyphs alongside `color`, through a shared helper used by both `LinePlotter` and `Overlay1DPlotter` (#973 missed the latter's endcaps as well). `Spread` (a subclass of `ErrorBars`) renders as a filled band with no endcaps and takes the plain color path.

**Distinct colors for overlaid lines.** #973 made `LinePlotter` store a single constant color and force it onto every line, so multiple overlaid sources (the default `combine_mode`) all rendered blue. Dropping the explicit color is not an option when error bars are shown: they then fall back to black, and the HoloViews `Cycle` neither locks error-bar order to the curves nor colors the endcaps. So each source with errors now gets a distinct cycle color, as `Overlay1DPlotter` already does: `compute()` passes the source index to `plot()`, which picks the matching cycle color and applies it to the line, the error body, and the endcaps. Error-free lines set no explicit color and keep auto-cycling.

Known limitation: explicit colors are assigned per-plotter, so lines *with error bars/bands* overlaid via the cell's layer mechanism each restart the cycle and can collide. Error-free lines auto-cycle and stay distinct across layers, so only the error case is affected. Tracked in #982.

The color test now renders to Bokeh and asserts the `Whisker` body and both endcaps match the line color, plus new tests that an overlay of multiple sources gets distinct curve colors with matching error bars, and that error-free lines from layered plotters stay distinct.

## Test plan

- [x] Visually confirm error-bar endcaps match the curve color in a 1D line+bars plot.
- [x] Visually confirm an overlay of multiple spectra shows distinct colors per source, each with matching error bars.
