### PR TITLE
Require message_id on commands, simplify acknowledgement

### DIFF
--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -461,12 +461,13 @@ class WorkflowConfig(BaseModel):
     identifier: WorkflowId = Field(
         description="Hash of the workflow, used to identify the workflow."
     )
-    message_id: str | None = Field(
-        default=None,
+    message_id: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
         description=(
-            "Transient identifier for command/response correlation. Frontend generates "
-            "this UUID and backend echoes it in CommandAcknowledgement responses. "
-            "Distinct from job_id which identifies the job itself."
+            "Transient identifier for command/response correlation. An initiator that "
+            "tracks the reply sets this; one that does not may omit it, in which case "
+            "an id is generated for the ack it ignores. Distinct from job_id which "
+            "identifies the job itself."
         ),
     )
     job_id: JobId = Field(
@@ -496,9 +497,9 @@ class WorkflowConfig(BaseModel):
         cls,
         workflow_id: WorkflowId,
         job_id: JobId,
+        message_id: str | None = None,
         params: dict | None = None,
         aux_source_names: dict | None = None,
-        message_id: str | None = None,
     ) -> WorkflowConfig:
         """
         Create a WorkflowConfig from parameters.
@@ -509,25 +510,28 @@ class WorkflowConfig(BaseModel):
             Identifier for the workflow
         job_id:
             Identity of the job this config starts.
+        message_id:
+            Message ID for command acknowledgement correlation. Omit to let an id
+            be generated for an ack the initiator does not consume.
         params:
             Workflow parameters as dict, or None if no params
         aux_source_names:
             Auxiliary source selections as dict, or None if no aux sources
-        message_id:
-            Optional message ID for command acknowledgement tracking
 
         Returns
         -------
         :
             WorkflowConfig instance ready to be sent to backend
         """
-        return cls(
-            identifier=workflow_id,
-            message_id=message_id,
-            job_id=job_id,
-            aux_source_names=aux_source_names or {},
-            params=params or {},
-        )
+        fields: dict[str, Any] = {
+            "identifier": workflow_id,
+            "job_id": job_id,
+            "aux_source_names": aux_source_names or {},
+            "params": params or {},
+        }
+        if message_id is not None:
+            fields["message_id"] = message_id
+        return cls(**fields)
 
 
 def _is_timeseries_output(da: sc.DataArray) -> bool:

--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import bisect
+import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -65,11 +66,13 @@ class JobAction(StrEnum):
 
 class JobCommand(pydantic.BaseModel):
     kind: Literal['job_command'] = 'job_command'
