### PR TITLE
Use cached watermark offsets for consumer lag

### DIFF
--- a/src/ess/livedata/kafka/source.py
+++ b/src/ess/livedata/kafka/source.py
@@ -142,7 +142,6 @@ class BackgroundMessageSource(KafkaMessageSource):
         self._batches_dropped_since_last_metrics = 0
 
         # Lag monitoring (computed in a separate thread to avoid blocking consumption)
-        self._lag_query_timeout = 0.1
         self._lag_lock = threading.Lock()
         self._cached_lag: dict[str, Any] | None = None
         self._lag_thread: threading.Thread | None = None
@@ -374,8 +373,12 @@ class BackgroundMessageSource(KafkaMessageSource):
     def _compute_consumer_lag(self) -> dict[str, Any] | None:
         """Compute consumer lag per partition.
 
-        Called by the lag monitor thread. Uses a short timeout to avoid
-        blocking for too long if the broker is slow to respond.
+        Called by the lag monitor thread. Uses cached watermark offsets to
+        avoid issuing ListOffsetsRequests to the broker: the high watermark is
+        piggybacked on every FetchResponse for partitions we actively consume,
+        so no network round-trip is needed. Querying the broker directly
+        (cached=False) competes with long-poll FetchRequests on the same broker
+        connection and times out, producing REQTMOUT log spam.
         """
         # The KafkaConsumer protocol only requires `consume`. `assignment` and
         # `get_watermark_offsets` are provided by `confluent_kafka.Consumer`
@@ -392,9 +395,7 @@ class BackgroundMessageSource(KafkaMessageSource):
 
             for tp in assignment:
                 try:
-                    _low, high = self._consumer.get_watermark_offsets(
-                        tp, timeout=self._lag_query_timeout
-                    )
+                    _low, high = self._consumer.get_watermark_offsets(tp, cached=True)
                     position = self._consumer.position([tp])[0].offset
                     if position >= 0 and high >= 0:
                         partition_lag = high - position

--- a/src/ess/livedata/kafka/source.py
+++ b/src/ess/livedata/kafka/source.py
@@ -141,11 +141,6 @@ class BackgroundMessageSource(KafkaMessageSource):
         self._messages_consumed_since_last_metrics = 0
         self._batches_dropped_since_last_metrics = 0
 
-        # Lag monitoring (computed in a separate thread to avoid blocking consumption)
-        self._lag_lock = threading.Lock()
-        self._cached_lag: dict[str, Any] | None = None
-        self._lag_thread: threading.Thread | None = None
-
     def __enter__(self):
         """Enter context manager and start background consumption."""
         self.start()
@@ -164,8 +159,6 @@ class BackgroundMessageSource(KafkaMessageSource):
         self._stop_event.clear()
         self._thread = threading.Thread(target=self._consume_loop, daemon=True)
         self._thread.start()
-        self._lag_thread = threading.Thread(target=self._lag_monitor_loop, daemon=True)
-        self._lag_thread.start()
         logger.info("background_consumer_started")
 
     def stop(self) -> None:
@@ -174,8 +167,6 @@ class BackgroundMessageSource(KafkaMessageSource):
             return
 
         self._stop_event.set()
-        if self._lag_thread and self._lag_thread.is_alive():
-            self._lag_thread.join(timeout=2.0)
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5.0)
             if self._thread.is_alive():
@@ -254,17 +245,6 @@ class BackgroundMessageSource(KafkaMessageSource):
         except Exception as e:
             self._failure_reason = f"Fatal error in consume loop: {e}"
             logger.exception("background_consumer_fatal_error")
-
-    def _lag_monitor_loop(self) -> None:
-        """Periodically compute consumer lag without blocking the consume loop."""
-        while not self._stop_event.is_set():
-            try:
-                lag = self._compute_consumer_lag()
-                with self._lag_lock:
-                    self._cached_lag = lag
-            except Exception:
-                logger.exception("lag_monitor_error")
-            self._stop_event.wait(timeout=self._metrics_interval)
 
     def _maybe_log_metrics(self) -> None:
         """Log metrics if the interval has elapsed."""
