### PR TITLE
Acknowledge a selector-keyed command only from the owning worker

### DIFF
--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -351,7 +351,14 @@ class JobManager:
             self._finishing_jobs.remove(job_id)
         logger.info("job_stopped", job_id=str(job_id))
 
-    def job_command(self, command: JobCommand) -> None:
+    def job_command(self, command: JobCommand) -> int:
+        """Apply a command and return the number of jobs it acted on.
+
+        The count is zero when no job on this worker matches the command's
+        selector. Backend services share the commands topic but each owns a
+        disjoint set of workflows, so a worker that matches nothing must stay
+        silent rather than acknowledge (see :class:`JobManagerAdapter`).
+        """
         logger.info(
             "job_command_received",
             action=command.action.value,
@@ -360,18 +367,20 @@ class JobManager:
         )
         if command.job_id is not None:
             self._perform_job_action(job_id=command.job_id, action=command.action)
+            return 1
         elif command.workflow_id is not None:
-            self._perform_action(
+            return self._perform_action(
                 action=command.action,
                 sel=lambda job: job.workflow_id == command.workflow_id,
             )
         else:
-            self._perform_action(action=command.action, sel=lambda job: True)
+            return self._perform_action(action=command.action, sel=lambda job: True)
 
-    def _perform_action(self, action: JobAction, sel: Callable[[Job], bool]) -> None:
+    def _perform_action(self, action: JobAction, sel: Callable[[Job], bool]) -> int:
         jobs_to_control = [job.job_id for job in self.all_jobs if sel(job)]
         for job_id in jobs_to_control:
             self._perform_job_action(job_id=job_id, action=action)
+        return len(jobs_to_control)
 
     def _perform_job_action(self, job_id: JobId, action: JobAction) -> None:
         match action:

--- a/src/ess/livedata/core/job_manager_adapter.py
+++ b/src/ess/livedata/core/job_manager_adapter.py
@@ -25,7 +25,7 @@ class JobManagerAdapter:
 
     def job_command(self, command: JobCommand) -> CommandAcknowledgement | None:
         try:
-            self._job_manager.job_command(command)
+            affected = self._job_manager.job_command(command)
         except KeyError:
             # Job not found. Similar to DifferentInstrument for workflows: multiple
             # backend services receive the same commands, but only the one owning the
@@ -47,7 +47,10 @@ class JobManagerAdapter:
                 )
             return None
         else:
-            if command.message_id is not None:
+            # A selector-keyed command (workflow_id / broadcast) matches no jobs on
+            # workers that do not own it; those stay silent, just as the job_id path
+            # does via KeyError. Only acknowledge when this worker actually acted.
+            if command.message_id is not None and affected:
                 return CommandAcknowledgement(
                     message_id=command.message_id,
                     device=str(command.job_id) if command.job_id else "all",

--- a/tests/core/job_manager_adapter_test.py
+++ b/tests/core/job_manager_adapter_test.py
@@ -17,13 +17,15 @@ class FakeJobManager:
         self.job_command_calls: list[JobCommand] = []
         self.should_raise_key_error = False
         self.should_raise_exception = False
+        self.affected_count = 1
 
-    def job_command(self, command: JobCommand) -> None:
+    def job_command(self, command: JobCommand) -> int:
         self.job_command_calls.append(command)
         if self.should_raise_key_error:
             raise KeyError(f"Job {command.job_id} not found")
         if self.should_raise_exception:
             raise RuntimeError("Test exception")
+        return self.affected_count
 
 
 def _job_id() -> JobId:
@@ -58,6 +60,44 @@ class TestJobManagerAdapter:
 
         assert result is None
         assert fake_job_manager.job_command_calls == [command]
+
+    def test_job_command_workflow_id_no_match_does_not_ack(
+        self, adapter, fake_job_manager
+    ):
+        """A selector-keyed command that matches no local job stays silent even
+        with a message_id, so a non-owning service does not spuriously ack.
+
+        Unlike the job_id path (which raises KeyError when the job is absent), a
+        workflow_id-keyed command simply matches nothing on a worker that does not
+        own the workflow; the adapter must suppress the ack for the empty case.
+        """
+        from ess.livedata.config.workflow_spec import WorkflowId
+
+        fake_job_manager.affected_count = 0
+        command = JobCommand(
+            action=JobAction.reset,
+            workflow_id=WorkflowId(instrument="test", name="wf", version=1),
+            message_id="test-msg-id",
+        )
+        result = adapter.job_command(command)
+
+        assert result is None
+
+    def test_job_command_workflow_id_match_acks(self, adapter, fake_job_manager):
+        """The owning service (which matches >=1 job) acks a selector-keyed command."""
+        from ess.livedata.config.workflow_spec import WorkflowId
+
+        fake_job_manager.affected_count = 2
+        command = JobCommand(
+            action=JobAction.reset,
+            workflow_id=WorkflowId(instrument="test", name="wf", version=1),
+            message_id="test-msg-id",
+        )
+        result = adapter.job_command(command)
+
+        assert result is not None
+        assert result.message_id == "test-msg-id"
+        assert result.response == AcknowledgementResponse.ACK
 
     def test_job_command_key_error_silently_ignored(self, adapter, fake_job_manager):
         """Test that KeyError (job not found) is silently ignored.

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -2617,3 +2617,28 @@ class TestContextStreamGate:
         manager.job_command(JobCommand(action=JobAction.stop))
 
         assert manager.get_job_status(job_id) is None
+
+    def test_job_command_returns_matched_job_count(self, fake_job_factory):
+        """`job_command` reports how many jobs it acted on.
+
+        A worker that owns none of the targeted jobs returns zero, letting the
+        adapter stay silent instead of spuriously acknowledging a selector-keyed
+        command handled by another worker.
+        """
+        from ess.livedata.core.job_manager import JobAction, JobCommand
+
+        manager = JobManager(fake_job_factory, context_reader=no_cached_context)
+        target = WorkflowId(instrument="test", name="wf_a", version=1)
+        manager.schedule_job(_make_config("source1", name="wf_a"))
+        manager.schedule_job(_make_config("source2", name="wf_a"))
+        manager.schedule_job(_make_config("source3", name="wf_b"))
+
+        assert (
+            manager.job_command(JobCommand(workflow_id=target, action=JobAction.reset))
+            == 2
+        )
+        absent = WorkflowId(instrument="test", name="absent", version=1)
+        assert (
+            manager.job_command(JobCommand(workflow_id=absent, action=JobAction.reset))
+            == 0
+        )


### PR DESCRIPTION
## Why

Backend services share the `livedata_commands` topic, so every service sees every command. A `job_id`-keyed command is naturally filtered to the worker that owns the job: non-owning workers raise `KeyError` and stay silent. A **selector-keyed** command (`workflow_id`-keyed, or a broadcast with neither `job_id` nor `workflow_id`) has no such filter — it simply matches no jobs on a non-owning worker and no-ops *without* raising. That worker then falls through to the success branch and returns an `ACK` (`device="all"`) whenever a `message_id` is supplied. The result is one spurious acknowledgement per service rather than a single ack from the owner.

This is latent on `main` today — the dashboard always keys commands per `job_id` — but it makes `workflow_id`-keyed and broadcast commands ill-defined for any future producer that supplies a `message_id`.

## What

`JobManager.job_command` now returns the number of jobs it acted on, and `JobManagerAdapter` acknowledges only when that count is non-zero. The owning worker (the one that matched ≥1 job) becomes the sole responder; non-owning workers stay silent, mirroring the existing `KeyError` behaviour of the `job_id` path. Behaviour for `job_id`-keyed commands is unchanged.

## Test plan

Covered by unit tests (`job_manager_test.py`, `job_manager_adapter_test.py`): `job_command` returns the matched-job count (including zero for a non-owned workflow), and the adapter suppresses the ack on a zero-match selector-keyed command while still acking when a job matched.
