### PR TITLE
Wire BIFROST chopper-cascade wavelength-LUT workflow

### DIFF
--- a/configs/log_producer_bifrost.json
+++ b/configs/log_producer_bifrost.json
@@ -21,6 +21,114 @@
             "target_stream": "rotation_stage/target_value",
             "idle_stream": "rotation_stage/idle_flag",
             "ramp_seconds": 2.0
+        },
+        {
+            "stream_name": "pulse_shaping_chopper_1/rotation_speed_setpoint",
+            "label": "PSC 1 speed setpoint (Hz)",
+            "min": 14.0,
+            "max": 210.0,
+            "step": 14.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "pulse_shaping_chopper_2/rotation_speed_setpoint",
+            "label": "PSC 2 speed setpoint (Hz)",
+            "min": 14.0,
+            "max": 210.0,
+            "step": 14.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "frame_overlap_chopper_1/rotation_speed_setpoint",
+            "label": "FOC 1 speed setpoint (Hz, fixed)",
+            "min": 14.0,
+            "max": 14.0,
+            "step": 14.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "frame_overlap_chopper_2/rotation_speed_setpoint",
+            "label": "FOC 2 speed setpoint (Hz, fixed)",
+            "min": 14.0,
+            "max": 14.0,
+            "step": 14.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "bandwidth_chopper_1/rotation_speed_setpoint",
+            "label": "BWC 1 speed setpoint (Hz, fixed)",
+            "min": 14.0,
+            "max": 14.0,
+            "step": 14.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "bandwidth_chopper_2/rotation_speed_setpoint",
+            "label": "BWC 2 speed setpoint (Hz, fixed)",
+            "min": 14.0,
+            "max": 14.0,
+            "step": 14.0,
+            "initial": 14.0
+        },
+        {
+            "stream_name": "pulse_shaping_chopper_1/delay",
+            "label": "PSC 1 delay readback (ns)",
+            "min": 0.0,
+            "max": 71428000.0,
+            "step": 100000.0,
+            "initial": 8000000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "pulse_shaping_chopper_2/delay",
+            "label": "PSC 2 delay readback (ns)",
+            "min": 0.0,
+            "max": 71428000.0,
+            "step": 100000.0,
+            "initial": 10000000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "frame_overlap_chopper_1/delay",
+            "label": "FOC 1 delay readback (ns)",
+            "min": 0.0,
+            "max": 71428000.0,
+            "step": 100000.0,
+            "initial": 12000000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "frame_overlap_chopper_2/delay",
+            "label": "FOC 2 delay readback (ns)",
+            "min": 0.0,
+            "max": 71428000.0,
+            "step": 100000.0,
+            "initial": 14000000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "bandwidth_chopper_1/delay",
+            "label": "BWC 1 delay readback (ns)",
+            "min": 0.0,
+            "max": 71428000.0,
+            "step": 100000.0,
+            "initial": 16000000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
+        },
+        {
+            "stream_name": "bandwidth_chopper_2/delay",
+            "label": "BWC 2 delay readback (ns)",
+            "min": 0.0,
+            "max": 71428000.0,
+            "step": 100000.0,
+            "initial": 18000000.0,
+            "noise_stddev": 100.0,
+            "publish_rate_hz": 5.0
         }
     ]
 }

--- a/src/ess/livedata/config/instruments/bifrost/factories.py
+++ b/src/ess/livedata/config/instruments/bifrost/factories.py
@@ -291,6 +291,11 @@ def _create_base_reduction_workflow():
 
     from ess.livedata.handlers.detector_data_handler import get_nexus_geometry_filename
 
