### PR TITLE
Fix dead log-scale start validator in edges models

### DIFF
--- a/src/ess/livedata/parameter_models.py
+++ b/src/ess/livedata/parameter_models.py
@@ -14,7 +14,7 @@ from enum import StrEnum
 from pathlib import Path
 
 import scipp as sc
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 def parse_number_list(value: str) -> list[float]:
@@ -89,13 +89,11 @@ class EdgesModel(BaseModel, ABC):
             raise ValueError('stop must be greater than start')
         return v
 
-    @field_validator('start')
-    @classmethod
-    def start_must_be_positive_if_log(cls, v, info):
-        log = info.data.get('log')
-        if log and v <= 0:
-            raise ValueError('start must be positive if log is True')
-        return v
+    @model_validator(mode='after')
+    def start_must_be_positive_if_log(self):
+        if self.scale == Scale.LOG and self.start <= 0:
+            raise ValueError("start must be positive when scale is 'log'")
+        return self
 
 
 class TimeUnit(StrEnum):

--- a/tests/parameter_models_test.py
+++ b/tests/parameter_models_test.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
 
+import pytest
 import scipp as sc
+from pydantic import ValidationError
 
 from ess.livedata.parameter_models import Scale, WavelengthEdges
 
@@ -13,3 +15,14 @@ def test_log_edges_are_geometrically_spaced_between_bounds() -> None:
 
     expected = sc.array(dims=['wavelength'], values=[1.0, 10.0, 100.0], unit='Å')
     assert sc.allclose(edges, expected)
+
+
+@pytest.mark.parametrize('start', [0.0, -1.0])
+def test_log_scale_rejects_non_positive_start(start: float) -> None:
+    with pytest.raises(ValidationError, match='start must be positive'):
+        WavelengthEdges(start=start, stop=100.0, scale=Scale.LOG)
+
+
+@pytest.mark.parametrize('start', [0.0, -1.0])
+def test_linear_scale_allows_non_positive_start(start: float) -> None:
+    WavelengthEdges(start=start, stop=100.0, scale=Scale.LINEAR)


### PR DESCRIPTION
Item 3 of #971.

The `start_must_be_positive_if_log` validator on `EdgesModel` never ran its check: it read a non-existent `log` field (the field is `scale`), and as a `field_validator('start')` it could not have seen `scale` regardless, since `scale` is declared after `start`. Log-scale edges with `start <= 0` therefore validated cleanly on the frontend and only failed later inside workflow creation with an opaque backend job error (`ValueError: Geometric sequence cannot include zero` from `sc.geomspace`).

Replaced it with a `model_validator(mode='after')` that inspects the actual `scale` field, so the constraint is enforced at input validation with a clear message.
