### PR TITLE
Wire DREAM choppers into wavelength-LUT workflow with per-chopper band diagnostic

### DIFF
--- a/configs/log_producer_dream.json
+++ b/configs/log_producer_dream.json
@@ -4,14 +4,14 @@
             "stream_name": "pulse_shaping_chopper1/rotation_speed_setpoint",
             "label": "Pulse-shaping chopper 1 speed setpoint (Hz)",
             "min": 7.0,
-            "max": 14.0,
+            "max": 210.0,
             "step": 7.0,
             "initial": 14.0
         },
         {
             "stream_name": "pulse_shaping_chopper2/rotation_speed_setpoint",
             "label": "Pulse-shaping chopper 2 speed setpoint (Hz, counter-rotating)",
-            "min": -14.0,
+            "min": -196.0,
             "max": -7.0,
             "step": 7.0,
             "initial": -14.0

--- a/configs/log_producer_dream.json
+++ b/configs/log_producer_dream.json
@@ -1,0 +1,94 @@
+{
+    "sliders": [
+        {
+            "stream_name": "pulse_shaping_chopper1/rotation_speed_setpoint",
+            "label": "Pulse-shaping chopper 1 speed setpoint (Hz)",
+            "min": 7.0,
+            "max": 14.0,
+            "step": 7.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "pulse_shaping_chopper2/rotation_speed_setpoint",
+            "label": "Pulse-shaping chopper 2 speed setpoint (Hz)",
+            "min": 7.0,
+            "max": 14.0,
+            "step": 7.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "overlap_chopper/rotation_speed_setpoint",
+            "label": "Overlap chopper speed setpoint (Hz)",
+            "min": 7.0,
+            "max": 14.0,
+            "step": 7.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "band_chopper/rotation_speed_setpoint",
+            "label": "Band-control chopper speed setpoint (Hz)",
+            "min": 14.0,
+            "max": 112.0,
+            "step": 14.0,
+            "initial": 112.0
+        },
+        {
+            "stream_name": "T0_chopper/rotation_speed_setpoint",
+            "label": "T0 chopper speed setpoint (Hz)",
+            "min": 14.0,
+            "max": 28.0,
+            "step": 14.0,
+            "initial": 28.0
+        },
+        {
+            "stream_name": "pulse_shaping_chopper1/delay",
+            "label": "Pulse-shaping chopper 1 delay readback (ns)",
+            "min": 0.0,
+            "max": 71428571.0,
+            "step": 100000.0,
+            "initial": 21000000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "pulse_shaping_chopper2/delay",
+            "label": "Pulse-shaping chopper 2 delay readback (ns)",
+            "min": 0.0,
+            "max": 71428571.0,
+            "step": 100000.0,
+            "initial": 24600000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "overlap_chopper/delay",
+            "label": "Overlap chopper delay readback (ns)",
+            "min": 0.0,
+            "max": 71428571.0,
+            "step": 100000.0,
+            "initial": 5360000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "band_chopper/delay",
+            "label": "Band-control chopper delay readback (ns)",
+            "min": 0.0,
+            "max": 8928571.0,
+            "step": 10000.0,
+            "initial": 500000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "T0_chopper/delay",
+            "label": "T0 chopper delay readback (ns)",
+            "min": 0.0,
+            "max": 35714286.0,
+            "step": 50000.0,
+            "initial": 9920000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        }
+    ]
+}

--- a/configs/log_producer_dream.json
+++ b/configs/log_producer_dream.json
@@ -10,11 +10,11 @@
         },
         {
             "stream_name": "pulse_shaping_chopper2/rotation_speed_setpoint",
-            "label": "Pulse-shaping chopper 2 speed setpoint (Hz)",
-            "min": 7.0,
-            "max": 14.0,
+            "label": "Pulse-shaping chopper 2 speed setpoint (Hz, counter-rotating)",
+            "min": -14.0,
+            "max": -7.0,
             "step": 7.0,
-            "initial": 14.0
+            "initial": -14.0
         },
         {
             "stream_name": "overlap_chopper/rotation_speed_setpoint",

--- a/configs/log_producer_dream.json
+++ b/configs/log_producer_dream.json
@@ -46,7 +46,7 @@
             "min": 0.0,
             "max": 71428571.0,
             "step": 100000.0,
-            "initial": 21000000.0,
+            "initial": 0.0,
             "noise_stddev": 100.0,
             "publish_rate_hz": 5.0
         },
@@ -56,7 +56,7 @@
             "min": 0.0,
             "max": 71428571.0,
             "step": 100000.0,
-            "initial": 24600000.0,
+            "initial": 4900000.0,
             "noise_stddev": 100.0,
             "publish_rate_hz": 5.0
         },
@@ -66,7 +66,7 @@
             "min": 0.0,
             "max": 71428571.0,
             "step": 100000.0,
-            "initial": 5360000.0,
+            "initial": 22100000.0,
             "noise_stddev": 100.0,
             "publish_rate_hz": 5.0
         },
@@ -76,7 +76,7 @@
             "min": 0.0,
             "max": 8928571.0,
             "step": 10000.0,
-            "initial": 500000.0,
+            "initial": 3090000.0,
             "noise_stddev": 100.0,
             "publish_rate_hz": 5.0
         },
@@ -86,7 +86,7 @@
             "min": 0.0,
             "max": 35714286.0,
             "step": 50000.0,
-            "initial": 9920000.0,
+            "initial": 250000.0,
             "noise_stddev": 100.0,
             "publish_rate_hz": 5.0
         }

--- a/src/ess/livedata/config/instruments/dream/grid_templates/choppers_-_wavelength.yaml
+++ b/src/ess/livedata/config/instruments/dream/grid_templates/choppers_-_wavelength.yaml
@@ -1,0 +1,92 @@
+title: Choppers -> Wavelength
+nrows: 2
+ncols: 3
+cells:
+- geometry:
+    row: 0
+    col: 0
+    row_span: 2
+    col_span: 2
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: dream/wavelength_lut/1
+        source_names:
+        - chopper_cascade
+        view_name: chopper_cascade_bands
+    plot_name: overlay_1d
+    params:
+      layout:
+        combine_mode: overlay
+        layout_columns: 2
+      plot_aspect:
+        aspect_type: Free
+        ratio: 1.0
+        stretch_mode: Fill width
+      plot_scale:
+        x_scale: linear
+        y_scale: linear
+      ticks:
+        custom_xticks: false
+        xticks: 5
+        custom_yticks: false
+        yticks: 5
+      line:
+        mode: points
+        errors: band
+      window:
+        mode: window
+        window_duration_seconds: 0.0
+        aggregation: auto
+      rate:
+        normalize_to_rate: false
+- geometry:
+    row: 0
+    col: 2
+    row_span: 2
+    col_span: 1
+  layers:
+  - data_sources:
+      primary:
+        workflow_id: dream/wavelength_lut/1
+        source_names:
+        - chopper_cascade
+        view_name: wavelength_lut
+    plot_name: image
+    params:
+      layout:
+        combine_mode: overlay
+        layout_columns: 2
+      plot_aspect:
+        aspect_type: Free
+        ratio: 1.0
+        stretch_mode: Fill width
+      plot_scale:
+        x_scale: linear
+        y_scale: linear
+        color_scale: log
+      ticks:
+        custom_xticks: false
+        xticks: 5
+        custom_yticks: false
+        yticks: 5
+      window:
+        mode: window
+        window_duration_seconds: 0.0
+        aggregation: auto
+      rate:
+        normalize_to_rate: false
+  - data_sources:
+      primary:
+        workflow_id: static/geometric/1
+        source_names: []
+        view_name: Choppers
+    plot_name: hlines
+    params:
+      geometry:
+        positions: 6.145,6.155,6.174,9.780,13.050
+      style:
+        color: '#ff0000'
+        line_width: 1.0
+        line_dash: solid
+        alpha: 0.7

