### PR TITLE
Stamp ROI requests with epoch-0 timestamp to avoid event-time batcher delay

### DIFF
--- a/src/ess/livedata/dashboard/roi_publisher.py
+++ b/src/ess/livedata/dashboard/roi_publisher.py
@@ -8,6 +8,7 @@ from ..config.models import PolygonROI, RectangleROI
 from ..config.roi_names import ROIGeometry
 from ..config.workflow_spec import JobId
 from ..core.message import Message, MessageSink, StreamId, StreamKind
+from ..core.timestamp import Timestamp
 
 logger = structlog.get_logger(__name__)
 
@@ -53,7 +54,14 @@ class ROIPublisher:
 
         data_array = geometry.roi_class.to_concatenated_data_array(rois)
 
-        msg = Message(value=data_array, stream=stream_id)
+        # ROI requests carry no meaningful event-time: the selection applies to
+        # data accumulated since run start, regardless of when the request was made.
+        # Stamp at epoch 0 so the event-time message batcher treats the request as
+        # already-current and applies it to the next processed window, instead of
+        # holding it until the data watermark catches up to wall-clock-now.
+        msg = Message(
+            value=data_array, stream=stream_id, timestamp=Timestamp.from_ns(0)
+        )
         self._sink.publish_messages([msg])
 
         if rois:

--- a/tests/dashboard/roi_publisher_test.py
+++ b/tests/dashboard/roi_publisher_test.py
@@ -34,6 +34,25 @@ def test_roi_publisher_publishes_single_roi():
     assert 'roi_index' in msg.value.coords
 
 
+def test_roi_publisher_stamps_request_with_epoch_zero():
+    """ROI requests are clock-independent and carry the epoch-0 sentinel.
+
+    This lets the event-time message batcher apply the selection to the current
+    window instead of holding it until the data watermark reaches wall-clock-now.
+    """
+    sink = FakeMessageSink()
+    publisher = ROIPublisher(sink=sink)
+    job_id = JobId(source_name='detector1', job_number=uuid.uuid4())
+    roi = RectangleROI(
+        x=Interval(min=1.0, max=5.0, unit=None),
+        y=Interval(min=2.0, max=6.0, unit=None),
+    )
+
+    publisher.publish(job_id, rois={0: roi}, geometry=RECT_GEOMETRY)
+
+    assert sink.messages[0].timestamp.to_ns() == 0
+
+
 def test_roi_publisher_publishes_multiple_rois():
     sink = FakeMessageSink()
     publisher = ROIPublisher(sink=sink)


### PR DESCRIPTION
## Summary

ROI requests were stamped with the dashboard's wall-clock time and routed through the event-time message batcher, which orders messages by data event-time. When the live detector stream's event-time trails wall-clock — as on the deployed LoKI `detector_data` service, where ~10 s of DAQ pipeline lag was observed — the request was parked in the batcher's future buffer until the data watermark caught up. This delayed the ROI readback (and made live plots look stale) by roughly that lag, independent of load and unaffected by restarts.

ROI requests carry no meaningful event-time: the selection applies to data accumulated since run start, and `LatestValueHandler` discards the message timestamp. Stamping the request at epoch 0 makes the batcher treat it as already-current and apply it at the next batch close. Result timestamps are unaffected — they derive from the data batch's event-time window, not the request. Confirmed batcher-agnostic: an epoch-0 request lands in the current / non-gated bucket and is delivered at the next close under both `SimpleMessageBatcher` and the optional `RateAwareMessageBatcher`, never the future-hold path.

This is the dashboard-side fix; the `ns=0` value applied as a live diagnostic on the deployed dashboard already exhibits the corrected behaviour.

## Test plan

- [x] `roi_publisher` unit tests, including a new regression test asserting the epoch-0 stamp
- [x] Manual: draw/move an ROI on a live (lagging) detector view and confirm the readback updates within ~1–2 s rather than ~10 s
