### PR TITLE
Fix three backend robustness bugs: consumer assignment, sink backpressure, service exit code

### DIFF
--- a/src/ess/livedata/core/service.py
+++ b/src/ess/livedata/core/service.py
@@ -49,7 +49,12 @@ class ServiceBase(ABC):
         self._logger.info("Received signal %d, initiating shutdown...", signum)
         self.stop()
         self._finalize_processor()
-        sys.exit(0)
+        sys.exit(self._exit_code)
+
+    @property
+    def _exit_code(self) -> int:
+        """Process exit code on shutdown; nonzero signals a fault to the supervisor."""
+        return 0
 
     def _finalize_processor(self) -> None:  # noqa: B027
         """Finalize processor after the worker thread has stopped.
@@ -167,6 +172,12 @@ class Service(ServiceBase):
                 os.kill(os.getpid(), signal.SIGINT)
         finally:
             self._logger.info("Service loop stopped")
+
+    @property
+    def _exit_code(self) -> int:
+        """Nonzero when the worker loop died on an error, so that
+        ``restart: on-failure`` supervisors actually restart the service."""
+        return 1 if self._worker_error is not None else 0
 
     def _finalize_processor(self) -> None:
         """Finalize processor after the worker thread has joined."""

--- a/src/ess/livedata/kafka/consumer.py
+++ b/src/ess/livedata/kafka/consumer.py
@@ -28,40 +28,52 @@ def validate_topics_exist(consumer: kafka.Consumer, topics: list[str]) -> None:
         raise ValueError(f"Failed to fetch topic metadata: {e}") from e
 
 
-def assign_partitions(consumer: kafka.Consumer, topic: str) -> None:
-    """Assign all partitions of a topic to a consumer."""
-    try:
-        partitions = consumer.list_topics(topic).topics[topic].partitions
+def assign_all_partitions(consumer: kafka.Consumer, topics: list[str]) -> None:
+    """Manually assign every partition of every topic to a consumer.
+
+    ``Consumer.assign`` replaces the entire assignment, so all partitions of all
+    topics must be passed in a single call; assigning per topic in a loop would
+    leave only the last topic assigned.
+    """
+    assignment: list[kafka.TopicPartition] = []
+    for topic in topics:
+        try:
+            partitions = consumer.list_topics(topic).topics[topic].partitions
+        except KafkaException as e:
+            logger.exception("partition_assignment_failed", topic=topic)
+            raise ValueError(
+                f"Failed to assign partitions for topic '{topic}': {e}"
+            ) from e
         if not partitions:
             logger.error("topic_has_no_partitions", topic=topic)
             raise ValueError(f"Topic '{topic}' exists but has no partitions")
         partition_ids = list(partitions.keys())
-        consumer.assign([kafka.TopicPartition(topic, p) for p in partition_ids])
+        assignment.extend(kafka.TopicPartition(topic, p) for p in partition_ids)
         logger.info(
-            "partitions_assigned",
+            "partitions_resolved",
             topic=topic,
             partition_count=len(partition_ids),
             partitions=partition_ids,
         )
-    except KafkaException as e:
-        logger.exception("partition_assignment_failed", topic=topic)
-        raise ValueError(f"Failed to assign partitions for topic '{topic}': {e}") from e
+    consumer.assign(assignment)
 
 
 @contextmanager
 def make_bare_consumer(
     topics: list[str], config: dict[str, Any]
 ) -> Generator[kafka.Consumer, None, None]:
-    """Create a bare confluent_kafka.Consumer that can be used by KafkaMessageSource."""
+    """Create a bare confluent_kafka.Consumer that can be used by KafkaMessageSource.
+
+    Partitions are assigned manually rather than via ``subscribe``; the two APIs
+    are mutually exclusive in librdkafka, and manual assignment guarantees every
+    partition is consumed immediately without waiting for a group rebalance.
+    """
     consumer = kafka.Consumer(config)
     try:
         validate_topics_exist(consumer, topics)
-        consumer.subscribe(topics)
-        for topic in topics:
-            assign_partitions(consumer, topic)
+        assign_all_partitions(consumer, topics)
         yield consumer
     finally:
-        consumer.unsubscribe()
         consumer.close()
 
 

--- a/src/ess/livedata/kafka/sink.py
+++ b/src/ess/livedata/kafka/sink.py
@@ -108,6 +108,15 @@ class KafkaSink(MessageSink[T]):
                     callback=delivery_callback,
                 )
                 self._producer.poll(0)
+            except BufferError:
+                # Local producer queue is full (backpressure, e.g. during a broker
+                # outage). Dropping live-data messages keeps the service alive;
+                # serving delivery callbacks frees queue space for the next batch.
+                self._publish_errors += 1
+                logger.error(
+                    "Producer queue full, dropping message to %s", serialized.topic
+                )
+                self._producer.poll(0)
             except kafka.KafkaException as e:
                 err = e.args[0] if e.args else None
                 if isinstance(err, kafka.KafkaError) and is_fatal(err):

--- a/tests/kafka/consumer_test.py
+++ b/tests/kafka/consumer_test.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
+"""Tests for manual partition assignment in :mod:`ess.livedata.kafka.consumer`.
+
+A running broker is unavoidable for a real ``confluent_kafka.Consumer``, so a
+hand-rolled fake records ``assign`` calls and reports topic metadata.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ess.livedata.kafka.consumer import assign_all_partitions
+
+
+class _Partition:
+    pass
+
+
+class _TopicMetadata:
+    def __init__(self, partition_ids: list[int]) -> None:
+        self.partitions = {p: _Partition() for p in partition_ids}
+
+
+class _ClusterMetadata:
+    def __init__(self, topics: dict[str, _TopicMetadata]) -> None:
+        self.topics = topics
+
+
+class _FakeConsumer:
+    """Records ``assign`` calls; serves per-topic partition metadata."""
+
+    def __init__(self, topic_partitions: dict[str, list[int]]) -> None:
+        self._topic_partitions = topic_partitions
+        self.assignments: list[list] = []
+
+    def list_topics(self, topic: str, timeout: float | None = None) -> _ClusterMetadata:
+        ids = self._topic_partitions.get(topic, [])
+        return _ClusterMetadata({topic: _TopicMetadata(ids)})
+
+    def assign(self, partitions: list) -> None:
+        self.assignments.append(partitions)
+
+
+def test_assigns_all_partitions_of_all_topics_in_one_call() -> None:
+    consumer = _FakeConsumer({'a': [0, 1], 'b': [0]})
+
+    assign_all_partitions(consumer, ['a', 'b'])
+
+    # Single assign call: a per-topic loop would clobber earlier topics.
+    assert len(consumer.assignments) == 1
+    assigned = {(tp.topic, tp.partition) for tp in consumer.assignments[0]}
+    assert assigned == {('a', 0), ('a', 1), ('b', 0)}
+
+
+def test_raises_when_topic_has_no_partitions() -> None:
+    consumer = _FakeConsumer({'a': [0], 'b': []})
+
+    with pytest.raises(ValueError, match="no partitions"):
+        assign_all_partitions(consumer, ['a', 'b'])
+    assert consumer.assignments == []