--- a/src/ess/livedata/config/instruments/dream/specs.py
+++ b/src/ess/livedata/config/instruments/dream/specs.py
@@ -103,6 +103,13 @@ instrument = Instrument(
     name='dream',
     detector_names=detector_names,
     monitors=monitor_names,
+    choppers=[
+        'pulse_shaping_chopper1',
+        'pulse_shaping_chopper2',
+        'band_chopper',
+        'overlap_chopper',
+        'T0_chopper',
+    ],
     streams=name_streams(PARSED_STREAMS),
     source_metadata={
         'mantle_detector': SourceMetadata(

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -1242,8 +1242,10 @@ class Overlay1DPlotter(Plotter):
     one for each position along the first dimension. Useful for visualizing multiple
     spectra (e.g., ROI spectra) from a single 2D array.
 
-    Colors are assigned by coordinate value (not position) when coordinates are
-    integer-like, providing stable color identity across updates.
+    Colors are assigned by coordinate value when coordinates are integer-like,
+    providing stable color identity across updates. For non-integer coordinates
+    colors are assigned by position, since rounding values to an integer color
+    index would collapse closely-spaced coordinates onto the same color.
 
     Supports the same line style options (mode, errors) as LinePlotter.
     """
@@ -1359,6 +1361,12 @@ class Overlay1DPlotter(Plotter):
         else:
             coord_values = np.arange(slice_size)
 
+        # Integer coords (e.g. ROI indices) color by value, giving each slice a
+        # stable color even when the set of slices changes between updates. For
+        # non-integer coords (e.g. distances in metres) ``int()`` would collapse
+        # nearby values onto the same color, so fall back to position instead.
+        color_by_value = np.issubdtype(coord_values.dtype, np.integer)
+
         data = plot_data
         use_histogram = actual_mode == 'histogram'
 
@@ -1374,8 +1382,7 @@ class Overlay1DPlotter(Plotter):
                 slice_data.name = output_display_name
             coord_val = coord_values[i]
 
-            # Assign color by coordinate value for stable identity
-            color_idx = int(coord_val) % len(self._colors)
+            color_idx = (int(coord_val) if color_by_value else i) % len(self._colors)
             color = self._colors[color_idx]
 
             curve_label = f"{slice_dim}={coord_val}" if label_slices else ''

--- a/src/ess/livedata/dashboard/static_plots.py
+++ b/src/ess/livedata/dashboard/static_plots.py
@@ -17,6 +17,8 @@ import holoviews as hv
 import pydantic
 from pydantic_core import core_schema
 
+from ..parameter_models import parse_number_list
+
 
 class LineDash(StrEnum):
     """Line dash styles for HoloViews plots."""
@@ -38,23 +40,6 @@ class Color(str):
         return core_schema.no_info_after_validator_function(
             cls, core_schema.str_schema()
         )
-
-
-def _parse_number_list(v: str) -> list[int | float]:
-    """Parse a comma-separated string into a list of numbers.
-
-    Example: "10, 20, 30" -> [10, 20, 30]
-    """
-    v = v.strip()
-    if not v:
-        return []
-    try:
-        result = json.loads(f"[{v}]")
-        if isinstance(result, list):
-            return result
-    except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid number: {e}") from e
-    return []
 
 
 def _parse_rectangle_list(v: str) -> list[list[int | float]]:
@@ -263,17 +248,13 @@ class LinesCoordinates(pydantic.BaseModel):
     @classmethod
     def validate_positions(cls, v: str) -> str:
         """Validate line position structure."""
-        positions = _parse_number_list(v)
-        if not positions:
+        if not parse_number_list(v):
             raise ValueError("At least one position is required")
-        for i, pos in enumerate(positions):
-            if not isinstance(pos, int | float):
-                raise ValueError(f"Position {i + 1}: must be a number")
         return v
 
     def parse(self) -> list[float]:
         """Parse validated positions into list of floats."""
-        return [float(p) for p in _parse_number_list(self.positions)]
+        return parse_number_list(self.positions)
 
 
 class LinesStyle(BaseStyle):

--- a/src/ess/livedata/handlers/detector_data_handler.py
+++ b/src/ess/livedata/handlers/detector_data_handler.py
@@ -66,6 +66,7 @@ class DetectorHandlerFactory(JobBasedPreprocessorFactoryBase):
 _registry = {
     'geometry-dream-2025-01-01.nxs': 'md5:91aceb884943c76c0c21400ee74ad9b6',
     'geometry-dream-no-shape-2025-05-01.nxs': 'md5:4471e2490a3dd7f6e3ed4aa0a1e0b47d',
+    'geometry-dream-no-shape-2026-06-09.nxs': 'md5:e6ce692b10488789d47a74c805309274',
     'geometry-loki-2025-01-01.nxs': 'md5:8d0e103276934a20ba26bb525e53924a',
     'geometry-loki-2025-03-26.nxs': 'md5:279dc8cf7dae1fac030d724bc45a2572',
     'geometry-loki-2026-02-11.nxs': 'md5:0b40ba0ec640f1c497ec02b233f42ec6',

--- a/src/ess/livedata/handlers/wavelength_lut_workflow.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow.py
@@ -28,7 +28,6 @@ An instrument with no choppers simply supplies a geometry artifact whose
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, NewType
@@ -40,7 +39,6 @@ from ess.reduce.nexus.types import (
     AnyRun,
     DiskChoppers,
     Filename,
-    Position,
     RawChoppers,
 )
 from ess.reduce.nexus.workflow import to_disk_choppers
@@ -81,12 +79,9 @@ ChopperCascadeTrigger = NewType('ChopperCascadeTrigger', sc.DataArray)
 WavelengthLut = NewType('WavelengthLut', sc.DataArray)
 
 #: Per-component wavelength bands evaluated at exact chopper distances, indexed
-#: by a ``distance`` dimension (source + one row per chopper, plus monitor and
-#: detector-range marker rows).
+#: by a ``distance`` dimension (source + one row per chopper, plus one row per
+#: configured cut distance).
 WavelengthBands = NewType('WavelengthBands', sc.DataArray)
-
-#: Distance-from-source of each monitor in the geometry artifact, keyed by name.
-MonitorDistances = NewType('MonitorDistances', dict)
 
 #: Sciline key for the user-facing parameter bundle, used by the provenance
 #: provider. Distinct from the individual parameter keys (PulsePeriod, etc.)
@@ -200,55 +195,25 @@ def _attach_provenance(
     return WavelengthLut(arr)
 
 
-def load_monitor_distances(
-    filename: Filename[AnyRun],
-    source_position: Position[snx.NXsource, AnyRun],
-) -> MonitorDistances:
-    """Distance-from-source of every ``NXmonitor`` in the geometry artifact.
-
-    Monitors are point devices, so each resolves to a single distance, computed
-    from its ``depends_on`` transformation chain. Instruments whose artifact has
-    no monitors (or monitors without a resolvable position) simply yield an
-    empty mapping. Detectors are intentionally excluded: in the shape-stripped
-    geometry artifacts they collapse to a single point, so their flight-path
-    range comes from the user's ``distance_range`` parameter instead.
-    """
-    distances: dict[str, sc.Variable] = {}
-    # scippnexus warns and falls back to a plain DataGroup for these
-    # signal-less NXmonitor groups; the transformation chain still resolves.
-    with warnings.catch_warnings(), snx.File(filename) as f:
-        warnings.simplefilter('ignore', category=UserWarning)
-        entry = next(iter(f[snx.NXentry].values()))
-        instrument = next(iter(entry[snx.NXinstrument].values()))
-        for name, group in instrument[snx.NXmonitor].items():
-            position = snx.compute_positions(group[()], store_position='position').get(
-                'position'
-            )
-            if position is None or position.ndim != 0:
-                continue
-            distances[name] = sc.norm(position - source_position.to(unit=position.unit))
-    return MonitorDistances(distances)
-
-
 def make_wavelength_bands_from_frames(
     time_resolution: TimeResolution,
     pulse_period: PulsePeriod,
     pulse_stride: PulseStride[AnyRun],
     frames: ChopperFrameSequence[AnyRun],
-    monitor_distances: MonitorDistances,
+    params: ParamsKey,
 ) -> WavelengthBands:
     """Wavelength band transmitted at points along the beamline.
 
     Evaluates the surviving wavelength vs ``event_time_offset`` at the exact
     distance of every frame in the cascade — the source pulse (distance 0)
-    followed by one row per chopper — plus a marker row at each monitor
-    position. A row that is entirely NaN means no neutrons are transmitted
-    there, i.e. the upstream chopper blocks the beam. Rows are ordered by
-    ascending distance.
+    followed by one row per chopper — plus a row at each user-configured cut
+    distance (typically monitor and detector positions). A row that is entirely
+    NaN means no neutrons are transmitted there, i.e. the upstream chopper
+    blocks the beam. Rows are ordered by ascending distance.
 
-    Monitor rows reuse :meth:`FrameSequence.__getitem__`, which propagates the
-    last cascade frame *before* the requested distance forward to it, so a
-    monitor between or beyond the choppers reflects the physically correct beam
+    Cut-distance rows reuse :meth:`FrameSequence.__getitem__`, which propagates
+    the last cascade frame *before* the requested distance forward to it, so a
+    point between or beyond the choppers reflects the physically correct beam
     state.
 
     Unlike :func:`make_wavelength_lut_from_polygons`, this does not rasterize
@@ -279,12 +244,13 @@ def make_wavelength_bands_from_frames(
             frame_period=frame_period,
         )
 
-    # Source + choppers sit at their own frame distances; monitor rows propagate
-    # the cascade forward to each monitor position.
+    # Source + choppers sit at their own frame distances; cut-distance rows
+    # propagate the cascade forward to each configured point.
     rows = [(frame.distance.to(unit='m'), frame) for frame in frames]
-    for distance in monitor_distances.values():
-        distance = distance.to(unit='m')
-        rows.append((distance, frames[distance]))
+    rows.extend(
+        (distance, frames[distance])
+        for distance in params.cut_distances.get().to(unit='m')
+    )
 
     # Round to whole millimetres so curve labels read cleanly (e.g. 6.145 m)
     # rather than carrying float-propagation noise.
@@ -316,7 +282,6 @@ def _build_pipeline(params: WavelengthLutParams) -> sciline.Pipeline:
     # Per-component diagnostic evaluated at exact chopper distances, sidestepping
     # the table's distance resolution. Reuses the analytical ChopperFrameSequence.
     wf.insert(make_wavelength_bands_from_frames)
-    wf.insert(load_monitor_distances)
     return wf
 
 

--- a/src/ess/livedata/handlers/wavelength_lut_workflow.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow.py
@@ -28,6 +28,7 @@ An instrument with no choppers simply supplies a geometry artifact whose
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, NewType
@@ -39,6 +40,7 @@ from ess.reduce.nexus.types import (
     AnyRun,
     DiskChoppers,
     Filename,
+    Position,
     RawChoppers,
 )
 from ess.reduce.nexus.workflow import to_disk_choppers
@@ -79,8 +81,12 @@ ChopperCascadeTrigger = NewType('ChopperCascadeTrigger', sc.DataArray)
 WavelengthLut = NewType('WavelengthLut', sc.DataArray)
 
 #: Per-component wavelength bands evaluated at exact chopper distances, indexed
-#: by a ``distance`` dimension (source + one row per chopper).
+#: by a ``distance`` dimension (source + one row per chopper, plus monitor and
+#: detector-range marker rows).
 WavelengthBands = NewType('WavelengthBands', sc.DataArray)
+
+#: Distance-from-source of each monitor in the geometry artifact, keyed by name.
+MonitorDistances = NewType('MonitorDistances', dict)
 
 #: Sciline key for the user-facing parameter bundle, used by the provenance
 #: provider. Distinct from the individual parameter keys (PulsePeriod, etc.)
@@ -194,19 +200,56 @@ def _attach_provenance(
     return WavelengthLut(arr)
 
 
+def load_monitor_distances(
+    filename: Filename[AnyRun],
+    source_position: Position[snx.NXsource, AnyRun],
+) -> MonitorDistances:
+    """Distance-from-source of every ``NXmonitor`` in the geometry artifact.
+
+    Monitors are point devices, so each resolves to a single distance, computed
+    from its ``depends_on`` transformation chain. Instruments whose artifact has
+    no monitors (or monitors without a resolvable position) simply yield an
+    empty mapping. Detectors are intentionally excluded: in the shape-stripped
+    geometry artifacts they collapse to a single point, so their flight-path
+    range comes from the user's ``distance_range`` parameter instead.
+    """
+    distances: dict[str, sc.Variable] = {}
+    # scippnexus warns and falls back to a plain DataGroup for these
+    # signal-less NXmonitor groups; the transformation chain still resolves.
+    with warnings.catch_warnings(), snx.File(filename) as f:
+        warnings.simplefilter('ignore', category=UserWarning)
+        entry = next(iter(f[snx.NXentry].values()))
+        instrument = next(iter(entry[snx.NXinstrument].values()))
+        for name, group in instrument[snx.NXmonitor].items():
+            position = snx.compute_positions(group[()], store_position='position').get(
+                'position'
+            )
+            if position is None or position.ndim != 0:
+                continue
+            distances[name] = sc.norm(position - source_position.to(unit=position.unit))
+    return MonitorDistances(distances)
+
+
 def make_wavelength_bands_from_frames(
     time_resolution: TimeResolution,
     pulse_period: PulsePeriod,
     pulse_stride: PulseStride[AnyRun],
     frames: ChopperFrameSequence[AnyRun],
+    monitor_distances: MonitorDistances,
 ) -> WavelengthBands:
-    """Wavelength band transmitted at each chopper-cascade frame.
+    """Wavelength band transmitted at points along the beamline.
 
     Evaluates the surviving wavelength vs ``event_time_offset`` at the exact
     distance of every frame in the cascade — the source pulse (distance 0)
-    followed by one row per chopper, ordered by ascending distance. A row that
-    is entirely NaN means no neutrons are transmitted at that component, i.e.
-    the corresponding chopper blocks the beam.
+    followed by one row per chopper — plus a marker row at each monitor
+    position. A row that is entirely NaN means no neutrons are transmitted
+    there, i.e. the upstream chopper blocks the beam. Rows are ordered by
+    ascending distance.
+
+    Monitor rows reuse :meth:`FrameSequence.__getitem__`, which propagates the
+    last cascade frame *before* the requested distance forward to it, so a
+    monitor between or beyond the choppers reflects the physically correct beam
+    state.
 
     Unlike :func:`make_wavelength_lut_from_polygons`, this does not rasterize
     onto a uniform distance grid, so closely-spaced choppers stay individually
@@ -227,24 +270,30 @@ def make_wavelength_bands_from_frames(
         'event_time_offset', 0.0, frame_period.value, nbins + 1, unit=pulse_period.unit
     )
 
-    bands = [
-        _estimate_wavelength_by_polygon_centers(
+    def band(frame) -> sc.Variable:
+        return _estimate_wavelength_by_polygon_centers(
             subframes=frame.subframes,
             time_edges=time_edges,
             time_unit=time_unit,
             wavelength_unit=wavelength_unit,
             frame_period=frame_period,
         )
-        for frame in frames
-    ]
-    distances = sc.concat(
-        [frame.distance.to(unit='m') for frame in frames], dim='distance'
-    )
+
+    # Source + choppers sit at their own frame distances; monitor rows propagate
+    # the cascade forward to each monitor position.
+    rows = [(frame.distance.to(unit='m'), frame) for frame in frames]
+    for distance in monitor_distances.values():
+        distance = distance.to(unit='m')
+        rows.append((distance, frames[distance]))
+
+    # Round to whole millimetres so curve labels read cleanly (e.g. 6.145 m)
+    # rather than carrying float-propagation noise.
+    distances = sc.round(sc.concat([d for d, _ in rows], dim='distance'), decimals=3)
     table = sc.DataArray(
-        data=sc.concat(bands, dim='distance'),
+        data=sc.concat([band(frame) for _, frame in rows], dim='distance'),
         coords={'distance': distances, 'event_time_offset': time_edges},
     )
-    return WavelengthBands(table)
+    return WavelengthBands(sc.sort(table, 'distance'))
 
 
 def _build_pipeline(params: WavelengthLutParams) -> sciline.Pipeline:
@@ -267,6 +316,7 @@ def _build_pipeline(params: WavelengthLutParams) -> sciline.Pipeline:
     # Per-component diagnostic evaluated at exact chopper distances, sidestepping
     # the table's distance resolution. Reuses the analytical ChopperFrameSequence.
     wf.insert(make_wavelength_bands_from_frames)
+    wf.insert(load_monitor_distances)
     return wf
 
 

--- a/src/ess/livedata/handlers/wavelength_lut_workflow.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow.py
@@ -196,7 +196,6 @@ def _attach_provenance(
 
 
 def make_wavelength_bands_from_frames(
-    time_resolution: TimeResolution,
     pulse_period: PulsePeriod,
     pulse_stride: PulseStride[AnyRun],
     frames: ChopperFrameSequence[AnyRun],
@@ -230,9 +229,12 @@ def make_wavelength_bands_from_frames(
     pulse_period = pulse_period.to(unit=time_unit)
     frame_period = pulse_period * pulse_stride
 
-    nbins = 10 * int(frame_period / time_resolution.to(unit=time_unit)) + 1
     time_edges = sc.linspace(
-        'event_time_offset', 0.0, frame_period.value, nbins + 1, unit=pulse_period.unit
+        'event_time_offset',
+        0.0,
+        frame_period.value,
+        params.cascade_bands.num_bins + 1,
+        unit=pulse_period.unit,
     )
 
     def band(frame) -> sc.Variable:
@@ -249,7 +251,7 @@ def make_wavelength_bands_from_frames(
     rows = [(frame.distance.to(unit='m'), frame) for frame in frames]
     rows.extend(
         (distance, frames[distance])
-        for distance in params.cut_distances.get().to(unit='m')
+        for distance in params.cascade_bands.get_distances().to(unit='m')
     )
 
     # Round to whole millimetres so curve labels read cleanly (e.g. 6.145 m)

--- a/src/ess/livedata/handlers/wavelength_lut_workflow.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow.py
@@ -44,12 +44,14 @@ from ess.reduce.nexus.types import (
 from ess.reduce.nexus.workflow import to_disk_choppers
 from ess.reduce.unwrap import GenericUnwrapWorkflow
 from ess.reduce.unwrap.lut import (
+    ChopperFrameSequence,
     DistanceResolution,
     LookupTable,
     LtotalRange,
     PulsePeriod,
     PulseStride,
     TimeResolution,
+    _estimate_wavelength_by_polygon_centers,
 )
 
 from ..config.chopper import delay_setpoint_stream, speed_setpoint_stream
@@ -57,6 +59,7 @@ from .dynamic_transforms import synthesise_provider
 from .stream_processor_workflow import StreamProcessorWorkflow
 from .wavelength_lut_workflow_specs import (
     CHOPPER_CASCADE_SOURCE,
+    WAVELENGTH_BANDS_OUTPUT,
     WAVELENGTH_LUT_OUTPUT,
     WavelengthLutParams,
 )
@@ -74,6 +77,10 @@ ChopperCascadeTrigger = NewType('ChopperCascadeTrigger', sc.DataArray)
 
 #: Wavelength lookup-table with provenance coords attached.
 WavelengthLut = NewType('WavelengthLut', sc.DataArray)
+
+#: Per-component wavelength bands evaluated at exact chopper distances, indexed
+#: by a ``distance`` dimension (source + one row per chopper).
+WavelengthBands = NewType('WavelengthBands', sc.DataArray)
 
 #: Sciline key for the user-facing parameter bundle, used by the provenance
 #: provider. Distinct from the individual parameter keys (PulsePeriod, etc.)
@@ -187,6 +194,59 @@ def _attach_provenance(
     return WavelengthLut(arr)
 
 
+def make_wavelength_bands_from_frames(
+    time_resolution: TimeResolution,
+    pulse_period: PulsePeriod,
+    pulse_stride: PulseStride[AnyRun],
+    frames: ChopperFrameSequence[AnyRun],
+) -> WavelengthBands:
+    """Wavelength band transmitted at each chopper-cascade frame.
+
+    Evaluates the surviving wavelength vs ``event_time_offset`` at the exact
+    distance of every frame in the cascade — the source pulse (distance 0)
+    followed by one row per chopper, ordered by ascending distance. A row that
+    is entirely NaN means no neutrons are transmitted at that component, i.e.
+    the corresponding chopper blocks the beam.
+
+    Unlike :func:`make_wavelength_lut_from_polygons`, this does not rasterize
+    onto a uniform distance grid, so closely-spaced choppers stay individually
+    resolved regardless of the table's distance resolution — letting one read
+    off which chopper in a tight cascade blocks the beam.
+
+    Reuses essreduce's (currently private)
+    ``_estimate_wavelength_by_polygon_centers``; once this diagnostic proves its
+    design, the whole function should move upstream into ``ess.reduce.unwrap``.
+    """
+    time_unit = 'us'
+    wavelength_unit = 'angstrom'
+    pulse_period = pulse_period.to(unit=time_unit)
+    frame_period = pulse_period * pulse_stride
+
+    nbins = 10 * int(frame_period / time_resolution.to(unit=time_unit)) + 1
+    time_edges = sc.linspace(
+        'event_time_offset', 0.0, frame_period.value, nbins + 1, unit=pulse_period.unit
+    )
+
+    bands = [
+        _estimate_wavelength_by_polygon_centers(
+            subframes=frame.subframes,
+            time_edges=time_edges,
+            time_unit=time_unit,
+            wavelength_unit=wavelength_unit,
+            frame_period=frame_period,
+        )
+        for frame in frames
+    ]
+    distances = sc.concat(
+        [frame.distance.to(unit='m') for frame in frames], dim='distance'
+    )
+    table = sc.DataArray(
+        data=sc.concat(bands, dim='distance'),
+        coords={'distance': distances, 'event_time_offset': time_edges},
+    )
+    return WavelengthBands(table)
+
+
 def _build_pipeline(params: WavelengthLutParams) -> sciline.Pipeline:
     wf = GenericUnwrapWorkflow(
         run_types=[AnyRun], monitor_types=[], wavelength_from='analytical'
@@ -204,6 +264,9 @@ def _build_pipeline(params: WavelengthLutParams) -> sciline.Pipeline:
     )
     wf[ParamsKey] = params
     wf.insert(_attach_provenance)
+    # Per-component diagnostic evaluated at exact chopper distances, sidestepping
+    # the table's distance resolution. Reuses the analytical ChopperFrameSequence.
+    wf.insert(make_wavelength_bands_from_frames)
     return wf
 
 
@@ -211,7 +274,10 @@ def _make_workflow(pipeline: sciline.Pipeline) -> StreamProcessorWorkflow:
     return StreamProcessorWorkflow(
         pipeline,
         dynamic_keys={CHOPPER_CASCADE_SOURCE: ChopperCascadeTrigger},
-        target_keys={WAVELENGTH_LUT_OUTPUT: WavelengthLut},
+        target_keys={
+            WAVELENGTH_LUT_OUTPUT: WavelengthLut,
+            WAVELENGTH_BANDS_OUTPUT: WavelengthBands,
+        },
         accumulators={},
         # The trigger flows straight to the DiskChoppers provider rather than
         # through an accumulator.

--- a/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
@@ -151,12 +151,12 @@ class WavelengthLutOutputs(WorkflowOutputsBase):
         default_factory=_empty_wavelength_bands_template,
         title='Chopper cascade bands',
         description=(
-            'Wavelength band transmitted at each beamline component (the source '
-            'and each chopper), evaluated at the component\'s exact distance. '
-            'Plot with the "Overlay 1D" plotter: one curve per distance. A curve '
-            'that vanishes (all-NaN) marks the chopper blocking the beam. Unlike '
-            'the lookup table, this resolves closely-spaced choppers regardless '
-            'of distance resolution.'
+            'Wavelength band transmitted along the beamline: the source and each '
+            'chopper at their exact distances, plus a marker row at each monitor '
+            'position. Plot with the "Overlay 1D" plotter: one curve per distance '
+            '(identified by its value in metres). A curve that vanishes (all-NaN) '
+            'marks where the beam is blocked. Unlike the lookup table, this '
+            'resolves closely-spaced choppers regardless of distance resolution.'
         ),
     )
 

--- a/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
@@ -22,6 +22,10 @@ CHOPPER_CASCADE_SOURCE = 'chopper_cascade'
 #: :class:`WavelengthLutOutputs`. Also the workflow ``name`` in the spec.
 WAVELENGTH_LUT_OUTPUT = 'wavelength_lut'
 
+#: Output key for the per-component wavelength bands diagnostic. Field name on
+#: :class:`WavelengthLutOutputs`.
+WAVELENGTH_BANDS_OUTPUT = 'chopper_cascade_bands'
+
 
 class Pulse(pydantic.BaseModel):
     """Source pulse properties.
@@ -119,6 +123,19 @@ def _empty_wavelength_lut_template() -> sc.DataArray:
     )
 
 
+def _empty_wavelength_bands_template() -> sc.DataArray:
+    """Empty placeholder used by the spec until the first computation."""
+    return sc.DataArray(
+        sc.zeros(dims=['distance', 'event_time_offset'], shape=[0, 0], unit='angstrom'),
+        coords={
+            'distance': sc.array(dims=['distance'], values=[], unit='m'),
+            'event_time_offset': sc.array(
+                dims=['event_time_offset'], values=[], unit='us'
+            ),
+        },
+    )
+
+
 class WavelengthLutOutputs(WorkflowOutputsBase):
     """Outputs of the wavelength lookup-table workflow."""
 
@@ -128,6 +145,18 @@ class WavelengthLutOutputs(WorkflowOutputsBase):
         description=(
             'Wavelength as a function of distance and event-time-offset, '
             'computed from the current chopper cascade.'
+        ),
+    )
+    chopper_cascade_bands: sc.DataArray = pydantic.Field(
+        default_factory=_empty_wavelength_bands_template,
+        title='Chopper cascade bands',
+        description=(
+            'Wavelength band transmitted at each beamline component (the source '
+            'and each chopper), evaluated at the component\'s exact distance. '
+            'Plot with the "Overlay 1D" plotter: one curve per distance. A curve '
+            'that vanishes (all-NaN) marks the chopper blocking the beam. Unlike '
+            'the lookup table, this resolves closely-spaced choppers regardless '
+            'of distance resolution.'
         ),
     )
 

--- a/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
@@ -10,7 +10,7 @@ import scipp as sc
 from ..config.instrument import Instrument
 from ..config.workflow_spec import REDUCTION, WorkflowOutputsBase
 from ..handlers.workflow_factory import SpecHandle
-from ..parameter_models import LengthUnit, RangeModel, TimeUnit
+from ..parameter_models import LengthUnit, RangeModel, TimeUnit, parse_number_list
 
 #: Logical primary stream name for the synthesized chopper-cascade tick. The
 #: synthesizer emits a single ``LogData`` message with this stream name once
@@ -85,6 +85,35 @@ class LtotalRange(RangeModel):
     unit: LengthUnit = pydantic.Field(default=LengthUnit.METER, description="Unit.")
 
 
+class CutDistances(pydantic.BaseModel):
+    """Beamline distances at which to show the transmitted wavelength band.
+
+    Each distance adds one curve to the chopper-cascade-bands diagnostic,
+    propagating the cascade forward to that point. Typically the monitor and
+    detector positions, but any point of interest is valid. Entered as a
+    comma-separated list, since the parameter widget has no native list input.
+    """
+
+    distances: str = pydantic.Field(
+        default='',
+        description="Comma-separated distances from the source, e.g. '6.2, 9.8'.",
+    )
+    unit: LengthUnit = pydantic.Field(default=LengthUnit.METER, description="Unit.")
+
+    @pydantic.field_validator('distances')
+    @classmethod
+    def _check(cls, v: str) -> str:
+        parse_number_list(v)  # raises on malformed input
+        return v
+
+    def get(self) -> sc.Variable:
+        return sc.array(
+            dims=['distance'],
+            values=parse_number_list(self.distances),
+            unit=self.unit.value,
+        )
+
+
 class WavelengthLutParams(pydantic.BaseModel):
     """User-facing parameters for the wavelength lookup-table workflow."""
 
@@ -107,6 +136,14 @@ class WavelengthLutParams(pydantic.BaseModel):
         title='Time resolution',
         description='Resolution of the event-time-offset axis in the lookup table.',
         default_factory=TimeResolution,
+    )
+    cut_distances: CutDistances = pydantic.Field(
+        title='Cut distances',
+        description=(
+            'Beamline distances at which to add a curve to the chopper-cascade '
+            'bands diagnostic (typically monitor and detector positions).'
+        ),
+        default_factory=CutDistances,
     )
 
 
@@ -152,8 +189,8 @@ class WavelengthLutOutputs(WorkflowOutputsBase):
         title='Chopper cascade bands',
         description=(
             'Wavelength band transmitted along the beamline: the source and each '
-            'chopper at their exact distances, plus a marker row at each monitor '
-            'position. Plot with the "Overlay 1D" plotter: one curve per distance '
+            'chopper at their exact distances, plus a row at each configured cut '
+            'distance. Plot with the "Overlay 1D" plotter: one curve per distance '
             '(identified by its value in metres). A curve that vanishes (all-NaN) '
             'marks where the beam is blocked. Unlike the lookup table, this '
             'resolves closely-spaced choppers regardless of distance resolution.'

--- a/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
@@ -103,7 +103,7 @@ class CascadeBands(pydantic.BaseModel):
     )
     unit: LengthUnit = pydantic.Field(default=LengthUnit.METER, description="Unit.")
     num_bins: int = pydantic.Field(
-        default=2000,
+        default=1000,
         ge=1,
         description=(
             "Number of event-time-offset bins sampling each curve. Independent "

--- a/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
@@ -85,13 +85,16 @@ class LtotalRange(RangeModel):
     unit: LengthUnit = pydantic.Field(default=LengthUnit.METER, description="Unit.")
 
 
-class CutDistances(pydantic.BaseModel):
-    """Beamline distances at which to show the transmitted wavelength band.
+class CascadeBands(pydantic.BaseModel):
+    """Configuration of the *Chopper cascade bands* output.
 
-    Each distance adds one curve to the chopper-cascade-bands diagnostic,
-    propagating the cascade forward to that point. Typically the monitor and
-    detector positions, but any point of interest is valid. Entered as a
-    comma-separated list, since the parameter widget has no native list input.
+    That diagnostic always draws one curve at the source and one at each chopper
+    (at their exact distances). ``distances`` adds *further* curves at arbitrary
+    beamline points, propagating the cascade forward to each (typically the
+    monitor and detector positions, but any point of interest is valid); entered
+    as a comma-separated list, since the parameter widget has no native list
+    input. ``num_bins`` sets how finely every curve samples the
+    event-time-offset axis.
     """
 
     distances: str = pydantic.Field(
@@ -99,6 +102,15 @@ class CutDistances(pydantic.BaseModel):
         description="Comma-separated distances from the source, e.g. '6.2, 9.8'.",
     )
     unit: LengthUnit = pydantic.Field(default=LengthUnit.METER, description="Unit.")
+    num_bins: int = pydantic.Field(
+        default=2000,
+        ge=1,
+        description=(
+            "Number of event-time-offset bins sampling each curve. Independent "
+            "of the lookup-table time resolution: chosen fine enough to resolve "
+            "narrow transmitted bands across the frame."
+        ),
+    )
 
     @pydantic.field_validator('distances')
     @classmethod
@@ -106,7 +118,7 @@ class CutDistances(pydantic.BaseModel):
         parse_number_list(v)  # raises on malformed input
         return v
 
-    def get(self) -> sc.Variable:
+    def get_distances(self) -> sc.Variable:
         return sc.array(
             dims=['distance'],
             values=parse_number_list(self.distances),
@@ -137,13 +149,15 @@ class WavelengthLutParams(pydantic.BaseModel):
         description='Resolution of the event-time-offset axis in the lookup table.',
         default_factory=TimeResolution,
     )
-    cut_distances: CutDistances = pydantic.Field(
-        title='Cut distances',
+    cascade_bands: CascadeBands = pydantic.Field(
+        title='Chopper cascade bands',
         description=(
-            'Beamline distances at which to add a curve to the chopper-cascade '
-            'bands diagnostic (typically monitor and detector positions).'
+            'Settings for the "Chopper cascade bands" output. The source and '
+            'every chopper always get a curve; add curves at further beamline '
+            'distances (typically monitor and detector positions) and set their '
+            'event-time-offset sampling here.'
         ),
-        default_factory=CutDistances,
+        default_factory=CascadeBands,
     )
 
 
@@ -188,12 +202,14 @@ class WavelengthLutOutputs(WorkflowOutputsBase):
         default_factory=_empty_wavelength_bands_template,
         title='Chopper cascade bands',
         description=(
-            'Wavelength band transmitted along the beamline: the source and each '
-            'chopper at their exact distances, plus a row at each configured cut '
-            'distance. Plot with the "Overlay 1D" plotter: one curve per distance '
-            '(identified by its value in metres). A curve that vanishes (all-NaN) '
-            'marks where the beam is blocked. Unlike the lookup table, this '
-            'resolves closely-spaced choppers regardless of distance resolution.'
+            'Wavelength band transmitted along the beamline: always one curve at '
+            'the source and one at each chopper (at their exact distances), plus '
+            'a curve at each distance configured in the "Cascade bands" '
+            'parameter section. Plot with the "Overlay 1D" plotter: one curve per '
+            'distance (identified by its value in metres). A curve that vanishes '
+            '(all-NaN) marks where the beam is blocked. Unlike the lookup table, '
+            'this resolves closely-spaced choppers regardless of distance '
+            'resolution.'
         ),
     )
 

--- a/src/ess/livedata/parameter_models.py
+++ b/src/ess/livedata/parameter_models.py
@@ -8,12 +8,36 @@ user interfaces for configuring workflows as well as validation of the inputs on
 frontend.
 """
 
+import json
 from abc import ABC
 from enum import StrEnum
 from pathlib import Path
 
 import scipp as sc
 from pydantic import BaseModel, Field, field_validator
+
+
+def parse_number_list(value: str) -> list[float]:
+    """Parse a comma-separated string of numbers into floats.
+
+    A blank (or whitespace-only) string yields an empty list. Raises
+    ``ValueError`` if any entry is not a number, so it can directly back a
+    pydantic ``field_validator`` for free-text numeric-list inputs — the
+    parameter widget has no native list input, so such lists are entered as
+    text.
+
+    Example: ``"6.2, 9.8, 13"`` -> ``[6.2, 9.8, 13.0]``.
+    """
+    value = value.strip()
+    if not value:
+        return []
+    try:
+        parsed = json.loads(f"[{value}]")
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid number list: {e}") from e
+    if any(isinstance(x, bool) or not isinstance(x, int | float) for x in parsed):
+        raise ValueError("All entries must be numbers")
+    return [float(x) for x in parsed]
 
 
 class RangeModel(BaseModel, ABC):

--- a/tests/config/chopper_wavelength_lut_test.py
+++ b/tests/config/chopper_wavelength_lut_test.py
@@ -31,6 +31,7 @@ from ess.livedata.core.job_manager import JobFactory
 from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.handlers.wavelength_lut_workflow_specs import (
     CHOPPER_CASCADE_SOURCE,
+    WAVELENGTH_BANDS_OUTPUT,
     WAVELENGTH_LUT_OUTPUT,
 )
 
@@ -101,3 +102,10 @@ def test_chopper_lut_computes_from_context_and_trigger(instrument) -> None:
     assert lut.dims == ('distance', 'event_time_offset')
     assert lut.unit == sc.units.angstrom
     assert np.isfinite(lut.values).any()
+
+    bands = result.data[WAVELENGTH_BANDS_OUTPUT]
+    assert bands.dims == ('distance', 'event_time_offset')
+    assert bands.unit == sc.units.angstrom
+    # One row for the source plus one per chopper, at exact distances.
+    assert bands.sizes['distance'] == len(instrument.choppers) + 1
+    assert np.isfinite(bands.values).any()

--- a/tests/config/chopper_wavelength_lut_test.py
+++ b/tests/config/chopper_wavelength_lut_test.py
@@ -19,7 +19,6 @@ import pytest
 import scipp as sc
 
 from ess.livedata.config.chopper import (
-    delay_readback_stream,
     delay_setpoint_stream,
     speed_setpoint_stream,
 )
@@ -88,7 +87,7 @@ def test_chopper_lut_computes_from_context_and_trigger(instrument) -> None:
     aux = {}
     for chopper in instrument.choppers:
         speed_unit = instrument.streams[speed_setpoint_stream(chopper)].units
-        delay_unit = instrument.streams[delay_readback_stream(chopper)].units
+        delay_unit = instrument.streams[delay_setpoint_stream(chopper)].units
         aux[speed_setpoint_stream(chopper)] = _nxlog(14.0, speed_unit)
         aux[delay_setpoint_stream(chopper)] = _nxlog(0.0, delay_unit)
     data = JobData(

--- a/tests/config/chopper_wavelength_lut_test.py
+++ b/tests/config/chopper_wavelength_lut_test.py
@@ -106,6 +106,10 @@ def test_chopper_lut_computes_from_context_and_trigger(instrument) -> None:
     bands = result.data[WAVELENGTH_BANDS_OUTPUT]
     assert bands.dims == ('distance', 'event_time_offset')
     assert bands.unit == sc.units.angstrom
-    # One row for the source plus one per chopper, at exact distances.
-    assert bands.sizes['distance'] == len(instrument.choppers) + 1
     assert np.isfinite(bands.values).any()
+    distances = bands.coords['distance']
+    # Source + one row per chopper, plus a marker per monitor (both test
+    # instruments declare monitors).
+    assert distances.sizes['distance'] > len(instrument.choppers) + 1
+    # Rows are ordered by ascending distance.
+    assert sc.allsorted(distances, 'distance')

--- a/tests/config/chopper_wavelength_lut_test.py
+++ b/tests/config/chopper_wavelength_lut_test.py
@@ -33,6 +33,8 @@ from ess.livedata.handlers.wavelength_lut_workflow_specs import (
     CHOPPER_CASCADE_SOURCE,
     WAVELENGTH_BANDS_OUTPUT,
     WAVELENGTH_LUT_OUTPUT,
+    CutDistances,
+    WavelengthLutParams,
 )
 
 pytestmark = pytest.mark.slow
@@ -46,13 +48,13 @@ def instrument(request):
     return inst
 
 
-def _create_lut_job(instrument) -> tuple:
+def _create_lut_job(instrument, params=None) -> tuple:
     workflow_id = next(
         w for w in instrument.workflow_factory if w.name == WAVELENGTH_LUT_OUTPUT
     )
     job_id = JobId(source_name=CHOPPER_CASCADE_SOURCE, job_number=uuid.uuid4())
     config = WorkflowConfig.from_params(
-        workflow_id=workflow_id, job_id=job_id, params=None, aux_source_names=None
+        workflow_id=workflow_id, job_id=job_id, params=params, aux_source_names=None
     )
     service = instrument.workflow_factory.get_service(workflow_id)
     return JobFactory(instrument, service_name=service).create(
@@ -79,7 +81,10 @@ def test_spec_scope_bindings_define_gating_set(instrument) -> None:
 
 
 def test_chopper_lut_computes_from_context_and_trigger(instrument) -> None:
-    job = _create_lut_job(instrument)
+    params = WavelengthLutParams(
+        cut_distances=CutDistances(distances='7.0, 12.0')
+    ).model_dump()
+    job = _create_lut_job(instrument, params=params)
     aux = {}
     for chopper in instrument.choppers:
         speed_unit = instrument.streams[speed_setpoint_stream(chopper)].units
@@ -108,8 +113,7 @@ def test_chopper_lut_computes_from_context_and_trigger(instrument) -> None:
     assert bands.unit == sc.units.angstrom
     assert np.isfinite(bands.values).any()
     distances = bands.coords['distance']
-    # Source + one row per chopper, plus a marker per monitor (both test
-    # instruments declare monitors).
-    assert distances.sizes['distance'] > len(instrument.choppers) + 1
+    # Source + one row per chopper + one row per configured cut distance.
+    assert distances.sizes['distance'] == len(instrument.choppers) + 1 + 2
     # Rows are ordered by ascending distance.
     assert sc.allsorted(distances, 'distance')

--- a/tests/config/chopper_wavelength_lut_test.py
+++ b/tests/config/chopper_wavelength_lut_test.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-"""Instrument-level integration test for LOKI's chopper wavelength-LUT workflow.
+"""Instrument-level integration test for chopper wavelength-LUT workflows.
 
-This is the first production user of spec-scope ``SpecHandle.add_context_binding``
-(ADR 0003). It exercises the full path the unit tests cannot: the spec-scope
-bindings declared in ``loki/factories.py`` flowing through ``JobFactory.create``
-into the job's gating set and the workflow's ``set_context`` keys, against the
-real LOKI geometry artifact.
+Exercises the full path the unit tests cannot, for every instrument that
+declares ``choppers``: the spec-scope ``SpecHandle.add_context_binding``\\ s
+(ADR 0003) auto-wired in ``Instrument.load_factories`` flow through
+``JobFactory.create`` into the job's gating set and the workflow's
+``set_context`` keys, against the real geometry artifact (which must carry the
+``NXdisk_chopper`` groups with resolvable positions).
 """
 
 from __future__ import annotations
@@ -17,7 +18,11 @@ import numpy as np
 import pytest
 import scipp as sc
 
-from ess.livedata.config.chopper import delay_setpoint_stream, speed_setpoint_stream
+from ess.livedata.config.chopper import (
+    delay_readback_stream,
+    delay_setpoint_stream,
+    speed_setpoint_stream,
+)
 from ess.livedata.config.instrument import instrument_registry
 from ess.livedata.config.instruments import get_config
 from ess.livedata.config.workflow_spec import JobId, WorkflowConfig
@@ -32,24 +37,26 @@ from ess.livedata.handlers.wavelength_lut_workflow_specs import (
 pytestmark = pytest.mark.slow
 
 
-@pytest.fixture(scope='module')
-def loki():
-    get_config('loki')  # register instrument
-    instrument = instrument_registry['loki']
-    instrument.load_factories()
-    return instrument
+@pytest.fixture(scope='module', params=['loki', 'dream'])
+def instrument(request):
+    get_config(request.param)  # register instrument
+    inst = instrument_registry[request.param]
+    inst.load_factories()
+    return inst
 
 
-def _create_lut_job(loki) -> tuple:
+def _create_lut_job(instrument) -> tuple:
     workflow_id = next(
-        w for w in loki.workflow_factory if w.name == WAVELENGTH_LUT_OUTPUT
+        w for w in instrument.workflow_factory if w.name == WAVELENGTH_LUT_OUTPUT
     )
     job_id = JobId(source_name=CHOPPER_CASCADE_SOURCE, job_number=uuid.uuid4())
     config = WorkflowConfig.from_params(
         workflow_id=workflow_id, job_id=job_id, params=None, aux_source_names=None
     )
-    service = loki.workflow_factory.get_service(workflow_id)
-    return JobFactory(loki, service_name=service).create(job_id=job_id, config=config)
+    service = instrument.workflow_factory.get_service(workflow_id)
+    return JobFactory(instrument, service_name=service).create(
+        job_id=job_id, config=config
+    )
 
 
 def _nxlog(value: float, unit: str | None) -> sc.DataArray:
@@ -59,23 +66,25 @@ def _nxlog(value: float, unit: str | None) -> sc.DataArray:
     )
 
 
-def test_spec_scope_bindings_define_gating_set(loki) -> None:
-    job = _create_lut_job(loki)
+def test_spec_scope_bindings_define_gating_set(instrument) -> None:
+    job = _create_lut_job(instrument)
     expected = {
         stream(chopper)
-        for chopper in loki.choppers
+        for chopper in instrument.choppers
         for stream in (speed_setpoint_stream, delay_setpoint_stream)
     }
     # Nothing seen yet → every per-chopper setpoint stream gates the job.
     assert job.missing_context(set()) == expected
 
 
-def test_chopper_lut_computes_from_context_and_trigger(loki) -> None:
-    job = _create_lut_job(loki)
+def test_chopper_lut_computes_from_context_and_trigger(instrument) -> None:
+    job = _create_lut_job(instrument)
     aux = {}
-    for chopper in loki.choppers:
-        aux[speed_setpoint_stream(chopper)] = _nxlog(14.0, 'Hz')
-        aux[delay_setpoint_stream(chopper)] = _nxlog(0.0, 'ns')
+    for chopper in instrument.choppers:
+        speed_unit = instrument.streams[speed_setpoint_stream(chopper)].units
+        delay_unit = instrument.streams[delay_readback_stream(chopper)].units
+        aux[speed_setpoint_stream(chopper)] = _nxlog(14.0, speed_unit)
+        aux[delay_setpoint_stream(chopper)] = _nxlog(0.0, delay_unit)
     data = JobData(
         start_time=Timestamp.from_ns(0),
         end_time=Timestamp.from_ns(1),

--- a/tests/config/chopper_wavelength_lut_test.py
+++ b/tests/config/chopper_wavelength_lut_test.py
@@ -33,7 +33,7 @@ from ess.livedata.handlers.wavelength_lut_workflow_specs import (
     CHOPPER_CASCADE_SOURCE,
     WAVELENGTH_BANDS_OUTPUT,
     WAVELENGTH_LUT_OUTPUT,
-    CutDistances,
+    CascadeBands,
     WavelengthLutParams,
 )
 
@@ -82,7 +82,7 @@ def test_spec_scope_bindings_define_gating_set(instrument) -> None:
 
 def test_chopper_lut_computes_from_context_and_trigger(instrument) -> None:
     params = WavelengthLutParams(
-        cut_distances=CutDistances(distances='7.0, 12.0')
+        cascade_bands=CascadeBands(distances='7.0, 12.0')
     ).model_dump()
     job = _create_lut_job(instrument, params=params)
     aux = {}

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1526,6 +1526,35 @@ class TestOverlay1DPlotter:
         assert curve_colors['roi=3'] == colors[3]
         assert curve_colors['roi=5'] == colors[5]
 
+    def test_float_coords_colored_by_position(self, overlay_plotter, data_key):
+        """Closely-spaced float coords must not collapse onto the same color.
+
+        Integer rounding (``int(6.1) == int(6.2) == 6``) would give all three
+        choppers the same color; non-integer coords color by position instead.
+        """
+        colors = hv.Cycle.default_cycles["default_colors"]
+        data = sc.DataArray(
+            sc.array(
+                dims=['distance', 'event_time_offset'],
+                values=[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+                unit='angstrom',
+            ),
+            coords={
+                'distance': sc.array(
+                    dims=['distance'], values=[6.155, 6.177, 6.185], unit='m'
+                ),
+                'event_time_offset': sc.array(
+                    dims=['event_time_offset'], values=[10.0, 20.0], unit='us'
+                ),
+            },
+        )
+        result = overlay_plotter.plot(data, data_key)
+        curve_colors = [
+            hv.Store.lookup_options('bokeh', curve, 'style').kwargs.get('color')
+            for curve in result
+        ]
+        assert curve_colors == [colors[0], colors[1], colors[2]]
+
     def test_fallback_to_indices_without_coord(
         self, overlay_plotter, data_2d_no_first_coord, data_key
     ):

--- a/tests/dashboard/static_plots_test.py
+++ b/tests/dashboard/static_plots_test.py
@@ -98,7 +98,7 @@ class TestLinesCoordinates:
 
     def test_empty_brackets_rejected(self):
         """Empty brackets is rejected."""
-        with pytest.raises(ValueError, match="must be a number"):
+        with pytest.raises(ValueError, match="must be numbers"):
             LinesCoordinates(positions="[]")
 
     def test_invalid_number(self):
@@ -108,7 +108,7 @@ class TestLinesCoordinates:
 
     def test_non_numeric_values_json(self):
         """Non-numeric values in JSON format raise ValueError."""
-        with pytest.raises(ValueError, match="must be a number"):
+        with pytest.raises(ValueError, match="must be numbers"):
             LinesCoordinates(positions='[1, "two", 3]')
 
 

--- a/tests/handlers/wavelength_lut_workflow_test.py
+++ b/tests/handlers/wavelength_lut_workflow_test.py
@@ -22,7 +22,7 @@ from ess.livedata.handlers.wavelength_lut_workflow import (
 from ess.livedata.handlers.wavelength_lut_workflow_specs import (
     CHOPPER_CASCADE_SOURCE,
     WAVELENGTH_LUT_OUTPUT,
-    CutDistances,
+    CascadeBands,
     Pulse,
     WavelengthLutParams,
 )
@@ -124,21 +124,21 @@ def lut(no_chopper_geometry: Path) -> sc.DataArray:
     return wf.finalize()[WAVELENGTH_LUT_OUTPUT]
 
 
-class TestCutDistances:
+class TestCascadeBands:
     def test_empty_default_yields_no_distances(self) -> None:
-        assert CutDistances().get().sizes == {'distance': 0}
+        assert CascadeBands().get_distances().sizes == {'distance': 0}
 
     def test_parses_comma_separated_values(self) -> None:
-        var = CutDistances(distances='6.2, 9.8, 13.0').get()
+        var = CascadeBands(distances='6.2, 9.8, 13.0').get_distances()
         assert var.values.tolist() == [6.2, 9.8, 13.0]
         assert var.unit == sc.Unit('m')
 
     def test_whitespace_only_is_empty(self) -> None:
-        assert CutDistances(distances='   ').get().sizes == {'distance': 0}
+        assert CascadeBands(distances='   ').get_distances().sizes == {'distance': 0}
 
     def test_rejects_non_numeric(self) -> None:
         with pytest.raises(pydantic.ValidationError):
-            CutDistances(distances='6.2, foo')
+            CascadeBands(distances='6.2, foo')
 
 
 class TestNoChopperWorkflow:

--- a/tests/handlers/wavelength_lut_workflow_test.py
+++ b/tests/handlers/wavelength_lut_workflow_test.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+import pydantic
 import pytest
 import scipp as sc
 import scippnexus as snx
@@ -21,6 +22,7 @@ from ess.livedata.handlers.wavelength_lut_workflow import (
 from ess.livedata.handlers.wavelength_lut_workflow_specs import (
     CHOPPER_CASCADE_SOURCE,
     WAVELENGTH_LUT_OUTPUT,
+    CutDistances,
     Pulse,
     WavelengthLutParams,
 )
@@ -120,6 +122,23 @@ def lut(no_chopper_geometry: Path) -> sc.DataArray:
     wf = _build_no_chopper_workflow(no_chopper_geometry)
     wf.accumulate(_trigger(), start_time=0, end_time=1)
     return wf.finalize()[WAVELENGTH_LUT_OUTPUT]
+
+
+class TestCutDistances:
+    def test_empty_default_yields_no_distances(self) -> None:
+        assert CutDistances().get().sizes == {'distance': 0}
+
+    def test_parses_comma_separated_values(self) -> None:
+        var = CutDistances(distances='6.2, 9.8, 13.0').get()
+        assert var.values.tolist() == [6.2, 9.8, 13.0]
+        assert var.unit == sc.Unit('m')
+
+    def test_whitespace_only_is_empty(self) -> None:
+        assert CutDistances(distances='   ').get().sizes == {'distance': 0}
+
+    def test_rejects_non_numeric(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            CutDistances(distances='6.2, foo')
 
 
 class TestNoChopperWorkflow:


### PR DESCRIPTION
## Summary

Wires DREAM's chopper cascade into the wavelength lookup-table workflow and adds a per-component wavelength-band diagnostic to make it easy to see, at a glance, which chopper in a tight cascade is blocking the beam.

## What changed

- DREAM's five choppers (pulse-shaping 1/2, band, overlap, T0) are declared on the instrument and flow into the wavelength-LUT workflow. Pulse-shaping chopper 2 defaults to counter-rotation, and initial chopper settings are tuned so neutrons make it through the full cascade.
- New `chopper_cascade_bands` workflow output: the surviving wavelength band evaluated at the *exact* distance of the source and each chopper — no rasterization onto the table's distance grid, so closely-spaced choppers stay individually resolved. An all-NaN row marks where the beam is blocked.
- A `cut_distances` workflow parameter adds extra rows to that diagnostic at scientist-chosen beamline points (typically monitor and detector positions), propagating the cascade forward to each. Entered as a comma-separated list, since the parameter widget has no native list input; the parsing is shared with the existing static line-coordinate input.
- `Overlay1DPlotter` colors curves by position rather than by coordinate value when coordinates are non-integer (e.g. distances in metres), so nearby distances no longer collapse onto the same color.
- A "Choppers → Wavelength" grid template, a dev log-producer config for the DREAM choppers, and a new no-shape DREAM geometry artifact in the registry.

## Examples

New workflow config options:
<img width="826" height="539" alt="image" src="https://github.com/user-attachments/assets/79aea59a-0bbf-4902-a486-1ea968d1cabb" />

New workflow output, showing disabled curve as well as two custom distances (70m and 200m, the latter with large wavelength spread, indicating frame overlap at this unrealistic distance):
<img width="2043" height="1732" alt="screenshot-2026-06-18T14:40:13" src="https://github.com/user-attachments/assets/a25f1843-b624-4043-a80e-4671cd3ad467" />

The band diagnostic reuses essreduce's private `_estimate_wavelength_by_polygon_centers`; the intent is to promote this upstream into `ess.reduce.unwrap` once the design proves out.

## Test plan

- [x] Drive the "Choppers → Wavelength" grid in the dashboard, configure a few cut distances, and confirm the band overlay distinguishes individual choppers and shows blocked rows vanishing.