+    # Detector group names in the pinned (pre-2026-06-08) geometry artifact
+    # carry a numeric prefix, e.g. ``123_channel_1_1_triplet``. Newer files
+    # drop the prefix (``channel_1_1_triplet``; ``detector_number`` content is
+    # identical). Switch to the unprefixed form once detector geometry is
+    # unpinned (see https://github.com/scipp/esslivedata/issues/962).
     _detector_names = [
         f'{123 + 4 * (arc - 1) + (5 * 4 + 1) * (channel - 1)}'
         f'_channel_{channel}_{arc}_triplet'
@@ -323,7 +328,15 @@ def _create_base_reduction_workflow():
         return DetectorRegionCounts(counts)
 
     reduction_workflow = TofWorkflow(run_types=(SampleRun,), monitor_types=())
-    reduction_workflow[Filename[SampleRun]] = get_nexus_geometry_filename('bifrost')
+    # Pin detector geometry to the pre-2026-06-08 survey. The 2026-06-08 file
+    # (added for the corrected chopper geometry, and the default the chopper
+    # factory uses) has a broken ``detector_tank_angle`` depends_on chain:
+    # missing ``_t0`` offset, stale ``117_`` prefix. Drop this pin once a file
+    # valid for both detectors and choppers is available
+    # (https://github.com/scipp/esslivedata/issues/962).
+    reduction_workflow[Filename[SampleRun]] = get_nexus_geometry_filename(
+        'bifrost', date=sc.datetime('2025-06-01T00:00:00')
+    )
     reduction_workflow[EmptyDetector[SampleRun]] = (
         reduction_workflow[EmptyDetector[SampleRun]]
         .map({NeXusName[NXdetector]: _detector_names})

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -28,6 +28,17 @@ from ess.livedata.parameter_models import EnergyEdges, QEdges
 
 from .streams_parsed import PARSED_STREAMS
 
+#: Disk choppers feeding the wavelength-LUT cascade, in beam order
+#: (source -> sample): pulse-shaping, frame-overlap, bandwidth.
+BIFROST_CHOPPERS = [
+    'pulse_shaping_chopper_1',
+    'pulse_shaping_chopper_2',
+    'frame_overlap_chopper_1',
+    'frame_overlap_chopper_2',
+    'bandwidth_chopper_1',
+    'bandwidth_chopper_2',
+]
+
 
 # Arc energies in meV
 class ArcEnergy(StrEnum):
@@ -208,6 +219,7 @@ instrument = Instrument(
     name='bifrost',
     detector_names=['unified_detector'],
     monitors=monitors,
+    choppers=BIFROST_CHOPPERS,
     streams=streams,
 )
 

--- a/src/ess/livedata/handlers/detector_data_handler.py
+++ b/src/ess/livedata/handlers/detector_data_handler.py
@@ -75,6 +75,7 @@ _registry = {
     'geometry-loki-2026-04-13.nxs': 'md5:5c4a6883cf34cee9836f543f4d70ae5c',
     'geometry-loki-2026-05-08.nxs': 'md5:4edc75ba015e7916dfc23e8d78f9cca6',
     'geometry-bifrost-2025-01-01.nxs': 'md5:ae3caa99dd56de9495b9321eea4e4fef',
+    'geometry-bifrost-2026-06-08.nxs': 'md5:31d0aa10243e29a14aac0655454ff205',
     'geometry-odin-2025-09-25.nxs': 'md5:5615a6203813b4ab84a191f7478ceb3c',
     'geometry-tbl-2025-12-03.nxs': 'md5:040a70659155eb386245755455ee3e62',
     'geometry-estia-2025-12-16.nxs': 'md5:07d33010189a50ee46ee5f649f848ca5',

--- a/src/ess/livedata/handlers/wavelength_lut_workflow.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow.py
@@ -39,6 +39,7 @@ from ess.reduce.nexus.types import (
     AnyRun,
     DiskChoppers,
     Filename,
+    Position,
     RawChoppers,
 )
 from ess.reduce.nexus.workflow import to_disk_choppers
@@ -302,6 +303,26 @@ def _make_workflow(pipeline: sciline.Pipeline) -> StreamProcessorWorkflow:
     )
 
 
+def _moderator_source_position(filename: str) -> sc.Variable | None:
+    """Neutron-source position when the file models the moderator as ``NXmoderator``.
+
+    essreduce takes the chopper-cascade reference from the file's unique
+    ``NXsource``. BIFROST instead labels the moderator ``NXmoderator`` and
+    reserves ``NXsource`` for accelerator metadata sitting at the origin, so
+    essreduce would measure flight distance from the accelerator and reject the
+    upstream choppers as lying behind the source. When an ``NXmoderator`` is
+    present, return its position to override the reference; otherwise return
+    ``None``, leaving essreduce's ``NXsource`` lookup in place (e.g. LOKI).
+    """
+    with snx.File(filename, definitions=snx.base_definitions()) as f:
+        moderators = f['entry/instrument'][snx.NXmoderator]
+        if not moderators:
+            return None
+        (group,) = moderators.values()
+        positions = snx.compute_positions(group[...], store_position='position')
+    return positions['position']
+
+
 def create_wavelength_lut_workflow(
     *,
     params: WavelengthLutParams,
@@ -319,6 +340,11 @@ def create_wavelength_lut_workflow(
     """
     pipeline = _build_pipeline(params)
     pipeline[Filename[AnyRun]] = nexus_filename
+    # Override the source position essreduce would load from NXsource when the
+    # real source is an NXmoderator; see _moderator_source_position.
+    source_position = _moderator_source_position(nexus_filename)
+    if source_position is not None:
+        pipeline[Position[snx.NXsource, AnyRun]] = source_position
     pipeline.insert(build_disk_choppers_provider(setpoint_keys))
     return _make_workflow(pipeline)
 

--- a/src/ess/livedata/scripts/make_geometry_nexus.py
+++ b/src/ess/livedata/scripts/make_geometry_nexus.py
@@ -15,6 +15,16 @@ def _copy_attributes(src: h5py.Group, dst: h5py.Group) -> None:
         dst.attrs[key] = value
 
 
+def _copy_depends_on(src: h5py.Group, dst: h5py.Group) -> None:
+    """Copy the ``depends_on`` dataset if present.
+
+    Components without placement in the instrument — such as event-only
+    backup monitors — carry no ``depends_on``.
+    """
+    if 'depends_on' in src:
+        src.copy('depends_on', dst)
+
+
 def _copy_detector_fields(
     src_group: h5py.Group, dst_group: h5py.Group, use_pixel_shape: bool
 ) -> None:
@@ -36,13 +46,13 @@ def _copy_detector_fields(
                 shuffle=True,
             )
             _copy_attributes(src_group[field], dst_group[field])
-    src_group.copy('depends_on', dst_group)
+    _copy_depends_on(src_group, dst_group)
     if use_pixel_shape and 'pixel_shape' in src_group:
         src_group.copy('pixel_shape', dst_group)
 
 
 def _copy_monitor_fields(src_group: h5py.Group, dst_group: h5py.Group) -> None:
-    src_group.copy('depends_on', dst_group)
+    _copy_depends_on(src_group, dst_group)
 
 
 def _nx_class(obj: h5py.Group | h5py.Dataset) -> str:
@@ -173,10 +183,14 @@ def _resolve_depends_on_chains(fin: h5py.File, fout: h5py.File) -> None:
             _copy_child(fin[parent_path or '/'], leaf, fout[parent_path or '/'])
 
 
+# NXmoderator alongside NXsource: BIFROST models the neutron source as an
+# NXmoderator (with NXsource reserved for accelerator metadata at the origin),
+# so its placement chain must be carried over like any other source's.
 _HANDLED_NX_CLASSES = (
     'NXdetector',
     'NXmonitor',
     'NXsource',
+    'NXmoderator',
     'NXsample',
     'NXtransformations',
     'NXdisk_chopper',
@@ -200,8 +214,8 @@ def write_minimal_geometry(
                 _copy_detector_fields(obj, dst, use_pixel_shape=use_pixel_shape)
             elif nx_class == 'NXmonitor':
                 _copy_monitor_fields(obj, dst)
-            elif nx_class in ('NXsource', 'NXsample'):
-                obj.copy('depends_on', dst)
+            elif nx_class in ('NXsource', 'NXmoderator', 'NXsample'):
+                _copy_depends_on(obj, dst)
             else:  # NXtransformations or NXdisk_chopper
                 for key in obj:
                     _copy_child(obj, key, dst)

--- a/tests/config/bifrost_wavelength_lut_test.py
+++ b/tests/config/bifrost_wavelength_lut_test.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Instrument-level integration test for BIFROST's chopper wavelength-LUT workflow.
+
+Exercises the spec-scope context bindings declared in ``bifrost/factories.py``
+flowing through ``JobFactory.create`` into the job's gating set and the
+workflow's ``set_context`` keys, against the real BIFROST geometry artifact.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import numpy as np
+import pytest
+import scipp as sc
+
+from ess.livedata.config.chopper import delay_setpoint_stream, speed_setpoint_stream
+from ess.livedata.config.instrument import instrument_registry
+from ess.livedata.config.instruments import get_config
+from ess.livedata.config.workflow_spec import JobId, WorkflowConfig
+from ess.livedata.core.job import JobData
+from ess.livedata.core.job_manager import JobFactory
+from ess.livedata.core.timestamp import Timestamp
+from ess.livedata.handlers.wavelength_lut_workflow_specs import (
+    CHOPPER_CASCADE_SOURCE,
+    WAVELENGTH_LUT_OUTPUT,
+)
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope='module')
+def bifrost():
+    get_config('bifrost')  # register instrument
+    instrument = instrument_registry['bifrost']
+    instrument.load_factories()
+    return instrument
+
+
+def _create_lut_job(bifrost) -> tuple:
+    workflow_id = next(
+        w for w in bifrost.workflow_factory if w.name == WAVELENGTH_LUT_OUTPUT
+    )
+    job_id = JobId(source_name=CHOPPER_CASCADE_SOURCE, job_number=uuid.uuid4())
+    config = WorkflowConfig.from_params(
+        workflow_id=workflow_id, job_id=job_id, params=None, aux_source_names=None
+    )
+    service = bifrost.workflow_factory.get_service(workflow_id)
+    return JobFactory(bifrost, service_name=service).create(
+        job_id=job_id, config=config
+    )
+
+
+def _nxlog(value: float, unit: str | None) -> sc.DataArray:
+    t = sc.epoch(unit='ns') + sc.arange('time', 3, unit='ns')
+    return sc.DataArray(
+        sc.full(value=value, sizes={'time': 3}, unit=unit), coords={'time': t}
+    )
+
+
+def test_spec_scope_bindings_define_gating_set(bifrost) -> None:
+    job = _create_lut_job(bifrost)
+    expected = {
+        stream(chopper)
+        for chopper in bifrost.choppers
+        for stream in (speed_setpoint_stream, delay_setpoint_stream)
+    }
+    # Nothing seen yet → every per-chopper setpoint stream gates the job.
+    assert job.missing_context(set()) == expected
+
+
+def test_chopper_lut_computes_from_context_and_trigger(bifrost) -> None:
+    job = _create_lut_job(bifrost)
+    aux = {}
+    for chopper in bifrost.choppers:
+        aux[speed_setpoint_stream(chopper)] = _nxlog(14.0, 'Hz')
+        aux[delay_setpoint_stream(chopper)] = _nxlog(0.0, 'ns')
+    data = JobData(
+        start_time=Timestamp.from_ns(0),
+        end_time=Timestamp.from_ns(1),
+        primary_data={CHOPPER_CASCADE_SOURCE: _nxlog(1.0, None)},
+        aux_data=aux,
+    )
+
+    reply, result = job.process(data, finalize=True)
+
+    assert not reply.has_error, reply.error_message
+    assert result is not None
+    assert result.error_message is None, result.error_message
+    lut = result.data[WAVELENGTH_LUT_OUTPUT]
+    assert lut.dims == ('distance', 'event_time_offset')
+    assert lut.unit == sc.units.angstrom
+    assert np.isfinite(lut.values).any()

--- a/tests/handlers/wavelength_lut_workflow_test.py
+++ b/tests/handlers/wavelength_lut_workflow_test.py
@@ -37,39 +37,49 @@ def _trigger() -> dict[str, sc.DataArray]:
     return {CHOPPER_CASCADE_SOURCE: sc.DataArray(sc.scalar(1))}
 
 
-def _write_chopper_nexus(path: Path, names: list[str], *, source_z: float = -25.0):
-    """Build a minimal NeXus file with NXdisk_chopper groups + NXsource.
+def _write_translation(group, z: float) -> None:
+    """Place ``group`` at ``z`` along the beam via a single translation chain."""
+    group.create_field('depends_on', sc.scalar('transformations/t1'))
+    transformations = group.create_class('transformations', snx.NXtransformations)
+    t1 = transformations.create_field('t1', sc.scalar(z, unit='m'))
+    t1.attrs['depends_on'] = '.'
+    t1.attrs['transformation_type'] = 'translation'
+    t1.attrs['vector'] = sc.vector([0.0, 0.0, 1.0]).value
+
+
+def _write_chopper_nexus(
+    path: Path,
+    names: list[str],
+    *,
+    source_z: float = -25.0,
+    moderator_z: float | None = None,
+):
+    """Build a minimal NeXus file with NXdisk_chopper groups + a neutron source.
 
     Static fields (slit_edges, radius, axle position) are populated; streamed
     quantities are length-0 NXlog placeholders, matching what
     ``make_geometry_nexus.py`` writes for real instruments. An empty ``names``
     yields a source-only file: the no-chopper geometry an instrument without
     choppers supplies.
+
+    By default the neutron source is a single ``NXsource`` at ``source_z``. When
+    ``moderator_z`` is given the file follows BIFROST's convention instead: the
+    ``NXsource`` is parked at the origin (accelerator metadata, position
+    irrelevant) and the real source is an ``NXmoderator`` at ``moderator_z``.
     """
     with snx.File(path, 'w') as root:
         entry = root.create_class('entry', snx.NXentry)
         instrument = entry.create_class('instrument', snx.NXinstrument)
 
         source = instrument.create_class('source', snx.NXsource)
-        source.create_field('depends_on', sc.scalar('transformations/t1'))
-        src_tr = source.create_class('transformations', snx.NXtransformations)
-        src_t1 = src_tr.create_field('t1', sc.scalar(source_z, unit='m'))
-        src_t1.attrs['depends_on'] = '.'
-        src_t1.attrs['transformation_type'] = 'translation'
-        src_t1.attrs['vector'] = sc.vector([0.0, 0.0, 1.0]).value
+        _write_translation(source, 0.0 if moderator_z is not None else source_z)
+        if moderator_z is not None:
+            moderator = instrument.create_class('moderator', snx.NXmoderator)
+            _write_translation(moderator, moderator_z)
 
         for i, name in enumerate(names):
             chop = instrument.create_class(name, snx.NXdisk_chopper)
-            chop.create_field('depends_on', sc.scalar('transformations/t1'))
-            transformations = chop.create_class(
-                'transformations', snx.NXtransformations
-            )
-            t1 = transformations.create_field(
-                't1', sc.scalar(-15.0 + 2.0 * i, unit='m')
-            )
-            t1.attrs['depends_on'] = '.'
-            t1.attrs['transformation_type'] = 'translation'
-            t1.attrs['vector'] = sc.vector([0.0, 0.0, 1.0]).value
+            _write_translation(chop, -15.0 + 2.0 * i)
             chop.create_field(
                 'slit_edges', sc.array(dims=['dim_0'], values=[0.0, 90.0], unit='deg')
             )
@@ -282,6 +292,25 @@ class TestMultiChopperWorkflow:
             params=params,
         )
         assert int(table.coords['pulse_stride'].value) == 1
+
+    def test_distance_measured_from_moderator_not_accelerator_source(
+        self, tmp_path: Path
+    ) -> None:
+        # BIFROST models the moderator as NXmoderator and reserves NXsource for
+        # accelerator metadata at the origin. essreduce keys the cascade
+        # reference off the unique NXsource, so measuring from it would place
+        # the upstream choppers behind the source (negative distance) and the
+        # cascade would reject them. The workflow resolves the source from the
+        # NXmoderator instead, so the table computes.
+        path = tmp_path / 'moderator_choppers.nxs'
+        _write_chopper_nexus(path, ['chopper1', 'chopper2'], moderator_z=-25.0)
+        table = _run_chopper_lut(
+            path,
+            ['chopper1', 'chopper2'],
+            {'chopper1': (-14.0, 0.0), 'chopper2': (-14.0, 0.0)},
+        )
+        assert table.dims == ('distance', 'event_time_offset')
+        assert np.isfinite(table.values).any()
 
     def test_missing_chopper_in_artifact_raises(self, tmp_path: Path) -> None:
         # A configured chopper absent from the geometry artifact is not validated

--- a/tests/make_geometry_nexus_test.py
+++ b/tests/make_geometry_nexus_test.py
@@ -52,6 +52,69 @@ def test_copies_detector_with_local_transformations(basic_nexus_file, tmp_path):
         assert ds.attrs['depends_on'] == '.'
 
 
+def test_copies_event_only_monitor_without_depends_on(tmp_path):
+    """A backup monitor carrying only event data has no ``depends_on``; the
+    geometry artifact must copy it without crashing on the missing chain."""
+    src = tmp_path / 'input.nxs'
+    with h5py.File(src, 'w') as f:
+        entry = f.create_group('entry')
+        entry.attrs['NX_class'] = 'NXentry'
+        inst = entry.create_group('instrument')
+        inst.attrs['NX_class'] = 'NXinstrument'
+        mon = inst.create_group('backup_monitor')
+        mon.attrs['NX_class'] = 'NXmonitor'
+        mon.create_group('events')
+
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(src, output)
+
+    with h5py.File(output, 'r') as f:
+        mon = f['entry/instrument/backup_monitor']
+        assert mon.attrs['NX_class'] == 'NXmonitor'
+        assert 'depends_on' not in mon
+
+
+def test_copies_moderator_depends_on(tmp_path):
+    """The neutron source may be modelled as ``NXmoderator`` (BIFROST's
+    convention) rather than ``NXsource``. Its ``depends_on`` chain must be
+    copied so the source position resolves in the artifact; dropping it leaves
+    the moderator at the origin and the chopper cascade measures flight
+    distances from the wrong point.
+    """
+    src = tmp_path / 'input.nxs'
+    with h5py.File(src, 'w') as f:
+        entry = f.create_group('entry')
+        entry.attrs['NX_class'] = 'NXentry'
+        inst = entry.create_group('instrument')
+        inst.attrs['NX_class'] = 'NXinstrument'
+        mod = inst.create_group('source')
+        mod.attrs['NX_class'] = 'NXmoderator'
+        mod.create_dataset(
+            'depends_on',
+            data='/entry/instrument/source/transformations/distance',
+        )
+        tr = mod.create_group('transformations')
+        tr.attrs['NX_class'] = 'NXtransformations'
+        ds = tr.create_dataset('distance', data=-160.0)
+        ds.attrs['transformation_type'] = 'translation'
+        ds.attrs['vector'] = [0.0, 0.0, 1.0]
+        ds.attrs['units'] = 'm'
+        ds.attrs['depends_on'] = '.'
+
+    output = tmp_path / 'output.nxs'
+    write_minimal_geometry(src, output)
+
+    with h5py.File(output, 'r') as f:
+        mod = f['entry/instrument/source']
+        assert mod.attrs['NX_class'] == 'NXmoderator'
+        assert mod['depends_on'][()].decode() == (
+            '/entry/instrument/source/transformations/distance'
+        )
+        ds = f['entry/instrument/source/transformations/distance']
+        assert ds[()] == pytest.approx(-160.0)
+        assert ds.attrs['depends_on'] == '.'
+
+
 @pytest.fixture
 def nexus_with_nxlog_chain(tmp_path):
     """NeXus file where a detector's depends_on chain passes through an NXlog


### PR DESCRIPTION
The substantive part here is the neutron-source handling. BIFROST models the real source as an `NXmoderator` ~162 m upstream and reserves `NXsource` for accelerator metadata pinned at the origin. essreduce keys the chopper-cascade reference off the unique `NXsource`, so it would measure flight distance from the accelerator and reject the upstream choppers as lying behind the source. Two fixes address this:
1. `make_geometry_nexus` now carries the `NXmoderator` placement chain into the artifact (it was silently dropping it)
2. the wavelength-LUT workflow resolves the source position from the `NXmoderator` when present, falling back to `NXsource` otherwise. The behaviour is convention-agnostic, so LOKI (source labelled `NXsource`) is unaffected.

This workflow-local fix leaves a latent trap for any other essreduce path that keys source position off `NXsource` for BIFROST (e.g. a detector `Ltotal` if the reduction ever leaves TOA mode); tracked in #989.

The geometry file's `detector_tank_angle` chain is still broken (missing `_t0` offset, stale group prefix), so detector geometry is pinned to the prior artifact while the choppers use the corrected one. The two collapse to a single file once a fixed source file is available (#962). The corrected `geometry-bifrost-2026-06-08.nxs` artifact has been re-uploaded to the `geometry-v0` release and the registry hash updated.
