### PR TITLE
Playwright driving kit for the dashboard, plus automation-hook and modal fixes

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -1,5 +1,5 @@
 ---
-paths: src/ess/livedata/dashboard/widgets/**/*.py
+paths: src/ess/livedata/dashboard/widgets/**/*.py, src/ess/livedata/dashboard/reduction.py, scripts/drive_dashboard.py
 ---
 
 # Dashboard Widget Patterns
@@ -106,6 +106,32 @@ elements. Two windows still detach the element under the cursor:
 Wrap clicks in a small retry-on-detach helper (catch the Playwright timeout, re-locate,
 retry) rather than assuming a single click lands. This is not a continuous re-render —
 untouched rows stay stable.
+
+### Keeping automation working
+
+A UI change can silently break `scripts/drive_dashboard.py`, the `lt-*` contract, or the
+seeded fixtures. When you touch the UI, keep these in sync:
+
+- **New tool button** → build it with `create_tool_button()`; it auto-tags `lt-tool` +
+  `lt-tool-{icon_name}`. If you must hand-roll one (toggling icon, `MenuButton`, etc.),
+  add `css_classes=['lt-tool', 'lt-tool-{semantic}']` by hand **and** a guard test —
+  `buttons_test.py` only covers the helper, so hand-rolled buttons drift unnoticed
+  (see `plot_widgets.py`, `plot_grid_manager.py` for examples + their tests).
+- **Repeated-instance view** (per-row/-cell/-grid controls) → pass a context class so
+  each instance is uniquely addressable (`lt-wf-{name}`, `lt-grid-{slug}`).
+- **New top-level tab** → tabs are Bokeh-owned `.bk-tab` with no hook, so the kit
+  navigates by visible text; add the new title to the tab inventory above so callers
+  aren't searching blind.
+- **New modal** → it opens as `[role=dialog]` and is closed on Escape by
+  `ModalEscapeCloser` automatically; nothing to wire, but verify it appears in the
+  inventory.
+- **Renamed/added workflow or output** → regenerate the affected `ui_config_fixtures`
+  (the drift-guard in `ui_config_fixtures_test.py` fails loudly to remind you).
+- **New instrument you want `--launch` to support** → add a
+  `tests/dashboard/ui_config_fixtures/<instrument>/` fixture (only `dummy` exists today).
+
+After a non-trivial UI change, sanity-check with
+`python scripts/drive_dashboard.py --launch --map` (and `--screenshot`).
 
 ## Model creation and visibility
 

--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -62,6 +62,29 @@ Treat them as a stable contract: do not drop them in refactors (a test in
 the same icon (e.g. per-grid/per-cell controls in `plot_grid_manager.py`), pass a
 context `css_classes` entry so each instance is uniquely addressable.
 
+### Driving the dashboard with Playwright
+
+`scripts/drive_dashboard.py` is the committed driving kit (`Dashboard` library class +
+a `--map` / `--launch` / `--screenshot` CLI). Reach for it before hand-rolling
+navigation; run `--map` first to inventory the live tabs and `lt-*` hooks rather than
+screenshotting to rediscover the layout.
+
+**Shadow DOM selectors.** Tool buttons and rows live in per-widget *open* shadow roots.
+Plain Playwright CSS locators pierce these, so `page.locator(".lt-tool-settings")` works
+— **but descendant combinators do not cross shadow boundaries.** Target a workflow's
+button with a *compound* selector on one element:
+
+- ✅ `.lt-wf-total_counts.lt-tool-player-stop` (both classes on the same button)
+- ❌ `.lt-wf-total_counts .lt-tool-player-stop` (matches nothing — the descendant
+  crosses a shadow boundary)
+
+**Tabs.** The top-level tabs are Bokeh-owned `.bk-tab` divs with no `lt-*` hooks, so
+navigate by visible text (`page.get_by_text("Detectors", exact=True)`). Static tab
+titles are code constants: **Workflows**, **System Status**, **Manage Plots**; further
+tabs are user/fixture plot-grid titles (the dummy fixture adds **Detectors**). With
+`dynamic=True` only the active tab's models exist, so a DOM/`lt-*` inventory reflects the
+*current* tab only — switch tabs before querying that tab's hooks.
+
 ### Driving workflow config flows
 
 A `WorkflowStatusWidget` rebuilds its row (`_build_widget`) only when that workflow's

--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -85,6 +85,13 @@ tabs are user/fixture plot-grid titles (the dummy fixture adds **Detectors**). W
 `dynamic=True` only the active tab's models exist, so a DOM/`lt-*` inventory reflects the
 *current* tab only — switch tabs before querying that tab's hooks.
 
+**Modals.** Settings (gear), edit (pencil), and grid/workflow config open a `pn.Modal`
+rendered as `[role=dialog]` — use that as the open/visible signal (`Dashboard.open_modal`
+waits on it). Footer buttons are reachable by text (`Cancel`, `Update Plot`, `Back`). To
+dismiss, press **Escape** (a `ModalEscapeCloser` widget makes this work from initial
+focus) or click `.pnx-dialog-close`. Per-grid rows in **Manage Plots** carry
+`lt-grid-{title-slug}` (e.g. `.lt-grid-detectors.lt-tool-pencil`).
+
 ### Driving workflow config flows
 
 A `WorkflowStatusWidget` rebuilds its row (`_build_widget`) only when that workflow's

--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -69,6 +69,24 @@ a `--map` / `--launch` / `--screenshot` CLI). Reach for it before hand-rolling
 navigation; run `--map` first to inventory the live tabs and `lt-*` hooks rather than
 screenshotting to rediscover the layout.
 
