### PR TITLE
Show plotter name in plot layer headers

### DIFF
--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -579,7 +579,23 @@ def get_plot_cell_display_info(
         workflow_registry, config.workflow_id, config.view_name
     )
 
-    # Build title: "Workflow → Output (source, window)"
+    # Look up the plotter's display title so layers differing only by plotter
+    # (ROI readback vs request, or a correlation plot over a timeseries) are
+    # distinguishable instead of rendering identical workflow/output text.
+    from ..plotter_registry import plotter_registry
+
+    try:
+        plotter_spec = plotter_registry.get_spec(config.plot_name)
+    except KeyError:
+        plotter_spec = None
+    plotter_title = plotter_spec.title if plotter_spec is not None else None
+    # Drop the plotter segment when it merely echoes the output (e.g. an "Image"
+    # output rendered by the "Image" plotter); it only adds information when it
+    # differs (ROI readback/request, correlation over a timeseries).
+    if plotter_title == output_title:
+        plotter_title = None
+
+    # Build title: "Workflow → Output → Plotter (source, window)"
     # Using HTML entity for arrow since title is rendered in HTML pane
     window_info = _format_window_info(config.params)
 
@@ -600,15 +616,20 @@ def get_plot_cell_display_info(
         detail_parts.append(window_info)
     details = ', '.join(detail_parts)
 
-    title = f'{workflow_title} &rarr; {output_title} ({details})'
+    view_chain = f'{workflow_title} &rarr; {output_title}'
+    if plotter_title:
+        view_chain += f' &rarr; {plotter_title}'
+    title = f'{view_chain} ({details})'
 
     # Build description for tooltip using display titles
     sources_str = ', '.join(_title(s) for s in config.source_names)
     description_parts = [
         f'Workflow: {workflow_title}',
         f'Output: {output_title}',
-        f'Sources: {sources_str}',
     ]
+    if plotter_title:
+        description_parts.append(f'Plotter: {plotter_title}')
+    description_parts.append(f'Sources: {sources_str}')
     if window_info:
         description_parts.append(f'Window: {window_info}')
 
@@ -623,14 +644,8 @@ def get_plot_cell_display_info(
         description_parts.append(f'\n{view.description}')
 
     # Append plotter-specific description (e.g., usage instructions)
-    from ..plotter_registry import plotter_registry
-
-    try:
-        plotter_desc = plotter_registry.get_spec(config.plot_name).description
-        if plotter_desc:
-            description_parts.append(f'\n{plotter_desc}')
-    except KeyError:
-        pass
+    if plotter_spec is not None and plotter_spec.description:
+        description_parts.append(f'\n{plotter_spec.description}')
 
     description = '\n'.join(description_parts)
 

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -182,6 +182,76 @@ class TestGetPlotCellDisplayInfo:
         assert 'since run start' in title
 
 
+class TestPlotterTitleInDisplayInfo:
+    """Plotter title disambiguates layers sharing workflow/output/source (#645)."""
+
+    class _ImageOutputs(WorkflowOutputsBase):
+        image: sc.DataArray = pydantic.Field(
+            default_factory=lambda: sc.DataArray(
+                sc.zeros(dims=['x'], shape=[0], unit='counts'),
+                coords={'x': sc.arange('x', 0, unit='m')},
+            ),
+            title='Image',
+        )
+
+    def _config(self, plot_name: str) -> PlotConfig:
+        wf_id = WorkflowId(instrument='test', name='wf', version=1)
+        spec = WorkflowSpec(
+            instrument='test',
+            name='wf',
+            version=1,
+            title='Detector counts',
+            description='D',
+            outputs=self._ImageOutputs,
+            params=None,
+            source_names=['src1'],
+            group=REDUCTION,
+        )
+        self._registry = {wf_id: spec}
+        return PlotConfig(
+            data_sources={
+                PRIMARY: DataSourceConfig(
+                    workflow_id=wf_id, source_names=['src1'], view_name='image'
+                )
+            },
+            plot_name=plot_name,
+            params=_FakeParams(),
+        )
+
+    def test_title_includes_plotter_title(self) -> None:
+        config = self._config('rectangles_readback')
+        title, _ = get_plot_cell_display_info(config, self._registry)
+        assert 'ROI Rectangles (Readback)' in title
+
+    def test_readback_and_request_layers_have_distinct_titles(self) -> None:
+        readback, _ = get_plot_cell_display_info(
+            self._config('rectangles_readback'), self._registry
+        )
+        request, _ = get_plot_cell_display_info(
+            self._config('rectangles_request'), self._registry
+        )
+        assert readback != request
+
+    def test_description_includes_plotter_title(self) -> None:
+        _, description = get_plot_cell_display_info(
+            self._config('rectangles_readback'), self._registry
+        )
+        assert 'Plotter: ROI Rectangles (Readback)' in description
+
+    def test_plotter_title_suppressed_when_equal_to_output(self) -> None:
+        # Output 'Image' rendered by the 'image' plotter (title 'Image').
+        config = self._config('image')
+        title, description = get_plot_cell_display_info(config, self._registry)
+        assert title == 'Detector counts &rarr; Image (src1)'
+        assert 'Plotter:' not in description
+
+    def test_unregistered_plotter_omits_plotter_title(self) -> None:
+        config = self._config('does_not_exist')
+        title, description = get_plot_cell_display_info(config, self._registry)
+        assert title == 'Detector counts &rarr; Image (src1)'
+        assert 'Plotter:' not in description
+
+
 _GEO = CellGeometry(row=0, col=0, row_span=1, col_span=1)
 
 


### PR DESCRIPTION
Closes #645.

The per-layer plot header showed only workflow → output (source), never which plotter renders the layer. This made layers that differ *only* by plotter indistinguishable: ROI readback vs request share the same data source, and correlation plots gave no hint that they plot the data against another timeseries rather than plotting it directly.

`PlotterSpec.title` already existed but was never surfaced. It is now folded into `get_plot_cell_display_info` — the single label source shared by the expandable layer-detail rows, the gear dropdown menu, and the edit-cell modal — so the name appears in all three at once. The layer label becomes `Workflow → Output → Plotter (sources, window)`. The plotter segment is suppressed when it merely echoes the output name (e.g. an `Image` output rendered by the `Image` plotter), keeping the common case clean and showing the plotter only where it disambiguates (ROI readback/request, correlation).

## Test plan
- [x] Unit tests for plotter title shown, readback ≠ request, tooltip line, output-echo suppression, unregistered-plotter fallback.
- [x] Expand a cell's layer details on an ROI plot; confirm readback and request rows now read distinctly.
- [x] Confirm the gear menu and edit-cell modal list the same disambiguated labels.
