### PR TITLE
Isolate per-message failures in dashboard ingestion loop

### DIFF
--- a/src/ess/livedata/dashboard/orchestrator.py
+++ b/src/ess/livedata/dashboard/orchestrator.py
@@ -74,7 +74,17 @@ class Orchestrator:
         with self._active_job_registry.ingestion_guard():
             with self._data_service.transaction():
                 for message in messages:
-                    self.forward(stream_id=message.stream, value=message.value)
+                    # Isolate per-message failures: a single poisoned stream (e.g.
+                    # corrupt payload, or data whose shape no longer fits its buffer)
+                    # must not abort the loop and drop every message sorted after it,
+                    # which would repeat on every polling cycle. Log and continue.
+                    try:
+                        self.forward(stream_id=message.stream, value=message.value)
+                    except Exception:
+                        self._logger.exception(
+                            "Failed to forward message from stream %s; skipping",
+                            message.stream,
+                        )
 
     def forward(self, stream_id: StreamId, value: Any) -> None:
         """

--- a/tests/dashboard/orchestrator_test.py
+++ b/tests/dashboard/orchestrator_test.py
@@ -201,6 +201,34 @@ class TestOrchestrator:
         assert sc.identical(data_service[result_key1], data1)
         assert sc.identical(data_service[result_key2], data2)
 
+    def test_update_isolates_poisoned_message_from_rest_of_batch(self) -> None:
+        source = FakeMessageSource()
+        data_service = DataService()
+        job_service = JobService()
+        orchestrator = _make_orchestrator(
+            message_source=source,
+            data_service=data_service,
+            job_service=job_service,
+        )
+
+        workflow_id = WorkflowId(instrument="test", name="wf", version=1)
+        good_key = ResultKey(
+            workflow_id=workflow_id,
+            job_id=JobId(source_name="detector1", job_number=make_job_number()),
+            output_name='result',
+        )
+        good_data = sc.DataArray(sc.array(dims=['x'], values=[1, 2, 3]))
+
+        # A message whose stream name is not a valid ResultKey raises in forward().
+        # It must not prevent the valid message that follows it from being stored.
+        source.add_message("not-a-valid-result-key", good_data)
+        source.add_message(good_key.model_dump_json(), good_data)
+
+        orchestrator.update()
+
+        assert good_key in data_service
+        assert sc.identical(data_service[good_key], good_data)
+
     def test_update_overwrites_existing_data(self) -> None:
         source = FakeMessageSource()
         data_service = DataService()


### PR DESCRIPTION
## Motivation

`Orchestrator.update` forwarded every polled message in a single loop with no per-message error handling. One poisoned stream (corrupt payload, or data whose shape no longer fits its buffer) raised out of `forward()` and aborted the loop, silently dropping every message sorted after it. Because the same offending message reappears on each polling cycle, the loss repeats indefinitely until the offending plot or job is removed.

This wraps each `forward()` in a try/except that logs and continues, so a single bad message no longer takes down ingestion for all other streams. The buffer write happens synchronously inside the loop (only subscriber notification is deferred to transaction commit), so this guard also covers buffer-level failures, not just malformed payloads.

Catching broad `Exception` is deliberate here: this is the live ingestion loop, where one backend's bad message must not halt all dashboards. That is fault isolation in a streaming loop, not masking a misconfiguration.

Companion to #1002; both address #971 (item 1). That PR stops `TemporalBuffer` from raising on a shape change; this one prevents any per-message failure in the loop from cascading.

## Test plan

- Added an `update()`-level regression test with a poisoned message followed by a valid one; verified it fails without the fix (whole batch aborted) and passes with it.