+**Launching & seeding.** `--launch` spawns a fake backend (no Kafka) seeded from the
+committed dummy fixture, drives it, and tears it down. To run a server yourself instead
+— e.g. to click the play buttons by hand rather than auto-starting — copy the fixture to
+a scratch dir first (the dashboard writes to its config dir) and point `--config-dir` at
+it, on a port other than 5009 (interactive dev uses 5009):
+
+```sh
+cp -r tests/dashboard/ui_config_fixtures/dummy "$TMP/cfg/dummy"
+python -m ess.livedata.dashboard.reduction --instrument dummy --transport fake \
+    --port 5011 --config-dir "$TMP/cfg" --no-fetch-announcements
+```
+
+Add `--auto-start` (requires `--transport fake`) to commit every staged workflow on
+launch so plots render with no interaction. Regenerate a fixture by configuring via the
+UI, then copying the persisted `workflow_configs.yaml` (strip the runtime
+`current_job`/`previous_job` keys, keep `jobs`) and `plot_configs.yaml` from the config
+dir back into the fixture; `ui_config_fixtures_test.py` guards against drift.
+
 **Shadow DOM selectors.** Tool buttons and rows live in per-widget *open* shadow roots.
 Plain Playwright CSS locators pierce these, so `page.locator(".lt-tool-settings")` works
 — **but descendant combinators do not cross shadow boundaries.** Target a workflow's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,50 +52,17 @@ Run as: `python -m ess.livedata.services.<name> --instrument dummy [--dev]`
 
 Dashboard: `python -m ess.livedata.dashboard.reduction --instrument dummy`
 
-Add `--transport none` to run the dashboard UI without Kafka (default port 5009; use
-`--port` to run several at once or to dodge a port a prior instance still holds).
-For browser automation / screenshots, target buttons via the stable `lt-tool-*` /
-`lt-wf-*` CSS classes (never coordinates) -- see "Stable CSS hooks for automation" in
-`.claude/rules/dashboard-widgets.md`. Note `--transport none` has no backend, so starting
-a workflow stays PENDING.
+`--transport none` runs the UI without Kafka (default port 5009; pass `--port` for a
+second instance or to dodge a port a prior run still holds). With no backend, started
+workflows stay PENDING. `--transport fake` adds an in-process fake backend (no Kafka):
+started workflows go ACTIVE and plots fill with synthesized data.
 
