### PR TITLE
Fix per-session Kafka producer leak in log-producer widget

### DIFF
--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -92,8 +92,18 @@ class DashboardBase(ServiceBase, ABC):
             raise ValueError(f"Unknown transport type: {transport}")
 
     @abstractmethod
-    def create_sidebar_content(self) -> pn.viewable.Viewable:
-        """Override this method to create the sidebar content."""
+    def create_sidebar_content(
+        self, session_updater: SessionUpdater
+    ) -> pn.viewable.Viewable:
+        """Override this method to create the sidebar content.
+
+        Parameters
+        ----------
+        session_updater:
+            The session updater for this browser session. Use
+            ``register_cleanup_handler`` to release per-session resources on
+            session teardown.
+        """
         pass
 
     @abstractmethod
@@ -201,7 +211,7 @@ class DashboardBase(ServiceBase, ABC):
         # Create session updater first so widgets can register handlers
         session_updater = self._create_session_updater()
 
-        sidebar_content = self.create_sidebar_content()
+        sidebar_content = self.create_sidebar_content(session_updater)
         main_content = self.create_main_content(session_updater)
 
         # Append heartbeat widget to sidebar (invisible but required for

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -121,13 +121,19 @@ class ReductionApp(DashboardBase):
         pn.state.add_periodic_callback(refresh, period=300_000)  # 5 minutes
         return pane
 
-    def create_sidebar_content(self) -> pn.viewable.Viewable:
+    def create_sidebar_content(
+        self, session_updater: SessionUpdater
+    ) -> pn.viewable.Viewable:
         """Create the sidebar content."""
         # Create log producer widget only in dev mode (per-session)
         dev_content = []
         if self._dev:
             dev_widget = LogProducerWidget(instrument=self._instrument)
