### PR TITLE
Fix fake_monitors and fake_detectors int timestamp in da00 mode

### DIFF
--- a/src/ess/livedata/services/fake_detectors.py
+++ b/src/ess/livedata/services/fake_detectors.py
@@ -18,6 +18,7 @@ from ess.livedata.config.config_loader import load_config
 from ess.livedata.config.instruments import get_config
 from ess.livedata.config.streams import stream_kind_to_topic
 from ess.livedata.core import IdentityProcessor
+from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.kafka.sink import (
     KafkaSink,
     MessageSerializer,
@@ -117,14 +118,16 @@ class FakeDetectorSource(MessageSource[sc.Dataset]):
             for i in range(num_intervals):
                 msg_time = self._last_message_time[name] + (i + 1) * self._interval_ns
                 messages.append(
-                    self._make_message(name=name, size=size, timestamp=msg_time)
+                    self._make_message(
+                        name=name, size=size, timestamp=Timestamp.from_ns(msg_time)
+                    )
                 )
             self._last_message_time[name] += num_intervals * self._interval_ns
 
         return messages
 
     def _make_message(
-        self, name: str, size: int, timestamp: int
+        self, name: str, size: int, timestamp: Timestamp
     ) -> Message[sc.Variable]:
         if self._nexus_data is not None and name in self._nexus_data:
             # Use data from nexus file
@@ -191,12 +194,14 @@ class FakeAreaDetectorSource(MessageSource[sc.DataArray]):
 
             for i in range(num_intervals):
                 msg_time = self._last_message_time[name] + (i + 1) * self._interval_ns
-                messages.append(self._make_message(name=name, timestamp=msg_time))
+                messages.append(
+                    self._make_message(name=name, timestamp=Timestamp.from_ns(msg_time))
+                )
             self._last_message_time[name] += num_intervals * self._interval_ns
 
         return messages
 
-    def _make_message(self, name: str, timestamp: int) -> Message[sc.DataArray]:
+    def _make_message(self, name: str, timestamp: Timestamp) -> Message[sc.DataArray]:
         shape = self._config[name]
         # Generate a random image with some structure (gaussian blob + noise)
         y, x = np.ogrid[: shape[0], : shape[1]]
@@ -241,7 +246,7 @@ class DetectorEv44Serializer(MessageSerializer):
             value = eventdata_ev44.serialise_ev44(
                 source_name=message.stream.name,
                 message_id=0,
-                reference_time=message.timestamp,
+                reference_time=message.timestamp.to_ns(),
                 reference_time_index=0,
                 time_of_flight=message.value['time_of_arrival'].values,
                 pixel_id=message.value['pixel_id'].values,
@@ -264,7 +269,7 @@ class AreaDetectorAd00Serializer(MessageSerializer[sc.DataArray]):
             value = area_detector_ad00.serialise_ad00(
                 source_name=message.stream.name,
                 unique_id=0,
-                timestamp_ns=message.timestamp,
+                timestamp_ns=message.timestamp.to_ns(),
                 data=data,
             )
         except (ValueError, TypeError) as e:

--- a/src/ess/livedata/services/fake_monitors.py
+++ b/src/ess/livedata/services/fake_monitors.py
@@ -16,6 +16,7 @@ from ess.livedata.config import config_names
 from ess.livedata.config.config_loader import load_config
 from ess.livedata.config.streams import stream_kind_to_topic
 from ess.livedata.core import IdentityProcessor
+from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.kafka.message_adapter import AdaptingMessageSource, MessageAdapter
 from ess.livedata.kafka.sink import (
     KafkaSink,
@@ -122,7 +123,10 @@ class FakeMonitorSource(MessageSource[sc.Variable | sc.Dataset]):
                 msg_time = self._last_message_time[name] + (j + 1) * self._interval_ns
                 messages.append(
                     self._make_message(
-                        name=name, size=size, timestamp=msg_time, mean_ms=mean_ms
+                        name=name,
+                        size=size,
+                        timestamp=Timestamp.from_ns(msg_time),
+                        mean_ms=mean_ms,
                     )
                 )
             self._last_message_time[name] += num_intervals * self._interval_ns
@@ -130,7 +134,7 @@ class FakeMonitorSource(MessageSource[sc.Variable | sc.Dataset]):
         return messages
 
     def _make_message(
-        self, name: str, size: int, timestamp: int, mean_ms: float
+        self, name: str, size: int, timestamp: Timestamp, mean_ms: float
     ) -> Message[sc.Variable | sc.Dataset]:
         if self._nexus_data is not None and name in self._nexus_data:
             s = slice(self._offset[name], self._offset[name] + size)
@@ -200,7 +204,7 @@ class MonitorEv44Serializer(MessageSerializer[sc.Variable | sc.Dataset]):
             value = eventdata_ev44.serialise_ev44(
                 source_name=message.stream.name,
                 message_id=0,
-                reference_time=message.timestamp,
+                reference_time=message.timestamp.to_ns(),
                 reference_time_index=0,
                 time_of_flight=toa.values,
                 pixel_id=pixel_id,


### PR DESCRIPTION
`FakeMonitorSource` and `FakeDetectorSource` both passed a plain `int` (from `time.time_ns()`) as `Message.timestamp`. `Da00Serializer` calls `message.timestamp.to_ns()`, which fails with `AttributeError: 'int' object has no attribute 'to_ns'`. The ev44/ad00 serializers in these files also need `.to_ns()` since they now receive a `Timestamp` instead of an `int`.

Fix: wrap timestamps with `Timestamp.from_ns()` at the call sites and call `.to_ns()` when passing to streaming-data-types serializers. `fake_logdata.py` already did this correctly.

Note that this only affected local development, this change is irrelevant for production/users.

## Test plan
- [x] Run `fake_monitors` in da00 mode and confirm no serialization errors in the log