### PR TITLE
Fix Bifrost unified detector view layout to match static grid

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -221,15 +221,18 @@ monitor_handle = register_monitor_workflow_specs(
 
 
 def _logical_view(obj: sc.Variable | sc.DataArray, source_name: str) -> sc.DataArray:
-    """Reshape raw detector data into ``(arc, detector_number_full)``.
+    """Reshape raw detector data into the 2D ``(arc/tube, channel/pixel)`` image.
 
-    ``arc`` is preserved so the spectrum transform can operate per-arc; the
-    remaining (tube, channel, pixel) axes are flattened into a single
-    ``detector_number_full`` dim of size 2700.
+    The 5 arcs and 3 tubes are stacked along the vertical ``arc/tube`` axis
+    (15 rows) and the 9 channels and 100 pixels along the horizontal
+    ``channel/pixel`` axis (900 columns). This matches the static triplet-bounds
+    grid overlaid on the unified detector view.
     """
     da = sc.DataArray(obj) if isinstance(obj, sc.Variable) else obj
-    return da.to(dtype='float32').flatten(
-        dims=('tube', 'channel', 'pixel'), to='detector_number_full'
+    return (
+        da.to(dtype='float32')
+        .flatten(dims=('arc', 'tube'), to='arc/tube')
+        .flatten(dims=('channel', 'pixel'), to='channel/pixel')
     )
 
 
@@ -248,16 +251,19 @@ def _bifrost_spectrum_transform(
 ) -> sc.DataArray:
     """Reshape the cumulative histogram into ``(arc, detector_number, toa)``.
 
-    ``detector_number_full`` is folded back into an outer ``detector_number``
-    axis of size ``pixels_per_tube`` and an inner ``subpixel`` axis;
-    summing over ``subpixel`` yields ``pixels_per_tube`` pixels per tube.
+    The 2D image stacks ``(arc, tube)`` and ``(channel, pixel)``; unfold both,
+    group adjacent pixels within a tube into ``pixels_per_tube`` output pixels
+    (summing the intervening ``subpixel`` axis), and flatten the per-arc
+    ``(tube, channel, pixel)`` axes into a single ``detector_number`` axis.
     """
     subpixel = 100 // params.pixels_per_tube
-    folded = histogram.fold(
-        'detector_number_full',
-        sizes={'detector_number': -1, 'subpixel': subpixel},
+    grouped = (
+        histogram.fold('arc/tube', sizes={'arc': 5, 'tube': 3})
+        .fold('channel/pixel', sizes={'channel': 9, 'pixel': 100})
+        .fold('pixel', sizes={'pixel': params.pixels_per_tube, 'subpixel': subpixel})
+        .sum('subpixel')
     )
-    return folded.sum('subpixel')
+    return grouped.flatten(dims=('tube', 'channel', 'pixel'), to='detector_number')
 
 
 # Register unified detector view with embedded spectrum output.

--- a/tests/bifrost_test.py
+++ b/tests/bifrost_test.py
@@ -218,3 +218,67 @@ class TestDetectorRatemeter:
 
         assert 'time' in result.coords
         assert result.coords['time'].unit == 'ns'
+
+
+class TestUnifiedDetectorViewLayout:
+    """Image and spectrum layouts the static triplet-bounds grid depends on.
+
+    The grid overlay (a second plot layer) is drawn in fixed coordinates for a
+    15-row by 900-column image, so the image must stack (arc, tube) as rows and
+    (channel, pixel) as columns. These pin that contract.
+    """
+
+    @pytest.fixture
+    def raw_detector(self) -> sc.DataArray:
+        """Raw combined detector data with dims (arc, tube, channel, pixel).
+
+        Values are bounded so float32 count sums stay exact for conservation.
+        """
+        n = 5 * 3 * 9 * 100
+        values = sc.array(
+            dims=['flat'],
+            values=[i % 7 for i in range(n)],
+            unit='counts',
+            dtype='float64',
+        )
+        return sc.DataArray(
+            values.fold('flat', sizes={'arc': 5, 'tube': 3, 'channel': 9, 'pixel': 100})
+        )
+
+    @pytest.fixture
+    def cumulative_histogram(self, raw_detector: sc.DataArray) -> sc.DataArray:
+        """Cumulative histogram: the 2D image with an appended spectral axis."""
+        image = specs._logical_view(raw_detector, 'unified_detector')
+        n_toa = 7
+        return sc.DataArray(
+            sc.broadcast(
+                image.data, dims=[*image.dims, 'toa'], shape=[*image.shape, n_toa]
+            ).copy()
+        )
+
+    def test_logical_view_produces_15x900_image(
+        self, raw_detector: sc.DataArray
+    ) -> None:
+        image = specs._logical_view(raw_detector, 'unified_detector')
+        assert image.dims == ('arc/tube', 'channel/pixel')
+        assert image.sizes == {'arc/tube': 15, 'channel/pixel': 900}
+
+    @pytest.mark.parametrize('pixels_per_tube', [1, 10, 100])
+    def test_spectrum_transform_groups_pixels_per_arc(
+        self, cumulative_histogram: sc.DataArray, pixels_per_tube: int
+    ) -> None:
+        params = specs.BifrostSpectrumParams(pixels_per_tube=pixels_per_tube)
+        spectrum = specs._bifrost_spectrum_transform(cumulative_histogram, params)
+        assert spectrum.dims == ('arc', 'detector_number', 'toa')
+        assert spectrum.sizes == {
+            'arc': 5,
+            'detector_number': 3 * 9 * pixels_per_tube,
+            'toa': cumulative_histogram.sizes['toa'],
+        }
+
+    def test_spectrum_transform_conserves_counts(
+        self, cumulative_histogram: sc.DataArray
+    ) -> None:
+        params = specs.BifrostSpectrumParams(pixels_per_tube=10)
+        spectrum = specs._bifrost_spectrum_transform(cumulative_histogram, params)
+        assert_identical(spectrum.sum().data, cumulative_histogram.sum().data)


### PR DESCRIPTION
## Problem

The Bifrost unified detector view rendered as 5 rows by 2700 columns, so the data overflowed the grid horizontally and showed only the 5 arcs as rows. The static triplet-bounds grid, overlaid as a second plot layer, is drawn for a 15×900 image (5 arcs × 3 tubes stacked as rows, 9 channels × 100 pixels as columns), so it no longer lined up with the data.

## Cause

The shared 2D logical view flattened `(tube, channel, pixel)` into a single 2700-wide axis while preserving only `arc`. This regressed in the spectrum-view unification (#884), which adopted that layout to make the per-arc spectrum fold trivial but left the image incompatible with the grid. The detector geometry and stream indexing were unchanged.

## Fix

Restore the `(arc/tube, channel/pixel)` = 15×900 layout for the image, and unfold the shared cumulative histogram from that layout in the spectrum transform. The spectrum view still produces `(arc, detector_number, toa)` with the same per-tube pixel grouping, and counts are conserved.

## Test plan

- [x] Image is 15×900 and the spectrum is `(arc, detector_number, toa)` across all `pixels_per_tube` values; counts conserved (unit checks)
- [x] Existing Bifrost, logical-view, detector-view-spec, and detector-data tests pass
- [x] Grid overlay aligns with the data in the live Bifrost unified detector view
