### PR TITLE
fix(dashboard): enforce frame aspect per sub-figure so layout-mode plots don't collapse

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -20,6 +20,7 @@ from ess.livedata.config.workflow_spec import ResultKey
 from ess.livedata.core.timestamp import Timestamp
 
 from .data_roles import PRIMARY
+from .frame_aspect import make_frame_aspect_hook_from_config
 from .plot_params import (
     CombineMode,
     LayoutParams,
@@ -478,8 +479,16 @@ class Plotter:
         # All non-free aspect types are enforced by a JS hook
         # (see frame_aspect.py) that adjusts the Bokeh figure dimensions.
         # HoloViews' own aspect/data_aspect opts are not set — they conflict
-        # with responsive mode in Panel containers (upstream bug).
+        # with responsive mode in Panel containers (upstream bug). The hook is
+        # declared per leaf element type alongside ``responsive`` so it lands on
+        # every figure the plotter produces, whether the datasets are overlaid
+        # (one shared figure) or laid out (one figure per sub-plot). Each layer
+        # carries its own aspect, so an overlay of layers with differing aspects
+        # applies each hook to the shared figure (free aspect contributes none).
         self._sizing_opts: dict[str, Any] = {'responsive': True}
+        aspect_hook = make_frame_aspect_hook_from_config(aspect_params)
+        if aspect_hook is not None:
+            self._sizing_opts['hooks'] = [aspect_hook]
 
     @staticmethod
     def _make_tick_opts(tick_params: TickParams | None) -> dict[str, Any]:
@@ -662,7 +671,7 @@ class Plotter:
         except Exception as e:
             self._range_targets = {}
             result = hv.Text(0.5, 0.5, f"Error: {e}").opts(
-                text_align='center', text_baseline='middle', **self._sizing_opts
+                text_align='center', text_baseline='middle', responsive=True
             )
 
         # Time bounds drive the cell titlebar's freshness indicator; they are
@@ -717,7 +726,7 @@ class Plotter:
         if len(plots) == 0:
             plots = [
                 hv.Text(0.5, 0.5, 'No data').opts(
-                    text_align='center', text_baseline='middle', **self._sizing_opts
+                    text_align='center', text_baseline='middle', responsive=True
                 )
             ]
 

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -27,7 +27,6 @@ from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
 
 from ..cell_autoscale import CellAutoscaleController, build_controller_from_layers
 from ..format_utils import extract_error_summary
-from ..frame_aspect import make_frame_aspect_hook_from_config
 from ..plot_data_service import LayerState, LayerStateMachine, PlotDataService
 from ..plot_orchestrator import (
     CellId,
@@ -643,10 +642,12 @@ class CellWidget:
             # opts applied afterwards land on the OverlayPlot and persist.
             result = hv.Overlay(plots).collate()
 
-        # Skip figure-level hooks for a non-overlayable layer: a Layout's
+        # Skip the cell-level hooks for a non-overlayable layer: a Layout's
         # sub-figures each carry their own SaveTool, and a Table's DataTable
-        # widget has no figure, toolbar, or sizing handle for the SaveTool/aspect
-        # hooks to act on.
+        # widget has no figure for the SaveTool/autoscale hooks to act on. The
+        # frame-aspect hook is not among these — it is declared per element type
+        # by the plotter (see Plotter._sizing_opts), so it reaches every
+        # sub-figure of a Layout regardless.
         if non_overlayable:
             return result
 
@@ -658,12 +659,6 @@ class CellWidget:
         )
         if filename is not None:
             hooks.append(make_save_filename_hook(filename))
-        if self._cell.layers:
-            params = self._cell.layers[0].config.params
-            if hasattr(params, 'plot_aspect'):
-                aspect_hook = make_frame_aspect_hook_from_config(params.plot_aspect)
-                if aspect_hook is not None:
-                    hooks.append(aspect_hook)
         # Fresh controller on every cell rebuild: keeps tools and toggle state
         # local to this session's Bokeh document. The previous cell widget's
         # controller is disposed by the owner after the swap, breaking its

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1216,6 +1216,44 @@ class TestPlotterOverlayMode:
         assert len(result) == 1
         assert isinstance(next(iter(result)), hv.Curve)
 
+    def test_layout_mode_applies_aspect_hook_to_every_subfigure(
+        self, simple_data_1, simple_data_2, data_key_1, data_key_2
+    ):
+        """A non-free aspect must reach every sub-figure of a layout-mode plot.
+
+        The frame-aspect hook is declared per element type by the plotter, so it
+        lands on each figure of the rendered Layout, switching it to the
+        one-axis responsive mode. Regression: detector images (square + layout)
+        collapsed to zero height when the hook only ran on a single shared
+        figure and was skipped for Layouts.
+        """
+        from bokeh.models import Plot
+
+        from ess.livedata.dashboard.plot_params import (
+            LayoutParams,
+            PlotAspect,
+            PlotAspectType,
+        )
+
+        params = PlotParams1d(
+            layout=LayoutParams(combine_mode='layout'),
+            plot_aspect=PlotAspect(aspect_type=PlotAspectType.square),
+        )
+        plotter = plots.LinePlotter.from_params(params)
+        plotter.compute(
+            {'primary': {data_key_1: simple_data_1, data_key_2: simple_data_2}}
+        )
+        result = plotter.get_cached_state()
+        assert isinstance(result, hv.Layout)
+
+        presenter = plotter.create_presenter()
+        pipe = hv.streams.Pipe(data=result)
+        state = render_to_bokeh(presenter.present(pipe)).state
+
+        figures = [m for m in state.references() if isinstance(m, Plot)]
+        assert len(figures) == 2
+        assert all(fig.sizing_mode == 'stretch_width' for fig in figures)
+
     def test_empty_data_returns_no_data_text(self):
         """Test that empty data returns 'No data' text element in overlay mode."""
         from ess.livedata.dashboard.plot_params import LayoutParams
@@ -1889,9 +1927,12 @@ class TestOverlay1DPlotter:
         for elem in result:
             assert isinstance(elem, hv.Curve), f"Expected Curve, got {type(elem)}"
 
-    def test_renders_responsive(self, data_2d_with_roi_coord, data_key):
-        """Aspect enforcement is handled by a JS hook (frame_aspect.py), so the
-        overlay renders responsive (stretch_both) regardless of aspect type."""
+    def test_non_free_aspect_switches_figure_to_one_axis_responsive(
+        self, data_2d_with_roi_coord, data_key
+    ):
+        """A non-free aspect makes the plotter declare the frame-aspect hook on
+        its elements, which switches the figure to a one-axis responsive mode
+        (fill-width -> stretch_width) so aspect can be enforced via JS."""
         from ess.livedata.dashboard.plot_params import PlotAspect, PlotAspectType
 
         params = PlotParams1d()
@@ -1899,7 +1940,7 @@ class TestOverlay1DPlotter:
         plotter = plots.Overlay1DPlotter.from_params(params)
 
         fig = present_figure(plotter, {data_key: data_2d_with_roi_coord})
-        assert fig.sizing_mode == 'stretch_both'
+        assert fig.sizing_mode == 'stretch_width'
         assert fig.aspect_ratio is None
 
     def test_free_aspect_renders_responsive_without_aspect(


### PR DESCRIPTION
## Problem

Layout-mode plots render with their vertical axis collapsed to zero height — only the toolbar, x-axis, and colorbar remain. The dummy detector images (`square` aspect + `combine_mode: layout`) hit this. First noticed in `scripts/drive_dashboard.py` screenshots, but it is a real rendering bug in the live DOM, not a screenshot artifact.

## Cause

The frame-aspect hook (`frame_aspect.py`) switches a Bokeh figure to a one-axis responsive mode (`stretch_width`/`stretch_height`) and pins the other dimension via JS — this is how non-free aspects are enforced. It was applied once, at the cell level, to the cell's single composed figure, and skipped entirely for non-overlayable layers. But a `Layout` has one figure *per sub-plot*, so those figures never received the hook: they stayed `stretch_both` while the cell's pane asked for `stretch_width`, leaving the free (vertical) axis unconstrained and collapsing the plot.

This surfaced when layout mode began always producing an `hv.Layout` (PR #1008's config-time `is_overlayable` invariant): single-source layout cells became `Layout`s and lost the hook. PR #1008 merged onto `main` after the most recent release (26.6.4, 2026-06-23) and is not contained in any tag, so this regression never reached a public release — it exists only on `main`.

## Fix

Declare the frame-aspect hook **per leaf element type in the plotter**, alongside `responsive=True`, so it lands on every figure the plotter produces — one shared figure when overlaid, one per sub-plot when laid out. Aspect becomes a per-figure property that survives composition. This fixes the collapse, keeps square detector images square, and now also honors aspect for multi-source layouts (previously it was silently ignored there). The plotter already received `aspect_params` but never used them.

PR #1008's design is untouched: layout mode still always produces a `Layout`, and the cell-sharing forbiddance still uses the config-time `is_overlayable`. The cell widget no longer applies a composed-level aspect hook; it still skips the genuinely cell-level SaveTool/autoscale hooks for `Layout`s and `Table`s. `No data`/error placeholders keep plain `responsive` (no forced aspect).

## Test plan

- [x] New real-component test renders a multi-source layout-mode plotter and asserts every sub-figure switches to the one-axis responsive mode (fails before the fix).
- [x] Updated the figure-level aspect test to reflect that the plotter now applies the hook.
- [x] Full dashboard test suite passes (1610).
- [x] Verified via `drive_dashboard.py`: detector images render square with full vertical axes (iw == ih).

