### PR TITLE
Reset TemporalBuffer on non-time shape change instead of crashing

### DIFF
--- a/src/ess/livedata/dashboard/temporal_buffers.py
+++ b/src/ess/livedata/dashboard/temporal_buffers.py
@@ -483,6 +483,13 @@ class TemporalBuffer(BufferProtocol[sc.DataArray]):
         new = data['time', 0] if 'time' in data.dims else data
         accumulated = self._accumulated_coord_names(data)
 
+        # A shape change (e.g. the number of ROIs in an ROI-spectra output changes
+        # while the job runs) means the buffered series can no longer be extended;
+        # the buffer must reset. assign() below would raise on a shape mismatch, so
+        # guard against it and report a mismatch instead.
+        if new.sizes != self._reference.sizes:
+            return False
+
         template = new.assign(self._reference.data)
         template = template.drop_coords(
             [name for name in accumulated if name in template.coords]

--- a/tests/dashboard/temporal_buffers_test.py
+++ b/tests/dashboard/temporal_buffers_test.py
@@ -435,6 +435,37 @@ class TestTemporalBuffer:
         assert result.sizes['time'] == 1
         assert result.coords['time'].values[0] == 1.0
 
+    def test_non_time_dim_size_change_resets_without_error(self):
+        """A changed non-time shape (e.g. ROI count) resets instead of raising.
+
+        ROI-spectra outputs change their ``roi`` dimension size while the job
+        runs as the user adds or removes regions. The buffer cannot extend a
+        series across such a change and must reset rather than raise.
+        """
+        buffer = TemporalBuffer()
+        first = sc.DataArray(
+            sc.array(dims=['time', 'roi'], values=[[1.0, 2.0]], unit='counts'),
+            coords={
+                'time': sc.array(dims=['time'], values=[0.0], unit='s'),
+                'roi': sc.arange('roi', 2),
+            },
+        )
+        second = sc.DataArray(
+            sc.array(dims=['time', 'roi'], values=[[3.0, 4.0, 5.0]], unit='counts'),
+            coords={
+                'time': sc.array(dims=['time'], values=[1.0], unit='s'),
+                'roi': sc.arange('roi', 3),
+            },
+        )
+
+        buffer.add(first)
+        buffer.add(second)
+
+        result = buffer.get()
+        assert result.sizes['time'] == 1
+        assert result.sizes['roi'] == 3
+        assert result.coords['time'].values[0] == 1.0
+
 
 class TestVariableBuffer:
     """Tests for VariableBuffer."""


### PR DESCRIPTION
## Motivation

`TemporalBuffer` is designed to reset when incoming metadata no longer matches the buffered reference, but `_metadata_matches` relied on `DataArray.assign`, which raises `DimensionError` when the non-time shape changes rather than reporting a mismatch. The exception propagated out of `add()` and aborted the orchestrator's per-cycle message loop, silently dropping every message sorted after the offending stream until the plot was closed.

A workflow restart (e.g. rebinning) does not reach this path: it mints a fresh `job_number`, so the new shape lands in a fresh buffer. The shape can however genuinely change *within a single job*: ROI-spectra outputs grow or shrink their `roi` dimension as the user adds or removes regions on a running workflow. This only surfaces when such an output is plotted with window aggregation, which forces a `TemporalBuffer` rather than the default `SingleValueBuffer`.

Aggregating a window across an ROI-count change is ill-defined, so resetting the buffer is the correct behavior. This guards the size comparison up front so a shape change is reported as a mismatch (triggering reset) instead of raising.

Part of #971 (item 1). The orchestrator-loop blast radius (one exception aborting a whole polling cycle) is left for a separate change.

## Test plan

- Added a unit test reproducing the `DimensionError` via a non-time dimension size change; verified it fails on `main` and passes with the fix.
