### PR TITLE
Add fake backend transport and seeded UI config for Kafka-free dashboard testing

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -62,6 +62,21 @@ Treat them as a stable contract: do not drop them in refactors (a test in
 the same icon (e.g. per-grid/per-cell controls in `plot_grid_manager.py`), pass a
 context `css_classes` entry so each instance is uniquely addressable.
 
+### Driving workflow config flows
+
+A `WorkflowStatusWidget` rebuilds its row (`_build_widget`) only when that workflow's
+state *version* changes — staging, commit, or stop (`job_orchestrator.py`). Steady-state
+status refresh just reassigns badge/dots/timing HTML in place, so it does *not* detach
+elements. Two windows still detach the element under the cursor:
+- **Cold start**: the first refresh tick after page load can fire one rebuild while
+  Bokeh models are still settling. Wait a few seconds after load before the first click.
+- **Multi-step flows**: each stage/commit rebuilds *that* row, so a click landing on a
+  just-mutated row races the rebuild.
+
+Wrap clicks in a small retry-on-detach helper (catch the Playwright timeout, re-locate,
+retry) rather than assuming a single click lands. This is not a continuous re-render —
+untouched rows stay stable.
+
 ## Model creation and visibility
 
 `pn.Tabs(dynamic=True)` prevents Bokeh model creation for hidden tabs — only the active

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,13 @@ dashboard writes to this dir, so copy the fixture to a scratch dir first:
 ```sh
 cp -r tests/dashboard/ui_config_fixtures/dummy "$TMP/cfg/dummy"
 python -m ess.livedata.dashboard.reduction --instrument dummy --transport fake \
-    --config-dir "$TMP/cfg" --no-fetch-announcements
+    --config-dir "$TMP/cfg" --auto-start --no-fetch-announcements
 ```
 
-Workflows then come pre-staged (play buttons ready) with grids restored; click play to
-start. Regenerate a fixture by configuring via the UI, then copying the persisted
+Workflows then come pre-staged (play buttons ready) with grids restored. `--auto-start`
+(requires `--transport fake`) commits every staged workflow on launch, so plots render
+with no interaction at all — omit it if you want to drive the play buttons yourself.
+Regenerate a fixture by configuring via the UI, then copying the persisted
 `workflow_configs.yaml` (strip the runtime `current_job`/`previous_job` keys, keep
 `jobs`) and `plot_configs.yaml` from the config dir back into the fixture.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,10 @@ For browser automation / screenshots, target buttons via the stable `lt-tool-*` 
 `.claude/rules/dashboard-widgets.md`. Note `--transport none` has no backend, so starting
 a workflow stays PENDING.
 
+Add `--transport fake` to run an in-process fake backend (no Kafka): starting a workflow
+in the UI flips it to ACTIVE and feeds plots with data synthesized from each workflow's
+output templates. Use this to verify plots render and to capture screenshots.
+
 ## Tools
 
 `src/ess/livedata/nexus_helpers.py` -- utilities for extracting Kafka topic and source names from NeXus files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,21 @@ Add `--transport fake` to run an in-process fake backend (no Kafka): starting a 
 in the UI flips it to ACTIVE and feeds plots with data synthesized from each workflow's
 output templates. Use this to verify plots render and to capture screenshots.
 
+To skip clicking through source selection and plot-grid setup, seed the UI from a
+committed fixture (staged workflow configs + plot grids) via `--config-dir`. The
+dashboard writes to this dir, so copy the fixture to a scratch dir first:
+
+```sh
+cp -r tests/dashboard/ui_config_fixtures/dummy "$TMP/cfg/dummy"
+python -m ess.livedata.dashboard.reduction --instrument dummy --transport fake \
+    --config-dir "$TMP/cfg" --no-fetch-announcements
+```
+
+Workflows then come pre-staged (play buttons ready) with grids restored; click play to
+start. Regenerate a fixture by configuring via the UI, then copying the persisted
+`workflow_configs.yaml` (strip the runtime `current_job`/`previous_job` keys, keep
+`jobs`) and `plot_configs.yaml` from the config dir back into the fixture.
+
 ## Tools
 
 `src/ess/livedata/nexus_helpers.py` -- utilities for extracting Kafka topic and source names from NeXus files.

--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -14,6 +14,7 @@ from ess.livedata import ServiceBase, __version__, format_version
 
 from .config_store import ConfigStoreManager
 from .dashboard_services import DashboardServices
+from .fake_backend import FakeBackendTransport
 from .kafka_transport import DashboardKafkaTransport
 from .session_registry import SessionId
 from .session_updater import SessionUpdater
@@ -77,7 +78,7 @@ class DashboardBase(ServiceBase, ABC):
         Parameters
         ----------
         transport:
-            Transport type ('kafka' or 'none')
+            Transport type ('kafka', 'none', or 'fake')
 
         Returns
         -------
@@ -88,6 +89,8 @@ class DashboardBase(ServiceBase, ABC):
             return DashboardKafkaTransport(instrument=self._instrument, dev=self._dev)
         elif transport == 'none':
             return NullTransport()
+        elif transport == 'fake':
+            return FakeBackendTransport(instrument=self._instrument)
         else:
             raise ValueError(f"Unknown transport type: {transport}")
 
@@ -184,7 +187,6 @@ class DashboardBase(ServiceBase, ABC):
 
     def _create_logout_header(self) -> list[pn.viewable.Viewable]:
         """Create a logout button for the header when auth is enabled."""
-        # ruff: disable[E501]
         logout_link = pn.pane.HTML(
             """<div style="text-align: right; padding-right: 8px;">
             <a href="/logout" style="
@@ -198,12 +200,14 @@ class DashboardBase(ServiceBase, ABC):
                 border-radius: 20px;
                 display: inline-block;
                 transition: background 0.2s, border-color 0.2s;
-                " onmouseover="this.style.background='rgba(255,255,255,0.2)';this.style.borderColor='white'"
-                onmouseout="this.style.background='none';this.style.borderColor='rgba(255,255,255,0.7)'"
+                "
+                onmouseover="this.style.background='rgba(255,255,255,0.2)';
+                             this.style.borderColor='white'"
+                onmouseout="this.style.background='none';
+                            this.style.borderColor='rgba(255,255,255,0.7)'"
             >Log out</a></div>""",
             sizing_mode='stretch_width',
         )
-        # ruff: enable[E501]
         return [logout_link]
 
     def create_layout(self) -> pn.template.MaterialTemplate:

--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -40,6 +40,7 @@ class DashboardBase(ServiceBase, ABC):
         dashboard_name: str,
         port: int = 5007,
         transport: str = 'kafka',
+        config_dir: str | None = None,
         basic_auth_password: str | None = None,
         basic_auth_cookie_secret: str | None = None,
     ):