-Add `--transport fake` to run an in-process fake backend (no Kafka): starting a workflow
-in the UI flips it to ACTIVE and feeds plots with data synthesized from each workflow's
-output templates. Use this to verify plots render and to capture screenshots.
-
-To skip clicking through source selection and plot-grid setup, seed the UI from a
-committed fixture (staged workflow configs + plot grids) via `--config-dir`. The
-dashboard writes to this dir, so copy the fixture to a scratch dir first:
-
-```sh
-cp -r tests/dashboard/ui_config_fixtures/dummy "$TMP/cfg/dummy"
-python -m ess.livedata.dashboard.reduction --instrument dummy --transport fake \
-    --port 5011 --config-dir "$TMP/cfg" --auto-start --no-fetch-announcements
-```
-
-Use a port other than 5009 (`--port 5011` above): interactive dev uses 5009.
-
-Workflows then come pre-staged (play buttons ready) with grids restored. `--auto-start`
-(requires `--transport fake`) commits every staged workflow on launch, so plots render
-with no interaction at all — omit it if you want to drive the play buttons yourself.
-Regenerate a fixture by configuring via the UI, then copying the persisted
-`workflow_configs.yaml` (strip the runtime `current_job`/`previous_job` keys, keep
-`jobs`) and `plot_configs.yaml` from the config dir back into the fixture.
-
-**Driving / screenshotting the live dashboard:** `scripts/drive_dashboard.py` is the
-reusable Playwright kit -- don't start blind or re-write navigation boilerplate. It
-exposes a `Dashboard` library class (readiness wait, `goto_tab`, retry-on-detach
-`click`, `screenshot`, `inventory`) and a CLI:
-
-```sh
-python scripts/drive_dashboard.py --map               # inventory a running server: tabs + live lt-* hooks
-python scripts/drive_dashboard.py --launch --tab Detectors --screenshot out.png  # spawn fake backend + fixture, shoot, tear down
-```
-
-`--launch` handles the whole lifecycle (fixture copy, readiness, teardown) on the dummy
-instrument. Run `--map` first to learn what is targetable before scripting clicks; see
-"Driving the dashboard with Playwright" in `.claude/rules/dashboard-widgets.md` for the
-shadow-DOM selector gotcha and tab inventory.
+To drive or screenshot the UI without Kafka, use `scripts/drive_dashboard.py`: `--launch`
+spawns a fake backend seeded from the dummy fixture, drives it, and tears it down;
+`--map` inventories the live tabs and `lt-*` automation hooks. For the library API,
+fixture seeding/regeneration, and automation gotchas (stable `lt-*` hooks, shadow-DOM
+selectors, modals), see the script's module docstring and "Driving the dashboard with
+Playwright" in `.claude/rules/dashboard-widgets.md`.
 
 ## Tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@ Run as: `python -m ess.livedata.services.<name> --instrument dummy [--dev]`
 
 Dashboard: `python -m ess.livedata.dashboard.reduction --instrument dummy`
 
-Add `--transport none` to run the dashboard UI without Kafka (port 5009, hardcoded).
+Add `--transport none` to run the dashboard UI without Kafka (default port 5009; use
+`--port` to run several at once or to dodge a port a prior instance still holds).
 For browser automation / screenshots, target buttons via the stable `lt-tool-*` /
 `lt-wf-*` CSS classes (never coordinates) -- see "Stable CSS hooks for automation" in
 `.claude/rules/dashboard-widgets.md`. Note `--transport none` has no backend, so starting
@@ -69,8 +70,10 @@ dashboard writes to this dir, so copy the fixture to a scratch dir first:
 ```sh
 cp -r tests/dashboard/ui_config_fixtures/dummy "$TMP/cfg/dummy"
 python -m ess.livedata.dashboard.reduction --instrument dummy --transport fake \
-    --config-dir "$TMP/cfg" --auto-start --no-fetch-announcements
+    --port 5011 --config-dir "$TMP/cfg" --auto-start --no-fetch-announcements
 ```
+
+Use a port other than 5009 (`--port 5011` above): interactive dev uses 5009.
 
 Workflows then come pre-staged (play buttons ready) with grids restored. `--auto-start`
 (requires `--transport fake`) commits every staged workflow on launch, so plots render
@@ -78,6 +81,21 @@ with no interaction at all — omit it if you want to drive the play buttons you
 Regenerate a fixture by configuring via the UI, then copying the persisted
 `workflow_configs.yaml` (strip the runtime `current_job`/`previous_job` keys, keep
 `jobs`) and `plot_configs.yaml` from the config dir back into the fixture.
+
+**Driving / screenshotting the live dashboard:** `scripts/drive_dashboard.py` is the
+reusable Playwright kit -- don't start blind or re-write navigation boilerplate. It
+exposes a `Dashboard` library class (readiness wait, `goto_tab`, retry-on-detach
+`click`, `screenshot`, `inventory`) and a CLI:
+
+```sh
+python scripts/drive_dashboard.py --map               # inventory a running server: tabs + live lt-* hooks
+python scripts/drive_dashboard.py --launch --tab Detectors --screenshot out.png  # spawn fake backend + fixture, shoot, tear down
+```
+
+`--launch` handles the whole lifecycle (fixture copy, readiness, teardown) on the dummy
+instrument. Run `--map` first to learn what is targetable before scripting clicks; see
+"Driving the dashboard with Playwright" in `.claude/rules/dashboard-widgets.md` for the
+shadow-DOM selector gotcha and tab inventory.
 
 ## Tools
 

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -109,6 +109,18 @@ class Dashboard:
                     raise
                 self.page.wait_for_timeout(1000)
 