--- a/tests/kafka/kafka_sink_test.py
+++ b/tests/kafka/kafka_sink_test.py
@@ -284,6 +284,16 @@ class TestErrorHandling:
             # Must not raise.
             sink.publish_messages([_data_message()])
 
+    def test_buffer_error_from_produce_does_not_propagate(
+        self, sink_factory, producer: _FakeProducer
+    ) -> None:
+        # A full local producer queue (backpressure) raises BufferError, not a
+        # KafkaException. Dropping the message must not crash the service.
+        producer.raise_on_produce = BufferError('Local: Queue full')
+        with sink_factory(Da00Serializer(instrument=INSTRUMENT)) as sink:
+            sink.publish_messages([_data_message()])
+        assert producer.produced == []
+
 
 class TestFailFast:
     """

--- a/tests/service_test.py
+++ b/tests/service_test.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import signal
+import subprocess
+import sys
+import textwrap
 import time
 
 from ess.livedata import Service
@@ -26,3 +30,37 @@ def test_create_start_stop_service() -> None:
     assert processor.call_count > 0
     service.stop()
     assert not service.is_running
+
+
+# These run a real blocking service in a subprocess: constructing a Service
+# installs process-wide signal handlers, and the worker loop signals the main
+# thread via SIGINT, so the exit code is only observable from outside the process.
+_SERVICE_SCRIPT = textwrap.dedent(
+    """
+    from ess.livedata import Service
+
+    class Processor:
+        def process(self):
+            {body}
+        def finalize(self, *, error=None):
+            pass
+
+    Service(processor=Processor(), poll_interval=0.005).start()
+    """
+)
+
+
+def test_worker_loop_error_exits_nonzero() -> None:
+    script = _SERVICE_SCRIPT.format(body='raise RuntimeError("boom")')
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 1
+
+
+def test_clean_shutdown_exits_zero() -> None:
+    script = _SERVICE_SCRIPT.format(body='pass')
+    proc = subprocess.Popen([sys.executable, "-c", script])  # noqa: S603
+    time.sleep(1.0)
+    proc.send_signal(signal.SIGTERM)
+    assert proc.wait(timeout=30) == 0


### PR DESCRIPTION
Three independent backend robustness fixes from the correctness survey (#971), items 5, 6, and 7. Each turns a transient or startup-time fault into a silent, often permanent failure.

## Consumer partition assignment (item 7)

`make_bare_consumer` assigned partitions one topic at a time in a loop. `Consumer.assign` replaces the entire assignment, so only the last topic's partitions ended up manually assigned; the others depended on a later group rebalance and, with `auto.offset.reset=latest`, could silently skip early messages on startup. It also mixed `subscribe` and `assign`, which are mutually exclusive in librdkafka. All partitions of all topics are now collected and assigned in a single call, and `subscribe` is dropped.

## Sink backpressure death (item 5)

`KafkaSink` only caught `KafkaException`, but a full local producer queue raises `BufferError`. During a broker outage the queue fills until `BufferError` propagates out of the worker loop and kills the service, turning a transient hiccup into a permanent outage. The sink now drops the message and serves delivery callbacks to free queue space, consistent with its existing live-data drop semantics for non-fatal failures.

## Nonzero exit on worker-loop death (item 6)

When the worker loop raised, the service signalled the main thread and `_handle_shutdown` unconditionally called `sys.exit(0)`, so a crash was indistinguishable from a clean operator shutdown. Supervisors with `restart: on-failure` left the crashed service down. The exit code now comes from an overridable `_exit_code` property: 1 when a worker error was recorded, 0 for operator-initiated shutdown. This compounds with item 5 — together a transient broker problem could silently and permanently take a backend down.

## Test plan

- [x] `tests/kafka/` (308 passed)
- [x] New consumer tests: single assign covering all topics; raises on empty-partition topic
- [x] New sink test: `BufferError` from `produce` does not propagate
- [x] New service tests (subprocess): worker-loop error exits 1; SIGTERM shutdown exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
