### PR TITLE
Add source offset option to wavelength-LUT workflow

### DIFF
--- a/src/ess/livedata/handlers/wavelength_lut_workflow.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow.py
@@ -303,22 +303,16 @@ def _make_workflow(pipeline: sciline.Pipeline) -> StreamProcessorWorkflow:
     )
 
 
-def _moderator_source_position(filename: str) -> sc.Variable | None:
-    """Neutron-source position when the file models the moderator as ``NXmoderator``.
+def _component_position(filename: str, nx_class: type) -> sc.Variable | None:
+    """Position of the file's unique component of ``nx_class``, or ``None``.
 
-    essreduce takes the chopper-cascade reference from the file's unique
-    ``NXsource``. BIFROST instead labels the moderator ``NXmoderator`` and
-    reserves ``NXsource`` for accelerator metadata sitting at the origin, so
-    essreduce would measure flight distance from the accelerator and reject the
-    upstream choppers as lying behind the source. When an ``NXmoderator`` is
-    present, return its position to override the reference; otherwise return
-    ``None``, leaving essreduce's ``NXsource`` lookup in place (e.g. LOKI).
+    Returns ``None`` when the file has no such component.
     """
     with snx.File(filename, definitions=snx.base_definitions()) as f:
-        moderators = f['entry/instrument'][snx.NXmoderator]
-        if not moderators:
+        groups = f['entry/instrument'][nx_class]
+        if not groups:
             return None
-        (group,) = moderators.values()
+        (group,) = groups.values()
         positions = snx.compute_positions(group[...], store_position='position')
     return positions['position']
 
@@ -340,13 +334,33 @@ def create_wavelength_lut_workflow(
     """
     pipeline = _build_pipeline(params)
     pipeline[Filename[AnyRun]] = nexus_filename
-    # Override the source position essreduce would load from NXsource when the
-    # real source is an NXmoderator; see _moderator_source_position.
-    source_position = _moderator_source_position(nexus_filename)
-    if source_position is not None:
-        pipeline[Position[snx.NXsource, AnyRun]] = source_position
+    _set_source_position(pipeline, nexus_filename, params.source.get())
     pipeline.insert(build_disk_choppers_provider(setpoint_keys))
     return _make_workflow(pipeline)
+
+
+def _set_source_position(
+    pipeline: sciline.Pipeline, nexus_filename: str, offset: sc.Variable
+) -> None:
+    """Set the chopper-cascade source reference, shifted by ``offset``.
+
+    essreduce would take the reference from the file's unique ``NXsource``.
+    BIFROST instead labels the moderator ``NXmoderator`` and reserves
+    ``NXsource`` for accelerator metadata sitting at the origin, so essreduce
+    would measure flight distance from the accelerator and reject the upstream
+    choppers as lying behind the source. The reference is therefore the
+    ``NXmoderator`` position when present, else the ``NXsource`` (e.g. LOKI).
+
+    ``offset`` is a beam-aligned displacement added to that reference; it is
+    zero by default, in which case this reproduces the position essreduce would
+    have loaded.
+    """
+    reference = _component_position(nexus_filename, snx.NXmoderator)
+    if reference is None:
+        reference = _component_position(nexus_filename, snx.NXsource)
+    pipeline[Position[snx.NXsource, AnyRun]] = reference + offset.to(
+        unit=reference.unit
+    )
 
 
 def attach_wavelength_lut_factory(

--- a/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
+++ b/src/ess/livedata/handlers/wavelength_lut_workflow_specs.py
@@ -91,6 +91,31 @@ class LtotalRange(RangeModel):
     )
 
 
