### PR TITLE
Add since_start output stream for monitor totals

### DIFF
--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -254,16 +254,35 @@ class PlottingController:
 
 
 def output_view_supports_windowing(workflow_spec: WorkflowSpec, view_name: str) -> bool:
-    """Return whether a window-mode choice (latest/window) is meaningful.
+    """Return whether the window controls (mode, duration, aggregation) apply.
 
-    Windowing is meaningful when the view exposes a ``per_update`` stream.
-    Views that are cumulative-only (e.g. ``I(Q)``) lock the mode to
-    ``since_start``.
+    Windowing applies when the view exposes a ``per_update`` stream: the window
+    duration aggregates a span of that stream, independent of whether a
+    ``since_start`` stream also exists. Cumulative-only views (e.g. ``I(Q)``)
+    have no per-update stream to window over, so the controls are hidden and the
+    view locks to ``since_start``.
+
+    Offering ``since_start`` mode on a view that lacks a cumulative stream is
+    rejected at config time (see :func:`since_start_available`), not by hiding
+    the controls -- that would also remove the still-meaningful duration control.
     """
     view = workflow_spec.get_output_view(view_name)
     if view is None:
         return True
     return 'per_update' in view.streams
+
+
+def since_start_available(workflow_spec: WorkflowSpec, view_name: str) -> bool:
+    """Return whether ``since_start`` mode resolves to a real cumulative stream.
+
+    ``False`` for per-update-only views, where selecting ``since_start`` would
+    silently fall back to the per-update stream (see ``OutputView.field_for``).
+    Permissive for unknown views.
+    """
+    view = workflow_spec.get_output_view(view_name)
+    if view is None:
+        return True
+    return 'since_start' in view.streams
 
 
 def create_extractors_from_params(

--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -1229,6 +1229,9 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
         if self._plotter_selection is None:
             return
 
+        if not self._validate_window_mode(params):
+            return
+
         # Create primary data source
         primary_source = DataSourceConfig(
             workflow_id=self._plotter_selection.workflow_id,
@@ -1262,6 +1265,33 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
             params=params,
             supports_windowing=self._supports_windowing,
         )
+
+    def _validate_window_mode(
+        self, params: pydantic.BaseModel | dict[str, Any]
+    ) -> bool:
+        """Reject ``since_start`` mode on views without a cumulative stream.
+
+        Returns ``True`` if the configuration may proceed. Otherwise shows an
+        error and returns ``False`` so the modal stays open.
+        """
+        from ess.livedata.dashboard.plot_params import WindowMode
+        from ess.livedata.dashboard.plotting_controller import since_start_available
+
+        window = getattr(params, 'window', None)
+        if window is None or window.mode is not WindowMode.since_start:
+            return True
+        if self._plotter_selection is None:
+            return True
+        spec = self._workflow_registry.get(self._plotter_selection.workflow_id)
+        if spec is None or since_start_available(
+            spec, self._plotter_selection.view_name
+        ):
+            return True
+        show_error(
+            "'Since run start' is not available for this output: it has no "
+            "cumulative stream. Choose 'Latest update'."
+        )
+        return False
 
 
 class PlotConfigModal:

--- a/src/ess/livedata/handlers/accumulation_mode.py
+++ b/src/ess/livedata/handlers/accumulation_mode.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Accumulation-mode marker types shared across workflows.
+
+These markers parametrize generic Sciline output types so a single provider
+serves both the run-cumulative and per-update views of a quantity. The window
+mode selected in the dashboard then picks which view to subscribe to.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+
+class Current:
+    """Marker type for window accumulation (clears after finalize)."""
+
+
+class Cumulative:
+    """Marker type for cumulative accumulation (accumulates forever)."""
+
+
+AccumulationMode = TypeVar('AccumulationMode', Current, Cumulative)
+"""Type variable for accumulation mode, constrained to Current or Cumulative."""

--- a/src/ess/livedata/handlers/detector_view/types.py
+++ b/src/ess/livedata/handlers/detector_view/types.py
@@ -11,13 +11,17 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, NewType, TypeVar
+from typing import TYPE_CHECKING, Literal, NewType
 
 import sciline
 import scipp as sc
 
+from ..accumulation_mode import AccumulationMode, Cumulative, Current
+
 if TYPE_CHECKING:
     from ..detector_view_specs import SpectrumViewSpec
+
+__all__ = ['AccumulationMode', 'Cumulative', 'Current']
 
 # Coordinate mode for detector view workflow
 CoordinateMode = Literal['toa', 'tof', 'wavelength']
@@ -27,19 +31,6 @@ CoordinateMode = Literal['toa', 'tof', 'wavelength']
 - 'tof': Time-of-flight (uses GenericTofWorkflow, TofDetector)
 - 'wavelength': Wavelength (uses GenericTofWorkflow, WavelengthDetector) - future
 """
