### PR TITLE
Add SSO disclaimer and Slack channel link to login screen

### DIFF
--- a/src/ess/livedata/dashboard/templates/login.html
+++ b/src/ess/livedata/dashboard/templates/login.html
@@ -29,7 +29,7 @@
       border-radius: 8px;
       box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
       padding: 2.5em 2em 2em;
-      width: 380px;
+      width: 440px;
       max-width: 90vw;
     }
     .form-header {
@@ -98,7 +98,7 @@
       background: #16637f;
     }
     .login-note {
-      margin-top: 1.25em;
+      margin-bottom: 1.25em;
       padding: 0.75em 1em;
       background: #f0f7fb;
       border-left: 3px solid #2596be;
@@ -127,6 +127,10 @@
         <p>{{ errormessage | escape }}</p>
       </div>
       {% endif %}
+      <div class="login-note">
+        <p><strong>Note: this is not the ESS Single Sign-On — these are separate credentials.</strong></p>
+        <p>Don't know the credentials? Join <a href="https://ess-eric.slack.com/channels/livedata" target="_blank" rel="noopener">#livedata</a> on Slack.</p>
+      </div>
       <div class="form-group">
         <label for="username">Username</label>
         <input id="username" name="username" type="text" class="form-input"
@@ -138,10 +142,6 @@
       </div>
       <div class="form-group">
         <button class="form-button" type="submit">Log in</button>
-      </div>
-      <div class="login-note">
-        <p>Note: this is not the ESS Single Sign-On — these are separate credentials.</p>
-        <p>Don't know the credentials? Join <a href="https://ess-eric.slack.com/channels/livedata" target="_blank" rel="noopener">#livedata</a> on Slack.</p>
       </div>
     </form>
   </div>

--- a/src/ess/livedata/dashboard/templates/login.html
+++ b/src/ess/livedata/dashboard/templates/login.html
@@ -97,6 +97,22 @@
     .form-button:active {
       background: #16637f;
     }
+    .login-note {
+      margin-top: 1.25em;
+      padding: 0.75em 1em;
+      background: #f0f7fb;
+      border-left: 3px solid #2596be;
+      border-radius: 4px;
+      font-size: 0.82em;
+      color: #555;
+      line-height: 1.5;
+    }
+    .login-note p + p {
+      margin-top: 0.4em;
+    }
+    .login-note a {
+      color: #2596be;
+    }
     </style>
 </head>
 <body>
@@ -122,6 +138,10 @@
       </div>
       <div class="form-group">
         <button class="form-button" type="submit">Log in</button>
+      </div>
+      <div class="login-note">
+        <p>Note: this is not the ESS Single Sign-On — these are separate credentials.</p>
+        <p>Don't know the credentials? Join <a href="https://ess-eric.slack.com/channels/livedata" target="_blank" rel="noopener">#livedata</a> on Slack.</p>
       </div>
     </form>
   </div>


### PR DESCRIPTION
Users landing on the login page currently have no indication that the credentials are separate from the ESS Single Sign-On, and no obvious way to find them.

Adds a small info note with:
- a reminder that this is not the ESS SSO
- a link to [#livedata](https://ess-eric.slack.com/channels/livedata) on Slack for credential help