+class SourceOffset(pydantic.BaseModel):
+    """Offset of the neutron source along the beam, relative to the file.
+
+    The chopper cascade measures every chopper's flight distance from the source
+    position loaded from the geometry artifact. This shifts that reference along
+    the beam (the lab +Z axis): a positive offset moves the source downstream
+    (toward the choppers), a negative offset upstream.
+    """
+
+    offset: float = pydantic.Field(
+        default=0.0,
+        description=(
+            "Signed source offset along the beam; positive moves the source "
+            "downstream (toward the choppers)."
+        ),
+    )
+    unit: LengthUnit = pydantic.Field(
+        default=LengthUnit.METER, description="Unit of the source offset."
+    )
+
+    def get(self) -> sc.Variable:
+        """Return the offset as a beam-aligned (Z) displacement vector."""
+        return sc.scalar(self.offset, unit=self.unit.value) * sc.vector([0.0, 0.0, 1.0])
+
+
 class CascadeBands(pydantic.BaseModel):
     """Configuration of the *Chopper cascade bands* output.
 
@@ -141,6 +166,11 @@ class WavelengthLutParams(pydantic.BaseModel):
         title='Source pulse',
         description='Source pulse frequency and stride.',
         default_factory=Pulse,
+    )
+    source: SourceOffset = pydantic.Field(
+        title='Source',
+        description='Offset of the neutron source along the beam.',
+        default_factory=SourceOffset,
     )
     distance_range: LtotalRange = pydantic.Field(
         title='Distance range',

--- a/tests/handlers/wavelength_lut_workflow_test.py
+++ b/tests/handlers/wavelength_lut_workflow_test.py
@@ -21,9 +21,11 @@ from ess.livedata.handlers.wavelength_lut_workflow import (
 )
 from ess.livedata.handlers.wavelength_lut_workflow_specs import (
     CHOPPER_CASCADE_SOURCE,
+    WAVELENGTH_BANDS_OUTPUT,
     WAVELENGTH_LUT_OUTPUT,
     CascadeBands,
     Pulse,
+    SourceOffset,
     WavelengthLutParams,
 )
 from ess.livedata.kafka.scipp_da00_compat import da00_to_scipp, scipp_to_da00
@@ -151,6 +153,23 @@ class TestCascadeBands:
             CascadeBands(distances='6.2, foo')
 
 
+class TestSourceOffset:
+    def test_default_is_zero(self) -> None:
+        assert_identical(
+            SourceOffset().get(), sc.scalar(0.0, unit='m') * sc.vector([0, 0, 1.0])
+        )
+
+    def test_offset_is_beam_aligned(self) -> None:
+        vec = SourceOffset(offset=2.5).get()
+        assert vec.fields.x.value == 0.0
+        assert vec.fields.y.value == 0.0
+        assert vec.fields.z.value == 2.5
+        assert vec.unit == sc.Unit('m')
+
+    def test_negative_offset(self) -> None:
+        assert SourceOffset(offset=-3.0).get().fields.z.value == -3.0
+
+
 class TestNoChopperWorkflow:
     def test_produces_table_with_expected_dims(self, lut: sc.DataArray) -> None:
         assert lut.dims == ('distance', 'event_time_offset')
@@ -196,16 +215,17 @@ class TestNoChopperWorkflow:
         assert first.unit == second.unit
 
 
-def _run_chopper_lut(
+def _run_chopper_workflow(
     geom: Path,
     names: list[str],
     setpoints: dict[str, tuple[float, float]],
     params: WavelengthLutParams | None = None,
-) -> sc.DataArray:
+) -> dict[str, sc.DataArray]:
     """Build the chopper LUT workflow, feed setpoint context + trigger, finalize.
 
     ``setpoints`` maps chopper name to ``(speed_hz, delay_ns)``. Choppers absent
     from ``setpoints`` get no context value (simulating a not-yet-locked chopper).
