### PR TITLE
Wire shared monitor workflow factory into instruments

### DIFF
--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -713,6 +713,8 @@ class Instrument:
         if hasattr(module, 'setup_factories'):
             module.setup_factories(self)
 
+        self._attach_default_monitor_factories()
+
         self.validate()
 
         for name in (*self.detector_names, *self._pixellated_monitors):
@@ -724,6 +726,33 @@ class Instrument:
                     # the expected path (e.g., monitors lack a detector_number
                     # dataset — they must provide it via configure_pixellated_monitor)
                     pass
+
+    def _attach_default_monitor_factories(self) -> None:
+        """Attach the shared monitor workflow factory where none was provided.
+
+        Monitor specs are parameterized by a :class:`MonitorDataParamsBase`
+        model and otherwise share a single factory. Instruments needing TOF
+        lookup tables for wavelength mode (DREAM, LOKI) attach their own in
+        ``setup_factories``; this fills in the default for the rest. Done in
+        this backend-only factory phase rather than at spec registration so the
+        dashboard, which imports specs but never calls ``load_factories``, holds
+        no factory references.
+        """
+        from ess.livedata.handlers.monitor_workflow_specs import (
+            MonitorDataParamsBase,
+            create_monitor_workflow_factory,
+        )
+
+        for reg in list(self.workflow_factory.registrations()):
+            params = reg.spec.params
+            if (
+                reg.factory is None
+                and params is not None
+                and issubclass(params, MonitorDataParamsBase)
+            ):
+                self.workflow_factory.attach_factory(reg.spec.get_id())(
+                    create_monitor_workflow_factory
+                )
 
     def validate(self) -> None:
         """Check registration-time invariants across all bindings and specs.

--- a/src/ess/livedata/config/instruments/bifrost/factories.py
+++ b/src/ess/livedata/config/instruments/bifrost/factories.py
@@ -87,18 +87,11 @@ def setup_factories(instrument: Instrument) -> None:
     specs.unified_detector_view_handle.skip_instrument_contexts()
 
     # Monitor workflow factory (TOA-only)
-    from ess.livedata.handlers.monitor_workflow import create_monitor_workflow
-    from ess.livedata.handlers.monitor_workflow_specs import TOAOnlyMonitorDataParams
+    from ess.livedata.handlers.monitor_workflow_specs import (
+        create_monitor_workflow_factory,
+    )
 
-    @specs.monitor_handle.attach_factory()
-    def _monitor_workflow_factory(source_name: str, params: TOAOnlyMonitorDataParams):
-        """Factory for Bifrost monitor workflow (TOA-only)."""
-        return create_monitor_workflow(
-            source_name=source_name,
-            edges=params.get_active_edges(),
-            range_filter=params.get_active_range(),
-            coordinate_mode='toa',
-        )
+    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)
 
     # Create base reduction workflow
     (

--- a/src/ess/livedata/config/instruments/bifrost/factories.py
+++ b/src/ess/livedata/config/instruments/bifrost/factories.py
@@ -86,13 +86,6 @@ def setup_factories(instrument: Instrument) -> None:
     specs.detector_ratemeter_handle.skip_instrument_contexts()
     specs.unified_detector_view_handle.skip_instrument_contexts()
 
-    # Monitor workflow factory (TOA-only)
-    from ess.livedata.handlers.monitor_workflow_specs import (
-        create_monitor_workflow_factory,
-    )
-
-    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)
-
     # Create base reduction workflow
     (
         reduction_workflow,

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -215,9 +215,7 @@ instrument = Instrument(
 instrument_registry.register(instrument)
 
 # Register monitor workflow spec (TOA-only, no TOF lookup tables)
-monitor_handle = register_monitor_workflow_specs(
-    instrument, monitors, params=TOAOnlyMonitorDataParams
-)
+register_monitor_workflow_specs(instrument, monitors, params=TOAOnlyMonitorDataParams)
 
 
 def _logical_view(obj: sc.Variable | sc.DataArray, source_name: str) -> sc.DataArray:

--- a/src/ess/livedata/config/instruments/dummy/factories.py
+++ b/src/ess/livedata/config/instruments/dummy/factories.py
@@ -54,18 +54,11 @@ def setup_factories(instrument: Instrument) -> None:
     specs.area_panel_view_handle.attach_factory()(AreaDetectorView.view_factory())
 
     # Monitor workflow factory (TOA-only)
-    from ess.livedata.handlers.monitor_workflow import create_monitor_workflow
-    from ess.livedata.handlers.monitor_workflow_specs import TOAOnlyMonitorDataParams
+    from ess.livedata.handlers.monitor_workflow_specs import (
+        create_monitor_workflow_factory,
+    )
 
-    @specs.monitor_handle.attach_factory()
-    def _monitor_workflow_factory(source_name: str, params: TOAOnlyMonitorDataParams):
-        """Factory for dummy monitor workflow (TOA-only)."""
-        return create_monitor_workflow(
-            source_name=source_name,
-            edges=params.get_active_edges(),
-            range_filter=params.get_active_range(),
-            coordinate_mode='toa',
-        )
+    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)
 
     # Total counts workflow
     _total_counts_workflow = sciline.Pipeline((_total_counts,))

--- a/src/ess/livedata/config/instruments/dummy/factories.py
+++ b/src/ess/livedata/config/instruments/dummy/factories.py
@@ -53,13 +53,6 @@ def setup_factories(instrument: Instrument) -> None:
     # Area detector view for area_panel (ad00 images)
     specs.area_panel_view_handle.attach_factory()(AreaDetectorView.view_factory())
 
-    # Monitor workflow factory (TOA-only)
-    from ess.livedata.handlers.monitor_workflow_specs import (
-        create_monitor_workflow_factory,
-    )
-
-    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)
-
     # Total counts workflow
     _total_counts_workflow = sciline.Pipeline((_total_counts,))
 

--- a/src/ess/livedata/config/instruments/dummy/specs.py
+++ b/src/ess/livedata/config/instruments/dummy/specs.py
@@ -48,7 +48,7 @@ instrument = Instrument(
 instrument_registry.register(instrument)
 
 # Register monitor workflow spec (TOA-only, no TOF lookup tables)
-monitor_handle = register_monitor_workflow_specs(
+register_monitor_workflow_specs(
     instrument, ['monitor1', 'monitor2'], params=TOAOnlyMonitorDataParams
 )
 

--- a/src/ess/livedata/config/instruments/estia/factories.py
+++ b/src/ess/livedata/config/instruments/estia/factories.py
@@ -43,18 +43,12 @@ def setup_factories(instrument: Instrument) -> None:
     )
     from scippnexus import NXdetector
 
-    from ess.livedata.handlers.monitor_workflow import create_monitor_workflow
-    from ess.livedata.handlers.monitor_workflow_specs import TOAOnlyMonitorDataParams
+    from ess.livedata.handlers.monitor_workflow_specs import (
+        create_monitor_workflow_factory,
+    )
     from ess.livedata.handlers.stream_processor_workflow import StreamProcessorWorkflow
 
-    @specs.monitor_handle.attach_factory()
-    def _monitor_workflow_factory(source_name: str, params: TOAOnlyMonitorDataParams):
-        return create_monitor_workflow(
-            source_name=source_name,
-            edges=params.get_active_edges(),
-            range_filter=params.get_active_range(),
-            coordinate_mode='toa',
-        )
+    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)
 
     @specs.reflectometry_reduction_handle.attach_factory()
     def _reflectometry_reduction_workflow_factory(

--- a/src/ess/livedata/config/instruments/estia/factories.py
+++ b/src/ess/livedata/config/instruments/estia/factories.py
@@ -43,12 +43,7 @@ def setup_factories(instrument: Instrument) -> None:
     )
     from scippnexus import NXdetector
 
-    from ess.livedata.handlers.monitor_workflow_specs import (
-        create_monitor_workflow_factory,
-    )
     from ess.livedata.handlers.stream_processor_workflow import StreamProcessorWorkflow
-
-    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)
 
     @specs.reflectometry_reduction_handle.attach_factory()
     def _reflectometry_reduction_workflow_factory(

--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -202,7 +202,7 @@ instrument = Instrument(
 
 instrument_registry.register(instrument)
 
-monitor_handle = register_monitor_workflow_specs(
+register_monitor_workflow_specs(
     instrument,
     instrument.monitors,
     params=TOAOnlyMonitorDataParams,

--- a/src/ess/livedata/config/instruments/nmx/factories.py
+++ b/src/ess/livedata/config/instruments/nmx/factories.py
@@ -44,15 +44,8 @@ def setup_factories(instrument: Instrument) -> None:
     specs.panel_xy_view_handle.attach_factory()(_nmx_panels_view.make_workflow)
 
     # Monitor workflow factory (TOA-only)
-    from ess.livedata.handlers.monitor_workflow import create_monitor_workflow
-    from ess.livedata.handlers.monitor_workflow_specs import TOAOnlyMonitorDataParams
+    from ess.livedata.handlers.monitor_workflow_specs import (
+        create_monitor_workflow_factory,
+    )
 
-    @specs.monitor_handle.attach_factory()
-    def _monitor_workflow_factory(source_name: str, params: TOAOnlyMonitorDataParams):
-        """Factory for NMX monitor workflow (TOA-only)."""
-        return create_monitor_workflow(
-            source_name=source_name,
-            edges=params.get_active_edges(),
-            range_filter=params.get_active_range(),
-            coordinate_mode='toa',
-        )
+    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)

--- a/src/ess/livedata/config/instruments/nmx/factories.py
+++ b/src/ess/livedata/config/instruments/nmx/factories.py
@@ -42,10 +42,3 @@ def setup_factories(instrument: Instrument) -> None:
     )
 
     specs.panel_xy_view_handle.attach_factory()(_nmx_panels_view.make_workflow)
-
-    # Monitor workflow factory (TOA-only)
-    from ess.livedata.handlers.monitor_workflow_specs import (
-        create_monitor_workflow_factory,
-    )
-
-    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)

--- a/src/ess/livedata/config/instruments/nmx/specs.py
+++ b/src/ess/livedata/config/instruments/nmx/specs.py
@@ -33,7 +33,7 @@ instrument = Instrument(
 instrument_registry.register(instrument)
 
 # Register monitor workflow spec (TOA-only, no TOF lookup tables)
-monitor_handle = register_monitor_workflow_specs(
+register_monitor_workflow_specs(
     instrument, ['monitor1', 'monitor2'], params=TOAOnlyMonitorDataParams
 )
 

--- a/src/ess/livedata/config/instruments/odin/factories.py
+++ b/src/ess/livedata/config/instruments/odin/factories.py
@@ -6,8 +6,6 @@ ODIN instrument factory implementations.
 
 from ess.livedata.config import Instrument
 
-from . import specs
-
 
 def setup_factories(instrument: Instrument) -> None:
     """Initialize ODIN-specific factories and workflows."""
@@ -15,10 +13,3 @@ def setup_factories(instrument: Instrument) -> None:
     instrument.configure_detector(
         'timepix3', detector_group_name='event_mode_detectors'
     )
-
-    # Monitor workflow factory (TOA-only)
-    from ess.livedata.handlers.monitor_workflow_specs import (
-        create_monitor_workflow_factory,
-    )
-
-    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)

--- a/src/ess/livedata/config/instruments/odin/factories.py
+++ b/src/ess/livedata/config/instruments/odin/factories.py
@@ -17,15 +17,8 @@ def setup_factories(instrument: Instrument) -> None:
     )
 
     # Monitor workflow factory (TOA-only)
-    from ess.livedata.handlers.monitor_workflow import create_monitor_workflow
-    from ess.livedata.handlers.monitor_workflow_specs import TOAOnlyMonitorDataParams
+    from ess.livedata.handlers.monitor_workflow_specs import (
+        create_monitor_workflow_factory,
+    )
 
-    @specs.monitor_handle.attach_factory()
-    def _monitor_workflow_factory(source_name: str, params: TOAOnlyMonitorDataParams):
-        """Factory for ODIN monitor workflow (TOA-only)."""
-        return create_monitor_workflow(
-            source_name=source_name,
-            edges=params.get_active_edges(),
-            range_filter=params.get_active_range(),
-            coordinate_mode='toa',
-        )
+    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)

--- a/src/ess/livedata/config/instruments/odin/specs.py
+++ b/src/ess/livedata/config/instruments/odin/specs.py
@@ -23,7 +23,7 @@ instrument = Instrument(
 instrument_registry.register(instrument)
 
 # Register monitor workflow spec (TOA-only, no TOF lookup tables)
-monitor_handle = register_monitor_workflow_specs(
+register_monitor_workflow_specs(
     instrument, ['monitor1', 'monitor2'], params=TOAOnlyMonitorDataParams
 )
 

--- a/src/ess/livedata/config/instruments/tbl/factories.py
+++ b/src/ess/livedata/config/instruments/tbl/factories.py
@@ -13,14 +13,9 @@ from .views import fold_image
 def setup_factories(instrument: Instrument) -> None:
     """Initialize TBL-specific factories and workflows."""
     from ess.livedata.handlers.area_detector_view import AreaDetectorView
-    from ess.livedata.handlers.monitor_workflow_specs import (
-        create_monitor_workflow_factory,
-    )
 
     specs.orca_view_handle.attach_factory()(
         AreaDetectorView.view_factory(
             transform=fold_image, reduction_dim=['x_bin', 'y_bin']
         )
     )
-
-    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)

--- a/src/ess/livedata/config/instruments/tbl/factories.py
+++ b/src/ess/livedata/config/instruments/tbl/factories.py
@@ -13,8 +13,9 @@ from .views import fold_image
 def setup_factories(instrument: Instrument) -> None:
     """Initialize TBL-specific factories and workflows."""
     from ess.livedata.handlers.area_detector_view import AreaDetectorView
-    from ess.livedata.handlers.monitor_workflow import create_monitor_workflow
-    from ess.livedata.handlers.monitor_workflow_specs import TOAOnlyMonitorDataParams
+    from ess.livedata.handlers.monitor_workflow_specs import (
+        create_monitor_workflow_factory,
+    )
 
     specs.orca_view_handle.attach_factory()(
         AreaDetectorView.view_factory(
@@ -22,11 +23,4 @@ def setup_factories(instrument: Instrument) -> None:
         )
     )
 
-    @specs.monitor_handle.attach_factory()
-    def _monitor_workflow_factory(source_name: str, params: TOAOnlyMonitorDataParams):
-        return create_monitor_workflow(
-            source_name=source_name,
-            edges=params.get_active_edges(),
-            range_filter=params.get_active_range(),
-            coordinate_mode='toa',
-        )
+    specs.monitor_handle.attach_factory()(create_monitor_workflow_factory)

--- a/src/ess/livedata/config/instruments/tbl/specs.py
+++ b/src/ess/livedata/config/instruments/tbl/specs.py
@@ -49,7 +49,7 @@ instrument = Instrument(
 
 instrument_registry.register(instrument)
 
-monitor_handle = register_monitor_workflow_specs(
+register_monitor_workflow_specs(
     instrument, monitor_names, params=TOAOnlyMonitorDataParams
 )
 

--- a/src/ess/livedata/handlers/monitor_workflow_specs.py
+++ b/src/ess/livedata/handlers/monitor_workflow_specs.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import abc
 from typing import ClassVar
 
 import pydantic
@@ -45,7 +46,29 @@ class TOAOnlyCoordinateModeSettings(pydantic.BaseModel):
         return v
 
 
-class TOAOnlyMonitorDataParams(pydantic.BaseModel):
+class MonitorDataParamsBase(pydantic.BaseModel, abc.ABC):
+    """Common interface for monitor histogram parameter models.
+
+    Subclasses expose the active coordinate mode together with the edges and
+    range filter for that mode. This lets a single workflow factory
+    (:func:`create_monitor_workflow_factory`) serve every monitor spec
+    regardless of which coordinate modes the instrument offers.
+    """
+
+    @abc.abstractmethod
+    def get_active_edges(self) -> sc.Variable:
+        """Return the edges for the active coordinate mode."""
+
+    @abc.abstractmethod
+    def get_active_range(self) -> tuple[sc.Variable, sc.Variable] | None:
+        """Return the range filter for the active coordinate mode, if enabled."""
+
+    @abc.abstractmethod
+    def get_coordinate_mode(self) -> CoordinateMode:
+        """Return the active coordinate mode."""
+
+
+class TOAOnlyMonitorDataParams(MonitorDataParamsBase):
     """
     Monitor data parameters restricted to TOA mode only.
 