@@ -55,7 +56,9 @@ class DashboardBase(ServiceBase, ABC):
         self._exit_stack.__enter__()
 
         # Config store manager for file-backed persistent UI state (GUI dashboards)
-        config_manager = ConfigStoreManager(instrument=instrument, store_type='file')
+        config_manager = ConfigStoreManager(
+            instrument=instrument, store_type='file', config_dir=config_dir
+        )
 
         # Setup all dashboard services (includes session registry)
         self._services = DashboardServices(

--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -41,14 +41,21 @@ class DashboardBase(ServiceBase, ABC):
         port: int = 5007,
         transport: str = 'kafka',
         config_dir: str | None = None,
+        auto_start: bool = False,
         basic_auth_password: str | None = None,
         basic_auth_cookie_secret: str | None = None,
     ):
+        if auto_start and transport != 'fake':
+            raise ValueError(
+                "auto_start requires transport='fake'; with other transports it "
+                "would issue real start commands (or stay PENDING with no backend)."
+            )
         name = f'{instrument}_{dashboard_name}'
         super().__init__(name=name, log_level=log_level)
         self._instrument = instrument
         self._port = port
         self._dev = dev
+        self._auto_start = auto_start
         self._basic_auth_password = basic_auth_password
         self._basic_auth_cookie_secret = basic_auth_cookie_secret
 
@@ -296,6 +303,22 @@ class DashboardBase(ServiceBase, ABC):
     def _start_impl(self) -> None:
         """Start the dashboard service."""
         self._services.start()
+        if self._auto_start:
+            self._auto_start_workflows()
+
+    def _auto_start_workflows(self) -> None:
+        """Commit every workflow that has staged config.
+
+        Drives the normal commit path (as the play button does) for each
+        configured workflow, so that with the fake transport plots come to
+        life on launch without any UI interaction. Intended for seeded
+        UI-test/screenshot runs (see ``--config-dir``).
+        """
+        orchestrator = self._services.job_orchestrator
+        for workflow_id in orchestrator.get_workflow_registry():
+            if orchestrator.get_staged_config(workflow_id):
+                orchestrator.commit_workflow(workflow_id)
+                self._logger.info("auto-started workflow %s", workflow_id)
 
     def run_forever(self) -> None:
         """Run the dashboard server."""

--- a/src/ess/livedata/dashboard/fake_backend.py
+++ b/src/ess/livedata/dashboard/fake_backend.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import threading
 import time
+import zlib
 from collections.abc import Mapping, Sequence
 from types import TracebackType
 
@@ -70,27 +71,39 @@ def _expand_coord(coord: sc.Variable, dim: str, size: int) -> sc.Variable:
     return sc.linspace(dim, 0.0, float(size), num=size, unit=coord.unit)
 
 
-def _synthesize_values(sizes: Sequence[int], update: int) -> np.ndarray:
-    """Generate plausible-looking data that varies over updates.
+def source_variant(source_name: str) -> float:
+    """Map a source name to a stable phase in ``[0, 1)``.
+
+    Used to give each source of a multi-source workflow a distinct curve, so
+    overlaid lines (e.g. per-monitor histograms) don't lie on top of each other.
+    """
+    return (zlib.crc32(source_name.encode()) % 1000) / 1000.0
+
+
+def _synthesize_values(sizes: Sequence[int], update: int, variant: float) -> np.ndarray:
+    """Generate plausible-looking data that varies over updates and sources.
 
     A wiggling scalar (0-D) or a Gaussian bump (1-D and 2-D) plus mild noise.
-    Amplitude grows with the update count to mimic accumulating statistics.
+    Amplitude grows with the update count to mimic accumulating statistics;
+    ``variant`` shifts peak position, amplitude, and phase so distinct sources
+    look distinct.
     """
-    rng = np.random.default_rng(seed=update)
-    amplitude = 100.0 * (update + 1)
+    rng = np.random.default_rng(seed=(update, int(variant * 1_000_000)))
+    phase = 2.0 * np.pi * variant
+    amplitude = 100.0 * (update + 1) * (0.6 + 0.8 * variant)
     if len(sizes) == 0:
-        signal = np.asarray(50.0 + 50.0 * np.sin(0.5 * update))
+        signal = np.asarray(50.0 + 50.0 * np.sin(0.5 * update + phase))
     elif len(sizes) == 1:
         (nx,) = sizes
         x = np.linspace(0.0, 1.0, nx)
-        center = 0.5 + 0.2 * np.sin(0.3 * update)
+        center = 0.25 + 0.5 * variant + 0.08 * np.sin(0.3 * update)
         signal = amplitude * np.exp(-(((x - center) / 0.12) ** 2))
     elif len(sizes) == 2:
         nx, ny = sizes
         x = np.linspace(0.0, 1.0, nx)[:, None]
         y = np.linspace(0.0, 1.0, ny)[None, :]
-        cx = 0.5 + 0.2 * np.sin(0.3 * update)
-        cy = 0.5 + 0.2 * np.cos(0.3 * update)
+        cx = 0.5 + 0.25 * np.sin(0.3 * update + phase)
+        cy = 0.5 + 0.25 * np.cos(0.3 * update + phase)
         signal = amplitude * np.exp(-((x - cx) ** 2 + (y - cy) ** 2) / (2 * 0.15**2))
     else:
         signal = np.full(sizes, amplitude, dtype=float)
@@ -99,7 +112,7 @@ def _synthesize_values(sizes: Sequence[int], update: int) -> np.ndarray:
 
 
 def expand_template(
-    template: sc.DataArray, update: int, timestamp_ns: int
+    template: sc.DataArray, update: int, timestamp_ns: int, variant: float = 0.0
 ) -> sc.DataArray:
     """Turn an empty output template into a populated DataArray.
 
