### PR TITLE
Log per-stream producer lag for upstream staleness detection

### DIFF
--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
+import logging
 import traceback
 from dataclasses import dataclass
 from enum import StrEnum, auto
@@ -128,12 +129,64 @@ class StreamStats:
     streams: tuple[StreamStat, ...]
 
 
+# Defaults chosen against realistic ESS conditions: inter-host NTP/chrony skew
+# stays in the single-digit-millisecond range and Kafka CreateTime has only
+# millisecond resolution, so 100 ms comfortably clears clock noise while a real
+# "payload from the future" anomaly (seconds) trips the ERROR band. The WARNING
+# band flags data already seconds stale at publish time.
+LAG_WARN_THRESHOLD_S = 2.0
+LAG_FUTURE_TOLERANCE_S = 0.1
+
+
+@dataclass(frozen=True, slots=True)
+class StreamLag:
+    """Lag statistics for one (topic, source, schema) over a time window.
+
+    Lag is ``kafka_create_time - payload_timestamp`` in seconds: how stale a
+    payload already was when the broker recorded it, isolating upstream producer
+    staleness from this service's own consumption delay.
+    """
+
+    topic: str
+    source: str
+    schema: str
+    min_s: float
+    max_s: float
+    count: int
+
+
+@dataclass(frozen=True, slots=True)
+class StreamLagReport:
+    """Per-stream lag for one window, ordered stably by (topic, source, schema)."""
+
+    streams: tuple[StreamLag, ...]
+    warn_threshold_s: float
+    future_tolerance_s: float
+
+    def level(self, lag: StreamLag) -> int:
+        """Python logging level reflecting a single stream's lag.
+
+        ERROR if the payload is meaningfully in the future (clock/logic fault),
+        WARNING if it is more than ``warn_threshold_s`` stale at publish time,
+        otherwise INFO.
+        """
+        if lag.min_s < -self.future_tolerance_s:
+            return logging.ERROR
+        if lag.max_s > self.warn_threshold_s:
+            return logging.WARNING
+        return logging.INFO
+
+
 @runtime_checkable
 class StreamStatsProvider(Protocol):
-    """Provides accumulated per-stream message counts."""
+    """Provides accumulated per-stream message counts and lag."""
 
     def drain(self, window_seconds: float) -> StreamStats:
-        """Return accumulated stats and reset counters."""
+        """Return accumulated counts and reset."""
+        ...
+
+    def drain_lag(self) -> StreamLagReport | None:
+        """Return accumulated per-stream lag and reset, or None if empty."""
         ...
 
 

--- a/src/ess/livedata/core/orchestrating_processor.py
+++ b/src/ess/livedata/core/orchestrating_processor.py
@@ -20,6 +20,7 @@ from .job import (
     JobStatus,
     ServiceState,
     ServiceStatus,
+    StreamLagReport,
     StreamStats,
     StreamStatsProvider,
 )
@@ -371,6 +372,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
                 self._pending_stream_stats = self._stream_stats_provider.drain(
                     window_seconds
                 )