-
-
-# Accumulation mode marker types
-class Current:
-    """Marker type for window accumulation (clears after finalize)."""
-
-
-class Cumulative:
-    """Marker type for cumulative accumulation (accumulates forever)."""
-
-
-AccumulationMode = TypeVar('AccumulationMode', Current, Cumulative)
-"""Type variable for accumulation mode, constrained to Window or Cumulative."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ess/livedata/handlers/monitor_workflow.py
+++ b/src/ess/livedata/handlers/monitor_workflow.py
@@ -21,16 +21,16 @@ from ess.reduce.unwrap import GenericUnwrapWorkflow, LookupTableFilename
 from ess.reduce.unwrap.types import LookupTableRelativeErrorThreshold, WavelengthMonitor
 from scippnexus import NXmonitor
 
+from .accumulation_mode import AccumulationMode, Cumulative, Current
 from .geometry_signal import geometry_signal
 from .monitor_workflow_types import (
-    CumulativeMonitorHistogram,
+    AccumulatedMonitorHistogram,
     HistogramEdges,
     HistogramRangeHigh,
     HistogramRangeLow,
     MonitorCountsInRange,
     MonitorCountsTotal,
     MonitorHistogram,
-    WindowMonitorHistogram,
 )
 
 MONITOR_TRANSFORM = 'monitor_transform'
@@ -130,31 +130,39 @@ def histogram_wavelength_monitor(
     return MonitorHistogram(_histogram_monitor(data, edges, 'wavelength', geometry))
 
 
-def cumulative_view(hist: MonitorHistogram) -> CumulativeMonitorHistogram:
-    """Identity transform for routing to cumulative accumulator."""
-    return CumulativeMonitorHistogram(hist)
+def accumulated_monitor_histogram(
+    hist: MonitorHistogram,
+) -> AccumulatedMonitorHistogram[AccumulationMode]:
+    """Route the histogram to the accumulation-mode-specific accumulator.
+
+    The histogram is computed once and accumulated differently based on the
+    accumulation mode type parameter (cumulative vs window). Sciline
+    instantiates this provider for each concrete mode.
+    """
+    return AccumulatedMonitorHistogram[AccumulationMode](hist)
 
 
-def window_view(hist: MonitorHistogram) -> WindowMonitorHistogram:
-    """Identity transform for routing to window accumulator."""
-    return WindowMonitorHistogram(hist)
-
-
-def counts_total(hist: WindowMonitorHistogram) -> MonitorCountsTotal:
-    """Total counts in window."""
-    return MonitorCountsTotal(hist.sum())
+def counts_total(
+    hist: AccumulatedMonitorHistogram[AccumulationMode],
+) -> MonitorCountsTotal[AccumulationMode]:
+    """Total counts, for the given accumulation mode."""
+    return MonitorCountsTotal[AccumulationMode](hist.sum())
 
 
 def counts_in_range(
-    hist: WindowMonitorHistogram, low: HistogramRangeLow, high: HistogramRangeHigh
-) -> MonitorCountsInRange:
-    """Counts within range filter in window."""
+    hist: AccumulatedMonitorHistogram[AccumulationMode],
+    low: HistogramRangeLow,
+    high: HistogramRangeHigh,
+) -> MonitorCountsInRange[AccumulationMode]:
+    """Counts within range filter, for the given accumulation mode."""
     dim = hist.dim
     # Convert range to histogram coordinate unit
     coord_unit = hist.coords[dim].unit
     low_converted = low.to(unit=coord_unit)
     high_converted = high.to(unit=coord_unit)
-    return MonitorCountsInRange(hist[dim, low_converted:high_converted].sum())
+    return MonitorCountsInRange[AccumulationMode](
+        hist[dim, low_converted:high_converted].sum()
+    )
 
 
 def build_monitor_workflow(
@@ -188,8 +196,7 @@ def build_monitor_workflow(
         raise ValueError(f"Unsupported coordinate mode: {coordinate_mode}")
 
     # Add downstream providers
-    workflow.insert(cumulative_view)
-    workflow.insert(window_view)
+    workflow.insert(accumulated_monitor_histogram)
     workflow.insert(counts_total)
     workflow.insert(counts_in_range)
 
@@ -296,9 +303,8 @@ def create_monitor_workflow(
         workflow[LookupTableFilename] = lookup_table_filename
         workflow[LookupTableRelativeErrorThreshold] = {source_name: float('inf')}
 
-    # Only accumulate CumulativeMonitorHistogram and WindowMonitorHistogram.
-    # MonitorCountsTotal and MonitorCountsInRange are computed from
-    # WindowMonitorHistogram during finalize, not accumulated separately.
+    # Only the histogram is accumulated; the scalar totals are derived from the
+    # accumulated histogram per mode during finalize, not accumulated separately.
     cumulative, window = make_no_copy_accumulator_pair(reset_coord=reset_coord)
     return StreamProcessorWorkflow(
         workflow,
@@ -308,14 +314,16 @@ def create_monitor_workflow(
         # WavelengthMonitor.
         dynamic_keys={source_name: NeXusData[NXmonitor, SampleRun]},
         target_keys={
-            'cumulative': CumulativeMonitorHistogram,
-            'current': WindowMonitorHistogram,
-            'counts_total': MonitorCountsTotal,
-            'counts_in_toa_range': MonitorCountsInRange,
+            'cumulative': AccumulatedMonitorHistogram[Cumulative],
+            'current': AccumulatedMonitorHistogram[Current],
+            'counts_total': MonitorCountsTotal[Current],
+            'counts_in_toa_range': MonitorCountsInRange[Current],
+            'counts_total_cumulative': MonitorCountsTotal[Cumulative],
+            'counts_in_toa_range_cumulative': MonitorCountsInRange[Cumulative],
         },
         accumulators={
-            CumulativeMonitorHistogram: cumulative,
-            WindowMonitorHistogram: window,
+            AccumulatedMonitorHistogram[Cumulative]: cumulative,
+            AccumulatedMonitorHistogram[Current]: window,
         },
         window_outputs=['current', 'counts_total', 'counts_in_toa_range'],
     )

--- a/src/ess/livedata/handlers/monitor_workflow_specs.py
+++ b/src/ess/livedata/handlers/monitor_workflow_specs.py
@@ -161,16 +161,27 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
         OutputView(
             name='total_counts',
             title='Total',
-            streams={'per_update': 'counts_total'},
-            description='Total number of monitor events per update interval.',
+            streams={
+                'since_start': 'counts_total_cumulative',
+                'per_update': 'counts_total',
+            },
+            description=(
+                'Total number of monitor events. With "since run start" shows '
+                'the accumulated total; with "latest update" or a window, shows '
+                'recent counts.'
+            ),
         ),
         OutputView(
             name='total_in_range',
             title='Total in range',
-            streams={'per_update': 'counts_in_toa_range'},
+            streams={
+                'since_start': 'counts_in_toa_range_cumulative',
+                'per_update': 'counts_in_toa_range',
+            },
             description=(
-                'Number of monitor events within the configured range filter '
-                'per update interval.'
+                'Number of monitor events within the configured range filter. '
+                'With "since run start" shows the accumulated total; with '
+                '"latest update" or a window, shows recent counts.'
             ),
         ),
     )
@@ -225,6 +236,18 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'Number of monitor events within the configured range filter '
             'for the latest update interval only. Resets each update interval.'
         ),
+    )
+    counts_total_cumulative: sc.DataArray = pydantic.Field(
+        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
+        title='Total',
+        description='Total number of monitor events accumulated since the start '
+        'of the run.',
+    )
+    counts_in_toa_range_cumulative: sc.DataArray = pydantic.Field(
+        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
+        title='Total in range',
+        description='Number of monitor events within the configured range filter '
+        'accumulated since the start of the run.',
     )
 
 

--- a/src/ess/livedata/handlers/monitor_workflow_types.py
+++ b/src/ess/livedata/handlers/monitor_workflow_types.py
@@ -4,22 +4,48 @@
 
 from typing import NewType
 
+import sciline
 import scipp as sc
+
+from .accumulation_mode import AccumulationMode
 
 # Input type: Use standard NeXusData[NXmonitor, SampleRun] from ess.reduce
 # The specific monitor is determined by NeXusName[NXmonitor] = source_name
 # Same pattern as detector workflows use NeXusName[NXdetector] = source_name
 
-# Intermediate type (computed once, routed to two accumulators)
+# Intermediate type (computed once, routed to both accumulators)
 MonitorHistogram = NewType('MonitorHistogram', sc.DataArray)
 
-# Output types (identity transforms for routing to different accumulators)
-CumulativeMonitorHistogram = NewType('CumulativeMonitorHistogram', sc.DataArray)
-WindowMonitorHistogram = NewType('WindowMonitorHistogram', sc.DataArray)
 
-# Ratemeter outputs (derived from window histogram)
-MonitorCountsTotal = NewType('MonitorCountsTotal', sc.DataArray)
-MonitorCountsInRange = NewType('MonitorCountsInRange', sc.DataArray)
+class AccumulatedMonitorHistogram(
+    sciline.Scope[AccumulationMode, sc.DataArray],
+    sc.DataArray,  # type: ignore[misc]
+):
+    """Monitor histogram parametrized by accumulation mode.
+
+    - AccumulatedMonitorHistogram[Cumulative]: Accumulated forever
+      (EternalAccumulator)
+    - AccumulatedMonitorHistogram[Current]: Current window only (clears
+      after finalize)
+    """
+
+
+class MonitorCountsTotal(
+    sciline.Scope[AccumulationMode, sc.DataArray],
+    sc.DataArray,  # type: ignore[misc]
+):
+    """Total monitor counts as 0D scalar, parametrized by accumulation mode."""
+
+
+class MonitorCountsInRange(
+    sciline.Scope[AccumulationMode, sc.DataArray],
+    sc.DataArray,  # type: ignore[misc]
+):
+    """Monitor counts within configured range as 0D scalar.
+
+    Parametrized by accumulation mode.
+    """
+
 
 # Configuration types (mode-agnostic names)
 HistogramEdges = NewType('HistogramEdges', sc.Variable)

--- a/tests/dashboard/plotting_controller_test.py
+++ b/tests/dashboard/plotting_controller_test.py
@@ -17,6 +17,7 @@ from ess.livedata.dashboard.data_service import DataService
 from ess.livedata.dashboard.plotting_controller import (
     PlottingController,
     output_view_supports_windowing,
+    since_start_available,
 )
 from ess.livedata.dashboard.stream_manager import StreamManager
 
@@ -491,7 +492,7 @@ class TestOverlayPatterns:
 
 
 class TestOutputViewSupportsWindowing:
-    def test_true_when_view_has_per_update_stream(self) -> None:
+    def test_true_when_view_has_both_streams(self) -> None:
         from typing import ClassVar
 
         from ess.livedata.config.workflow_spec import OutputView
@@ -559,6 +560,37 @@ class TestOutputViewSupportsWindowing:
         )
         assert output_view_supports_windowing(spec, 'i_of_q') is False
 
+    def test_true_for_per_update_only_view(self) -> None:
+        # A per_update-only view still supports the duration/aggregation controls;
+        # the since_start mode is rejected at config time, not by hiding controls.
+        from typing import ClassVar
+
+        from ess.livedata.config.workflow_spec import OutputView
+
+        class Outputs(WorkflowOutputsBase):
+            output_views: ClassVar[tuple[OutputView, ...]] = (
+                OutputView(
+                    name='total',
+                    title='Total',
+                    streams={'per_update': 'counts_total'},
+                ),
+            )
+            counts_total: sc.DataArray = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
+            )
+
+        spec = WorkflowSpec(
+            instrument='test',
+            name='wf',
+            version=1,
+            title='T',
+            description='D',
+            outputs=Outputs,
+            params=None,
+            group=REDUCTION,
+        )
+        assert output_view_supports_windowing(spec, 'total') is True
+
     def test_true_when_view_unknown(self) -> None:
         class Outputs(WorkflowOutputsBase):
             result: sc.DataArray = pydantic.Field(title='Result')
@@ -577,6 +609,63 @@ class TestOutputViewSupportsWindowing:
         assert output_view_supports_windowing(spec, 'result') is False
         # Unknown view name → True (be permissive).
         assert output_view_supports_windowing(spec, 'nonexistent') is True
+
+
+class TestSinceStartAvailable:
+    def _spec(self, outputs: type[WorkflowOutputsBase]) -> WorkflowSpec:
+        return WorkflowSpec(
+            instrument='test',
+            name='wf',
+            version=1,
+            title='T',
+            description='D',
+            outputs=outputs,
+            params=None,
+            group=REDUCTION,
+        )
+
+    def test_true_when_view_has_since_start_stream(self) -> None:
+        from typing import ClassVar
+
+        from ess.livedata.config.workflow_spec import OutputView
+
+        class Outputs(WorkflowOutputsBase):
+            output_views: ClassVar[tuple[OutputView, ...]] = (
+                OutputView(
+                    name='total',
+                    title='Total',
+                    streams={'since_start': 'cumulative', 'per_update': 'current'},
+                ),
+            )
+            cumulative: sc.DataArray = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
+            )
+            current: sc.DataArray = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
+            )
+
+        spec = self._spec(Outputs)
+        assert since_start_available(spec, 'total') is True
+
+    def test_false_for_per_update_only_view(self) -> None:
+        from typing import ClassVar
+
+        from ess.livedata.config.workflow_spec import OutputView
+
+        class Outputs(WorkflowOutputsBase):
+            output_views: ClassVar[tuple[OutputView, ...]] = (
+                OutputView(
+                    name='total', title='Total', streams={'per_update': 'counts_total'}
+                ),
+            )
+            counts_total: sc.DataArray = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
+            )
+
+        spec = self._spec(Outputs)
+        assert since_start_available(spec, 'total') is False
+        # Unknown view name → permissive.
+        assert since_start_available(spec, 'nonexistent') is True
 
 
 class TestCreateExtractorsFromParams:

--- a/tests/handlers/monitor_workflow_test.py
+++ b/tests/handlers/monitor_workflow_test.py
@@ -18,29 +18,29 @@ from ess.livedata.config.stream import ChainPatchBinding
 from ess.livedata.config.value_log import ValueLog
 from ess.livedata.config.workflow_spec import JobId
 from ess.livedata.core.timestamp import Timestamp
+from ess.livedata.handlers.accumulation_mode import Cumulative, Current
 from ess.livedata.handlers.accumulators import make_no_copy_accumulator_pair
 from ess.livedata.handlers.detector_view_specs import CoordinateModeSettings
 from ess.livedata.handlers.monitor_workflow import (
     MONITOR_TRANSFORM,
+    accumulated_monitor_histogram,
     build_monitor_workflow,
     counts_in_range,
     counts_total,
     create_monitor_workflow,
-    cumulative_view,
     histogram_raw_monitor,
     histogram_wavelength_monitor,
-    window_view,
 )
 from ess.livedata.handlers.monitor_workflow_specs import (
     MonitorDataParams,
     register_monitor_workflow_specs,
 )
 from ess.livedata.handlers.monitor_workflow_types import (
+    AccumulatedMonitorHistogram,
     HistogramEdges,
     HistogramRangeHigh,
     HistogramRangeLow,
     MonitorHistogram,
-    WindowMonitorHistogram,
 )
 from ess.livedata.parameter_models import (
     TimeUnit,
@@ -214,25 +214,22 @@ class TestMonitorWorkflowProviders:
         assert result.dims == ('time_of_arrival',)
         assert result.sum().value == 10.0
 
-    def test_cumulative_view_returns_same_data(self):
+    def test_accumulated_monitor_histogram_returns_same_data(self):
         hist = sc.DataArray(sc.array(dims=['x'], values=[1.0, 2.0], unit='counts'))
-        result = cumulative_view(MonitorHistogram(hist))
+        result = accumulated_monitor_histogram(MonitorHistogram(hist))
         assert sc.identical(result, hist)
 
-    def test_window_view_returns_same_data(self):
-        hist = sc.DataArray(sc.array(dims=['x'], values=[1.0, 2.0], unit='counts'))
-        result = window_view(MonitorHistogram(hist))
-        assert sc.identical(result, hist)
-
-    def test_counts_total(self):
+    @pytest.mark.parametrize('mode', [Current, Cumulative])
+    def test_counts_total(self, mode):
         hist = sc.DataArray(
             sc.array(dims=['time_of_arrival'], values=[1.0, 2.0, 3.0], unit='counts')
         )
-        result = counts_total(WindowMonitorHistogram(hist))
+        result = counts_total(AccumulatedMonitorHistogram[mode](hist))
         assert result.value == 6.0
         assert result.unit == 'counts'
 
-    def test_counts_in_range(self):
+    @pytest.mark.parametrize('mode', [Current, Cumulative])
+    def test_counts_in_range(self, mode):
         edges = sc.linspace('time_of_arrival', 0, 10, num=6, unit='ns')
         hist = sc.DataArray(
             sc.array(dims=['time_of_arrival'], values=[1.0, 2.0, 3.0, 4.0, 5.0]),
@@ -241,7 +238,7 @@ class TestMonitorWorkflowProviders:
         # Select bins 1-3 (values 2.0, 3.0, 4.0)
         low = HistogramRangeLow(sc.scalar(2, unit='ns'))
         high = HistogramRangeHigh(sc.scalar(8, unit='ns'))
-        result = counts_in_range(WindowMonitorHistogram(hist), low, high)
+        result = counts_in_range(AccumulatedMonitorHistogram[mode](hist), low, high)
         assert result.value == 9.0  # 2 + 3 + 4
 
 
@@ -381,12 +378,16 @@ class TestMonitorWorkflowIntegration:
         assert 'current' in results
         assert 'counts_total' in results
         assert 'counts_in_toa_range' in results
+        assert 'counts_total_cumulative' in results
+        assert 'counts_in_toa_range_cumulative' in results
 
         # Check counts
         assert results['cumulative'].sum().value == 5.0
         assert results['current'].sum().value == 5.0
         assert results['counts_total'].value == 5.0
         assert results['counts_in_toa_range'].value == 5.0
+        assert results['counts_total_cumulative'].value == 5.0
+        assert results['counts_in_toa_range_cumulative'].value == 5.0
 
     def test_time_coords_on_delta_outputs(self, toa_edges, sample_binned_events):
         """Delta outputs get time, start_time, end_time coords."""
@@ -439,6 +440,9 @@ class TestMonitorWorkflowIntegration:
         assert 'time' not in results['cumulative'].coords
         assert 'start_time' not in results['cumulative'].coords
         assert 'end_time' not in results['cumulative'].coords
+        # Cumulative scalar totals also span all time, so no time coords.
+        assert 'time' not in results['counts_total_cumulative'].coords
+        assert 'time' not in results['counts_in_toa_range_cumulative'].coords
 
     def test_time_coords_track_first_start_last_end(
         self, toa_edges, sample_binned_events
@@ -521,8 +525,12 @@ class TestMonitorWorkflowIntegration:
 
         # Cumulative has accumulated both cycles
         assert results2['cumulative'].sum().value == 10.0
+        assert results2['counts_total_cumulative'].value == 10.0
+        assert results2['counts_in_toa_range_cumulative'].value == 10.0
         # Current only has the latest cycle
         assert results2['current'].sum().value == 5.0
+        assert results2['counts_total'].value == 5.0
+        assert results2['counts_in_toa_range'].value == 5.0
 
     def test_full_workflow_cycle_histogram_mode(self, toa_edges):
         """Test full workflow cycle with histogram-mode monitor data."""

--- a/tests/services/monitor_data_test.py
+++ b/tests/services/monitor_data_test.py
@@ -8,6 +8,7 @@ are similar to those in `tests/services/data_reduction_test.py`. Many tests are 
 duplicated here.
 """
 
