### PR TITLE
Fix broken datetime axis when fitting range after zoom

### DIFF
--- a/src/ess/livedata/dashboard/plot_params.py
+++ b/src/ess/livedata/dashboard/plot_params.py
@@ -357,9 +357,26 @@ class TimeseriesDownsamplingParams(pydantic.BaseModel):
     )
 
 
+class TimeseriesScaleParams(pydantic.BaseModel):
+    """Axis scaling for the timeseries plotter.
+
+    The x-axis is always an absolute datetime axis, on which log scale is
+    meaningless (it would depend on the arbitrary epoch zero), so only the
+    y-axis scale is offered.
+    """
+
+    y_scale: PlotScale = pydantic.Field(
+        default=PlotScale.linear, description="Scale for y-axis", title="Y Axis Scale"
+    )
+
+
 class PlotParamsTimeseries(PlotDisplayParams1d):
     """Parameters for the timeseries plotter (downsampling + display)."""
 
+    plot_scale: TimeseriesScaleParams = pydantic.Field(
+        default_factory=TimeseriesScaleParams,
+        description="Scaling options for the plot axes.",
+    )
     downsampling: TimeseriesDownsamplingParams = pydantic.Field(
         default_factory=TimeseriesDownsamplingParams,
         description=_TIMESERIES_DOWNSAMPLING_DESCRIPTION,

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -927,11 +927,21 @@ class LinePlotter(Plotter):
     def from_timeseries_params(cls, params: PlotParamsTimeseries):
         """Create LinePlotter for the timeseries plotter, with downsampling on.
 
+        The x-axis is always datetime, so only the y-axis scale is configurable
+        (see ``TimeseriesScaleParams``); x is fixed to linear.
+
         Downsampling and update throttling live at the plotter rather than at
         the extractor: the subscription still pulls the full-history, and
         per-plot config can change without re-subscribing.
         """
-        instance = cls.from_display_params(params)
+        instance = cls(
+            layout_params=params.layout,
+            aspect_params=params.plot_aspect,
+            scale_opts=PlotScaleParams(y_scale=params.plot_scale.y_scale),
+            tick_params=params.ticks,
+            mode=params.line.mode,
+            errors=params.line.errors,
+        )
         instance._downsampling = params.downsampling
         return instance
 

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -139,6 +139,13 @@ def _finite_min_max(
     finite = values[mask]
     if finite.size == 0:
         return None
+    if np.issubdtype(finite.dtype, np.datetime64):
+        # Range targets are bare floats. For a datetime axis the agreed unit is
+        # epoch nanoseconds -- the unit ``range_hook`` reconstructs a datetime64
+        # against. Normalize here so that contract holds regardless of the
+        # source coord's datetime unit (and so ``float()`` does not choke on a
+        # non-ns datetime64 scalar, which converts to ``datetime.datetime``).
+        finite = finite.astype('datetime64[ns]').astype('int64')
     return float(finite.min()), float(finite.max())
 
 

--- a/src/ess/livedata/dashboard/range_hook.py
+++ b/src/ess/livedata/dashboard/range_hook.py
@@ -47,21 +47,19 @@ def _ordered_write(
     is above the current high, write the high first; otherwise write the low
     first.
 
-    On a datetime axis the float targets (epoch-ns; see
-    ``plots._finite_min_max``) are cast back to ``np.datetime64`` so Bokeh's
-    range patch does not mix incompatible numpy dtypes. ``datetime`` is decided
-    from the figure's axis type, not the current bound's dtype: after a zoom
-    the bound is an epoch-ms float, yet the axis is still datetime.
+    On a datetime axis the float targets are epoch *nanoseconds* by contract
+    (see ``plots._finite_min_max``); they are cast back to ``np.datetime64[ns]``
+    so Bokeh's range patch does not mix incompatible numpy dtypes. The unit is
+    fixed at ns rather than copied from the current bound: the target is an
+    ns count, so interpreting it in any other unit would corrupt the value.
+    ``datetime`` is decided from the figure's axis type, not the current bound's
+    dtype: after a zoom the bound is an epoch-ms float, yet the axis is still
+    datetime.
     """
     current_hi = getattr(model, hi_attr, None)
     if datetime:
-        unit = (
-            np.datetime_data(current_hi)[0]
-            if isinstance(current_hi, np.datetime64)
-            else 'ns'
-        )
-        lo_value: Any = np.datetime64(round(lo), unit)
-        hi_value: Any = np.datetime64(round(hi), unit)
+        lo_value: Any = np.datetime64(round(lo), 'ns')
+        hi_value: Any = np.datetime64(round(hi), 'ns')
         write_hi_first = current_hi is None or _to_ns_float(hi_value) >= _to_ns_float(
             current_hi
         )

--- a/src/ess/livedata/dashboard/range_hook.py
+++ b/src/ess/livedata/dashboard/range_hook.py
@@ -40,12 +40,14 @@ def _ordered_write(
 ) -> None:
     """Set ``(lo_attr, hi_attr)`` on ``model`` without ever inverting them.
 
-    Bokeh's ``Document.hold`` is imperative (paired with ``unhold``), not a
-    context manager, so we cannot batch the two writes into one PATCH-DOC
-    dispatch without owning the document state. Instead, order the writes so
-    ``lo <= hi`` holds after each individual property set: when the new high
-    is above the current high, write the high first; otherwise write the low
-    first.
+    The two writes are ordered so ``lo <= hi`` holds after each individual
+    property set: when the new high is above the current high, write the high
+    first; otherwise write the low first. This guards renders that run outside
+    a document hold, where each set dispatches its own PATCH-DOC and a stale
+    intermediate could momentarily invert the range. Per-tick autoscale writes
+    do run under ``session_updater._batched_update`` (``pn.io.hold`` +
+    ``doc.models.freeze``), which collapses both sets into one frame, so the
+    ordering is belt-and-suspenders there rather than load-bearing.
 
     On a datetime axis the float targets are epoch *nanoseconds* by contract
     (see ``plots._finite_min_max``); they are cast back to ``np.datetime64[ns]``
@@ -148,6 +150,9 @@ class RangeHandles:
         handle = cls.x_range(plot) if axis == 'x' else cls.y_range(plot)
         if handle is None:
             return False
+        # The bound-dtype check is a fallback for figures without introspectable
+        # axis state (test stubs, non-HoloViews figures): a ``datetime64`` bound
+        # implies a datetime axis even when ``_axis_is_datetime`` cannot see it.
         datetime = _axis_is_datetime(plot, axis) or isinstance(
             getattr(handle, 'end', None), np.datetime64
         )

--- a/src/ess/livedata/dashboard/range_hook.py
+++ b/src/ess/livedata/dashboard/range_hook.py
@@ -20,24 +20,23 @@ Axis = Literal['x', 'y', 'c']
 RangeTargets = dict[Axis, tuple[float, float]]
 
 
-def _coerce_to(value: float, reference: Any) -> Any:
-    """Coerce a float target to ``reference``'s type for assignment.
+def _to_ns_float(value: Any) -> float:
+    """Normalize a datetime range value to an epoch-nanosecond float.
 
-    Bokeh stores datetime axis ranges as ``np.datetime64`` (matching the unit
-    of the source coord). Range targets are computed in float space (epoch
-    counts for datetime coords; see ``plots._finite_min_max``), so on a
-    datetime axis a raw float would mix incompatible numpy dtypes -- both the
-    ordering comparison below and Bokeh's range patch raise a ``UFuncTypeError``
-    ('less_equal' loop missing for datetime64/float). Cast back to a datetime64
-    of the same unit so the value round-trips and stays comparable.
+    A datetime axis bound is ``np.datetime64`` on a fresh render but a plain
+    float after an interactive zoom: Bokeh holds datetime axes in epoch
+    *milliseconds* on the JS side, so a range that round-trips through the
+    browser comes back as an epoch-ms float. Normalize both forms to epoch-ns
+    floats so ordering comparisons never mix datetime64 with float (which
+    raises ``UFuncTypeError``).
     """
-    if isinstance(reference, np.datetime64):
-        return np.datetime64(round(value), np.datetime_data(reference)[0])
-    return value
+    if isinstance(value, np.datetime64):
+        return float(value.astype('datetime64[ns]').astype('int64'))
+    return value * 1e6  # epoch-ms -> epoch-ns
 
 
 def _ordered_write(
-    model: Any, lo: float, hi: float, lo_attr: str, hi_attr: str
+    model: Any, lo: float, hi: float, lo_attr: str, hi_attr: str, *, datetime: bool
 ) -> None:
     """Set ``(lo_attr, hi_attr)`` on ``model`` without ever inverting them.
 
@@ -47,17 +46,48 @@ def _ordered_write(
     ``lo <= hi`` holds after each individual property set: when the new high
     is above the current high, write the high first; otherwise write the low
     first.
+
+    On a datetime axis the float targets (epoch-ns; see
+    ``plots._finite_min_max``) are cast back to ``np.datetime64`` so Bokeh's
+    range patch does not mix incompatible numpy dtypes. ``datetime`` is decided
+    from the figure's axis type, not the current bound's dtype: after a zoom
+    the bound is an epoch-ms float, yet the axis is still datetime.
     """
     current_hi = getattr(model, hi_attr, None)
-    lo = _coerce_to(lo, current_hi)
-    hi = _coerce_to(hi, current_hi)
-    write_hi_first = current_hi is None or hi >= current_hi
-    if write_hi_first:
-        setattr(model, hi_attr, hi)
-        setattr(model, lo_attr, lo)
+    if datetime:
+        unit = (
+            np.datetime_data(current_hi)[0]
+            if isinstance(current_hi, np.datetime64)
+            else 'ns'
+        )
+        lo_value: Any = np.datetime64(round(lo), unit)
+        hi_value: Any = np.datetime64(round(hi), unit)
+        write_hi_first = current_hi is None or _to_ns_float(hi_value) >= _to_ns_float(
+            current_hi
+        )
     else:
-        setattr(model, lo_attr, lo)
-        setattr(model, hi_attr, hi)
+        lo_value, hi_value = lo, hi
+        write_hi_first = current_hi is None or hi >= current_hi
+    if write_hi_first:
+        setattr(model, hi_attr, hi_value)
+        setattr(model, lo_attr, lo_value)
+    else:
+        setattr(model, lo_attr, lo_value)
+        setattr(model, hi_attr, hi_value)
+
+
+def _axis_is_datetime(plot: Any, axis: Axis) -> bool:
+    """Whether ``plot``'s ``x``/``y`` axis renders datetime values.
+
+    Detected from the Bokeh figure's axis type rather than the current range
+    bound's dtype: the bound is ``np.datetime64`` only until the first
+    interactive zoom, after which Bokeh replaces it with an epoch-ms float.
+    """
+    from bokeh.models import DatetimeAxis
+
+    state = getattr(plot, 'state', None)
+    axes = getattr(state, 'xaxis' if axis == 'x' else 'yaxis', None)
+    return any(isinstance(a, DatetimeAxis) for a in axes or ())
 
 
 class RangeHandles:
@@ -115,10 +145,13 @@ class RangeHandles:
             mapper = cls.color_mapper(plot)
             if mapper is None:
                 return False
-            _ordered_write(mapper, lo, hi, 'low', 'high')
+            _ordered_write(mapper, lo, hi, 'low', 'high', datetime=False)
             return True
         handle = cls.x_range(plot) if axis == 'x' else cls.y_range(plot)
         if handle is None:
             return False
-        _ordered_write(handle, lo, hi, 'start', 'end')
+        datetime = _axis_is_datetime(plot, axis) or isinstance(
+            getattr(handle, 'end', None), np.datetime64
+        )
+        _ordered_write(handle, lo, hi, 'start', 'end', datetime=datetime)
         return True

--- a/tests/dashboard/plot_padding_test.py
+++ b/tests/dashboard/plot_padding_test.py
@@ -115,6 +115,39 @@ class TestFiniteMinMax:
     def test_log_returns_none_for_all_zero(self):
         assert _finite_min_max(np.array([0.0, 0.0, 0.0]), log=True) is None
 
+    def test_datetime_ns_returns_epoch_ns_floats(self):
+        t = np.array(
+            ['2026-06-23T00:00:00', '2026-06-23T00:00:02'], dtype='datetime64[ns]'
+        )
+        expected = (
+            float(t[0].astype('int64')),
+            float(t[1].astype('int64')),
+        )
+        assert _finite_min_max(t) == expected
+
+    def test_datetime_non_ns_normalized_to_epoch_ns(self):
+        # A non-ns coord must still yield epoch-ns floats (range_hook's contract)
+        # rather than crashing on ``float()`` of a datetime.datetime scalar.
+        t_us = np.array(
+            ['2026-06-23T00:00:00', '2026-06-23T00:00:02'], dtype='datetime64[us]'
+        )
+        t_ns = t_us.astype('datetime64[ns]')
+        expected = (
+            float(t_ns[0].astype('int64')),
+            float(t_ns[1].astype('int64')),
+        )
+        assert _finite_min_max(t_us) == expected
+
+    def test_datetime_drops_nat(self):
+        t = np.array(
+            ['2026-06-23T00:00:00', 'NaT', '2026-06-23T00:00:02'],
+            dtype='datetime64[ns]',
+        )
+        assert _finite_min_max(t) == (
+            float(t[0].astype('int64')),
+            float(t[2].astype('int64')),
+        )
+
     def test_log_ignores_nan(self):
         assert _finite_min_max(np.array([np.nan, -1.0, 2.0]), log=True) == (2.0, 2.0)
 

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -2469,6 +2469,35 @@ def _make_timeseries_data_array(n_points: int, period_s: float = 1.0) -> sc.Data
     )
 
 
+class TestTimeseriesScale:
+    """The timeseries x-axis is datetime, so x scale is not configurable."""
+
+    def test_x_scale_not_offered(self):
+        from ess.livedata.dashboard.plot_params import PlotParamsTimeseries
+
+        scale_fields = PlotParamsTimeseries.model_fields[
+            'plot_scale'
+        ].annotation.model_fields
+        assert 'x_scale' not in scale_fields
+        assert 'y_scale' in scale_fields
+
+    def test_x_axis_is_always_linear_y_configurable(self):
+        from ess.livedata.dashboard.plot_params import PlotParamsTimeseries
+
+        params = PlotParamsTimeseries.model_validate({'plot_scale': {'y_scale': 'log'}})
+        plotter = plots.LinePlotter.from_timeseries_params(params)
+        assert plotter._logx is False
+        assert plotter._logy is True
+
+    def test_stray_x_scale_in_config_is_ignored(self):
+        from ess.livedata.dashboard.plot_params import PlotParamsTimeseries
+
+        params = PlotParamsTimeseries.model_validate(
+            {'plot_scale': {'x_scale': 'log', 'y_scale': 'linear'}}
+        )
+        assert plots.LinePlotter.from_timeseries_params(params)._logx is False
+
+
 class TestTimeseriesDownsamplingAndThrottle:
     """Downsampling + throttle in LinePlotter.from_timeseries_params."""
 

--- a/tests/dashboard/range_hook_test.py
+++ b/tests/dashboard/range_hook_test.py
@@ -161,6 +161,36 @@ def test_write_datetime_axis_coerces_float_targets() -> None:
     assert handle.end == np.datetime64('2026-06-17T11:52:03', 'ns')
 
 
+def test_write_datetime_axis_after_zoom_uses_axis_type() -> None:
+    """After an interactive zoom Bokeh replaces the ``np.datetime64`` range
+    bounds with epoch-*millisecond* floats. The datetime nature must then be
+    read from the figure's ``DatetimeAxis``, not the bound's dtype, or the
+    epoch-ns float target would be written raw and interpreted as ms -- pushing
+    the axis to the far future and emptying it (issue #992)."""
+    import holoviews as hv
+
+    hv.extension('bokeh')
+    t = np.arange(
+        '2025-01-01T00:00:00',
+        '2025-01-01T00:10:00',
+        np.timedelta64(1, 'm'),
+        dtype='datetime64[ns]',
+    )
+    y = np.arange(len(t), dtype=float)
+    plot = hv.renderer('bokeh').get_plot(hv.Curve((t, y)))
+    xr = plot.handles['x_range']
+    # Simulate the post-zoom state: bounds are now epoch-ms floats.
+    xr.start = float(np.datetime64('2025-01-01T00:02:00', 'ms').astype('int64'))
+    xr.end = float(np.datetime64('2025-01-01T00:05:00', 'ms').astype('int64'))
+
+    target_lo = float(t.min())
+    target_hi = float(t.max())
+    assert RangeHandles.write(plot, 'x', target_lo, target_hi)
+
+    assert xr.start == np.datetime64('2025-01-01T00:00:00', 'ns')
+    assert xr.end == np.datetime64('2025-01-01T00:09:00', 'ns')
+
+
 def test_write_color_mapper_avoids_inversion() -> None:
     mapper = _StubColorMapper(low=0.0, high=1.0)
     RangeHandles.write(_StubPlot(color_mapper=mapper), 'c', 10.0, 11.0)

--- a/tests/dashboard/range_hook_test.py
+++ b/tests/dashboard/range_hook_test.py
@@ -146,8 +146,8 @@ def test_write_avoids_inverted_range_downward() -> None:
 
 def test_write_datetime_axis_coerces_float_targets() -> None:
     """Bokeh stores datetime ranges as ``np.datetime64``; range targets are
-    floats (epoch counts). The float must be cast back to a datetime64 of the
-    handle's unit so neither the ordering comparison nor Bokeh's range patch
+    floats (epoch nanoseconds by contract). The float must be cast back to a
+    datetime64[ns] so neither the ordering comparison nor Bokeh's range patch
     mixes datetime64/float (which raises ``UFuncTypeError``)."""
     lo_dt = np.datetime64('2026-06-17T11:52:00', 'ns')
     hi_dt = np.datetime64('2026-06-17T11:52:04', 'ns')


### PR DESCRIPTION
Fixes #992.

Clicking "Fit to range" on a timeseries plot while zoomed in emptied the time axis (no ticks). The axis's datetime nature was inferred from the current range bound's dtype, which is `np.datetime64` only until the first interactive zoom — Bokeh then replaces it with an epoch-millisecond float on the JS round-trip. The epoch-nanosecond float target was subsequently written raw and interpreted as milliseconds, pushing the range far into the future and leaving the axis without ticks.

The datetime nature is now read from the figure's `DatetimeAxis`, independent of the bound's current dtype, and both `datetime64` and epoch-ms-float bounds are normalized to epoch-ns before the ordering comparison so the range patch never mixes numpy dtypes.

## Also fixes: timeseries zoom freezing the browser

The same root cause had a second, more severe symptom: zooming a timeseries plot froze the browser with no server-side logs. The fit-to-range bug and the zoom-freeze are the same bug reached by two trigger paths. Timeseries plots use `LinePlotter`, whose x-axis autoscale toggle defaults to active, so the autoscale hook writes the x-range on every render (every live tick) — not just on a button click. After the first zoom flips the bound to an epoch-ms float, every subsequent tick wrote the raw epoch-ns target, which Bokeh read as epoch-ms and shoved the axis to roughly year 56,000,000. The user was then trapped interacting with a far-future datetime range at a magnitude where float64 resolution is hundreds of milliseconds, and Bokeh's datetime ticker churned over the degenerate configuration on each tick — pegging the browser. Reading the datetime nature from the axis type fixes both paths, so the corruption never occurs and the freeze cannot arise.

## Hardening: lock the epoch-ns contract for datetime range targets

Range targets are bare floats, and for a datetime axis both the producer and the consumer implicitly assumed epoch nanoseconds — an assumption that was only coincidentally safe. `_finite_min_max` did `float(finite.min())`, which works on a `datetime64[ns]` scalar but raises `TypeError` on any other datetime unit (a non-ns scalar converts to a `datetime.datetime`). It now normalizes datetime arrays to epoch-ns before the `float()`, so the contract holds regardless of the source coord's unit (NaT is still dropped). On the consumer side, `_ordered_write` re-derived the datetime unit from the current bound and applied it to the ns target — a non-ns bound would have stamped an ns count with the wrong unit (1000x off). It now always builds `datetime64[ns]`, matching the explicit contract.

## Also fixes: log scale on the timeseries x-axis

Setting the x-axis to log scale on a timeseries plot raised an unhandled error rendered into the plot (`UFuncTypeError`: no `greater` loop for `datetime64` vs a scalar, hit by the log filter's `values > 0`). Log scale on an absolute datetime axis is meaningless — it depends on the arbitrary epoch zero, and HoloViews renders a datetime axis on a linear scale regardless. Rather than silently ignoring the setting (which would leave the toggle visibly "on" while the axis stayed linear), the timeseries config no longer offers it: a dedicated scale model exposes only the y-axis scale, and the factory fixes the x-axis to linear. A stray `x_scale` in an existing config is ignored rather than erroring. The rare case of a generic line plot whose workflow emits a datetime coord with log-x configured is left to surface the error.

## Test plan
- [x] On a timeseries (datetime-axis) plot, zoom in, then click "Fit to range" — axis fits to the data and keeps its ticks.
- [x] On a timeseries plot, zoom in — the browser stays responsive (no freeze).
- [x] The timeseries plot config no longer shows an "X Axis Scale" control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
