### PR TITLE
Add stable CSS hooks to tool buttons for automation

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -43,6 +43,25 @@ def refresh(self):
 
 Do not use Unicode characters for button icons. Use embedded SVG icons from `dashboard/widgets/icons.py` via `get_icon()`. Use the `create_tool_button()` helper from `dashboard/widgets/buttons.py` for consistent styling.
 
+## Stable CSS hooks for automation
+
+Tool buttons render as label-less icons inside per-widget shadow DOM, so they carry
+no text, `title`, or `aria-label` — leaving nothing semantic for browser automation
+(Playwright) or screenshot tooling to target. To avoid brittle coordinate-clicking,
+`create_tool_button()` tags every button with **committed, visually-inert CSS classes**:
+
+- `lt-tool` on all tool buttons, plus `lt-tool-{icon_name}` (e.g. `lt-tool-settings`,
+  `lt-tool-player-play`, `lt-tool-x`).
+- Callers pass `css_classes=[...]` for context. Workflow rows add `lt-wf-{workflow_id.name}`
+  (the WorkflowId *name* slug, not the display title), so a workflow's gear is
+  `.lt-wf-monitor_histogram.lt-tool-settings`.
+
+These classes have no associated style rules — adding/removing them is visually inert.
+Treat them as a stable contract: do not drop them in refactors (a test in
+`buttons_test.py` guards the helper). When adding tool buttons to a view that repeats
+the same icon (e.g. per-grid/per-cell controls in `plot_grid_manager.py`), pass a
+context `css_classes` entry so each instance is uniquely addressable.
+
 ## Model creation and visibility
 
 `pn.Tabs(dynamic=True)` prevents Bokeh model creation for hidden tabs — only the active

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ Run as: `python -m ess.livedata.services.<name> --instrument dummy [--dev]`
 
 Dashboard: `python -m ess.livedata.dashboard.reduction --instrument dummy`
 
+Add `--transport none` to run the dashboard UI without Kafka (port 5009, hardcoded).
+For browser automation / screenshots, target buttons via the stable `lt-tool-*` /
+`lt-wf-*` CSS classes (never coordinates) -- see "Stable CSS hooks for automation" in
+`.claude/rules/dashboard-widgets.md`. Note `--transport none` has no backend, so starting
+a workflow stays PENDING.
+
 ## Tools
 
 `src/ess/livedata/nexus_helpers.py` -- utilities for extracting Kafka topic and source names from NeXus files.