+import json
 import logging
 import uuid
 
@@ -71,32 +72,46 @@ def test_can_configure_and_stop_monitor_workflow(
     # No ack when message_id not set
     assert len(sink.messages) == 0
 
+    # Each workflow call returns six results: the cumulative/current histograms
+    # plus per-update and cumulative scalar totals (counts_total[_cumulative],
+    # counts_in_toa_range[_cumulative]).
+    n_target = 6
+
+    def latest_outputs() -> dict[str, object]:
+        outputs: dict[str, object] = {}
+        for msg in sink.messages[-n_target:]:
+            result_key = json.loads(msg.stream.name)
+            outputs[result_key['output_name']] = msg.value
+        return outputs
+
     app.publish_monitor_events(size=2000, time=2)
     service.step()
-    # Each workflow call returns 4 results: cumulative, current, counts_total,
-    # counts_in_toa_range
-    assert len(sink.messages) == 4
-    assert sink.messages[-4].value.values.sum() == 2000  # cumulative
-    assert sink.messages[-3].value.values.sum() == 2000  # current
-    assert sink.messages[-2].value.value == 2000  # counts_total
+    assert len(sink.messages) == n_target
+    outputs = latest_outputs()
+    assert outputs['cumulative'].values.sum() == 2000
+    assert outputs['current'].values.sum() == 2000
+    assert outputs['counts_total'].value == 2000
+    assert outputs['counts_total_cumulative'].value == 2000
     # No data -> no data published
     service.step()
-    assert len(sink.messages) == 4
+    assert len(sink.messages) == n_target
 
     app.publish_monitor_events(size=3000, time=4)
     service.step()
-    assert len(sink.messages) == 8
-    assert sink.messages[-4].value.values.sum() == 5000  # cumulative
-    assert sink.messages[-3].value.values.sum() == 3000  # current
-    assert sink.messages[-2].value.value == 3000  # counts_total
+    assert len(sink.messages) == 2 * n_target
+    outputs = latest_outputs()
+    assert outputs['cumulative'].values.sum() == 5000
+    assert outputs['current'].values.sum() == 3000
+    assert outputs['counts_total'].value == 3000  # per-update resets
+    assert outputs['counts_total_cumulative'].value == 5000  # keeps accumulating
 
     # More events but the same time
     app.publish_monitor_events(size=1000, time=4)
     # Later time
     app.publish_monitor_events(size=1000, time=5)
     service.step()
-    assert len(sink.messages) == 12
-    assert sink.messages[-4].value.values.sum() == 7000  # cumulative
+    assert len(sink.messages) == 3 * n_target
+    assert latest_outputs()['cumulative'].values.sum() == 7000
 
     # Stop workflow
     command = JobCommand(action=JobAction.stop)
@@ -105,4 +120,4 @@ def test_can_configure_and_stop_monitor_workflow(
     service.step()
     app.publish_monitor_events(size=1000, time=20)
     service.step()
-    assert len(sink.messages) == 12
+    assert len(sink.messages) == 3 * n_target


### PR DESCRIPTION
## Why

After unifying workflow output streams behind the dashboard's window-mode selection, the `since_start` mode worked for the Lines plotter (histogram view) but the Bars plotter of the total counts always showed the latest per-update value. The monitor scalar Total / Total-in-range views were missed during the unification: they declared only a `per_update` stream, so selecting "since run start" silently fell back to that same stream via `OutputView.field_for` and changed nothing. Detectors already exposed cumulative scalar streams; monitors did not.

Fixes #991.

## What

Produce cumulative scalar totals in the monitor workflow, mirroring the detector. The two scalar views now declare both stream roles, so `since_start` mode subscribes to the run-cumulative stream while `window`/latest stays on the per-update stream. To avoid duplicating the sum logic, the monitor adopts the detector's generic `AccumulationMode` pattern (one provider serves both the cumulative and window views, instantiated per mode by sciline); the shared `Current` / `Cumulative` / `AccumulationMode` markers move to a small `accumulation_mode` module both workflows depend on.

Separately, this fixes a latent footgun: selecting "since run start" on a view that has no cumulative stream was a silent no-op (`OutputView.field_for` falls back to the per-update stream). Rather than hide controls — the window duration aggregates the per-update stream and stays useful regardless of whether a cumulative stream exists — the modal now rejects the unsupported selection at config time with a clear error.