### PR TITLE
Suppress out-of-scope streams in backend stream stats

### DIFF
--- a/src/ess/livedata/kafka/stream_counter.py
+++ b/src/ess/livedata/kafka/stream_counter.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from ess.livedata.core.job import (
@@ -15,6 +16,7 @@ from ess.livedata.core.job import (
     StreamStat,
     StreamStats,
 )
+from ess.livedata.kafka.stream_mapping import InputStreamKey
 
 # EPICS PV field suffixes that are noise for reporting.
 # Only .RBV (Read Back Value) carries the actual readback; .VAL (setpoint)
@@ -47,12 +49,14 @@ class StreamCounter:
     def __init__(
         self,
         *,
+        out_of_scope: Iterable[InputStreamKey] = (),
         lag_warn_threshold_s: float = LAG_WARN_THRESHOLD_S,
         lag_future_tolerance_s: float = LAG_FUTURE_TOLERANCE_S,
     ) -> None:
         self._counts: dict[tuple[str, str], _Entry] = defaultdict(
             lambda: _Entry(stream=None, count=0)
         )
+        self._out_of_scope = {(k.topic, k.source_name) for k in out_of_scope}
         self._lag: dict[tuple[str, str, str], _LagEntry] = {}
         self._lag_warn_threshold_s = lag_warn_threshold_s
         self._lag_future_tolerance_s = lag_future_tolerance_s
@@ -61,11 +65,16 @@ class StreamCounter:
         """Increment count for a (topic, source_name) combination.
 
         Sources whose names end with known EPICS noise suffixes (.DMOV, .VAL)
-        are silently dropped to reduce clutter in status displays.
+        are silently dropped to reduce clutter in status displays. Streams known
+        to the instrument but routed to another service (``out_of_scope``) are
+        also dropped: they only arrive because Kafka subscription is per-topic,
+        and counting them as unmapped pollutes the status display.
         """
         if source_name.endswith(_IGNORED_SOURCE_SUFFIXES):
             return
         key = (topic, source_name)
+        if key in self._out_of_scope:
+            return
         entry = self._counts[key]
         entry.count += 1
         entry.stream = stream

--- a/src/ess/livedata/kafka/stream_mapping.py
+++ b/src/ess/livedata/kafka/stream_mapping.py
@@ -148,6 +148,16 @@ class StreamMapping:
             names |= set(self._logs.values())
         return names
 
+    @property
+    def input_keys(self) -> set[InputStreamKey]:
+        """Returns the ``(topic, source_name)`` keys across all data LUTs."""
+        keys = set(self._detectors.keys())
+        keys |= set(self._monitors.keys())
+        keys |= set(self._area_detectors.keys())
+        if self._logs is not None:
+            keys |= set(self._logs.keys())
+        return keys
+
     def filtered(self, needed: set[str]) -> StreamMapping:
         """Return copy with only entries whose internal names are in ``needed``."""
         return StreamMapping._from_luts(

--- a/src/ess/livedata/services/data_reduction.py
+++ b/src/ess/livedata/services/data_reduction.py
@@ -28,7 +28,9 @@ def make_reduction_service_builder(
 
     scoped = scope_stream_mapping(instrument_config, stream_mapping, 'data_reduction')
 
-    stream_counter = StreamCounter()
+    stream_counter = StreamCounter(
+        out_of_scope=stream_mapping.input_keys - scoped.input_keys
+    )
     adapter = (
         RoutingAdapterBuilder(stream_mapping=scoped, stream_counter=stream_counter)
         .with_routes_from_mapping()

--- a/src/ess/livedata/services/detector_data.py
+++ b/src/ess/livedata/services/detector_data.py
@@ -28,7 +28,9 @@ def make_detector_service_builder(
 
     scoped = scope_stream_mapping(instrument_obj, stream_mapping, 'detector_data')
 
-    stream_counter = StreamCounter()
+    stream_counter = StreamCounter(
+        out_of_scope=stream_mapping.input_keys - scoped.input_keys
+    )
     adapter = (
         RoutingAdapterBuilder(stream_mapping=scoped, stream_counter=stream_counter)
         .with_routes_from_mapping()

--- a/src/ess/livedata/services/monitor_data.py
+++ b/src/ess/livedata/services/monitor_data.py
@@ -22,7 +22,9 @@ def make_monitor_service_builder(
 
     scoped = scope_stream_mapping(instrument_obj, stream_mapping, 'monitor_data')
 
-    stream_counter = StreamCounter()
+    stream_counter = StreamCounter(
+        out_of_scope=stream_mapping.input_keys - scoped.input_keys
+    )
     adapter = (
         RoutingAdapterBuilder(stream_mapping=scoped, stream_counter=stream_counter)
         .with_routes_from_mapping(

--- a/src/ess/livedata/services/timeseries.py
+++ b/src/ess/livedata/services/timeseries.py
@@ -29,7 +29,9 @@ def make_timeseries_service_builder(
 
     scoped = scope_stream_mapping(instrument_obj, stream_mapping, 'timeseries')
 
-    stream_counter = StreamCounter()
+    stream_counter = StreamCounter(
+        out_of_scope=stream_mapping.input_keys - scoped.input_keys
+    )
     adapter = (
         RoutingAdapterBuilder(stream_mapping=scoped, stream_counter=stream_counter)
         .with_routes_from_mapping()

--- a/tests/kafka/stream_counter_test.py
+++ b/tests/kafka/stream_counter_test.py
@@ -9,6 +9,7 @@ from ess.livedata.core.job import (
     StreamStatsProvider,
 )
 from ess.livedata.kafka.stream_counter import StreamCounter
+from ess.livedata.kafka.stream_mapping import InputStreamKey
 
 
 class TestStreamCounter:
@@ -103,6 +104,33 @@ class TestStreamCounter:
         counter.record("other_topic", "PV.RBV", "resolved")
         stats = counter.drain(window_seconds=30.0)
         assert len(stats.streams) == 1
+
+    def test_drops_out_of_scope_streams(self) -> None:
+        counter = StreamCounter(
+            out_of_scope=[InputStreamKey(topic="logs", source_name="other_pv.RBV")]
+        )
+        counter.record("logs", "other_pv.RBV", None)
+        stats = counter.drain(window_seconds=30.0)
+        assert stats.streams == ()
+
+    def test_genuinely_unmapped_still_recorded_with_out_of_scope_set(self) -> None:
+        counter = StreamCounter(
+            out_of_scope=[InputStreamKey(topic="logs", source_name="other_pv.RBV")]
+        )
+        counter.record("logs", "unexpected_pv.RBV", None)
+        stats = counter.drain(window_seconds=30.0)
+        assert len(stats.streams) == 1
+        assert stats.streams[0].source_name == "unexpected_pv.RBV"
+        assert stats.streams[0].stream is None
+
+    def test_out_of_scope_match_is_topic_specific(self) -> None:
+        counter = StreamCounter(
+            out_of_scope=[InputStreamKey(topic="logs", source_name="pv.RBV")]
+        )
+        counter.record("other_topic", "pv.RBV", None)
+        stats = counter.drain(window_seconds=30.0)
+        assert len(stats.streams) == 1
+        assert stats.streams[0].topic == "other_topic"
 
 
 class TestStreamCounterLag:

--- a/tests/kafka/stream_mapping_test.py
+++ b/tests/kafka/stream_mapping_test.py
@@ -87,3 +87,39 @@ class TestStreamMappingFiltered:
         assert set(f.monitors.values()) == {"mon_2"}
         assert f.area_detectors == {}
         assert set(f.logs.values()) == {"motor_y"}
+
+
+class TestStreamMappingInputKeys:
+    def test_collects_keys_across_all_luts(self, full_mapping: StreamMapping) -> None:
+        assert full_mapping.input_keys == {
+            InputStreamKey(topic="det_topic_a", source_name="src"),
+            InputStreamKey(topic="det_topic_b", source_name="src"),
+            InputStreamKey(topic="det_topic_c", source_name="src"),
+            InputStreamKey(topic="mon_topic", source_name="mon1"),
+            InputStreamKey(topic="mon_topic", source_name="mon2"),
+            InputStreamKey(topic="area_topic", source_name="cam"),
+            InputStreamKey(topic="motion", source_name="m1"),
+            InputStreamKey(topic="motion", source_name="m2"),
+        }
+
+    def test_logs_none(self, infra_kwargs: dict) -> None:
+        m = StreamMapping(
+            instrument="test", detectors={}, monitors={}, logs=None, **infra_kwargs
+        )
+        assert m.input_keys == set()
+
+    def test_difference_yields_out_of_scope_keys(
+        self, full_mapping: StreamMapping
+    ) -> None:
+        # Mirrors what services compute: full minus scoped == out-of-scope keys
+        # that arrive on a shared topic but are routed to another service.
+        scoped = full_mapping.filtered({"motor_x"})
+        assert full_mapping.input_keys - scoped.input_keys == {
+            InputStreamKey(topic="det_topic_a", source_name="src"),
+            InputStreamKey(topic="det_topic_b", source_name="src"),
+            InputStreamKey(topic="det_topic_c", source_name="src"),
+            InputStreamKey(topic="mon_topic", source_name="mon1"),
+            InputStreamKey(topic="mon_topic", source_name="mon2"),
+            InputStreamKey(topic="area_topic", source_name="cam"),
+            InputStreamKey(topic="motion", source_name="m2"),
+        }


### PR DESCRIPTION
## Problem

The dashboard backend-status display showed a large, misleading list of "unmapped" streams for the `detector_data` and `data_reduction` services.

Kafka subscription is per-topic, but each service's stream mapping is scoped per-source (via `scope_stream_mapping`). Shared topics — most notably the f144 log topic, which carries the readbacks of *every* device — therefore deliver messages for sources a service does not handle. Those sources missed the scoped lookup table and were counted as "unmapped", even though they are perfectly well-known streams that are simply routed to a different service.

## Change

`StreamCounter` now takes the set of known-but-unsubscribed `(topic, source)` keys — the full mapping minus the scoped mapping — and drops them instead of recording them as unmapped. Genuinely unknown sources (schema drift, mistyped PVs) still surface as unmapped, so the signal that matters is preserved.

## Test plan

- [x] Unit tests for `StreamCounter` suppression and for the `StreamMapping.input_keys` difference that the services feed it.
- [x] `tests/kafka` and `route_derivation` suites pass.
- [ ] On a running backend, confirm the dashboard status display no longer lists the device readbacks under "unmapped" for `data_reduction` / `detector_data`.