-            pn.state.on_session_destroyed(lambda _ctx: dev_widget.close())
+            # Release the per-session Kafka producer on session teardown. Routed
+            # through the session updater (not on_session_destroyed directly) so
+            # the heartbeat-based stale reaper also triggers cleanup when Panel's
+            # on_session_destroyed fails to fire.
+            session_updater.register_cleanup_handler(dev_widget.close)
             dev_content = [dev_widget.panel, pn.layout.Divider()]
 
         return pn.Column(

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -126,10 +126,8 @@ class ReductionApp(DashboardBase):
         # Create log producer widget only in dev mode (per-session)
         dev_content = []
         if self._dev:
-            dev_widget = LogProducerWidget(
-                instrument=self._instrument,
-                exit_stack=self._exit_stack,
-            )
+            dev_widget = LogProducerWidget(instrument=self._instrument)
+            pn.state.on_session_destroyed(lambda _ctx: dev_widget.close())
             dev_content = [dev_widget.panel, pn.layout.Divider()]
 
         return pn.Column(

--- a/src/ess/livedata/dashboard/session_updater.py
+++ b/src/ess/livedata/dashboard/session_updater.py
@@ -65,6 +65,8 @@ class SessionUpdater:
 
         # Callbacks for custom updates (e.g., SessionPlotManager.update_pipes)
         self._custom_handlers: list[Callable[[], None]] = []
+        # Handlers run once when the session is torn down (see cleanup).
+        self._cleanup_handlers: list[Callable[[], None]] = []
         self._periodic_callback: pn.io.PeriodicCallback | None = None
 
         # Browser heartbeat mechanism using ReactiveHTML.
@@ -113,6 +115,24 @@ class SessionUpdater:
         """Unregister a custom handler."""
         if handler in self._custom_handlers:
             self._custom_handlers.remove(handler)
+
+    def register_cleanup_handler(self, handler: Callable[[], None]) -> None:
+        """
+        Register a handler to run once when the session is torn down.
+
+        Use this for releasing per-session resources (e.g. a Kafka producer).
+        Handlers run from :meth:`cleanup`, which fires both on clean browser
+        disconnect (``on_session_destroyed``) and via the heartbeat-based stale
+        session reaper, so resources are released even when Panel's
+        ``on_session_destroyed`` does not fire. Handlers may be invoked from a
+        background thread and must be safe to call there.
+
+        Parameters
+        ----------
+        handler:
+            Callback to invoke on session teardown.
+        """
+        self._cleanup_handlers.append(handler)
 
     def periodic_update(self) -> None:
         """
@@ -178,6 +198,15 @@ class SessionUpdater:
             self._periodic_callback.stop()
 
         self._notification_queue.unregister_session(self._session_id)
+
+        for handler in self._cleanup_handlers:
+            try:
+                handler()
+            except Exception:
+                logger.exception(
+                    "Error in cleanup handler for session %s", self._session_id
+                )
+        self._cleanup_handlers.clear()
 
         self._custom_handlers.clear()
 

--- a/src/ess/livedata/dashboard/widgets/log_producer_widget.py
+++ b/src/ess/livedata/dashboard/widgets/log_producer_widget.py
@@ -114,15 +114,22 @@ class LogProducerWidget:
     plus DMOV transitions on each change.
     """
 
-    def __init__(self, instrument: str, exit_stack: ExitStack):
+    def __init__(self, instrument: str):
         self._instrument = instrument
 
-        self._sink = exit_stack.enter_context(
+        # This widget is created per browser session, so the Kafka producer must
+        # live for the session, not the application. The owning exit stack is
+        # closed in close() on session teardown; otherwise every session (and
+        # every dev autoreload) would leak a producer with its background thread
+        # and broker connections, slowing the process over time.
+        self._exit_stack = ExitStack()
+        self._sink = self._exit_stack.enter_context(
             KafkaSink(
                 kafka_config=load_config(namespace=config_names.kafka),
                 serializer=F144Serializer(instrument=instrument),
             )
         )
+        self._periodic_callbacks: list[pn.io.PeriodicCallback] = []
 
         self._throttled_checkbox = pn.widgets.Checkbox(
             label='Continuous updates', value=True, width=300
@@ -205,12 +212,13 @@ class LogProducerWidget:
         publish_rate_hz = config.get('publish_rate_hz')
         if publish_rate_hz is not None:
             interval_ms = max(1, int(1000.0 / float(publish_rate_hz)))
-            pn.state.add_periodic_callback(
+            callback = pn.state.add_periodic_callback(
                 lambda s=slider, n=stream_name, sd=noise_stddev: self._publish_value(
                     self._sample(s.value, sd), n
                 ),
                 period=interval_ms,
             )
+            self._periodic_callbacks.append(callback)
         else:
             slider.param.watch(
                 lambda event, name=stream_name, sd=noise_stddev: self._publish_value(
@@ -235,7 +243,7 @@ class LogProducerWidget:
         )
         msg = Message(value=da, stream=StreamId(kind=StreamKind.LOG, name=stream_name))
         self._sink.publish_messages([msg])
-        logger.info(
+        logger.debug(
             "Stream '%s' - Published message with value: %s", stream_name, value
         )
 
@@ -243,6 +251,20 @@ class LogProducerWidget:
         """Update pn.config.throttled when checkbox value changes."""
         pn.config.throttled = event.new
         logger.info("Throttled mode set to: %s", event.new)
+
+    def close(self) -> None:
+        """Stop streaming callbacks and close the Kafka producer.
+
+        Wire this to ``pn.state.on_session_destroyed`` so the per-session
+        producer and its readback callbacks are released when the browser
+        session ends. Callbacks are stopped before the sink is closed so none
+        can fire against a closed producer.
+        """
+        for callback in self._periodic_callbacks:
+            if callback.running:
+                callback.stop()
+        self._periodic_callbacks.clear()
+        self._exit_stack.close()
 
     @property
     def panel(self) -> pn.viewable.Viewable:

--- a/tests/dashboard/session_updater_test.py
+++ b/tests/dashboard/session_updater_test.py
@@ -111,6 +111,49 @@ class TestSessionUpdater:
         notifications = queue.get_new_events(session_id)
         assert notifications == []
 
+    def test_cleanup_handler_called_on_cleanup(self):
+        registry = SessionRegistry()
+        updater = _make_updater(SessionId('session-1'), registry)
+
+        calls = []
+        updater.register_cleanup_handler(lambda: calls.append(1))
+
+        updater.cleanup()
+
+        assert calls == [1]
+
+    def test_cleanup_handler_invoked_by_stale_session_reaper(self):
+        # The heartbeat-based stale reaper must run cleanup handlers even when
+        # Panel's on_session_destroyed never fires. Negative timeout makes the
+        # session stale immediately, regardless of elapsed time.
+        registry = SessionRegistry(stale_timeout_seconds=-1.0)
+        session_id = SessionId('session-1')
+        updater = _make_updater(session_id, registry)
+
+        calls = []
+        updater.register_cleanup_handler(lambda: calls.append(1))
+
+        cleaned = registry.cleanup_stale_sessions()
+
+        assert session_id in cleaned
+        assert calls == [1]
+
+    def test_cleanup_handler_exception_does_not_block_others(self):
+        registry = SessionRegistry()
+        updater = _make_updater(SessionId('session-1'), registry)
+
+        calls = []
+
+        def boom() -> None:
+            raise RuntimeError("boom")
+
+        updater.register_cleanup_handler(boom)
+        updater.register_cleanup_handler(lambda: calls.append(1))
+
+        updater.cleanup()  # must not raise
+
+        assert calls == [1]
+
     def test_session_id_property(self):
         session_id = SessionId('test-session')
         registry = SessionRegistry()


### PR DESCRIPTION
## Problem

Streaming fake chopper signals via the dev-mode log-producer widget makes dashboard actions progressively slower after a few minutes / many reloads.

The dev-only `LogProducerWidget` is created **per browser session**, but entered its `KafkaSink` into the **application-level** exit stack. The producer — with its background librdkafka thread and broker connections — was therefore never released until process shutdown. Every session and every dev autoreload leaked a producer, accumulating background threads and connections that drag the whole process down over time. The widget's streaming-readback periodic callbacks were likewise untracked, with no way to stop them, and each published value logged at INFO (~12 lines/s/session).

This leak is specific to this widget: the dashboard's command/ROI sinks and consumer are app-level singletons created once, so their lifetimes are already correct.

## Fix

The widget now owns a session-scoped exit stack for its sink and exposes `close()`. Readback callbacks are tracked and stopped before the sink closes, so none fire against a closed producer. Per-publish logging is dropped to debug.

Cleanup is routed through the **heartbeat-based** session teardown rather than `pn.state.on_session_destroyed` alone, which is unreliable (browser crashes, dropped connections) — the very reason the heartbeat stale-session reaper exists. `SessionUpdater` gains a cleanup-handler hook invoked from `cleanup()`, the single teardown chokepoint reached both by `on_session_destroyed` (via `SessionRegistry.unregister`) and by the stale reaper (`cleanup_stale_sessions`). The widget registers its `close()` there, so the producer is released on clean disconnect and, failing that, when the session goes stale. `create_sidebar_content` now receives the session updater to allow registering the handler.

The per-call `flush()` in `KafkaSink.publish_messages` is deliberately left untouched: it is the delivery contract shared by the command/ROI sinks and the backend data pipeline, and with the leak fixed its cost in a single session is negligible.

## Test plan

- [x] Unit tests cover the cleanup-handler hook, including invocation via the stale-session reaper path.
- [x] Full dashboard test suite passes (1531 tests).
- [x] Run the dev dashboard, stream chopper signals for several minutes, and confirm dashboard actions stay responsive.
- [x] Reload the dashboard many times and confirm Kafka producers do not accumulate (clean disconnect and, by leaving a tab to go stale, the heartbeat path).
