### PR TITLE
Drop al00/ep01 status schemas on forwarder log topics

### DIFF
--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -105,8 +105,26 @@ class UnmappedStreamError(KeyError):
     """
 
 
+class IgnoredMessageError(Exception):
+    """Raised to silently drop an expected-but-unused message.
+
+    Used for schemas that are known to share a topic with data we consume but
+    that we deliberately ignore (e.g. EPICS ``al00`` alarm and ``ep01``
+    connection-status messages on forwarder log topics). Distinct from
+    ``WrongSchemaException``, which signals a genuinely unexpected schema worth
+    a warning.
+    """
+
+
 class MessageAdapter(Protocol, Generic[T, U]):
     def adapt(self, message: T) -> U: ...
+
+
+class NullAdapter(MessageAdapter[KafkaMessage, Any]):
+    """Silently drops every message routed to it by raising IgnoredMessageError."""
+
+    def adapt(self, message: KafkaMessage) -> Any:
+        raise IgnoredMessageError
 
 
 class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
@@ -534,12 +552,19 @@ class AdaptingMessageSource(MessageSource[U]):
         for msg in raw_messages:
             try:
                 adapted.append(self._adapter.adapt(msg))
+            except IgnoredMessageError:
+                # Expected-but-unused schema (e.g. al00/ep01); drop silently.
+                continue
             except UnmappedStreamError:
                 # Already recorded in the stream counter by get_stream_id.
                 if self._raise_on_error:
                     raise
-            except streaming_data_types.exceptions.WrongSchemaException:
-                logger.warning('Message %s has an unknown schema. Skipping.', msg)
+            except streaming_data_types.exceptions.WrongSchemaException as e:
+                logger.warning(
+                    'Skipping message with unknown schema',
+                    topic=msg.topic() if hasattr(msg, 'topic') else None,
+                    detail=str(e),
+                )
                 self._record_error(msg)
                 if self._raise_on_error:
                     raise

--- a/src/ess/livedata/kafka/routes.py
+++ b/src/ess/livedata/kafka/routes.py
@@ -18,6 +18,7 @@ from .message_adapter import (
     KafkaToF144Adapter,
     KafkaToMonitorEventsAdapter,
     MessageAdapter,
+    NullAdapter,
     ResponsesAdapter,
     RouteBySchemaAdapter,
     RouteByTopicAdapter,
@@ -100,13 +101,24 @@ class RoutingAdapterBuilder:
         return self
 
     def with_logdata_route(self) -> Self:
-        """Adds the logdata route."""
-        adapter = ChainedAdapter(
-            first=KafkaToF144Adapter(
-                stream_lut=self._stream_mapping.logs,
-                stream_counter=self._stream_counter,
-            ),
-            second=F144ToLogDataAdapter(),
+        """Adds the logdata route.
+
+        Forwarder log topics carry f144 numeric data interleaved with al00
+        (alarm) and ep01 (connection-status) messages for the same PVs. We
+        consume only f144 and silently drop the status schemas.
+        """
+        adapter = RouteBySchemaAdapter(
+            routes={
+                'f144': ChainedAdapter(
+                    first=KafkaToF144Adapter(
+                        stream_lut=self._stream_mapping.logs,
+                        stream_counter=self._stream_counter,
+                    ),
+                    second=F144ToLogDataAdapter(),
+                ),
+                'al00': NullAdapter(),
+                'ep01': NullAdapter(),
+            }
         )
         for topic in self._stream_mapping.log_topics:
             self._routes[topic] = adapter

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -31,6 +31,7 @@ from ess.livedata.kafka.message_adapter import (
     Ev44ToMonitorEventsAdapter,
     F144ToLogDataAdapter,
     FakeKafkaMessage,
+    IgnoredMessageError,
     InputStreamKey,
     KafkaMessage,
     KafkaToAd00Adapter,
@@ -38,6 +39,7 @@ from ess.livedata.kafka.message_adapter import (
     KafkaToEv44Adapter,
     KafkaToF144Adapter,
     KafkaToMonitorEventsAdapter,
+    NullAdapter,
     ResponsesAdapter,
     RouteBySchemaAdapter,
     RouteByTopicAdapter,
@@ -566,6 +568,21 @@ class TestRouteBySchemaAdapter:
         assert adapter.adapt(message_with_schema('da00')).value == "adapter2"
 
 
+class TestNullAdapter:
+    def test_adapt_raises_IgnoredMessageError(self) -> None:
+        with pytest.raises(IgnoredMessageError):
+            NullAdapter().adapt(message_with_schema('al00'))
+
+    def test_routed_schemas_are_dropped(self) -> None:
+        adapter = RouteBySchemaAdapter(
+            routes={'al00': NullAdapter(), 'ep01': NullAdapter()}
+        )
+        with pytest.raises(IgnoredMessageError):
+            adapter.adapt(message_with_schema('al00'))
+        with pytest.raises(IgnoredMessageError):
+            adapter.adapt(message_with_schema('ep01'))
+
+
 class TestRouteByTopicAdapter:
     def test_route_by_topic(self) -> None:
         class TestAdapter:
@@ -1022,3 +1039,44 @@ class TestErrorHandling:
         exception_logs = [log for log in captured if log['log_level'] == 'error']
         assert len(exception_logs) >= 1
         assert "Simulated adapter failure" in str(exception_logs[-1])
+
+    def test_ignored_message_is_dropped_silently(self):
+        """IgnoredMessageError drops the message without warning or error record."""
+        from structlog.testing import capture_logs
+
+        class IgnoringSource(MessageSource[KafkaMessage]):
+            def get_messages(self):
+                return [FakeKafkaMessage(value=b"xxxxal00", topic="logs")]
+
+        source = AdaptingMessageSource(
+            source=IgnoringSource(),
+            adapter=RouteBySchemaAdapter(routes={'al00': NullAdapter()}),
+        )
+
+        with capture_logs() as captured:
+            messages = source.get_messages()
+
+        assert messages == []
+        assert captured == []
+
+    def test_unknown_schema_warning_includes_topic_and_schema(self):
+        """The unknown-schema warning names the topic and the offending schema."""
+        from structlog.testing import capture_logs
+
+        class UnknownSchemaSource(MessageSource[KafkaMessage]):
+            def get_messages(self):
+                return [FakeKafkaMessage(value=b"xxxxzzzz", topic="logs")]
+
+        source = AdaptingMessageSource(
+            source=UnknownSchemaSource(),
+            adapter=RouteBySchemaAdapter(routes={'f144': NullAdapter()}),
+        )
+
+        with capture_logs() as captured:
+            source.get_messages()
+
+        warnings = [log for log in captured if log['log_level'] == 'warning']
+        assert len(warnings) == 1
+        rendered = str(warnings[0])
+        assert "logs" in rendered
+        assert "zzzz" in rendered

--- a/tests/kafka/routing_adapter_test.py
+++ b/tests/kafka/routing_adapter_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from ess.livedata.config.instruments import available_instruments
 from ess.livedata.config.streams import get_stream_mapping
+from ess.livedata.kafka.message_adapter import FakeKafkaMessage, IgnoredMessageError
 from ess.livedata.kafka.routes import RoutingAdapterBuilder
 from ess.livedata.kafka.stream_mapping import InputStreamKey, StreamMapping
 
@@ -94,6 +95,26 @@ class TestWithRoutesFromMapping:
             .build()
         )
         assert "log" in adapter._routes
+
+    @pytest.mark.parametrize('schema', ['al00', 'ep01'])
+    def test_log_route_drops_status_schemas(
+        self, infra_kwargs: dict, schema: str
+    ) -> None:
+        mapping = StreamMapping(
+            instrument="test",
+            detectors={},
+            monitors={},
+            logs={InputStreamKey(topic="log", source_name="s"): "l"},
+            **infra_kwargs,
+        )
+        adapter = (
+            RoutingAdapterBuilder(stream_mapping=mapping)
+            .with_routes_from_mapping()
+            .build()
+        )
+        message = FakeKafkaMessage(value=f"xxxx{schema}".encode(), topic="log")
+        with pytest.raises(IgnoredMessageError):
+            adapter.adapt(message)
 
     def test_adds_area_detector_route_when_present(self, infra_kwargs: dict) -> None:
         mapping = StreamMapping(

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -645,9 +645,7 @@ def test_message_with_unknown_schema_is_ignored(
 
     # Check log messages for warnings
     warning_logs = [log for log in captured if log['log_level'] == 'warning']
-    assert any(
-        "has an unknown schema. Skipping." in log['event'] for log in warning_logs
-    )
+    assert any("unknown schema" in log['event'] for log in warning_logs)
 
 
 def test_message_that_cannot_be_decoded_is_ignored(

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -247,9 +247,7 @@ def test_message_with_unknown_schema_is_ignored(
 
     # Check log messages for warnings
     warning_logs = [log for log in captured if log['log_level'] == 'warning']
-    assert any(
-        "has an unknown schema. Skipping." in log['event'] for log in warning_logs
-    )
+    assert any("unknown schema" in log['event'] for log in warning_logs)
 
 
 def test_message_that_cannot_be_decoded_is_ignored(


### PR DESCRIPTION
## Motivation

EPICS forwarder log topics carry `f144` numeric data interleaved with `al00` (alarm) and `ep01` (EPICS connection-status) messages for the same PVs — this is the forwarder's intended convention, not a misconfiguration. We consume only `f144`, so every `al00`/`ep01` message reached the `f144` deserializer and raised `WrongSchemaException`. On LOKI this was a continuous flood (~4–5/s, roughly balanced between the two schemas) and it affects every service that subscribes to log topics: detector, timeseries, and data_reduction.

These status schemas are *validity metadata* orthogonal to the data we reduce; there is nothing useful to do with them in live processing (alarms surface in NICOS, and dropping data while any device alarms is overkill). So they are dropped, not consumed.

## Change

Route log topics by schema: `f144` to the existing adapter chain, `al00`/`ep01` to a `NullAdapter` that drops them silently via a dedicated `IgnoredMessageError`. The single change in the route builder covers all three consuming services.

While here, the unknown-schema warning was a blind spot: it named neither the topic nor the offending schema. Genuinely-unexpected schemas now warn with both.

## Test plan

- [x] Unit tests: status schemas dropped silently (no log, no error count); unknown schema warns with topic + schema; builder-level log route drops `al00`/`ep01`.
- [x] Full `tests/kafka/` suite green.
