### PR TITLE
Fix announcement fetch blocking session creation and IOLoop

### DIFF
--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import argparse
 import os
+import threading
 import urllib.request
 from urllib.error import URLError
 from urllib.request import urlopen
@@ -108,11 +109,15 @@ class ReductionApp(DashboardBase):
                 self._logger.warning("Failed to fetch announcements: %s", e)
                 return "*Unable to load announcements.*"
 
-        pane = pn.pane.Markdown(read_announcements(), sizing_mode='stretch_width')
+        pane = pn.pane.Markdown("", sizing_mode='stretch_width')
 
-        def refresh():
+        def fetch_and_update():
             pane.object = read_announcements()
 
+        def refresh():
+            threading.Thread(target=fetch_and_update, daemon=True).start()
+
+        refresh()
         pn.state.add_periodic_callback(refresh, period=300_000)  # 5 minutes
         return pane
 


### PR DESCRIPTION
The initial announcement fetch was called synchronously during Panel session creation (`_create_announcements_pane`), with a 10-second `urlopen` timeout. This blocked every new browser session for up to 10 s when the URL was unreachable. The periodic `add_periodic_callback` had the same problem — `refresh` ran on the Tornado IOLoop thread, stalling all sessions for up to 10 s every 5 minutes.

Both the initial fetch and the periodic refresh now spawn daemon threads, so session creation and the IOLoop are never blocked by a slow or unreachable announcements URL.

## Test plan
- [x] Open a fresh dashboard session with the announcements URL unreachable (or firewall blocked) — session should load immediately, then show the error text in the sidebar once the background fetch times out
- [x] Confirm the periodic refresh (5 min) also no longer causes visible lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)