+                self._log_stream_lag(self._stream_stats_provider.drain_lag())
 
             logger.info(
                 'processor_metrics',
@@ -385,6 +387,26 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
             self._empty_batches = 0
             self._errors_since_last_metrics = 0
             self._last_metrics_time = timestamp
+
+    def _log_stream_lag(self, report: StreamLagReport | None) -> None:
+        """Log one line per stream at a severity reflecting its lag.
+
+        ERROR for a payload from the future (clock/logic fault upstream),
+        WARNING for data seconds stale at publish time, INFO otherwise.
+        """
+        if report is None:
+            return
+        for lag in report.streams:
+            logger.log(
+                report.level(lag),
+                'stream_lag',
+                topic=lag.topic,
+                source=lag.source,
+                schema=lag.schema,
+                min_lag_s=round(lag.min_s, 3),
+                max_lag_s=round(lag.max_s, 3),
+                count=lag.count,
+            )
 
     def finalize(self, *, error: str | None = None) -> None:
         """Mark jobs as stopped, send final heartbeat, and shut down.

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -69,12 +69,19 @@ class KafkaMessage(Protocol):
 
 class FakeKafkaMessage(KafkaMessage):
     def __init__(
-        self, *, key: bytes = b'', value: bytes, topic: str, timestamp: int = 0
+        self,
+        *,
+        key: bytes = b'',
+        value: bytes,
+        topic: str,
+        timestamp: int = 0,
+        timestamp_type: int = 0,
     ):
         self._key = key
         self._value = value
         self._topic = topic
         self._timestamp = timestamp
+        self._timestamp_type = timestamp_type
 
     def error(self) -> Any | None:
         return None
@@ -86,7 +93,7 @@ class FakeKafkaMessage(KafkaMessage):
         return self._value
 
     def timestamp(self) -> tuple[int, int]:
-        return (0, self._timestamp)
+        return (self._timestamp_type, self._timestamp)
 
     def topic(self) -> str:
         return self._topic
@@ -119,6 +126,10 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
     the Kafka topics.
     """
 
+    #: Wire (flatbuffer) schema identifier, e.g. 'ev44'; set by subclasses that
+    #: carry a payload timestamp and record lag.
+    schema: str
+
     def __init__(
         self,
         *,
@@ -147,8 +158,26 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
             self._stream_counter.record(topic, source_name, resolved)
         return stream_id
 
+    def _record_lag(
+        self, message: KafkaMessage, source_name: str, timestamp: Timestamp
+    ) -> None:
+        """Record producer lag (Kafka create time minus payload time) in the
+        stream counter, keyed by (topic, source, wire schema).
+        """
+        if self._stream_counter is None:
+            return
+        kind, kafka_ms = message.timestamp()
+        if kind == 0:  # confluent_kafka.TIMESTAMP_NOT_AVAILABLE
+            return
+        lag_s = (kafka_ms * 1_000_000 - timestamp.to_ns()) / 1e9
+        self._stream_counter.record_lag(
+            message.topic(), source_name, self.schema, lag_s
+        )
+
 
 class KafkaToEv44Adapter(KafkaAdapter[eventdata_ev44.EventData]):
+    schema = 'ev44'
+
     def adapt(self, message: KafkaMessage) -> Message[eventdata_ev44.EventData]:
         ev44 = eventdata_ev44.deserialise_ev44(message.value())
         stream = self.get_stream_id(topic=message.topic(), source_name=ev44.source_name)
@@ -157,6 +186,7 @@ class KafkaToEv44Adapter(KafkaAdapter[eventdata_ev44.EventData]):
             timestamp = Timestamp.from_ns(ev44.reference_time[-1])
         else:
             timestamp = Timestamp.from_ms(message.timestamp()[1])
+        self._record_lag(message, ev44.source_name, timestamp)
         return Message(timestamp=timestamp, stream=stream, value=ev44)
 
 
@@ -188,6 +218,8 @@ def _extract_reference_time(
 
 
 class KafkaToDa00Adapter(KafkaAdapter[list[dataarray_da00.Variable]]):
+    schema = 'da00'
+
     def adapt(self, message: KafkaMessage) -> Message[list[dataarray_da00.Variable]]:
         da00: dataarray_da00.da00_DataArray_t
         da00 = dataarray_da00.deserialise_da00(message.value())  # type: ignore[reportAssignmentType]
@@ -198,10 +230,13 @@ class KafkaToDa00Adapter(KafkaAdapter[list[dataarray_da00.Variable]]):
         timestamp = (
             ref_time if ref_time is not None else Timestamp.from_ns(da00.timestamp_ns)
         )
+        self._record_lag(message, da00.source_name, timestamp)
         return Message(timestamp=timestamp, stream=key, value=da00.data)
 
 
 class KafkaToF144Adapter(KafkaAdapter[logdata_f144.ExtractedLogData]):
+    schema = 'f144'
+
     def __init__(
         self,
         *,
@@ -220,6 +255,7 @@ class KafkaToF144Adapter(KafkaAdapter[logdata_f144.ExtractedLogData]):
             topic=message.topic(), source_name=log_data.source_name
         )
         timestamp = Timestamp.from_ns(log_data.timestamp_unix_ns)
+        self._record_lag(message, log_data.source_name, timestamp)
         return Message(timestamp=timestamp, stream=key, value=log_data)
 
 
@@ -314,6 +350,8 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
     The stream kind stays MONITOR_EVENTS so the standard preprocessor handles it.
     """
 
+    schema = 'ev44'
+
     def __init__(
         self,
         stream_lut: StreamLUT,
@@ -332,9 +370,8 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
         buffer = message.value()
         eventdata_ev44.check_schema_identifier(buffer, eventdata_ev44.FILE_IDENTIFIER)
         event = Event44Message.Event44Message.GetRootAs(buffer, 0)
-        stream = self.get_stream_id(
-            topic=message.topic(), source_name=event.SourceName().decode("utf-8")
-        )
+        source_name = event.SourceName().decode("utf-8")
+        stream = self.get_stream_id(topic=message.topic(), source_name=source_name)
         reference_time = event.ReferenceTimeAsNumpy()
         time_of_arrival = event.TimeOfFlightAsNumpy()
 
@@ -352,6 +389,7 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
             )
         else:
             value = MonitorEvents(time_of_arrival=time_of_arrival, unit='ns')
+        self._record_lag(message, source_name, timestamp)
         return Message(timestamp=timestamp, stream=stream, value=value)
 
 
@@ -397,10 +435,13 @@ class Da00ToScippAdapter(
 
 
 class KafkaToAd00Adapter(KafkaAdapter[area_detector_ad00.ADArray]):
+    schema = 'ad00'
+
     def adapt(self, message: KafkaMessage) -> Message[area_detector_ad00.ADArray]:
         ad00 = area_detector_ad00.deserialise_ad00(message.value())
         key = self.get_stream_id(topic=message.topic(), source_name=ad00.source_name)
         timestamp = Timestamp.from_ns(ad00.timestamp_ns)
+        self._record_lag(message, ad00.source_name, timestamp)
         return Message(timestamp=timestamp, stream=key, value=ad00)
 
 

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -253,7 +253,10 @@ class KafkaToDa00Adapter(KafkaAdapter[list[dataarray_da00.Variable]]):
 
 
 class KafkaToF144Adapter(KafkaAdapter[logdata_f144.ExtractedLogData]):
-    schema = 'f144'
+    # No producer lag recorded: the forwarder resends each value on a periodic
+    # heartbeat with the original EPICS source timestamp but a fresh Kafka
+    # CreateTime, so kafka_create - payload measures time-since-last-change, not
+    # producer staleness, and would spuriously flag healthy static PVs as stale.
 
     def __init__(
         self,
@@ -273,7 +276,6 @@ class KafkaToF144Adapter(KafkaAdapter[logdata_f144.ExtractedLogData]):
             topic=message.topic(), source_name=log_data.source_name
         )
         timestamp = Timestamp.from_ns(log_data.timestamp_unix_ns)
-        self._record_lag(message, log_data.source_name, timestamp)
         return Message(timestamp=timestamp, stream=key, value=log_data)
 
 

--- a/src/ess/livedata/kafka/stream_counter.py
+++ b/src/ess/livedata/kafka/stream_counter.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-"""Per-stream message counter for observability."""
+"""Per-stream message counter and lag tracker for observability."""
 
 from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
 
-from ess.livedata.core.job import StreamStat, StreamStats
+from ess.livedata.core.job import (
+    LAG_FUTURE_TOLERANCE_S,
+    LAG_WARN_THRESHOLD_S,
+    StreamLag,
+    StreamLagReport,
+    StreamStat,
+    StreamStats,
+)
 
 # EPICS PV field suffixes that are noise for reporting.
 # Only .RBV (Read Back Value) carries the actual readback; .VAL (setpoint)
@@ -21,18 +28,34 @@ class _Entry:
     count: int
 
 
+@dataclass(slots=True)
+class _LagEntry:
+    min_s: float
+    max_s: float
+    count: int
+
+
 class StreamCounter:
-    """Counts messages per (topic, source_name) for inclusion in service heartbeats.
+    """Counts messages per (topic, source_name) and tracks per-stream lag.
 
     Call :meth:`record` from the adapter layer each time a message is mapped
-    (or fails to map) to a stream. Call :meth:`drain` from the processor on
-    metrics rollover to collect the accumulated counts and reset.
+    (or fails to map) to a stream, and :meth:`record_lag` when a payload-derived
+    timestamp is available. Call :meth:`drain` / :meth:`drain_lag` from the
+    processor on metrics rollover to collect the accumulated values and reset.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        lag_warn_threshold_s: float = LAG_WARN_THRESHOLD_S,
+        lag_future_tolerance_s: float = LAG_FUTURE_TOLERANCE_S,
+    ) -> None:
         self._counts: dict[tuple[str, str], _Entry] = defaultdict(
             lambda: _Entry(stream=None, count=0)
         )
+        self._lag: dict[tuple[str, str, str], _LagEntry] = {}
+        self._lag_warn_threshold_s = lag_warn_threshold_s
+        self._lag_future_tolerance_s = lag_future_tolerance_s
 
     def record(self, topic: str, source_name: str, stream: str | None) -> None:
         """Increment count for a (topic, source_name) combination.
@@ -47,8 +70,27 @@ class StreamCounter:
         entry.count += 1
         entry.stream = stream
 
+    def record_lag(
+        self, topic: str, source_name: str, schema: str, lag_s: float
+    ) -> None:
+        """Fold one message's lag into the current window.
+
+        Lag is ``kafka_create_time - payload_timestamp`` in seconds. Sources with
+        known EPICS noise suffixes are dropped, mirroring :meth:`record`.
+        """
+        if source_name.endswith(_IGNORED_SOURCE_SUFFIXES):
+            return
+        key = (topic, source_name, schema)
+        entry = self._lag.get(key)
+        if entry is None:
+            self._lag[key] = _LagEntry(min_s=lag_s, max_s=lag_s, count=1)
+        else:
+            entry.min_s = min(entry.min_s, lag_s)
+            entry.max_s = max(entry.max_s, lag_s)
+            entry.count += 1
+
     def drain(self, window_seconds: float) -> StreamStats:
-        """Return accumulated stats and reset counters."""
+        """Return accumulated counts and reset."""
         stats = StreamStats(
             window_seconds=window_seconds,
             streams=tuple(
@@ -63,3 +105,29 @@ class StreamCounter:
         )
         self._counts.clear()
         return stats
+
+    def drain_lag(self) -> StreamLagReport | None:
+        """Return accumulated per-stream lag and reset, or None if empty.
+
+        Streams are ordered by ``(topic, source, schema)`` so that successive
+        windows list them in the same positions, easing line-by-line comparison.
+        """
+        if not self._lag:
+            return None
+        streams = tuple(
+            StreamLag(
+                topic=topic,
+                source=source,
+                schema=schema,
+                min_s=entry.min_s,
+                max_s=entry.max_s,
+                count=entry.count,
+            )
+            for (topic, source, schema), entry in sorted(self._lag.items())
+        )
+        self._lag.clear()
+        return StreamLagReport(
+            streams=streams,
+            warn_threshold_s=self._lag_warn_threshold_s,
+            future_tolerance_s=self._lag_future_tolerance_s,
+        )

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -1022,3 +1022,51 @@ class TestErrorHandling:
         exception_logs = [log for log in captured if log['log_level'] == 'error']
         assert len(exception_logs) >= 1
         assert "Simulated adapter failure" in str(exception_logs[-1])
+
+
+class TestAdapterLagRecording:
+    def _ev44(self, *, reference_time_ns: int) -> bytes:
+        return eventdata_ev44.serialise_ev44(
+            source_name="monitor1",
+            message_id=0,
+            reference_time=[reference_time_ns],
+            reference_time_index=0,
+            time_of_flight=[123456],
+            pixel_id=[1],
+        )
+
+    def test_records_producer_lag_keyed_by_topic_source_schema(self) -> None:
+        counter = StreamCounter()
+        adapter = KafkaToEv44Adapter(
+            stream_kind=StreamKind.MONITOR_EVENTS, stream_counter=counter
+        )
+        # Payload at 2.0 s, broker CreateTime at 10.0 s -> 8.0 s producer lag.
+        message = FakeKafkaMessage(
+            value=self._ev44(reference_time_ns=2_000_000_000),
+            topic="monitors",
+            timestamp=10_000,
+            timestamp_type=1,
+        )
+        adapter.adapt(message)
+
+        report = counter.drain_lag()
+        assert report is not None
+        (lag,) = report.streams
+        assert (lag.topic, lag.source, lag.schema) == ("monitors", "monitor1", "ev44")
+        assert lag.max_s == pytest.approx(8.0)
+        assert lag.count == 1
+
+    def test_skips_when_broker_timestamp_unavailable(self) -> None:
+        counter = StreamCounter()
+        adapter = KafkaToEv44Adapter(
+            stream_kind=StreamKind.MONITOR_EVENTS, stream_counter=counter
+        )
+        # Default timestamp_type=0 (NOT_AVAILABLE) -> lag cannot be computed.
+        message = FakeKafkaMessage(
+            value=self._ev44(reference_time_ns=2_000_000_000),
+            topic="monitors",
+            timestamp=10_000,
+        )
+        adapter.adapt(message)
+
+        assert counter.drain_lag() is None

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -1128,3 +1128,19 @@ class TestAdapterLagRecording:
         adapter.adapt(message)
 
         assert counter.drain_lag() is None
+
+    def test_f144_records_no_lag(self) -> None:
+        # The forwarder resends each value periodically with the original EPICS
+        # source timestamp, so producer lag is meaningless for f144 and is not
+        # recorded even when a broker CreateTime is available.
+        counter = StreamCounter()
+        adapter = KafkaToF144Adapter(stream_counter=counter)
+        message = FakeKafkaMessage(
+            value=make_serialized_f144(),
+            topic="sensors",
+            timestamp=10_000,
+            timestamp_type=1,
+        )
+        adapter.adapt(message)
+
+        assert counter.drain_lag() is None

--- a/tests/kafka/stream_counter_test.py
+++ b/tests/kafka/stream_counter_test.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-from ess.livedata.core.job import StreamStat, StreamStatsProvider
+import logging
+
+from ess.livedata.core.job import (
+    LAG_FUTURE_TOLERANCE_S,
+    LAG_WARN_THRESHOLD_S,
+    StreamStat,
+    StreamStatsProvider,
+)
 from ess.livedata.kafka.stream_counter import StreamCounter
 
 
@@ -96,3 +103,88 @@ class TestStreamCounter:
         counter.record("other_topic", "PV.RBV", "resolved")
         stats = counter.drain(window_seconds=30.0)
         assert len(stats.streams) == 1
+
+
+class TestStreamCounterLag:
+    def test_drain_lag_empty_returns_none(self) -> None:
+        assert StreamCounter().drain_lag() is None
+
+    def test_aggregates_min_max_count_per_key(self) -> None:
+        counter = StreamCounter()
+        for lag in (1.0, 3.0, 2.0):
+            counter.record_lag("topic_a", "source_1", "ev44", lag)
+        report = counter.drain_lag()
+        assert report is not None
+        (entry,) = report.streams
+        assert (entry.topic, entry.source, entry.schema) == (
+            "topic_a",
+            "source_1",
+            "ev44",
+        )
+        assert (entry.min_s, entry.max_s, entry.count) == (1.0, 3.0, 3)
+
+    def test_distinct_keys_by_topic_source_schema(self) -> None:
+        counter = StreamCounter()
+        counter.record_lag("t", "s", "ev44", 1.0)
+        counter.record_lag("t", "s", "da00", 1.0)
+        counter.record_lag("t", "other", "ev44", 1.0)
+        report = counter.drain_lag()
+        assert report is not None
+        assert len(report.streams) == 3
+
+    def test_drain_lag_resets(self) -> None:
+        counter = StreamCounter()
+        counter.record_lag("t", "s", "ev44", 1.0)
+        counter.drain_lag()
+        assert counter.drain_lag() is None
+
+    def test_streams_ordered_by_key(self) -> None:
+        counter = StreamCounter()
+        counter.record_lag("t_b", "s", "ev44", 1.0)
+        counter.record_lag("t_a", "s", "f144", 1.0)
+        counter.record_lag("t_a", "s", "ev44", 1.0)
+        report = counter.drain_lag()
+        assert report is not None
+        keys = [(s.topic, s.source, s.schema) for s in report.streams]
+        assert keys == [
+            ("t_a", "s", "ev44"),
+            ("t_a", "s", "f144"),
+            ("t_b", "s", "ev44"),
+        ]
+
+    def test_ignores_epics_noise_suffixes(self) -> None:
+        counter = StreamCounter()
+        counter.record_lag("motion", "PV.DMOV", "f144", 1.0)
+        counter.record_lag("motion", "PV.VAL", "f144", 1.0)
+        counter.record_lag("motion", "PV.RBV", "f144", 1.0)
+        report = counter.drain_lag()
+        assert report is not None
+        assert [s.source for s in report.streams] == ["PV.RBV"]
+
+    def _level(self, lag_s: float) -> int:
+        counter = StreamCounter()
+        counter.record_lag("t", "s", "ev44", lag_s)
+        report = counter.drain_lag()
+        assert report is not None
+        return report.level(report.streams[0])
+
+    def test_level_info_for_small_positive_lag(self) -> None:
+        assert self._level(0.5) == logging.INFO
+
+    def test_level_warning_above_threshold(self) -> None:
+        assert self._level(LAG_WARN_THRESHOLD_S + 0.1) == logging.WARNING
+
+    def test_level_error_for_future_payload(self) -> None:
+        assert self._level(-(LAG_FUTURE_TOLERANCE_S + 0.1)) == logging.ERROR
+
+    def test_small_negative_within_tolerance_stays_info(self) -> None:
+        assert self._level(-LAG_FUTURE_TOLERANCE_S / 2) == logging.INFO
+
+    def test_level_is_per_stream(self) -> None:
+        counter = StreamCounter()
+        counter.record_lag("t", "stale", "ev44", LAG_WARN_THRESHOLD_S + 5)
+        counter.record_lag("t", "future", "ev44", -(LAG_FUTURE_TOLERANCE_S + 1))
+        report = counter.drain_lag()
+        assert report is not None
+        by_source = {lag.source: report.level(lag) for lag in report.streams}
+        assert by_source == {"stale": logging.WARNING, "future": logging.ERROR}


### PR DESCRIPTION
## Motivation

Debugging the Loki `detector_data` service showed an 8-10 s displayed lag while Kafka offset lag stayed near zero. The cause was upstream: ev44 payloads arrive promptly (Kafka CreateTime ~current) but carry a `reference_time` ~8.8 s in the past, i.e. the producer buffered the data before publishing. The existing `consumer_metrics` offset lag cannot reveal this, and diagnosing it required hacking a `print` into production code.

## What this adds

Per-stream **producer lag** = `kafka_create_time - payload_timestamp`, which isolates upstream producer staleness from this service's own consumption delay. It is tracked in `StreamCounter` keyed by `(topic, source, wire schema)` — the identifiers needed to report issues upstream, not the internal stream name — and the processor logs one `stream_lag` line per stream each metrics window:

```
stream_lag  topic=... source=... schema=ev44 min_lag_s=8.51 max_lag_s=8.85 count=412   [WARNING]
```

Severity reflects the lag, so issues surface by log level without flooding:

- **ERROR** — payload timestamped in the future (clock/logic fault), beyond a 100 ms inter-host clock-skew tolerance
- **WARNING** — more than 2 s stale at publish time
- **INFO** — baseline

Flat per-stream lines (stable `(topic, source, schema)` ordering) keep the output greppable through journald, including by severity.

## Design notes

Recording lives in the adapter layer, where the wire identifiers and the schema-specific payload timestamp coexist (each adapter already normalizes its own timestamp). The lag DTOs live in `core` so the `StreamStatsProvider` protocol return type respects the `kafka -> core` import direction. `StreamStats` and the status heartbeat are unchanged, so this is log-only today; surfacing lag in the worker-status UI later is a small follow-up (add a field to `StreamStat` and a column).

## Test plan

- [x] Unit tests: `StreamCounter` lag aggregation, ordering, reset, EPICS-suffix filtering, and per-stream severity bands incl. the skew tolerance
- [x] Adapter-level: real ev44 through `KafkaToEv44Adapter` records lag keyed by topic/source/schema; unavailable broker timestamp is skipped
- [x] Full fast suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