+    Returns the full ``finalize`` output (LUT and cascade bands).
     """
     keys = {name: make_chopper_setpoint_keys(name) for name in names}
     wf = create_wavelength_lut_workflow(
@@ -222,7 +242,17 @@ def _run_chopper_lut(
         data[speed_setpoint_stream(name)] = _nxlog(speed, 'Hz')
         data[delay_setpoint_stream(name)] = _nxlog(delay, 'ns')
     wf.accumulate(data, start_time=0, end_time=1)
-    return wf.finalize()[WAVELENGTH_LUT_OUTPUT]
+    return wf.finalize()
+
+
+def _run_chopper_lut(
+    geom: Path,
+    names: list[str],
+    setpoints: dict[str, tuple[float, float]],
+    params: WavelengthLutParams | None = None,
+) -> sc.DataArray:
+    """Build the chopper LUT workflow and return just the lookup-table output."""
+    return _run_chopper_workflow(geom, names, setpoints, params)[WAVELENGTH_LUT_OUTPUT]
 
 
 @pytest.fixture
@@ -323,6 +353,50 @@ class TestMultiChopperWorkflow:
                 ['chopper1', 'chopper2'],
                 {'chopper1': (-14.0, 0.0), 'chopper2': (-14.0, 0.0)},
             )
+
+
+class TestSourceOffsetWorkflow:
+    def test_offset_shifts_chopper_distances_from_moderator(
+        self, tmp_path: Path
+    ) -> None:
+        # Moderator at -25 m, choppers at -15 and -13 m: distances 10 and 12 m
+        # from the source. A +2 m offset moves the source downstream to -23 m,
+        # shrinking every chopper's distance-from-source by 2 m.
+        path = tmp_path / 'moderator_choppers.nxs'
+        _write_chopper_nexus(path, ['chopper1', 'chopper2'], moderator_z=-25.0)
+        names = ['chopper1', 'chopper2']
+        setpoints = {'chopper1': (-14.0, 0.0), 'chopper2': (-14.0, 0.0)}
+
+        base = _run_chopper_workflow(path, names, setpoints)[WAVELENGTH_BANDS_OUTPUT]
+        shifted = _run_chopper_workflow(
+            path,
+            names,
+            setpoints,
+            params=WavelengthLutParams(source=SourceOffset(offset=2.0)),
+        )[WAVELENGTH_BANDS_OUTPUT]
+
+        # Source row stays at distance 0; chopper rows move closer by 2 m.
+        base_d = base.coords['distance']
+        shifted_d = shifted.coords['distance']
+        assert_identical(base_d.max() - sc.scalar(2.0, unit='m'), shifted_d.max())
+
+    def test_offset_applies_without_moderator(self, two_chopper_geometry: Path) -> None:
+        # NXsource-only file (no moderator): the offset still shifts the
+        # reference, exercising the NXsource branch. The table differs from the
+        # unshifted one and remains finite.
+        names = ['chopper1', 'chopper2']
+        setpoints = {'chopper1': (-14.0, 0.0), 'chopper2': (-14.0, 0.0)}
+        base = _run_chopper_lut(two_chopper_geometry, names, setpoints)
+        shifted = _run_chopper_lut(
+            two_chopper_geometry,
+            names,
+            setpoints,
+            params=WavelengthLutParams(source=SourceOffset(offset=1.5)),
+        )
+        assert np.isfinite(shifted.values).any()
+        assert not np.array_equal(
+            np.nan_to_num(base.values), np.nan_to_num(shifted.values)
+        )
 
 
 class TestDa00RoundTrip:


### PR DESCRIPTION
Adds a `source` parameter to the wavelength-LUT workflow that shifts the chopper-cascade source reference along the beam (lab +Z) relative to the position loaded from the geometry file. A positive offset moves the source downstream (toward the choppers), a negative offset upstream. This lets operators correct or explore the source position without regenerating the geometry artifact.

The source reference is the moderator when present (BIFROST) and otherwise the `NXsource` (LOKI). With no moderator and a zero offset nothing is overridden, so essreduce's own `NXsource` lookup -- the long-standing default path -- is left untouched.

This implements only the source-offset half of the originally discussed extension; per-chopper disabling is deferred.

## Test plan

- [x] Unit tests for the `SourceOffset` model and for the offset shifting chopper distances (moderator and `NXsource` geometries).
