### PR TITLE
Stop/reset scheduled jobs on workflow and broadcast commands

### DIFF
--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -369,8 +369,7 @@ class JobManager:
             self._perform_action(action=command.action, sel=lambda job: True)
 
     def _perform_action(self, action: JobAction, sel: Callable[[Job], bool]) -> None:
-        controllable = (*self.active_jobs, *self._pending_context_jobs.values())
-        jobs_to_control = [job.job_id for job in controllable if sel(job)]
+        jobs_to_control = [job.job_id for job in self.all_jobs if sel(job)]
         for job_id in jobs_to_control:
             self._perform_job_action(job_id=job_id, action=action)
 

--- a/src/ess/livedata/core/job_manager_adapter.py
+++ b/src/ess/livedata/core/job_manager_adapter.py
@@ -15,12 +15,9 @@ class JobManagerAdapter:
     """
     Adapter to convert calls to JobManager into ConfigHandler actions.
 
-    This has two purposes:
-
-    1. We can keep using ConfigHandler until we have fully refactored everything.
-    2. We keep the legacy one-source-one-job behavior, replacing old jobs if a new one
-       is started. The long-term goal is to change this to a more flexible mechanism,
-       but this, too, would require frontend changes.
+    Lets us keep using ConfigHandler until we have fully refactored everything.
+    A WorkflowConfig is translated into a new scheduled job and a JobCommand into
+    a job action, each wrapped in a CommandAcknowledgement for the frontend.
     """
 
     def __init__(self, *, job_manager: JobManager) -> None:

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -2571,3 +2571,49 @@ class TestContextStreamGate:
         manager.job_command(JobCommand(action=JobAction.stop))
 
         assert manager.get_job_status(job_id) is None
+
+    def test_job_command_stop_by_workflow_reaches_scheduled_job(self, fake_job_factory):
+        """A `job_command` targeting a workflow_id stops not-yet-active jobs.
+
+        Without this, a scheduled job survives the stop and later activates as a
+        zombie the user believes was stopped.
+        """
+        from ess.livedata.core.job_manager import JobAction, JobCommand
+
+        manager = JobManager(fake_job_factory, context_reader=no_cached_context)
+        config = _make_config(
+            "test_source",
+            schedule=JobSchedule(start_time=Timestamp.from_ns(200)),
+        )
+        job_id = manager.schedule_job(config)
+
+        manager.job_command(
+            JobCommand(workflow_id=config.identifier, action=JobAction.stop)
+        )
+
+        assert manager.get_job_status(job_id) is None
+        # Reaching the start time must not resurrect the job.
+        manager.push_data(
+            WorkflowData(
+                start_time=Timestamp.from_ns(250),
+                end_time=Timestamp.from_ns(300),
+                data={StreamId(name="test_source"): sc.scalar(42.0)},
+            )
+        )
+        assert len(manager.active_jobs) == 0
+
+    def test_job_command_broadcast_stop_reaches_scheduled_job(self, fake_job_factory):
+        """Broadcast `job_command` without job_id/workflow_id stops scheduled jobs."""
+        from ess.livedata.core.job_manager import JobAction, JobCommand
+
+        manager = JobManager(fake_job_factory, context_reader=no_cached_context)
+        job_id = manager.schedule_job(
+            _make_config(
+                "test_source",
+                schedule=JobSchedule(start_time=Timestamp.from_ns(200)),
+            )
+        )
+
+        manager.job_command(JobCommand(action=JobAction.stop))
+
+        assert manager.get_job_status(job_id) is None


### PR DESCRIPTION
Addresses item 8 of #971.

A stop/reset command targeting a `workflow_id`, or a broadcast command (no `job_id`, no `workflow_id`), only reached active and pending-context jobs. Scheduled-but-not-yet-active jobs were left untouched and later activated as zombies the user believed were stopped. The per-`job_id` path already handled every job bucket, so this aligns the broadcast/by-workflow path by iterating `all_jobs`.

Also corrects the `JobManagerAdapter` docstring, which described a legacy replace-on-restart behavior that `set_workflow_with_config` never implemented — it only schedules a new job.

## Test plan

- [x] New unit tests cover stop-by-workflow and broadcast-stop reaching a scheduled job; both fail without the fix.