@@ -119,9 +132,11 @@ def expand_template(
         Monotonic update counter; varies the data so plots appear live.
     timestamp_ns:
         Wall-clock time of this update, used for the ``time`` coordinate.
+    variant:
+        Per-source phase in ``[0, 1)`` distinguishing overlaid sources.
     """
     sizes = [size or _DEFAULT_DIM_SIZE for size in template.shape]
-    values = _synthesize_values(sizes, update)
+    values = _synthesize_values(sizes, update, variant)
     data = sc.array(
         dims=template.dims, values=values, unit=template.unit, dtype='float64'
     )
@@ -143,6 +158,7 @@ class _Job:
         self.spec = spec
         self.update = 0
         self.next_emit = 0.0  # monotonic deadline; 0 => emit immediately
+        self.variant = source_variant(config.job_id.source_name)
 
     def output_templates(self) -> Mapping[str, sc.DataArray]:
         """Templates for every output field that declares one."""
@@ -229,7 +245,7 @@ class FakeBackend:
                 output_name=output_name,
             )
             stream = StreamId(kind=StreamKind.LIVEDATA_DATA, name=key.model_dump_json())
-            value = expand_template(template, job.update, timestamp_ns)
+            value = expand_template(template, job.update, timestamp_ns, job.variant)
             messages.append(Message(stream=stream, value=value))
         job.update += 1
         return messages

--- a/src/ess/livedata/dashboard/fake_backend.py
+++ b/src/ess/livedata/dashboard/fake_backend.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""In-process fake backend transport for Kafka-free dashboard testing.
+
+This transport mimics a backend worker without Kafka. Commands the dashboard
+sends (``WorkflowConfig``, ``JobCommand``) are captured by an in-process
+:class:`FakeBackend`, which responds exactly as a real backend would: it
+acknowledges the command, reports the job as running, and emits periodic
+result data on the data stream.
+
+Result data is synthesized from each workflow's output templates (the
+``default_factory`` DataArrays declared on ``WorkflowSpec.outputs``). Because
+the dashboard selects plotters from these same templates, generated data is
+guaranteed to match what the plotter expects, so plots render correctly.
+
+The whole flow is driven by the normal UI: start a workflow and plots come to
+life. No fixtures, no external injection, no Kafka.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from types import TracebackType
+
+import numpy as np
+import scipp as sc
+import structlog
+
+from ..config.acknowledgement import AcknowledgementResponse, CommandAcknowledgement
+from ..config.instruments import get_config
+from ..config.workflow_spec import (
+    JobId,
+    ResultKey,
+    WorkflowConfig,
+    WorkflowId,
+    WorkflowSpec,
+)
+from ..core.job import JobState, JobStatus
+from ..core.job_manager import Command, JobAction, JobCommand
+from ..core.message import (
+    RESPONSES_STREAM_ID,
+    STATUS_STREAM_ID,
+    Message,
+    StreamId,
+    StreamKind,
+)
+from .transport import DashboardResources, NullMessageSink, Transport
+
+logger = structlog.get_logger(__name__)
+
+# Number of points to expand each empty template dimension to.
+_DEFAULT_DIM_SIZE = 64
+# Wall-clock interval between synthesized data updates per job.
+_UPDATE_PERIOD_SECONDS = 1.0
+
+
+def _expand_coord(coord: sc.Variable, dim: str, size: int) -> sc.Variable:
+    """Build a length-``size`` coordinate from an empty template coordinate.
+
+    Templates carry coordinates of zero length that only declare dim, unit, and
+    dtype. We synthesize a monotonically increasing coordinate spanning a unit
+    range so plots have a sensible axis.
+    """
+    if coord.dtype == sc.DType.datetime64:
+        start = np.datetime64('2025-01-01T00:00:00', 's')
+        values = start + np.arange(size, dtype='timedelta64[s]')
+        return sc.array(dims=[dim], values=values, unit=coord.unit)
+    return sc.linspace(dim, 0.0, float(size), num=size, unit=coord.unit)
+
+
+def _synthesize_values(sizes: Sequence[int], update: int) -> np.ndarray:
+    """Generate plausible-looking data that varies over updates.
+
+    A wiggling scalar (0-D) or a Gaussian bump (1-D and 2-D) plus mild noise.
+    Amplitude grows with the update count to mimic accumulating statistics.
+    """
+    rng = np.random.default_rng(seed=update)
+    amplitude = 100.0 * (update + 1)
+    if len(sizes) == 0:
+        signal = np.asarray(50.0 + 50.0 * np.sin(0.5 * update))
+    elif len(sizes) == 1:
+        (nx,) = sizes
+        x = np.linspace(0.0, 1.0, nx)
+        center = 0.5 + 0.2 * np.sin(0.3 * update)
+        signal = amplitude * np.exp(-(((x - center) / 0.12) ** 2))
+    elif len(sizes) == 2:
+        nx, ny = sizes
+        x = np.linspace(0.0, 1.0, nx)[:, None]
+        y = np.linspace(0.0, 1.0, ny)[None, :]
+        cx = 0.5 + 0.2 * np.sin(0.3 * update)
+        cy = 0.5 + 0.2 * np.cos(0.3 * update)
+        signal = amplitude * np.exp(-((x - cx) ** 2 + (y - cy) ** 2) / (2 * 0.15**2))
+    else:
+        signal = np.full(sizes, amplitude, dtype=float)
+    noise = rng.normal(scale=max(amplitude * 0.02, 1.0), size=tuple(sizes))
+    return np.clip(signal + noise, a_min=0.0, a_max=None)
+
+
+def expand_template(
+    template: sc.DataArray, update: int, timestamp_ns: int
+) -> sc.DataArray:
+    """Turn an empty output template into a populated DataArray.
+
+    Zero-length template dimensions are expanded to a default size; existing
+    sized dimensions are preserved. Coordinates and synthetic values are
+    generated to match the template's dims, units, and dtype.
+
+    A scalar ``time`` coordinate (carried by per-update and timeseries outputs)
+    is stamped with the current time. The backend emits a fresh scalar each
+    update; the dashboard accumulates these into the time series.
+
+    Parameters
+    ----------
+    template:
+        Empty DataArray from a workflow output field's ``default_factory``.
+    update:
+        Monotonic update counter; varies the data so plots appear live.
+    timestamp_ns:
+        Wall-clock time of this update, used for the ``time`` coordinate.
+    """
+    sizes = [size or _DEFAULT_DIM_SIZE for size in template.shape]
+    values = _synthesize_values(sizes, update)
+    data = sc.array(
+        dims=template.dims, values=values, unit=template.unit, dtype='float64'
+    )
+    coords = {
+        dim: _expand_coord(template.coords[dim], dim, size)
+        for dim, size in zip(template.dims, sizes, strict=True)
+        if dim in template.coords
+    }
+    if (time := template.coords.get('time')) is not None and time.ndim == 0:
+        coords['time'] = sc.scalar(timestamp_ns, unit=time.unit, dtype=time.dtype)
+    return sc.DataArray(data=data, coords=coords)
+
+
+class _Job:
+    """A running fake job and its synthesized output state."""
+
+    def __init__(self, config: WorkflowConfig, spec: WorkflowSpec) -> None:
+        self.config = config
+        self.spec = spec
+        self.update = 0
+        self.next_emit = 0.0  # monotonic deadline; 0 => emit immediately
+
+    def output_templates(self) -> Mapping[str, sc.DataArray]:
+        """Templates for every output field that declares one."""
+        return {
+            name: field.default_factory()
+            for name, field in self.spec.outputs.model_fields.items()
+            if field.default_factory is not None
+        }
+
+
+class FakeBackend:
+    """Captures dashboard commands and synthesizes backend responses.
+
+    Thread-safe: commands arrive on the UI thread via :meth:`submit`; data is
+    drained on the background update thread via :meth:`poll`.
+    """
+
+    def __init__(self, workflows: Mapping[WorkflowId, WorkflowSpec]) -> None:
+        self._workflows = workflows
+        self._jobs: dict[JobId, _Job] = {}
+        self._control: list[Message] = []
+        self._lock = threading.Lock()
+
+    def submit(self, command: Command) -> None:
+        """Handle a command sent by the dashboard."""
+        with self._lock:
+            if isinstance(command, WorkflowConfig):
+                self._start(command)
+            elif isinstance(command, JobCommand):
+                self._control_job(command)
+
+    def _start(self, config: WorkflowConfig) -> None:
+        spec = self._workflows.get(config.identifier)
+        if spec is None:
+            self._ack(config.message_id, config.job_id.source_name, error='unknown')
+            return
+        self._jobs[config.job_id] = _Job(config=config, spec=spec)
+        self._ack(config.message_id, config.job_id.source_name)
+        self._control.append(self._status(config.job_id, config.identifier))
+        logger.info("fake_backend_started", job_id=str(config.job_id))
+
+    def _control_job(self, command: JobCommand) -> None:
+        if command.action is JobAction.stop and command.job_id is not None:
+            self._jobs.pop(command.job_id, None)
+            self._ack(command.message_id, command.job_id.source_name)
+
+    def _ack(
+        self, message_id: str | None, device: str, error: str | None = None
+    ) -> None:
+        if message_id is None:
+            return
+        response = AcknowledgementResponse.ERR if error else AcknowledgementResponse.ACK
+        ack = CommandAcknowledgement(
+            message_id=message_id, device=device, response=response, message=error
+        )
+        self._control.append(Message(stream=RESPONSES_STREAM_ID, value=ack))
+
+    @staticmethod
+    def _status(job_id: JobId, workflow_id: WorkflowId) -> Message:
+        status = JobStatus(
+            job_id=job_id, workflow_id=workflow_id, state=JobState.active
+        )
+        return Message(stream=STATUS_STREAM_ID, value=status)
+
+    def poll(self) -> Sequence[Message]:
+        """Return queued control messages plus due data updates."""
+        now = time.monotonic()
+        with self._lock:
+            messages = self._control
+            self._control = []
+            for job in self._jobs.values():
+                if now >= job.next_emit:
+                    messages = [*messages, *self._emit_data(job)]
+                    job.next_emit = now + _UPDATE_PERIOD_SECONDS
+        return messages
+
+    def _emit_data(self, job: _Job) -> list[Message]:
+        timestamp_ns = time.time_ns()
+        messages = []
+        for output_name, template in job.output_templates().items():
+            key = ResultKey(
+                workflow_id=job.config.identifier,
+                job_id=job.config.job_id,
+                output_name=output_name,
+            )
+            stream = StreamId(kind=StreamKind.LIVEDATA_DATA, name=key.model_dump_json())
+            value = expand_template(template, job.update, timestamp_ns)
+            messages.append(Message(stream=stream, value=value))
+        job.update += 1
+        return messages
+
+
+class _FakeMessageSource:
+    """Drains synthesized messages from the backend."""
+
+    def __init__(self, backend: FakeBackend) -> None:
+        self._backend = backend
+
+    def get_messages(self) -> Sequence[Message]:
+        return self._backend.poll()
+
+
+class _FakeCommandSink:
+    """Feeds dashboard commands into the backend."""
+
+    def __init__(self, backend: FakeBackend) -> None:
+        self._backend = backend
+
+    def publish_messages(self, messages: list[Message[Command]]) -> None:
+        for message in messages:
+            self._backend.submit(message.value)
+
+
+class FakeBackendTransport(Transport[DashboardResources]):
+    """Transport with an in-process fake backend instead of Kafka.
+
+    Parameters
+    ----------
+    instrument:
+        Instrument name; its workflow registry provides the output templates.
+    """
+
+    def __init__(self, *, instrument: str) -> None:
+        self._instrument = instrument
+
+    def __enter__(self) -> DashboardResources:
+        # Importing the instrument module registers its workflows.
+        get_config(self._instrument)
+        from ..config import instrument_registry
+
+        workflows = instrument_registry[self._instrument].workflow_factory
+        self._backend = FakeBackend(workflows)
+        logger.info("fake_backend_transport_initialized", instrument=self._instrument)
+        return DashboardResources(
+            message_source=_FakeMessageSource(self._backend),
+            command_sink=_FakeCommandSink(self._backend),
+            roi_sink=NullMessageSink(),
+        )
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        logger.info("fake_backend_transport_cleaned_up")
+
+    def start(self) -> None:
+        """No background tasks; data is generated on poll."""
+
+    def stop(self) -> None:
+        """No background tasks to stop."""

--- a/src/ess/livedata/dashboard/fake_backend.py
+++ b/src/ess/livedata/dashboard/fake_backend.py
@@ -47,6 +47,7 @@ from ..core.message import (
     StreamId,
     StreamKind,
 )
+from ..core.timestamp import Timestamp
 from .transport import DashboardResources, NullMessageSink, Transport
 
 logger = structlog.get_logger(__name__)
@@ -159,6 +160,7 @@ class _Job:
         self.update = 0
         self.next_emit = 0.0  # monotonic deadline; 0 => emit immediately
         self.variant = source_variant(config.job_id.source_name)
+        self.start_time = Timestamp.now()
 
     def output_templates(self) -> Mapping[str, sc.DataArray]:
         """Templates for every output field that declares one."""
@@ -197,7 +199,6 @@ class FakeBackend:
             return
         self._jobs[config.job_id] = _Job(config=config, spec=spec)
         self._ack(config.message_id, config.job_id.source_name)
-        self._control.append(self._status(config.job_id, config.identifier))
         logger.info("fake_backend_started", job_id=str(config.job_id))
 
     def _control_job(self, command: JobCommand) -> None:
@@ -217,21 +218,28 @@ class FakeBackend:
         self._control.append(Message(stream=RESPONSES_STREAM_ID, value=ack))
 
     @staticmethod
-    def _status(job_id: JobId, workflow_id: WorkflowId) -> Message:
+    def _status(job: _Job) -> Message:
         status = JobStatus(
-            job_id=job_id, workflow_id=workflow_id, state=JobState.active
+            job_id=job.config.job_id,
+            workflow_id=job.config.identifier,
+            state=JobState.active,
+            start_time=job.start_time,
         )
         return Message(stream=STATUS_STREAM_ID, value=status)
 
     def poll(self) -> Sequence[Message]:
-        """Return queued control messages plus due data updates."""
+        """Return queued control messages plus due status and data updates.
+
+        Each due cycle re-emits the job status, acting as a heartbeat so the
+        dashboard keeps the job ACTIVE rather than letting it go stale.
+        """
         now = time.monotonic()
         with self._lock:
             messages = self._control
             self._control = []
             for job in self._jobs.values():
                 if now >= job.next_emit:
-                    messages = [*messages, *self._emit_data(job)]
+                    messages = [*messages, self._status(job), *self._emit_data(job)]
                     job.next_emit = now + _UPDATE_PERIOD_SECONDS
         return messages
 

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -76,6 +76,7 @@ class ReductionApp(DashboardBase):
         dev: bool = False,
         log_level: int,
         transport: str = 'kafka',
+        config_dir: str | None = None,
         fetch_announcements: bool = True,
         basic_auth_password: str | None = None,
         basic_auth_cookie_secret: str | None = None,
@@ -87,6 +88,7 @@ class ReductionApp(DashboardBase):
             dashboard_name='reduction_dashboard',
             port=5009,  # Default port for reduction dashboard
             transport=transport,
+            config_dir=config_dir,
             basic_auth_password=basic_auth_password,
             basic_auth_cookie_secret=basic_auth_cookie_secret,
         )
@@ -196,6 +198,13 @@ def get_arg_parser() -> argparse.ArgumentParser:
         default='kafka',
         help='Transport backend for message handling. "fake" runs an in-process '
         'backend that synthesizes data for started workflows (no Kafka).',
+    )
+    parser.add_argument(
+        '--config-dir',
+        default=None,
+        help='Base directory for persistent UI config (workflow/plot YAML). '
+        'Overrides LIVEDATA_CONFIG_DIR. Point at a seeded fixture (copied to a '
+        'scratch dir, since the dashboard writes to it) to launch pre-configured.',
     )
     parser.add_argument(
         '--no-fetch-announcements',

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -77,6 +77,7 @@ class ReductionApp(DashboardBase):
         log_level: int,
         transport: str = 'kafka',
         config_dir: str | None = None,
+        auto_start: bool = False,
         fetch_announcements: bool = True,
         basic_auth_password: str | None = None,
         basic_auth_cookie_secret: str | None = None,
@@ -89,6 +90,7 @@ class ReductionApp(DashboardBase):
             port=5009,  # Default port for reduction dashboard
             transport=transport,
             config_dir=config_dir,
+            auto_start=auto_start,
             basic_auth_password=basic_auth_password,
             basic_auth_cookie_secret=basic_auth_cookie_secret,
         )
@@ -205,6 +207,14 @@ def get_arg_parser() -> argparse.ArgumentParser:
         help='Base directory for persistent UI config (workflow/plot YAML). '
         'Overrides LIVEDATA_CONFIG_DIR. Point at a seeded fixture (copied to a '
         'scratch dir, since the dashboard writes to it) to launch pre-configured.',
+    )
+    parser.add_argument(
+        '--auto-start',
+        action='store_true',
+        default=False,
+        help='Commit every workflow that has staged config on startup. Requires '
+        '--transport fake; combine with --config-dir to launch a fully live '
+        'dashboard with no UI interaction (e.g. for screenshots).',
     )
     parser.add_argument(
         '--no-fetch-announcements',

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -192,9 +192,10 @@ def get_arg_parser() -> argparse.ArgumentParser:
     parser = Service.setup_arg_parser(description='ESSlivedata Dashboard')
     parser.add_argument(
         '--transport',
-        choices=['kafka', 'none'],
+        choices=['kafka', 'none', 'fake'],
         default='kafka',
-        help='Transport backend for message handling',
+        help='Transport backend for message handling. "fake" runs an in-process '
+        'backend that synthesizes data for started workflows (no Kafka).',
     )
     parser.add_argument(
         '--no-fetch-announcements',

--- a/tests/dashboard/auto_start_test.py
+++ b/tests/dashboard/auto_start_test.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import logging
+
+import pytest
+
+from ess.livedata.dashboard.reduction import ReductionApp
+
+
+@pytest.mark.parametrize('transport', ['kafka', 'none'])
+def test_auto_start_requires_fake_transport(transport: str) -> None:
+    # The guard fires before any transport setup, so no broker is contacted.
+    with pytest.raises(ValueError, match="auto_start requires"):
+        ReductionApp(log_level=logging.INFO, transport=transport, auto_start=True)

--- a/tests/dashboard/fake_backend_test.py
+++ b/tests/dashboard/fake_backend_test.py
@@ -162,6 +162,26 @@ class TestFakeBackend:
         assert isinstance(data[0].value, sc.DataArray)
         assert data[0].value.sizes == {'x': 64}
 
+    def test_distinct_sources_yield_distinct_data(self) -> None:
+        spec = _spec(Outputs1D, 'wf1d')
+        backend = FakeBackend(_registry(spec))
+        job_number = uuid.uuid4()  # same job, two sources -> overlaid lines
+        for source in ('monitor1', 'monitor2'):
+            backend.submit(
+                WorkflowConfig.from_params(
+                    workflow_id=spec.get_id(),
+                    job_id=JobId(source_name=source, job_number=job_number),
+                    message_id=source,
+                )
+            )
+        data = {
+            ResultKey.model_validate_json(m.stream.name).job_id.source_name: m.value
+            for m in backend.poll()
+            if m.stream.kind is StreamKind.LIVEDATA_DATA
+        }
+        assert set(data) == {'monitor1', 'monitor2'}
+        assert not sc.allclose(data['monitor1'].data, data['monitor2'].data)
+
     def test_emits_one_data_message_per_output_field(self) -> None:
         class MultiOutputs(WorkflowOutputsBase):
             a: sc.DataArray = Field(

--- a/tests/dashboard/fake_backend_test.py
+++ b/tests/dashboard/fake_backend_test.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import uuid
+
+import pytest
+import scipp as sc
+from pydantic import Field
+
+from ess.livedata.config.acknowledgement import (
+    AcknowledgementResponse,
+    CommandAcknowledgement,
+)
+from ess.livedata.config.workflow_spec import (
+    REDUCTION,
+    JobId,
+    ResultKey,
+    WorkflowConfig,
+    WorkflowId,
+    WorkflowOutputsBase,
+    WorkflowSpec,
+)
+from ess.livedata.core.job import JobState, JobStatus
+from ess.livedata.core.job_manager import JobAction, JobCommand
+from ess.livedata.core.message import (
+    RESPONSES_STREAM_ID,
+    STATUS_STREAM_ID,
+    StreamKind,
+)
+from ess.livedata.dashboard.fake_backend import FakeBackend, expand_template
+
+
+class Outputs1D(WorkflowOutputsBase):
+    histogram: sc.DataArray = Field(
+        default_factory=lambda: sc.DataArray(
+            sc.zeros(dims=['x'], shape=[0], unit='counts'),
+            coords={'x': sc.array(dims=['x'], values=[], unit='m')},
+        ),
+        title='Histogram',
+    )
+
+
+class Outputs2D(WorkflowOutputsBase):
+    image: sc.DataArray = Field(
+        default_factory=lambda: sc.DataArray(
+            sc.zeros(dims=['y', 'x'], shape=[0, 0], unit='counts')
+        ),
+        title='Image',
+    )
+
+
+class OutputsTimeseries(WorkflowOutputsBase):
+    reading: sc.DataArray = Field(
+        default_factory=lambda: sc.DataArray(
+            sc.zeros(dims=[], shape=[], unit='K'),
+            coords={'time': sc.scalar(0, unit='ns', dtype='int64')},
+        ),
+        title='Reading',
+    )
+
+
+class OutputsNoTemplate(WorkflowOutputsBase):
+    result: sc.DataArray = Field(title='Result')
+
+
+def _spec(outputs: type[WorkflowOutputsBase], name: str) -> WorkflowSpec:
+    return WorkflowSpec(
+        instrument='test',
+        name=name,
+        version=1,
+        title=name,
+        description='',
+        params=None,
+        outputs=outputs,
+        group=REDUCTION,
+        source_names=['source1'],
+    )
+
+
+def _registry(*specs: WorkflowSpec) -> dict[WorkflowId, WorkflowSpec]:
+    return {spec.get_id(): spec for spec in specs}
+
+
+def _config(spec: WorkflowSpec, message_id: str = 'm1') -> WorkflowConfig:
+    return WorkflowConfig.from_params(
+        workflow_id=spec.get_id(),
+        job_id=JobId(source_name='source1', job_number=uuid.uuid4()),
+        message_id=message_id,
+    )
+
+
+class TestExpandTemplate:
+    def test_expands_empty_dim_and_preserves_unit(self) -> None:
+        template = Outputs1D().histogram
+        out = expand_template(template, update=0, timestamp_ns=0)
+        assert out.sizes == {'x': 64}
+        assert out.unit == sc.Unit('counts')
+        assert out.coords['x'].sizes == {'x': 64}
+        assert out.coords['x'].unit == sc.Unit('m')
+
+    def test_two_dimensional(self) -> None:
+        out = expand_template(Outputs2D().image, update=0, timestamp_ns=0)
+        assert out.sizes == {'y': 64, 'x': 64}
+
+    def test_values_are_finite_and_nonnegative(self) -> None:
+        out = expand_template(Outputs1D().histogram, update=2, timestamp_ns=0)
+        assert sc.all(sc.isfinite(out.data)).value
+        assert (out.data.values >= 0).all()
+
+    def test_update_counter_changes_values(self) -> None:
+        a = expand_template(Outputs1D().histogram, update=0, timestamp_ns=0)
+        b = expand_template(Outputs1D().histogram, update=5, timestamp_ns=0)
+        assert not sc.allclose(a.data, b.data)
+
+    def test_scalar_timeseries_output_stamps_time(self) -> None:
+        out = expand_template(
+            OutputsTimeseries().reading, update=3, timestamp_ns=1_700_000_000
+        )
+        assert out.ndim == 0
+        assert out.unit == sc.Unit('K')
+        time = out.coords['time']
+        assert time.ndim == 0
+        assert time.value == 1_700_000_000
+        assert time.unit == sc.Unit('ns')
+
+
+class TestFakeBackend:
+    def test_workflow_config_yields_ack_and_active_status(self) -> None:
+        spec = _spec(Outputs1D, 'wf1d')
+        backend = FakeBackend(_registry(spec))
+        config = _config(spec)
+
+        backend.submit(config)
+        messages = backend.poll()
+
+        acks = [m.value for m in messages if m.stream == RESPONSES_STREAM_ID]
+        assert len(acks) == 1
+        ack = acks[0]
+        assert isinstance(ack, CommandAcknowledgement)
+        assert ack.message_id == config.message_id
+        assert ack.response is AcknowledgementResponse.ACK
+
+        statuses = [m.value for m in messages if m.stream == STATUS_STREAM_ID]
+        assert len(statuses) == 1
+        status = statuses[0]
+        assert isinstance(status, JobStatus)
+        assert status.job_id == config.job_id
+        assert status.state is JobState.active
+
+    def test_emits_data_with_matching_result_key(self) -> None:
+        spec = _spec(Outputs1D, 'wf1d')
+        backend = FakeBackend(_registry(spec))
+        config = _config(spec)
+
+        backend.submit(config)
+        data = [m for m in backend.poll() if m.stream.kind is StreamKind.LIVEDATA_DATA]
+
+        assert len(data) == 1
+        key = ResultKey.model_validate_json(data[0].stream.name)
+        assert key.workflow_id == config.identifier
+        assert key.job_id == config.job_id
+        assert key.output_name == 'histogram'
+        assert isinstance(data[0].value, sc.DataArray)
+        assert data[0].value.sizes == {'x': 64}
+
+    def test_emits_one_data_message_per_output_field(self) -> None:
+        class MultiOutputs(WorkflowOutputsBase):
+            a: sc.DataArray = Field(
+                default_factory=lambda: sc.DataArray(
+                    sc.zeros(dims=['x'], shape=[0], unit='counts')
+                ),
+                title='A',
+            )
+            b: sc.DataArray = Field(
+                default_factory=lambda: sc.DataArray(
+                    sc.zeros(dims=['x'], shape=[0], unit='counts')
+                ),
+                title='B',
+            )
+
+        spec = _spec(MultiOutputs, 'multi')
+        backend = FakeBackend(_registry(spec))
+        backend.submit(_config(spec))
+
+        data = [m for m in backend.poll() if m.stream.kind is StreamKind.LIVEDATA_DATA]
+        output_names = {
+            ResultKey.model_validate_json(m.stream.name).output_name for m in data
+        }
+        assert output_names == {'a', 'b'}
+
+    def test_output_without_template_is_skipped(self) -> None:
+        spec = _spec(OutputsNoTemplate, 'no_template')
+        backend = FakeBackend(_registry(spec))
+        backend.submit(_config(spec))
+
+        data = [m for m in backend.poll() if m.stream.kind is StreamKind.LIVEDATA_DATA]
+        assert data == []
+
+    def test_unknown_workflow_yields_error_ack(self) -> None:
+        backend = FakeBackend({})
+        unknown = WorkflowId(instrument='test', name='ghost', version=1)
+        config = WorkflowConfig.from_params(
+            workflow_id=unknown,
+            job_id=JobId(source_name='source1', job_number=uuid.uuid4()),
+            message_id='m1',
+        )
+
+        backend.submit(config)
+        messages = backend.poll()
+
+        acks = [m.value for m in messages if m.stream == RESPONSES_STREAM_ID]
+        assert len(acks) == 1
+        assert acks[0].response is AcknowledgementResponse.ERR
+        assert not [m for m in messages if m.stream.kind is StreamKind.LIVEDATA_DATA]
+
+    def test_stop_command_halts_data_emission(self) -> None:
+        spec = _spec(Outputs1D, 'wf1d')
+        backend = FakeBackend(_registry(spec))
+        config = _config(spec)
+        backend.submit(config)
+        backend.poll()  # drain initial ack/status/data
+
+        backend.submit(
+            JobCommand(job_id=config.job_id, action=JobAction.stop, message_id='m2')
+        )
+        messages = backend.poll()
+
+        assert not [m for m in messages if m.stream.kind is StreamKind.LIVEDATA_DATA]
+
+    def test_poll_is_empty_without_active_jobs(self) -> None:
+        backend = FakeBackend({})
+        assert backend.poll() == []
+
+
+@pytest.mark.parametrize('update', [0, 1, 7])
+def test_data_emitted_each_poll_when_due(update: int) -> None:
+    # next_emit starts at 0, so each poll after the period emits fresh data.
+    spec = _spec(Outputs1D, 'wf1d')
+    backend = FakeBackend(_registry(spec))
+    backend.submit(_config(spec))
+    data = [m for m in backend.poll() if m.stream.kind is StreamKind.LIVEDATA_DATA]
+    assert len(data) == 1

--- a/tests/dashboard/fake_backend_test.py
+++ b/tests/dashboard/fake_backend_test.py
@@ -145,6 +145,27 @@ class TestFakeBackend:
         assert isinstance(status, JobStatus)
         assert status.job_id == config.job_id
         assert status.state is JobState.active
+        # start_time drives the dashboard's runtime clock; without it the
+        # workflow stays stuck at "Starting...".
+        assert status.start_time is not None
+
+    def test_status_reemitted_as_heartbeat(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Zero update period makes every poll due, so each poll re-emits status.
+        monkeypatch.setattr(
+            'ess.livedata.dashboard.fake_backend._UPDATE_PERIOD_SECONDS', 0.0
+        )
+        spec = _spec(Outputs1D, 'wf1d')
+        backend = FakeBackend(_registry(spec))
+        config = _config(spec)
+        backend.submit(config)
+
+        for _ in range(3):
+            statuses = [m.value for m in backend.poll() if m.stream == STATUS_STREAM_ID]
+            assert len(statuses) == 1
+            assert statuses[0].state is JobState.active
+            assert statuses[0].start_time is not None
 
     def test_emits_data_with_matching_result_key(self) -> None:
         spec = _spec(Outputs1D, 'wf1d')

--- a/tests/dashboard/ui_config_fixtures/dummy/plot_configs.yaml
+++ b/tests/dashboard/ui_config_fixtures/dummy/plot_configs.yaml
@@ -1,0 +1,78 @@
+plot_grids:
+  grids:
+  - title: Detectors
+    nrows: 2
+    ncols: 2
+    cells:
+    - geometry:
+        row: 0
+        col: 0
+        row_span: 2
+        col_span: 1
+      layers:
+      - data_sources:
+          primary:
+            workflow_id: dummy/area_panel_xy/1
+            source_names:
+            - area_panel
+            view_name: image
+        plot_name: image
+        params:
+          layout:
+            combine_mode: layout
+            layout_columns: 2
+          plot_aspect:
+            aspect_type: Square
+            ratio: 1.0
+            stretch_mode: Fill width
+          plot_scale:
+            x_scale: linear
+            y_scale: linear
+            color_scale: log
+          ticks:
+            custom_xticks: false
+            xticks: 5
+            custom_yticks: false
+            yticks: 5
+          window:
+            mode: window
+            window_duration_seconds: 0.0
+            aggregation: auto
+          rate:
+            normalize_to_rate: false
+    - geometry:
+        row: 0
+        col: 1
+        row_span: 2
+        col_span: 1
+      layers:
+      - data_sources:
+          primary:
+            workflow_id: dummy/panel_0_xy/1
+            source_names:
+            - panel_0
+            view_name: image
+        plot_name: image
+        params:
+          layout:
+            combine_mode: layout
+            layout_columns: 2
+          plot_aspect:
+            aspect_type: Square
+            ratio: 1.0
+            stretch_mode: Fill width
+          plot_scale:
+            x_scale: linear
+            y_scale: linear
+            color_scale: log
+          ticks:
+            custom_xticks: false
+            xticks: 5
+            custom_yticks: false
+            yticks: 5
+          window:
+            mode: window
+            window_duration_seconds: 0.0
+            aggregation: auto
+          rate:
+            normalize_to_rate: false

--- a/tests/dashboard/ui_config_fixtures/dummy/workflow_configs.yaml
+++ b/tests/dashboard/ui_config_fixtures/dummy/workflow_configs.yaml
@@ -1,0 +1,76 @@
+dummy/area_panel_xy/1:
+  jobs:
+    area_panel:
+      aux_source_names: {}
+      params: {}
+dummy/monitor_histogram/1:
+  jobs:
+    monitor1:
+      aux_source_names: {}
+      params:
+        coordinate_mode: &id001
+          mode: toa
+        toa_edges: &id002
+          num_bins: 100
+          scale: linear
+          start: 0.0
+          stop: 71.42857142857143
+          unit: ms
+        toa_range: &id003
+          enabled: false
+          start: 0.0
+          stop: 10.0
+          unit: μs
+    monitor2:
+      aux_source_names: {}
+      params:
+        coordinate_mode: *id001
+        toa_edges: *id002
+        toa_range: *id003
+dummy/panel_0_xy/1:
+  jobs:
+    panel_0:
+      aux_source_names:
+        roi_polygon: roi_polygon
+        roi_rectangle: roi_rectangle
+      params:
+        coordinate_mode:
+          mode: toa
+        pixel_weighting:
+          enabled: false
+          method: pixel_number
+        toa_edges:
+          num_bins: 100
+          scale: linear
+          start: 0.0
+          stop: 71.42857142857143
+          unit: ms
+        toa_range:
+          enabled: false
+          start: 0.0
+          stop: 10.0
+          unit: μs
+        wavelength_edges:
+          num_bins: 100
+          scale: linear
+          start: 1.0
+          stop: 10.0
+          unit: Å
+        wavelength_range:
+          enabled: false
+          start: 0.0
+          stop: 10.0
+          unit: Å
+dummy/timeseries_data/1:
+  jobs:
+    motion1:
+      aux_source_names: {}
+      params: {}
+    motion2:
+      aux_source_names: {}
+      params: {}
+dummy/total_counts/1:
+  jobs:
+    panel_0:
+      aux_source_names: {}
+      params: {}

--- a/tests/dashboard/ui_config_fixtures_test.py
+++ b/tests/dashboard/ui_config_fixtures_test.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Guards the committed UI config fixtures against workflow/output schema drift.
+
+These fixtures (``tests/dashboard/ui_config_fixtures/<instrument>/``) seed the
+dashboard via ``--config-dir`` so UI-test runs skip clicking through source
+selection and plot-grid setup. When workflows or their outputs are renamed the
+fixtures go stale; these tests fail loudly so they get regenerated.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ess.livedata.config import instrument_registry
+from ess.livedata.config.instruments import get_config
+from ess.livedata.config.workflow_spec import WorkflowId
+
+FIXTURES_DIR = Path(__file__).parent / 'ui_config_fixtures'
+INSTRUMENTS = [p.name for p in FIXTURES_DIR.iterdir() if p.is_dir()]
+
+
+def _load(instrument: str, name: str) -> dict:
+    with open(FIXTURES_DIR / instrument / f'{name}.yaml') as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(params=INSTRUMENTS)
+def instrument(request: pytest.FixtureRequest) -> str:
+    name = request.param
+    get_config(name)  # registers the instrument's workflows
+    return name
+
+
+def _registry(instrument: str):
+    return instrument_registry[instrument].workflow_factory
+
+
+class TestWorkflowConfigsFixture:
+    def test_workflow_ids_exist(self, instrument: str) -> None:
+        registry = _registry(instrument)
+        for workflow_id_str in _load(instrument, 'workflow_configs'):
+            assert WorkflowId.from_string(workflow_id_str) in registry
+
+    def test_staged_sources_are_valid(self, instrument: str) -> None:
+        registry = _registry(instrument)
+        for workflow_id_str, entry in _load(instrument, 'workflow_configs').items():
+            spec = registry[WorkflowId.from_string(workflow_id_str)]
+            staged_sources = set(entry['jobs'])
+            assert staged_sources <= set(spec.source_names)
+
+    def test_no_runtime_state_persisted(self, instrument: str) -> None:
+        # Fixtures must be reproducible: no runtime job UUIDs.
+        for entry in _load(instrument, 'workflow_configs').values():
+            assert set(entry) == {'jobs'}
+
+
+class TestPlotConfigsFixture:
+    def test_plot_data_sources_resolve(self, instrument: str) -> None:
+        registry = _registry(instrument)
+        config = _load(instrument, 'plot_configs')
+        for grid in config['plot_grids']['grids']:
+            for cell in grid['cells']:
+                for layer in cell['layers']:
+                    for ds in layer['data_sources'].values():
+                        spec = registry[WorkflowId.from_string(ds['workflow_id'])]
+                        assert set(ds['source_names']) <= set(spec.source_names)
+                        view_names = {v.name for v in spec.get_output_views()}
+                        assert ds['view_name'] in view_names


### PR DESCRIPTION
## Motivation

We could launch the dashboard UI without Kafka (`--transport none`, see #979), but had no way to push data into it, so plots could never be verified or screenshotted. Setting up a representative view also meant clicking through source selection and plot-grid configuration every time.

## Change

Adds an in-process **fake backend** transport and a way to seed the UI from committed config, so the whole flow runs without Kafka and without repetitive clicking.

**`--transport fake`** runs an in-process backend that mimics a real worker: it captures the `WorkflowConfig` command the dashboard sends (which carries the runtime `job_number`), acknowledges it, reports the job ACTIVE, and emits periodic result data. Because data is synthesized from each workflow's output templates (the `default_factory` DataArrays on `WorkflowSpec.outputs`) — the same templates the dashboard uses for plotter selection — generated data matches what the plotter expects, so plots render correctly. Driven entirely by the normal "start workflow" UI flow. Timeseries/scalar outputs emit a fresh `time`-stamped scalar each update, which the dashboard accumulates into a series.

This supersedes the old HTTP-injection idea (#602): routing through the command path means the fake backend learns the runtime `job_number` itself, rather than an external injector having to guess it.

**`--config-dir`** points the persistent UI config store at an arbitrary base directory (a CLI equivalent of the existing `LIVEDATA_CONFIG_DIR`). Combined with the committed dummy fixture (all workflows staged with default sources + a detector plot grid), launching gives a pre-configured dashboard where starting a workflow immediately renders live plots. The dashboard writes to this directory, so callers copy the fixture to a scratch dir first; the recipe is documented in `CLAUDE.md`. A test guards the fixtures against workflow/output schema drift.

The automation rule gains a note on when workflow rows rebuild (state-version changes only) versus in-place status refresh, and the cold-start / multi-step windows where a browser click can race a rebuild.

## Test plan

- [x] Unit tests for data synthesis and the fake backend's command/response/data flow
- [x] Fixture drift-guard test (workflow ids, sources, output views resolve against the registry)
- [x] Verified live: launched `--transport fake --config-dir <fixture copy>`, started workflows via Playwright, confirmed detector (2-D image) and other plots render with synthesized data