@@ -362,23 +342,15 @@ class BackgroundMessageSource(KafkaMessageSource):
         )
 
     def get_consumer_lag(self) -> dict[str, Any] | None:
-        """Get the most recently computed consumer lag.
+        """Compute consumer lag per partition, or None if unsupported.
 
-        Returns cached lag information computed by the lag monitor thread,
-        or None if no lag data is available yet.
-        """
-        with self._lag_lock:
-            return self._cached_lag
-
-    def _compute_consumer_lag(self) -> dict[str, Any] | None:
-        """Compute consumer lag per partition.
-
-        Called by the lag monitor thread. Uses cached watermark offsets to
-        avoid issuing ListOffsetsRequests to the broker: the high watermark is
-        piggybacked on every FetchResponse for partitions we actively consume,
-        so no network round-trip is needed. Querying the broker directly
-        (cached=False) competes with long-poll FetchRequests on the same broker
-        connection and times out, producing REQTMOUT log spam.
+        Uses cached watermark offsets to avoid issuing ListOffsetsRequests to
+        the broker: the high watermark is piggybacked on every FetchResponse
+        for partitions we actively consume, so no network round-trip is needed.
+        Querying the broker directly (cached=False) competes with long-poll
+        FetchRequests on the same broker connection and times out, producing
+        REQTMOUT log spam. Being broker-free, this is cheap enough to call
+        directly from the consume loop.
         """
         # The KafkaConsumer protocol only requires `consume`. `assignment` and
         # `get_watermark_offsets` are provided by `confluent_kafka.Consumer`

--- a/tests/kafka/source_test.py
+++ b/tests/kafka/source_test.py
@@ -783,7 +783,7 @@ class LagSupportingConsumer:
         return [FakeTopicPartition(self._topic, p) for p in self._partitions]
 
     def get_watermark_offsets(
-        self, tp: FakeTopicPartition, timeout: float = 1.0
+        self, tp: FakeTopicPartition, timeout: float = 1.0, cached: bool = False
     ) -> tuple[int, int]:
         return self._watermarks[(tp.topic, tp.partition)]
 


### PR DESCRIPTION
## Problem

PROD detector services flood the journal with `REQTMOUT` warnings for `ListOffsetsRequest`:

```
REQTMOUT|rdkafka#consumer-2| Timed out ListOffsetsRequest in flight (after 100ms, timeout #0): possibly held back by preceeding FetchRequest with timeout in 59998ms
```

The source is the consumer-lag monitor. Every 30s its background thread called `get_watermark_offsets(tp, timeout=0.1)` (default `cached=False`) for every assigned partition, issuing a live `ListOffsetsRequest` to the broker. rdkafka serializes requests per broker connection, so each of these queues behind the consumer's long-poll `FetchRequest` (up to 60s) and times out after 100ms — exactly what the log's "held back by preceeding FetchRequest" notes. A detector consumer spanning many brokers therefore produces a burst of timeouts every metrics cycle.

## Fix

Query with `cached=True`. The high watermark is piggybacked on every `FetchResponse` for partitions we actively consume, so the cached value is fresh with no network round-trip, removing the `ListOffsetsRequest`s entirely. `position()` is already local.

Trade-off: cached high only refreshes while messages flow on a partition, so a genuinely idle partition could report stale lag — but that is the case where lag is ~0 and uninteresting.

## Follow-on simplification

The lag computation ran in its own thread purely to keep those blocking ListOffsets calls off the consume loop. With cached offsets it is a local, microsecond-cheap operation, so the thread, lock, and cached-lag indirection are removed and lag is computed inline where metrics are logged. As a side effect the consumer is no longer accessed concurrently from two threads.
