### PR TITLE
Fix subscriber skipped when subscriber list mutated during notification

### DIFF
--- a/src/ess/livedata/dashboard/data_service.py
+++ b/src/ess/livedata/dashboard/data_service.py
@@ -184,7 +184,11 @@ class DataService(MutableMapping[K, V]):
         updated_keys
             The set of data keys that were updated.
         """
-        for subscriber in self._subscribers:
+        # Iterate over a snapshot: a subscriber's trigger, or a concurrent
+        # unregister from the UI thread, may mutate self._subscribers mid-loop.
+        # Without the copy the list-index iterator would silently skip the
+        # subscriber following a removed one.
+        for subscriber in list(self._subscribers):
             if updated_keys & subscriber.keys:
                 try:
                     subscriber_data = self._build_subscriber_data(subscriber)

--- a/tests/dashboard/data_service_test.py
+++ b/tests/dashboard/data_service_test.py
@@ -144,6 +144,52 @@ def test_unregister_nonexistent_subscriber_returns_false(
     assert result is False
 
 
+def test_unregister_during_notification_does_not_skip_other_subscribers(
+    data_service: DataService[str, int],
+):
+    """A subscriber removed mid-notification must not cause a sibling to be skipped.
+
+    Reproduces the list-index skip: notifying iterates the subscriber list, and a
+    trigger (or, in production, a concurrent UI-thread teardown) removes a
+    subscriber positioned before one not yet visited. A raw list-index iterator
+    would then skip the following subscriber.
+    """
+    triggered: list[str] = []
+
+    class RemovingSubscriber(DataServiceSubscriber[str]):
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.target: DataServiceSubscriber[str] | None = None
+            self._extractors = {"key1": LatestValueExtractor()}
+            super().__init__()
+
+        @property
+        def extractors(self):
+            return self._extractors
+
+        def trigger(self, store: dict[str, Any]) -> None:
+            if "key1" not in store:
+                return
+            triggered.append(self.name)
+            if self.target is not None:
+                data_service.unregister_subscriber(self.target)
+                self.target = None
+
+    first = RemovingSubscriber("first")
+    middle = RemovingSubscriber("middle")
+    last = RemovingSubscriber("last")
+    # Registration order fixes iteration order: middle removes the earlier
+    # 'first', shifting indices so a naive iterator would skip 'last'.
+    middle.target = first
+    for sub in (first, middle, last):
+        data_service.register_subscriber(sub)
+
+    triggered.clear()
+    data_service["key1"] = make_test_data(42)
+
+    assert triggered == ["first", "middle", "last"]
+
+
 def test_setitem_notifies_matching_subscriber(data_service: DataService[str, int]):
     subscriber, get_pipe = create_test_subscriber({"key1", "key2"})
     data_service.register_subscriber(subscriber)


### PR DESCRIPTION
Item 10 of #971. `DataService._notify_subscribers` iterated `self._subscribers` directly. When a subscriber is removed mid-iteration, the list-index iterator silently skips the subscriber positioned after the removed one, so it misses that notification cycle.

Two ways this is reached: a subscriber's `trigger` removing another subscriber, and — the production case — a UI-thread plot teardown or reconfiguration (`PlotOrchestrator.remove_cell` / `remove_grid` / `update_layer_config` → `unregister_subscriber`) racing the background ingestion thread that drives notifications. These two threads share the global subscriber list with no lock covering it. Impact is mild and self-healing (one skipped refresh, recovered on the next data batch), but it is a real correctness gap.

Fix iterates over a snapshot of the list. This resolves the skip but does not close the broader gap that `register_subscriber`/`unregister_subscriber` also mutate `TemporalBufferManager` extractors off-thread without synchronization; that is left as a follow-up since it warrants a deliberate locking decision.

## Test plan
- [x] New regression test fails without the snapshot, passes with it
- [x] `data_service_test.py` suite green