--- a/src/ess/livedata/dashboard/widgets/buttons.py
+++ b/src/ess/livedata/dashboard/widgets/buttons.py
@@ -133,6 +133,7 @@ def create_tool_button(
     button_color: str,
     hover_color: str,
     on_click_callback: Callable[[], None],
+    css_classes: list[str] | None = None,
 ) -> pn.widgets.Button:
     """
     Create a styled tool button.
@@ -147,6 +148,13 @@ def create_tool_button(
         RGBA color for the hover background.
     on_click_callback:
         Callback function to invoke when the button is clicked.
+    css_classes:
+        Extra CSS classes for the button host element. Tool buttons render as
+        label-less icons, so they carry no stable, queryable identity for tests
+        or automation. Every button additionally gets ``lt-tool`` and
+        ``lt-tool-{icon_name}`` classes; callers pass context (e.g. a workflow
+        name) for finer targeting. These classes have no associated style rules
+        and are visually inert.
 
     Returns
     -------
@@ -162,6 +170,7 @@ def create_tool_button(
         color='light',
         sizing_mode='fixed',
         margin=0,
+        css_classes=['lt-tool', f'lt-tool-{icon_name}', *(css_classes or [])],
         stylesheets=create_tool_button_stylesheet(button_color, hover_color),
     )
     button.on_click(lambda _: on_click_callback())

--- a/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
@@ -287,6 +287,11 @@ class WorkflowStatusWidget:
         """Get the workflow ID for this widget."""
         return self._workflow_id
 
+    @property
+    def _tool_css_class(self) -> str:
+        """CSS class scoping this workflow's tool buttons for automation/tests."""
+        return f'lt-wf-{self._workflow_id.name}'
+
     def _build_widget(self) -> None:
         """Build or rebuild the entire widget.
 
@@ -333,6 +338,7 @@ class WorkflowStatusWidget:
             button_color=StatusColors.MUTED,
             hover_color='rgba(0, 0, 0, 0.05)',
             on_click_callback=lambda: self.set_expanded(not self._expanded),
+            css_classes=[self._tool_css_class, 'lt-wf-expand'],
         )
 
         # Workflow title
@@ -411,6 +417,7 @@ class WorkflowStatusWidget:
                 button_color=WorkflowWidgetStyles.STATUS_COLORS['active'],
                 hover_color=HoverColors.SUCCESS,
                 on_click_callback=self._on_commit_click,
+                css_classes=[self._tool_css_class],
             )
             buttons.append(play_btn)
 
@@ -421,6 +428,7 @@ class WorkflowStatusWidget:
                 button_color=ButtonStyles.DANGER_RED,
                 hover_color=ButtonStyles.DANGER_HOVER,
                 on_click_callback=self._on_stop_click,
+                css_classes=[self._tool_css_class],
             )
             buttons.append(stop_btn)
 
@@ -429,6 +437,7 @@ class WorkflowStatusWidget:
                 button_color=StatusColors.MUTED,
                 hover_color=HoverColors.MUTED,
                 on_click_callback=self._on_reset_click,
+                css_classes=[self._tool_css_class],
             )
             buttons.append(reset_btn)
 
@@ -602,6 +611,7 @@ class WorkflowStatusWidget:
             button_color=ButtonStyles.PRIMARY_BLUE,
             hover_color=ButtonStyles.PRIMARY_HOVER,
             on_click_callback=lambda: self._on_gear_click(list(group.source_names)),
+            css_classes=[self._tool_css_class],
         )
 
         buttons = [gear_btn]
@@ -615,6 +625,7 @@ class WorkflowStatusWidget:
                 on_click_callback=lambda: self._on_remove_click(
                     list(group.source_names)
                 ),
+                css_classes=[self._tool_css_class],
             )
             buttons.append(remove_btn)
 

--- a/tests/dashboard/widgets/buttons_test.py
+++ b/tests/dashboard/widgets/buttons_test.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for tool button creation helpers."""
+
+from ess.livedata.dashboard.widgets.buttons import (
+    ButtonStyles,
+    create_tool_button,
+)
+
+
+def test_tool_button_carries_stable_css_classes() -> None:
+    # These classes are a committed convention for automation/tests to target
+    # label-less icon buttons. Do not drop them without updating consumers.
+    button = create_tool_button(
+        icon_name='settings',
+        button_color=ButtonStyles.PRIMARY_BLUE,
+        hover_color=ButtonStyles.PRIMARY_HOVER,
+        on_click_callback=lambda: None,
+    )
+    assert 'lt-tool' in button.css_classes
+    assert 'lt-tool-settings' in button.css_classes
+
+
+def test_tool_button_appends_caller_css_classes() -> None:
+    button = create_tool_button(
+        icon_name='x',
+        button_color=ButtonStyles.DANGER_RED,
+        hover_color=ButtonStyles.DANGER_HOVER,
+        on_click_callback=lambda: None,
+        css_classes=['lt-wf-monitor_histogram'],
+    )
+    assert 'lt-tool' in button.css_classes
+    assert 'lt-tool-x' in button.css_classes
+    assert 'lt-wf-monitor_histogram' in button.css_classes


### PR DESCRIPTION
## Motivation

Dashboard tool buttons (gear, play, stop, reset, remove, expand) render as label-less icons inside per-widget shadow DOM, exposing no text, `title`, or `aria-label`. Browser automation and screenshot tooling were therefore left clicking by pixel coordinates, which silently breaks on any layout change. This makes it hard for me (and other automation) to reliably drive and screenshot the UI.

## Change

`create_tool_button()` now tags every button with `lt-tool` and `lt-tool-{icon_name}`, and accepts a `css_classes` argument for caller context. Workflow rows add `lt-wf-{workflow_id.name}`, so each control is uniquely addressable, e.g. `.lt-wf-monitor_histogram.lt-tool-settings`. Playwright pierces shadow DOM, so these class locators resolve directly.

The classes have no associated style rules and are visually inert. They are intended as a committed convention; a helper test guards against silently dropping them, and the convention plus the no-Kafka launch recipe (`--transport none`) are documented for contributors and automation.

Per-widget context classes are currently threaded only through the workflow rows. Other repeated-icon views (e.g. plot grid controls) keep the universal type class and can gain context classes when a concrete automation flow needs them.

## Test plan

- [x] `buttons_test.py` asserts the type and caller classes are present
- [x] Existing workflow/button widget tests pass
- [x] Verified with Playwright against a running dashboard: targeting `.lt-wf-monitor_histogram.lt-tool-settings` by class alone (no coordinates) yields a unique match and opens the correct config modal; UI renders identically (classes visually inert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