+    def open_modal(self, trigger_selector: str, *, retries: int = 3):
+        """Click a trigger and wait for its modal (``[role=dialog]``) to show.
+
+        Returns the dialog locator. Dismiss with ``page.keyboard.press("Escape")``
+        (a ModalEscapeCloser widget makes Escape work from initial focus) or by
+        clicking ``.pnx-dialog-close``.
+        """
+        self.click(trigger_selector, retries=retries)
+        dialog = self.page.locator("[role=dialog]").first
+        dialog.wait_for(state="visible", timeout=10000)
+        return dialog
+
     def screenshot(self, path: str | Path, *, full_page: bool = True) -> None:
         self.page.screenshot(path=str(path), full_page=full_page)
 

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+"""Drive the live reduction dashboard with Playwright for verification/screenshots.
+
+This is the reusable kit for browser-driving the dashboard so each session does
+not re-discover the layout or re-write navigation boilerplate. See the companion
+notes in ``.claude/rules/dashboard-widgets.md`` ("Driving the dashboard with
+Playwright").
+
+Two ways to use it:
+
+* As a **library** -- :class:`Dashboard` wraps a Playwright page with readiness
+  waiting, tab navigation, retry-on-detach clicks, and a runtime UI inventory::
+
+      with Dashboard.connect() as dash:  # default localhost:5011
+          dash.goto_tab("Detectors")
+          dash.screenshot("plots.png")
+
+* As a **CLI** against a running server, or self-launching a Kafka-free fake
+  backend seeded from the committed dummy fixture::
+
+      # inventory the live UI (tabs + stable lt-* hooks) -- start here, not blind
+      python scripts/drive_dashboard.py --map
+
+      # launch fake backend + fixture, screenshot the Detectors grid, tear down
+      python scripts/drive_dashboard.py --launch --tab Detectors --screenshot out.png
+
+The ``lt-*`` classes are the stable automation contract (see the rule file).
+Plain Playwright CSS locators pierce the dashboard's open shadow DOM, so
+``page.locator(".lt-tool-settings")`` works -- but **descendant combinators do
+not cross shadow boundaries**. Target a workflow's button with a *compound*
+selector on one element (``.lt-wf-total_counts.lt-tool-player-stop``), never a
+descendant one (``.lt-wf-total_counts .lt-tool-player-stop`` matches nothing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.error import URLError
+
+from playwright.sync_api import (
+    Page,
+    sync_playwright,
+)
+from playwright.sync_api import (
+    TimeoutError as PlaywrightTimeoutError,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+# Default off 5009 (the reduction app default) so automation never collides with
+# an interactive dev dashboard.
+DEFAULT_PORT = 5011
+DEFAULT_URL = f"http://localhost:{DEFAULT_PORT}"
+# Time for Bokeh models to settle / the first refresh tick to rebuild rows after
+# load, before any click. See the "cold start" window in the rule file.
+SETTLE_MS = 5000
+
+
+class Dashboard:
+    """Thin Playwright wrapper exposing the dashboard's stable automation hooks."""
+
+    def __init__(self, page: Page):
+        self.page = page
+
+    @classmethod
+    @contextmanager
+    def connect(cls, url: str = DEFAULT_URL, *, settle_ms: int = SETTLE_MS):
+        """Open a browser on a running dashboard, waiting for it to settle."""
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page(viewport={"width": 1600, "height": 1000})
+            page.goto(url, wait_until="networkidle")
+            page.wait_for_timeout(settle_ms)
+            try:
+                yield cls(page)
+            finally:
+                browser.close()
+
+    def tab_names(self) -> list[str]:
+        """Visible titles of all tabs, in order (static tabs then grid tabs)."""
+        return [t.strip() for t in self.page.locator(".bk-tab").all_inner_texts()]
+
+    def goto_tab(self, name: str) -> None:
+        """Activate a tab by its visible title and let it render."""
+        self.page.get_by_text(name, exact=True).first.click()
+        self.page.wait_for_timeout(SETTLE_MS)
+
+    def click(self, selector: str, *, retries: int = 3) -> None:
+        """Click a stable ``lt-*`` selector, retrying if a rebuild detaches it.
+
+        Staging/commit/stop rebuilds the affected workflow row, so a click can
+        race the rebuild and hit a detached element. Re-locate and retry.
+        """
+        for attempt in range(retries):
+            try:
+                self.page.locator(selector).first.click(timeout=4000)
+                return
+            except PlaywrightTimeoutError:
+                if attempt == retries - 1:
+                    raise
+                self.page.wait_for_timeout(1000)
+
+    def screenshot(self, path: str | Path, *, full_page: bool = True) -> None:
+        self.page.screenshot(path=str(path), full_page=full_page)
+
+    def inventory(self) -> dict:
+        """Runtime UI map: tabs and counts of each stable ``lt-*`` hook present.
+
+        The ``lt-*`` hooks live in per-widget shadow roots; this walks them so the
+        report reflects what is actually targetable right now.
+        """
+        hooks = self.page.evaluate(
+            """() => {
+                const counts = {};
+                const walk = (root) => root.querySelectorAll('*').forEach(el => {
+                    el.classList && el.classList.forEach(c => {
+                        if (c.startsWith('lt-')) counts[c] = (counts[c] || 0) + 1;
+                    });
+                    if (el.shadowRoot) walk(el.shadowRoot);
+                });
+                walk(document);
+                return counts;
+            }"""
+        )
+        return {"tabs": self.tab_names(), "lt_hooks": dict(sorted(hooks.items()))}
+
+
+def _port_in_use(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _wait_until_ready(url: str, log: Path, *, timeout_s: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310
+                if resp.status == 200:
+                    return
+        except (URLError, ConnectionError, OSError):
+            time.sleep(0.5)
+    tail = "\n".join(log.read_text().splitlines()[-15:])
+    raise TimeoutError(f"Dashboard at {url} not ready within {timeout_s}s.\n{tail}")
+
+
+@contextmanager
+def _fake_dashboard(instrument: str, port: int):
+    """Launch a Kafka-free fake-backend dashboard seeded from the fixture.
+
+    Copies the committed fixture to a writable scratch dir (the dashboard writes
+    to its config dir), waits for readiness, and tears the server down on exit.
+    """
+    fixture = REPO_ROOT / "tests/dashboard/ui_config_fixtures" / instrument
+    if not fixture.is_dir():
+        raise SystemExit(f"No UI config fixture for instrument {instrument!r}")
+    if _port_in_use(port):
+        raise SystemExit(
+            f"Port {port} is already in use (a prior dashboard?). Stop it or pass "
+            f"--port with a free port."
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = Path(tmp) / "cfg"
+        shutil.copytree(fixture, cfg / instrument)
+        log = Path(tmp) / "dashboard.log"
+        with log.open("w") as logf:
+            proc = subprocess.Popen(  # noqa: S603
+                [
+                    sys.executable,
+                    "-m",
+                    "ess.livedata.dashboard.reduction",
+                    "--instrument",
+                    instrument,
+                    "--transport",
+                    "fake",
+                    "--port",
+                    str(port),
+                    "--config-dir",
+                    str(cfg),
+                    "--auto-start",
+                    "--no-fetch-announcements",
+                ],
+                cwd=REPO_ROOT,
+                stdout=logf,
+                stderr=subprocess.STDOUT,
+            )
+            try:
+                _wait_until_ready(f"http://localhost:{port}", log)
+                yield f"http://localhost:{port}"
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--url", default=DEFAULT_URL, help="Dashboard URL (running server)."
+    )
+    parser.add_argument(
+        "--launch",
+        action="store_true",
+        help="Start a fake-backend dashboard from the fixture, then tear it down.",
+    )
+    parser.add_argument("--instrument", default="dummy", help="For --launch.")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="For --launch.")
+    parser.add_argument("--tab", help="Activate this tab before acting.")
+    parser.add_argument("--screenshot", help="Write a full-page screenshot here.")
+    parser.add_argument(
+        "--map",
+        action="store_true",
+        help="Print the runtime UI inventory (tabs + stable lt-* hooks) as JSON.",
+    )
+    args = parser.parse_args()
+    if not (args.map or args.screenshot):
+        parser.error("nothing to do: pass --map and/or --screenshot")
+
+    @contextmanager
+    def target_url():
+        if args.launch:
+            with _fake_dashboard(args.instrument, args.port) as url:
+                yield url
+        else:
+            yield args.url
+
+    with target_url() as url, Dashboard.connect(url) as dash:
+        if args.tab:
+            dash.goto_tab(args.tab)
+        if args.map:
+            print(json.dumps(dash.inventory(), indent=2))
+        if args.screenshot:
+            dash.screenshot(args.screenshot)
+            print(f"wrote {args.screenshot}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -75,6 +75,7 @@ class ReductionApp(DashboardBase):
         instrument: str = 'dummy',
         dev: bool = False,
         log_level: int,
+        port: int = 5009,
         transport: str = 'kafka',
         config_dir: str | None = None,
         auto_start: bool = False,
@@ -87,7 +88,7 @@ class ReductionApp(DashboardBase):
             dev=dev,
             log_level=log_level,
             dashboard_name='reduction_dashboard',
-            port=5009,  # Default port for reduction dashboard
+            port=port,
             transport=transport,
             config_dir=config_dir,
             auto_start=auto_start,
@@ -194,6 +195,13 @@ class ReductionApp(DashboardBase):
 
 def get_arg_parser() -> argparse.ArgumentParser:
     parser = Service.setup_arg_parser(description='ESSlivedata Dashboard')
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=5009,
+        help='Port for the Bokeh server. Override to run several dashboards at '
+        'once or to sidestep a port left in use by a prior instance.',
+    )
     parser.add_argument(
         '--transport',
         choices=['kafka', 'none', 'fake'],

--- a/src/ess/livedata/dashboard/widgets/modal_escape_closer.py
+++ b/src/ess/livedata/dashboard/widgets/modal_escape_closer.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Close any open Panel modal when Escape is pressed."""
+
+from typing import ClassVar
+
+from panel.reactive import ReactiveHTML
+
+
+class ModalEscapeCloser(ReactiveHTML):
+    """Invisible widget that closes the open Panel modal on Escape.
+
+    Panel's ``Modal`` (backed by a11y-dialog) binds its Escape handler to the
+    main ``document.body``, but the dialog renders inside Bokeh's shadow DOM and
+    Panel focuses the dialog *container* on open. From that initial focus the
+    keydown never triggers a11y-dialog's handler, so a modal only closes on
+    Escape once focus has moved into its content -- surprising for users who just
+    opened it. One instance per session installs a ``document``-level Escape
+    listener that clicks the close button of whichever dialog is currently shown,
+    covering every modal in the app regardless of where it is mounted.
+
+    Mirrors the ReactiveHTML ``_scripts['render']`` pattern of
+    :class:`~ess.livedata.dashboard.widgets.heartbeat_widget.HeartbeatWidget`.
+    """
+
+    _template = """<div id="modal_esc" style="display:none;"></div>"""
+
+    _scripts: ClassVar = {
+        'render': """
+            if (window.__esslivedataModalEsc) { return; }
+            window.__esslivedataModalEsc = true;
+            const findShownClose = (node) => {
+                if (node.id === 'pnx_dialog' && node.style &&
+                        node.style.display !== 'none') {
+                    const btn = node.querySelector('.pnx-dialog-close');
+                    if (btn) { return btn; }
+                }
+                if (node.shadowRoot) {
+                    const r = findShownClose(node.shadowRoot);
+                    if (r) { return r; }
+                }
+                for (const child of node.children || []) {
+                    const r = findShownClose(child);
+                    if (r) { return r; }
+                }
+                return null;
+            };
+            state.handler = (e) => {
+                if (e.key !== 'Escape') { return; }
+                const btn = findShownClose(document.documentElement);
+                if (btn) { btn.click(); }
+            };
+            document.body.addEventListener('keydown', state.handler);
+        """,
+        'remove': """
+            if (state.handler) {
+                document.body.removeEventListener('keydown', state.handler);
+                window.__esslivedataModalEsc = false;
+            }
+        """,
+    }
+
+    def __init__(self, **params):
+        params.setdefault('width', 0)
+        params.setdefault('height', 0)
+        params.setdefault('sizing_mode', 'fixed')
+        params.setdefault('visible', False)
+        super().__init__(**params)

--- a/src/ess/livedata/dashboard/widgets/plot_grid_manager.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_manager.py
@@ -117,12 +117,18 @@ class GridRow:
         self._grid_id = grid_id
         self._grid_config = grid_config
 
+        # Per-grid automation hook so each row's repeated tool buttons are
+        # uniquely targetable (e.g. .lt-grid-detectors.lt-tool-pencil). The
+        # title slug also drives the download filename below.
+        context = [f'lt-grid-{_sanitize_filename(grid_config.title)}']
+
         # Move up button
         move_up_button = create_tool_button(
             icon_name='chevron-up',
             button_color=StatusColors.MUTED,
             hover_color=HoverColors.MUTED,
             on_click_callback=on_move_up or (lambda: None),
+            css_classes=context,
         )
         move_up_button.disabled = is_first or on_move_up is None
 
@@ -132,6 +138,7 @@ class GridRow:
             button_color=StatusColors.MUTED,
             hover_color=HoverColors.MUTED,
             on_click_callback=on_move_down or (lambda: None),
+            css_classes=context,
         )
         move_down_button.disabled = is_last or on_move_down is None
 
@@ -150,6 +157,7 @@ class GridRow:
                 button_color='#ffffff',
                 hover_color='rgba(0, 123, 255, 0.8)',
                 on_click_callback=on_edit or (lambda: None),
+                css_classes=context,
             )
             edit_button.stylesheets = [
                 *edit_button.stylesheets,
@@ -162,6 +170,7 @@ class GridRow:
                 button_color=ButtonStyles.PRIMARY_BLUE,
                 hover_color=ButtonStyles.PRIMARY_HOVER,
                 on_click_callback=on_edit or (lambda: None),
+                css_classes=context,
             )
         if on_edit is None:
             edit_button.disabled = True
@@ -178,6 +187,7 @@ class GridRow:
                 if on_toggle_enabled
                 else None
             ),
+            css_classes=context,
         )
         if on_toggle_enabled is None:
             self._toggle_button.disabled = True
@@ -197,6 +207,7 @@ class GridRow:
             button_color=ButtonStyles.DANGER_RED,
             hover_color=ButtonStyles.DANGER_HOVER,
             on_click_callback=on_remove,
+            css_classes=context,
         )
 
         card_styles = (

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -34,6 +34,7 @@ from ..session_layer import SessionLayer
 from ..session_updater import SessionUpdater
 from .cell import CellDeps, CellWidget
 from .cell_properties_modal import CellPropertiesModal
+from .modal_escape_closer import ModalEscapeCloser
 from .plot_config_modal import PlotConfigModal
 from .plot_grid import PlotGrid
 from .plot_grid_manager import PlotGridManager
@@ -185,7 +186,10 @@ class PlotGridTabs:
         # each .panel access, the modal_container would be reparented repeatedly,
         # breaking its connection to the component tree.
         self._widget = pn.Column(
-            self._tabs, self._modal_container, sizing_mode='stretch_both'
+            self._tabs,
+            self._modal_container,
+            ModalEscapeCloser(),
+            sizing_mode='stretch_both',
         )
 
         # Subscribe to lifecycle events

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -268,6 +268,10 @@ def _create_toolbar_visibility_button(
         sizing_mode='fixed',
         margin=0,
         description=_tip(visible),
+        # Hand-rolled (toggling icon) so it bypasses create_tool_button; tag it
+        # with the stable automation hooks by hand. Icon name varies, so use a
+        # semantic suffix rather than lt-tool-{icon_name}.
+        css_classes=['lt-tool', 'lt-tool-layer-details'],
         stylesheets=create_tool_button_stylesheet(Colors.TEXT_MUTED, HoverColors.MUTED),
     )
     state = {'visible': visible}
@@ -347,6 +351,9 @@ def _create_configure_button_or_menu(
         color='light',
         sizing_mode='fixed',
         margin=0,
+        # MenuButton (dropdown), so it bypasses create_tool_button; tag it with
+        # the same hooks as the single-layer gear for consistent automation.
+        css_classes=['lt-tool', 'lt-tool-settings'],
         stylesheets=stylesheets,
     )
 

--- a/tests/dashboard/widgets/plot_grid_manager_test.py
+++ b/tests/dashboard/widgets/plot_grid_manager_test.py
@@ -178,6 +178,30 @@ class TestGridRow:
 
         assert isinstance(row.panel, pn.Row)
 
+    def test_tool_buttons_carry_per_grid_automation_hook(
+        self, plot_orchestrator, workflow_registry
+    ):
+        """Each row's tool buttons get an lt-grid-{slug} class for automation.
+
+        Repeated icons (e.g. the pencil) across grids are only uniquely
+        addressable with a per-grid context class. See dashboard-widgets.md.
+        """
+        from io import StringIO
+
+        from ess.livedata.dashboard.plot_orchestrator import PlotGridConfig
+
+        config = PlotGridConfig(title='My Grid', nrows=2, ncols=3)
+        row = GridRow(
+            grid_id=None,  # type: ignore[arg-type]
+            grid_config=config,
+            instrument='dummy',
+            on_remove=lambda: None,
+            get_yaml_content=lambda: StringIO(''),
+        )
+        edit_button = row.panel[3]
+        assert 'lt-grid-my_grid' in edit_button.css_classes
+        assert 'lt-tool-pencil' in edit_button.css_classes
+
     def test_download_button_has_correct_filename(
         self, plot_orchestrator, workflow_registry
     ):

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -20,10 +20,36 @@ from ess.livedata.dashboard.plot_orchestrator import (
 )
 from ess.livedata.dashboard.plot_params import WindowMode, WindowParams
 from ess.livedata.dashboard.widgets.plot_widgets import (
+    _create_configure_button_or_menu,
+    _create_toolbar_visibility_button,
     _format_window_info,
     derive_cell_title,
     get_plot_cell_display_info,
 )
+
+
+class TestPerPanelToolHooks:
+    """Per-panel tools must carry the stable lt-* automation hooks.
+
+    Unlike the create_tool_button-based buttons, these are hand-rolled (a
+    toggling icon, a dropdown menu), so they tag themselves and can silently
+    drift. See .claude/rules/dashboard-widgets.md.
+    """
+
+    def test_toolbar_visibility_toggle_has_layer_details_hook(self) -> None:
+        button = _create_toolbar_visibility_button(
+            visible=True, on_toggle=lambda _: None
+        )
+        assert 'lt-tool' in button.css_classes
+        assert 'lt-tool-layer-details' in button.css_classes
+
+    def test_multi_layer_configure_menu_has_settings_hook(self) -> None:
+        layers = [(LayerId('a'), 'A'), (LayerId('b'), 'B')]
+        menu = _create_configure_button_or_menu(
+            layers=layers, on_configure=lambda _: None
+        )
+        assert 'lt-tool' in menu.css_classes
+        assert 'lt-tool-settings' in menu.css_classes
 
 
 class _FakeParams(pydantic.BaseModel):


### PR DESCRIPTION
## Motivation

Driving the live dashboard with Playwright (for verification and screenshots) meant re-discovering the layout and re-writing navigation boilerplate every session, with no clean way to recover when a prior instance held the hardcoded port. This makes that flow turnkey and removes the friction the previous fake-backend work (#985) left behind.

## What changed

A reusable Playwright driving kit, `scripts/drive_dashboard.py`, exposed both as a `Dashboard` library class (readiness wait, tab navigation, retry-on-detach click, modal open, screenshot, runtime UI inventory) and a CLI. `--map` dumps the live tabs and stable `lt-*` hooks so a session starts informed rather than blind; `--launch` runs the whole Kafka-free fake-backend lifecycle (fixture copy, readiness, teardown) in one command, defaulting off port 5009 so automation never collides with interactive dev.

The dashboard gains a `--port` flag for running several instances or sidestepping a held port.

Two rounds of agent-driven dogfooding then surfaced real gaps, which are fixed here:

- **Stable hooks completed.** Per-panel tool buttons that were hand-rolled (the layer-details toggle, the multi-layer settings dropdown) and the per-grid row controls carried no `lt-*` automation hook, unlike the buttons built via `create_tool_button`. They are now tagged and guarded by tests.
- **Escape closes modals.** Panel's modal (a11y-dialog) binds Escape on `document.body`, but the dialog renders in Bokeh's shadow DOM and Panel focuses the dialog container on open, so Escape did nothing until focus moved into the content — affecting real users, not just automation. An invisible per-session `ModalEscapeCloser` installs a document-level Escape handler covering every modal. The cleaner long-term fix is upstream in Panel; this is a local shim.

Finally, the docs were brought in line: the automation rule documents the shadow-DOM selector gotcha, the tab/modal inventory, and a "keeping automation working" checklist mapping each kind of UI change to what must be kept in sync; its path scope now also covers `reduction.py` and the driving kit. The verbose driving and fixture recipes were moved out of the always-loaded `CLAUDE.md` into that path-scoped rule, trimming `CLAUDE.md` by a third with no loss of information.

## Test plan

- [x] Unit tests for the new automation hooks (per-panel buttons, per-grid rows)
- [x] Existing dashboard widget suite passes
- [x] Verified live with the kit: `--launch --map` inventories tabs/hooks, `--screenshot` renders detector plots, and Escape closes the settings, edit, and config modals from initial focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