-    message_id: str | None = pydantic.Field(
-        default=None,
+    message_id: str = pydantic.Field(
+        default_factory=lambda: str(uuid.uuid4()),
         description=(
-            "Unique identifier for command correlation. Frontend generates this UUID "
-            "and backend echoes it in CommandAcknowledgement responses."
+            "Unique identifier for command correlation. An initiator that tracks the "
+            "reply sets this; one that does not may omit it, in which case an id is "
+            "generated for the ack it ignores. The owning backend echoes it in the "
+            "CommandAcknowledgement."
         ),
     )
     job_id: JobId | None = pydantic.Field(

--- a/src/ess/livedata/core/job_manager_adapter.py
+++ b/src/ess/livedata/core/job_manager_adapter.py
@@ -38,25 +38,23 @@ class JobManagerAdapter:
             return None
         except Exception as e:
             logger.exception("job_command_failed", action=command.action)
-            if command.message_id is not None:
-                return CommandAcknowledgement(
-                    message_id=command.message_id,
-                    device=str(command.job_id) if command.job_id else "all",
-                    response=AcknowledgementResponse.ERR,
-                    message=str(e),
-                )
-            return None
+            return CommandAcknowledgement(
+                message_id=command.message_id,
+                device=str(command.job_id) if command.job_id else "all",
+                response=AcknowledgementResponse.ERR,
+                message=str(e),
+            )
         else:
             # A selector-keyed command (workflow_id / broadcast) matches no jobs on
             # workers that do not own it; those stay silent, just as the job_id path
             # does via KeyError. Only acknowledge when this worker actually acted.
-            if command.message_id is not None and affected:
-                return CommandAcknowledgement(
-                    message_id=command.message_id,
-                    device=str(command.job_id) if command.job_id else "all",
-                    response=AcknowledgementResponse.ACK,
-                )
-            return None
+            if not affected:
+                return None
+            return CommandAcknowledgement(
+                message_id=command.message_id,
+                device=str(command.job_id) if command.job_id else "all",
+                response=AcknowledgementResponse.ACK,
+            )
 
     def set_workflow_with_config(
         self, config: WorkflowConfig
@@ -81,19 +79,15 @@ class JobManagerAdapter:
             logger.exception(
                 "workflow_start_failed", workflow_id=str(config.identifier)
             )
-            if config.message_id is not None:
-                return CommandAcknowledgement(
-                    message_id=config.message_id,
-                    device=config.job_id.source_name,
-                    response=AcknowledgementResponse.ERR,
-                    message=str(e),
-                )
-            return None
+            return CommandAcknowledgement(
+                message_id=config.message_id,
+                device=config.job_id.source_name,
+                response=AcknowledgementResponse.ERR,
+                message=str(e),
+            )
         else:
-            if config.message_id is not None:
-                return CommandAcknowledgement(
-                    message_id=config.message_id,
-                    device=config.job_id.source_name,
-                    response=AcknowledgementResponse.ACK,
-                )
-            return None
+            return CommandAcknowledgement(
+                message_id=config.message_id,
+                device=config.job_id.source_name,
+                response=AcknowledgementResponse.ACK,
+            )

--- a/src/ess/livedata/dashboard/fake_backend.py
+++ b/src/ess/livedata/dashboard/fake_backend.py
@@ -206,11 +206,7 @@ class FakeBackend:
             self._jobs.pop(command.job_id, None)
             self._ack(command.message_id, command.job_id.source_name)
 
-    def _ack(
-        self, message_id: str | None, device: str, error: str | None = None
-    ) -> None:
-        if message_id is None:
-            return
+    def _ack(self, message_id: str, device: str, error: str | None = None) -> None:
         response = AcknowledgementResponse.ERR if error else AcknowledgementResponse.ACK
         ack = CommandAcknowledgement(
             message_id=message_id, device=device, response=response, message=error

--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -389,7 +389,9 @@ class JobOrchestrator:
                 workflow_id,
                 state.current.job_number,
             )
-            # Create stop commands for all old jobs (no message_id - fire and forget)
+            # Fire-and-forget: each stop gets an auto-generated message_id the
+            # dashboard does not register, so the owning worker's ack is dropped.
+            # Reusing the start's message_id would inflate its tracked ack count.
             commands.extend(
                 JobCommand(job_id=job_id, action=JobAction.stop)
                 for job_id in state.current.job_ids()

--- a/src/ess/livedata/fakes.py
+++ b/src/ess/livedata/fakes.py
@@ -3,7 +3,7 @@
 from typing import Generic, TypeVar
 
 from .core import Message
-from .core.message import STATUS_STREAM_ID
+from .core.message import RESPONSES_STREAM_ID, STATUS_STREAM_ID
 
 T = TypeVar('T')
 
@@ -29,16 +29,18 @@ class FakeMessageSink(Generic[T]):
     """
     A fake message sink that stores messages in memory for testing purposes.
 
-    Provides two views of published messages:
+    Provides several views of published messages:
     - published_messages: Each publish_messages() call stored as a separate batch
-    - messages: Flattened list of all non-status messages
+    - messages: Flattened list of all data messages
     - status_messages: Flattened list of all status messages
+    - response_messages: Flattened list of all command-acknowledgement messages
     """
 
     def __init__(self) -> None:
         self.published_messages: list[list[Message[T]]] = []
         self.messages: list[Message[T]] = []
         self.status_messages: list[Message[T]] = []
+        self.response_messages: list[Message[T]] = []
 
     def publish_messages(self, messages: list[Message[T]]) -> None:
         # Store batch as-is
@@ -47,5 +49,7 @@ class FakeMessageSink(Generic[T]):
         for msg in messages:
             if msg.stream == STATUS_STREAM_ID:
                 self.status_messages.append(msg)
+            elif msg.stream == RESPONSES_STREAM_ID:
+                self.response_messages.append(msg)
             else:
                 self.messages.append(msg)

--- a/tests/core/job_manager_adapter_test.py
+++ b/tests/core/job_manager_adapter_test.py
@@ -53,14 +53,6 @@ class TestJobManagerAdapter:
         assert result.response == AcknowledgementResponse.ACK
         assert fake_job_manager.job_command_calls == [command]
 
-    def test_job_command_success_without_message_id(self, adapter, fake_job_manager):
-        """Test successful job command returns None when no message_id."""
-        command = JobCommand(action=JobAction.reset)
-        result = adapter.job_command(command)
-
-        assert result is None
-        assert fake_job_manager.job_command_calls == [command]
-
     def test_job_command_workflow_id_no_match_does_not_ack(
         self, adapter, fake_job_manager
     ):
@@ -129,15 +121,3 @@ class TestJobManagerAdapter:
         assert result.message_id == "test-msg-id"
         assert result.response == AcknowledgementResponse.ERR
         assert "Test exception" in result.message
-
-    def test_job_command_other_exception_without_message_id_returns_none(
-        self, adapter, fake_job_manager
-    ):
-        """Test that exceptions without message_id return None."""
-        fake_job_manager.should_raise_exception = True
-
-        command = JobCommand(action=JobAction.stop)
-        result = adapter.job_command(command)
-
-        # No message_id means no response even on error
-        assert result is None

--- a/tests/handlers/config_handler_test.py
+++ b/tests/handlers/config_handler_test.py
@@ -20,7 +20,7 @@ def _workflow_config(source: str = "source1", message_id: str | None = None):
     return WorkflowConfig(
         identifier=WorkflowId(instrument="dummy", name="wf", version=1),
         job_id=_job_id(source),
-        message_id=message_id,
+        message_id=message_id or str(uuid.uuid4()),
     )
 
 
@@ -38,8 +38,6 @@ class FakeJobManagerAdapter:
         self.job_command_calls.append(command)
         if self.should_raise:
             raise ValueError("Test exception")
-        if command.message_id is None:
-            return None
         return CommandAcknowledgement(
             message_id=command.message_id,
             device=str(command.job_id) if command.job_id else "all",
@@ -53,7 +51,7 @@ class FakeJobManagerAdapter:
         if self.should_raise:
             raise ValueError("Test exception")
         return CommandAcknowledgement(
-            message_id=config.message_id or "mock-msg-id",
+            message_id=config.message_id,
             device=config.job_id.source_name,
             response=AcknowledgementResponse.ACK,
         )
@@ -85,16 +83,6 @@ class TestConfigProcessor:
         assert adapter.job_command_calls == [command]
         assert len(result_messages) == 1
         assert result_messages[0].value.message_id == "msg-1"
-
-    def test_process_job_command_without_message_id_no_ack(self):
-        adapter = FakeJobManagerAdapter()
-        processor = ConfigProcessor(job_manager_adapter=adapter)
-        command = JobCommand(action=JobAction.reset)
-
-        result_messages = processor.process_messages([_msg(command)])
-
-        assert adapter.job_command_calls == [command]
-        assert result_messages == []
 
     def test_processes_multiple_commands_in_order(self):
         adapter = FakeJobManagerAdapter()

--- a/tests/services/data_reduction_test.py
+++ b/tests/services/data_reduction_test.py
@@ -70,7 +70,7 @@ def test_can_configure_and_stop_workflow_with_detector(
     # Trigger workflow start
     app.publish_config_message(workflow_config)
     service.step()
-    # No acknowledgement sent when message_id is not set (backward compatibility)
+    # Config ack lands on response_messages, not the data sink
     assert len(sink.messages) == 0
 
     app.publish_events(size=2000, time=2)
@@ -384,7 +384,7 @@ def test_can_clear_workflow_via_config(caplog: pytest.LogCaptureFixture) -> None
     app.publish_events(size=2000, time=1)
     app.publish_events(size=3000, time=2)
     service.step()
-    # Only data reduction result (no ack when message_id not set)
+    # Only the data reduction result; the ack is on response_messages
     assert len(sink.messages) == 1
     assert sink.messages[-1].value.values.sum() == 5000
 
@@ -443,7 +443,7 @@ def test_service_can_recover_after_bad_workflow_id_was_set(
     app.publish_config_message(valid_workflow_config)
     app.publish_events(size=1000, time=5)
     service.step()
-    # Service recovered; get data only (no ack without message_id)
+    # Service recovered; data only -- the ack is on response_messages
     assert len(sink.messages) == 1
 
 
@@ -479,7 +479,7 @@ def test_service_can_recover_after_bad_workflow_param_was_set(
     app.publish_config_message(valid_config)
     app.publish_events(size=1000, time=5)
     service.step()
-    # Service recovered; get data only (no ack without message_id)
+    # Service recovered; data only -- the ack is on response_messages
     assert len(sink.messages) == 1
 
 
@@ -499,7 +499,7 @@ def test_active_workflow_keeps_running_when_bad_workflow_id_or_params_were_set(
     )
     app.publish_config_message(workflow_config)
     service.step()
-    # No ack without message_id
+    # Config ack lands on response_messages, not the data sink
     assert len(sink.messages) == 0
 
     # Add events and verify workflow is running

--- a/tests/services/detector_data_test.py
+++ b/tests/services/detector_data_test.py
@@ -66,7 +66,7 @@ def test_can_configure_and_stop_detector_workflow(
     # Trigger workflow start
     app.publish_config_message(workflow_config)
     service.step()
-    # No ack when message_id not set
+    # Config ack lands on response_messages, not the data sink
     assert len(sink.messages) == 0
 
     if instrument == 'loki':
@@ -231,7 +231,7 @@ def test_service_can_recover_after_bad_workflow_id_was_set(
     app.publish_config_message(good_workflow_config)
     app.publish_events(size=1000, time=5)
     service.step()
-    # Service recovered; get data only (no ack without message_id)
+    # Service recovered; data only -- the ack is on response_messages
     # First finalize sends 10 data messages (8 + 2 initial ROI readbacks)
     assert len(sink.messages) == 10
 
@@ -252,7 +252,7 @@ def test_active_workflow_keeps_running_when_bad_workflow_id_was_set(
     )
     app.publish_config_message(workflow_config)
     service.step()
-    # No ack without message_id
+    # Config ack lands on response_messages, not the data sink
     assert len(sink.messages) == 0
 
     # Add events and verify workflow is running

--- a/tests/services/monitor_data_test.py
+++ b/tests/services/monitor_data_test.py
@@ -69,7 +69,7 @@ def test_can_configure_and_stop_monitor_workflow(
     # Trigger workflow start
     app.publish_config_message(workflow_config)
     service.step()
-    # No ack when message_id not set
+    # Config ack lands on response_messages, not the data sink
     assert len(sink.messages) == 0
 
     # Each workflow call returns six results: the cumulative/current histograms

--- a/tests/services/timeseries_test.py
+++ b/tests/services/timeseries_test.py
@@ -67,7 +67,7 @@ def test_updates_are_published_immediately(
     # Trigger workflow start
     app.publish_config_message(workflow_config)
     service.step()
-    # No ack when message_id not set
+    # Config ack lands on response_messages, not the data sink
     assert len(sink.messages) == 0
 
     app.publish_log_message(source_name=source_name, time=1, value=1.5)


### PR DESCRIPTION
Building on #1022, which made a command's acknowledgement depend only on whether the owning worker acted. The optional `message_id` was a second, redundant axis: whether the initiator wanted a reply at all. That decision already lives in the dashboard's pending-command tracker, so the optional wire field duplicated it and forced `if message_id is not None` branching through the adapter for both `JobCommand` and `WorkflowConfig`.

This gives `message_id` a `default_factory` so it is always populated, and collapses the adapter to a single rule: the owning worker acks (or errs), every other worker stays silent — via `KeyError` on the `job_id` path, or `affected == 0` on the selector path. "Fire-and-forget" stops being a wire concept: an initiator that tracks the reply sets the id; one that does not — the orchestrator stopping superseded jobs, or an external producer such as NICOS — omits it and an id is generated for the ack it ignores.

`FakeMessageSink` now routes acknowledgements to a separate `response_messages` view, keeping `messages` data-only. This preserves service-test assertions about emitted data, which previously relied on omitting `message_id` to suppress acks entirely; the routing is exercised implicitly by every service test, whose data-message counts would shift if an ack leaked into the data sink.

This is a prerequisite for the NICOS derived-devices work (ADR 0006): with acks uniform, the reset path no longer needs a special "omit message_id to avoid an ack storm" story. NICOS keeps omitting `message_id` exactly as the ADR describes, and confirms the reset from the `start_time` generation jump rather than the ack.