@@ -82,8 +105,12 @@ class TOAOnlyMonitorDataParams(pydantic.BaseModel):
         """Return the TOA range if enabled."""
         return self.toa_range.range if self.toa_range.enabled else None
 
+    def get_coordinate_mode(self) -> CoordinateMode:
+        """Return the active coordinate mode (always 'toa')."""
+        return self.coordinate_mode.mode
 
-class MonitorDataParams(pydantic.BaseModel):
+
+class MonitorDataParams(MonitorDataParamsBase):
     """Parameters for monitor histogram workflow."""
 
     coordinate_mode: CoordinateModeSettings = pydantic.Field(
@@ -143,6 +170,10 @@ class MonitorDataParams(pydantic.BaseModel):
                     if self.wavelength_range.enabled
                     else None
                 )
+
+    def get_coordinate_mode(self) -> CoordinateMode:
+        """Return the currently selected coordinate mode."""
+        return self.coordinate_mode.mode
 
 
 class MonitorHistogramOutputs(WorkflowOutputsBase):
@@ -254,7 +285,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
 def register_monitor_workflow_specs(
     instrument: Instrument,
     source_names: list[str],
-    params: type[MonitorDataParams] = MonitorDataParams,
+    params: type[MonitorDataParamsBase] = MonitorDataParams,
     aux_sources: AuxSources | None = None,
     extra_description: str | None = None,
 ) -> SpecHandle | None:
@@ -269,9 +300,10 @@ def register_monitor_workflow_specs(
         List of monitor names (source names) for which to register the workflow.
         If empty, returns None without registering.
     params
-        Parameter model class for the workflow. Defaults to MonitorDataParams.
-        Instruments can provide a subclass with additional fields (e.g., for
-        instrument-specific configuration like chopper mode selection).
+        Parameter model class for the workflow, a MonitorDataParamsBase
+        subclass. Defaults to MonitorDataParams. Instruments can provide the
+        restricted TOAOnlyMonitorDataParams or a subclass with additional fields
+        (e.g., for instrument-specific configuration like chopper mode selection).
     aux_sources
         Optional auxiliary source specification for position or other dynamic data
         streams. Instruments with movable monitors can provide an AuxSources spec
@@ -308,21 +340,23 @@ def register_monitor_workflow_specs(
     )
 
 
-def create_monitor_workflow_factory(source_name: str, params: MonitorDataParams):
+def create_monitor_workflow_factory(source_name: str, params: MonitorDataParamsBase):
     """
-    Factory function for monitor workflow from MonitorDataParams.
+    Factory function for monitor workflow from monitor data parameters.
 
-    This is a wrapper around create_monitor_workflow that unpacks the params.
+    Wraps :func:`create_monitor_workflow`, unpacking the params. It serves any
+    spec whose params subclass :class:`MonitorDataParamsBase`, including the
+    TOA-only restricted variant. Instruments needing TOF lookup tables for
+    wavelength mode (DREAM, LOKI) provide their own factory instead.
+
     Defined here so the params type hint can be properly resolved by the
     workflow factory registration system.
     """
     from .monitor_workflow import create_monitor_workflow
 
-    mode = params.coordinate_mode.mode
-
     return create_monitor_workflow(
         source_name=source_name,
         edges=params.get_active_edges(),
         range_filter=params.get_active_range(),
-        coordinate_mode=mode,
+        coordinate_mode=params.get_coordinate_mode(),
     )


### PR DESCRIPTION
`create_monitor_workflow_factory` was tested but never wired into production: six instruments (dummy, odin, nmx, tbl, bifrost, estia) each hand-rolled an identical TOA-only closure. The factory could not be reused as-is because it was typed against `MonitorDataParams`, whereas those specs register `TOAOnlyMonitorDataParams` — a sibling model, not a subclass — so `attach_factory`'s `issubclass` check rejected the pairing.

This introduces `MonitorDataParamsBase` as the common interface for both parameter models and types the factory against it. Rather than attach the shared factory in each instrument (config-free boilerplate), `load_factories` now attaches it to any monitor spec that `setup_factories` did not give a factory of its own. This stays in the backend-only factory phase: doing it at spec registration would also run in the dashboard, which imports specs but never calls `load_factories` and must hold no factory references. The concrete parameter model still comes from the spec, so the restricted TOA-only UI form and runtime validation are unchanged. DREAM and LOKI keep their own lookup-table factories.

## Test plan

- [x] Full fast suite passes
- [x] Verified at runtime that all six instruments resolve `TOAOnlyMonitorDataParams` with the shared factory, DREAM/LOKI retain their custom factories, and workflow creation succeeds in every case
