### PR TITLE
tests: guard against collapsed/inconsistently-sized plots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ addopts = """
 --strict-markers
 --import-mode=importlib
 --benchmark-skip
--m "not integration and not slow"
+-m "not integration and not slow and not browser"
 -ra
 """
 testpaths = "tests"
@@ -112,6 +112,7 @@ markers = [
   "instrument: Specify instrument name for parameterized tests",
   "services: Specify which services to use in integration_env fixture (monitor, detector, or reduction)",
   "slow: Slow tests (>2s) excluded by default, run in CI via tox",
+  "browser: Browser-driven (Playwright) UI tests; run locally, excluded from CI",
 ]
 filterwarnings = [
   "error",

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 
 import holoviews as hv
 import panel as pn
+import pydantic
 import structlog
 
 from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
@@ -32,7 +33,6 @@ from ..plot_orchestrator import (
     CellId,
     LayerId,
     PlotCell,
-    PlotConfig,
     PlotOrchestrator,
 )
 from ..plot_params import PlotAspectType, StretchMode
@@ -52,20 +52,23 @@ from .styles import Colors, FreshnessPill, StatusColors
 logger = structlog.get_logger(__name__)
 
 
-def _get_sizing_mode(config: PlotConfig) -> str:
-    """Extract Panel sizing_mode from plot configuration.
+def _get_sizing_mode(params: pydantic.BaseModel) -> str:
+    """Panel sizing_mode the plotter's aspect implies for the cell's pane.
+
+    Must match the responsive mode the plotter switches its figures to (the
+    frame-aspect hook in ``Plotter._sizing_opts``): a one-axis pane around a
+    ``stretch_both`` figure leaves the free axis unconstrained and collapses.
 
     Parameters
     ----------
-    config:
-        Plot configuration containing plotter params.
+    params:
+        Plotter params, optionally carrying ``plot_aspect``.
 
     Returns
     -------
     :
         Panel sizing_mode string ('stretch_both', 'stretch_width', or 'stretch_height').
     """
-    params = config.params
     if hasattr(params, 'plot_aspect'):
         aspect = params.plot_aspect
         if aspect.aspect_type == PlotAspectType.free:
@@ -548,7 +551,7 @@ class CellWidget:
         """
         # Use sizing mode from first layer (they should be consistent for overlay)
         if self._cell.layers:
-            sizing_mode = _get_sizing_mode(self._cell.layers[0].config)
+            sizing_mode = _get_sizing_mode(self._cell.layers[0].config.params)
         else:
             sizing_mode = 'stretch_both'
 

--- a/tests/dashboard/plot_sizing_invariant_test.py
+++ b/tests/dashboard/plot_sizing_invariant_test.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Render-geometry invariant: a plot's figures must be sized consistently.
+
+The "collapsed detector image" bug (figures left ``stretch_both`` while their
+pane asked for ``stretch_width``, so the free axis was unconstrained and the
+plot rendered at zero height) passed every functional test: the data and the
+figure existed, only the *rendered geometry* was wrong.
+
+A real browser is needed to observe the collapse itself (``inner_height``), but
+the upstream cause is observable headlessly: every figure a plotter produces
+must adopt the responsive sizing mode the cell's pane will wrap it in. These
+tests render each plotter through the real ``compute -> present -> bokeh`` path
+and assert that invariant across aspect types and combine modes -- including
+the layout-mode sub-figures that the original bug skipped.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import holoviews as hv
+import numpy as np
+import pytest
+import scipp as sc
+from bokeh.models import Plot
+from holoviews.plotting.bokeh import BokehRenderer
+
+from ess.livedata.config.workflow_spec import JobId, ResultKey, WorkflowId
+from ess.livedata.dashboard import plots
+from ess.livedata.dashboard.plot_params import (
+    CombineMode,
+    LayoutParams,
+    PlotAspect,
+    PlotAspectType,
+    PlotParams1d,
+    PlotParams2d,
+    StretchMode,
+)
+from ess.livedata.dashboard.widgets.cell import _get_sizing_mode
+
+hv.extension('bokeh')
+
+
+def _figures(hv_obj) -> list[Plot]:
+    """All Bokeh figures in the rendered HoloViews object (Layout -> one per cell)."""
+    state = BokehRenderer.instance().get_plot(hv_obj).state
+    return [m for m in state.references() if isinstance(m, Plot)]
+
+
+def _present_figures(plotter, data: dict) -> list[Plot]:
+    plotter.compute({'primary': data})
+    presenter = plotter.create_presenter()
+    pipe = hv.streams.Pipe(data=plotter.get_cached_state())
+    return _figures(presenter.present(pipe))
+
+
+def _keys(n: int) -> list[ResultKey]:
+    wf = WorkflowId(instrument='test', name='wf', version=1)
+    return [
+        ResultKey(
+            workflow_id=wf,
+            job_id=JobId(source_name=f's{i}', job_number=uuid.uuid4()),
+            output_name='out',
+        )
+        for i in range(n)
+    ]
+
+
+def _data_1d(n: int) -> dict:
+    da = sc.DataArray(
+        sc.array(dims=['x'], values=[1.0, 2.0, 3.0]),
+        coords={'x': sc.array(dims=['x'], values=[10.0, 20.0, 30.0])},
+    )
+    return dict.fromkeys(_keys(n), da)
+
+
+def _data_2d(n: int) -> dict:
+    da = sc.DataArray(
+        sc.array(dims=['y', 'x'], values=np.arange(12.0).reshape(3, 4)),
+        coords={
+            'x': sc.arange('x', 4, dtype='float64'),
+            'y': sc.arange('y', 3, dtype='float64'),
+        },
+    )
+    return dict.fromkeys(_keys(n), da)
+
+
+_ASPECTS = [
+    PlotAspect(aspect_type=PlotAspectType.free),
+    PlotAspect(aspect_type=PlotAspectType.square, stretch_mode=StretchMode.width),
+    PlotAspect(aspect_type=PlotAspectType.square, stretch_mode=StretchMode.height),
+    PlotAspect(aspect_type=PlotAspectType.equal, stretch_mode=StretchMode.width),
+    PlotAspect(aspect_type=PlotAspectType.aspect, ratio=2.0),
+]
+
+
+@pytest.mark.parametrize('combine', [CombineMode.overlay, CombineMode.layout])
+@pytest.mark.parametrize('n_sources', [1, 2])
+@pytest.mark.parametrize('aspect', _ASPECTS, ids=lambda a: a.aspect_type.name)
+class TestFigureSizingInvariant:
+    """Every figure a plotter renders adopts the aspect's responsive mode.
+
+    Covers both overlay (one shared figure) and layout (one figure per source),
+    so a regression that skips the aspect hook for any figure -- as the
+    collapsed-image bug did for Layout sub-figures -- fails here.
+    """
+
+    def test_line_plotter(self, aspect, n_sources, combine):
+        params = PlotParams1d(
+            layout=LayoutParams(combine_mode=combine), plot_aspect=aspect
+        )
+        figures = _present_figures(
+            plots.LinePlotter.from_params(params), _data_1d(n_sources)
+        )
+        expected_n = n_sources if combine == CombineMode.layout else 1
+        assert len(figures) == expected_n
+        for fig in figures:
+            assert fig.sizing_mode == _get_sizing_mode(params)
+
+    def test_image_plotter(self, aspect, n_sources, combine):
+        params = PlotParams2d(
+            layout=LayoutParams(combine_mode=combine), plot_aspect=aspect
+        )
+        figures = _present_figures(
+            plots.ImagePlotter.from_params(params), _data_2d(n_sources)
+        )
+        expected_n = n_sources if combine == CombineMode.layout else 1
+        assert len(figures) == expected_n
+        for fig in figures:
+            assert fig.sizing_mode == _get_sizing_mode(params)

--- a/tests/dashboard/render_geometry_test.py
+++ b/tests/dashboard/render_geometry_test.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Rendered-geometry smoke test: no plot collapses to zero size in a real browser.
+
+The "collapsed detector image" bug left figures with ``inner_height == 0`` while
+every functional/headless test stayed green -- the data and figure models were
+fine, only the browser-computed layout was broken. The only faithful guard is to
+render the dashboard in an actual browser and measure the laid-out figures.
+
+This drives the Kafka-free fake backend (seeded from the committed dummy fixture)
+with Playwright, visits every plot-grid tab, and asserts that every Bokeh figure
+has a non-degenerate data area. It is fix-agnostic: it fails whenever a plot
+renders collapsed, whatever the cause.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+pytest.importorskip("playwright.sync_api")
+from drive_dashboard import Dashboard, _fake_dashboard  # noqa: E402
+
+# Below this many CSS pixels a figure's data area is considered collapsed.
+_MIN_FRAME_PX = 50
+
+_FIGURE_DIMS_JS = """() => {
+  const out = [];
+  for (const doc of (window.Bokeh && Bokeh.documents) || []) {
+    for (const m of Array.from(doc._all_models.values())) {
+      if (m.type === 'Figure') {
+        out.push({iw: m.inner_width, ih: m.inner_height,
+                  ow: m.outer_width, oh: m.outer_height});
+      }
+    }
+  }
+  return out;
+}"""
+
+
+@pytest.fixture(scope="module")
+def dashboard():
+    """Launch the fake-backend dummy dashboard once and drive it with Playwright."""
+    with _fake_dashboard("dummy", 5031) as url, Dashboard.connect(url) as dash:
+        yield dash
+
+
+def _plot_grid_tabs(dash: Dashboard) -> list[str]:
+    """Tab titles that hold plot grids (exclude the static control tabs)."""
+    static = {"Workflows", "System Status", "Manage Plots"}
+    return [t for t in dash.tab_names() if t not in static]
+
+
+@pytest.mark.browser
+def test_no_plot_renders_collapsed(dashboard):
+    grid_tabs = _plot_grid_tabs(dashboard)
+    assert grid_tabs, "fixture should expose at least one plot-grid tab"
+
+    collapsed: dict[str, list] = {}
+    for tab in grid_tabs:
+        dashboard.goto_tab(tab)
+        figures = dashboard.page.evaluate(_FIGURE_DIMS_JS)
+        assert figures, f"tab {tab!r} rendered no figures"
+        bad = [f for f in figures if f["iw"] < _MIN_FRAME_PX or f["ih"] < _MIN_FRAME_PX]
+        if bad:
+            collapsed[tab] = bad
+
+    assert not collapsed, f"figures collapsed below {_MIN_FRAME_PX}px: {collapsed}"

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ isolated_build = true
 deps = -r requirements/test.txt
 setenv =
   JUPYTER_PLATFORM_DIRS = 1
-# Override pyproject.toml addopts to include slow tests in CI
-commands = pytest -m "not integration" {posargs}
+# Override pyproject.toml addopts: include slow tests, still skip browser tests
+commands = pytest -m "not integration and not browser" {posargs}
 
 [testenv:integration]
 description = Run integration tests (requires Kafka to be running)
@@ -21,16 +21,16 @@ deps = -r requirements/nightly.txt
 setenv =
   PIP_INDEX_URL = https://pypi.anaconda.org/scipp-nightly-wheels/simple
   PIP_EXTRA_INDEX_URL = https://pypi.org/simple
-# Override pyproject.toml addopts to include slow tests in CI
-commands = pytest -m "not integration" {posargs}
+# Override pyproject.toml addopts: include slow tests, still skip browser tests
+commands = pytest -m "not integration and not browser" {posargs}
 
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.
 deps =
   -r requirements/basetest.txt
   esslivedata
-# Override pyproject.toml addopts to include slow tests in CI
-commands = pytest -m "not integration" {posargs}
+# Override pyproject.toml addopts: include slow tests, still skip browser tests
+commands = pytest -m "not integration and not browser" {posargs}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
The Option 3 fix (#1029) is now on main. The collapsed-detector-image bug was a close call: it passed every functional test because the data and figure models were correct — only the *rendered geometry* was wrong. These add deterministic guards for that whole class.

## Two complementary guards

**Headless invariant** (`plot_sizing_invariant_test.py`, runs in CI). Renders each plotter across aspect × combine-mode × source-count and asserts every figure — the overlay's shared one *and each layout sub-figure* — adopts the responsive mode the cell's pane will wrap it in. It asserts against the real `cell._get_sizing_mode`, so figure sizing and pane sizing are tied together: a future divergence (exactly what caused the collapse) fails here. Catches the bug at the cause, fast, no new deps.

**Browser smoke test** (`render_geometry_test.py`, local-only). Drives the Kafka-free fake dashboard with Playwright, visits every plot-grid tab, and asserts no figure's data area is degenerate (`inner_width`/`inner_height`). This is the fix-agnostic ground truth — it fails whenever a plot renders collapsed, whatever the cause (verified: it fails on buggy `main` with `ih: 0`, passes on the fix). Coverage scales with fixture coverage, so it is the natural home for a future kitchen-sink fixture.

## Marker

Added a `browser` marker, excluded from the default run and the three CI tox envs. Playwright-in-CI is a separate decision; until then the browser test runs locally via `pytest -m browser` (it `importorskip`s Playwright, so it skips cleanly where the dep is absent). The headless invariant is the CI-gating guard in the meantime.

## Also

`cell._get_sizing_mode` now takes `params` directly (it only ever used `config.params`) so the invariant test can call it without fabricating a `PlotConfig`.

## Test plan

- [x] Headless invariant: 40 cases pass on the fix; fails on `main` (hook was applied at the cell level, so plotter figures weren't sized by aspect).
- [x] Browser test: passes on the fix; fails on buggy `main` (`figures collapsed below 50px ... ih: 0`).
- [x] Full dashboard suite green (1650); browser test deselected by default and by the CI filter.
