### PR TITLE
dashboard: manual color limits (vmin/vmax) for 2D plots

### DIFF
--- a/src/ess/livedata/dashboard/cell_autoscale.py
+++ b/src/ess/livedata/dashboard/cell_autoscale.py
@@ -101,7 +101,7 @@ class CellAutoscaleController:
     def __init__(self, layer_plotters: list[Plotter]) -> None:
         self._plotters: list[Plotter] = list(layer_plotters)
         self._axes: frozenset[Axis] = frozenset().union(
-            *(plotter.AUTOSCALE_AXES for plotter in self._plotters)
+            *(plotter.autoscale_axes for plotter in self._plotters)
         )
         # Lazy-created on first render so each session's tools live in the
         # session's own Bokeh document (see dashboard-widgets rules).
@@ -129,7 +129,7 @@ class CellAutoscaleController:
         """
         result: tuple[float, float] | None = None
         for plotter in self._plotters:
-            if axis not in plotter.AUTOSCALE_AXES:
+            if axis not in plotter.autoscale_axes:
                 continue
             for _key, targets in plotter.iter_range_targets():
                 target = targets.get(axis)

--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -266,6 +266,16 @@ class CorrelationHistogramPlotter:
         """Check if the renderer has computed state."""
         return self._renderer.has_cached_state()
 
+    @property
+    def autoscale_axes(self) -> frozenset[Axis]:
+        """Delegate effective autoscale axes to the inner renderer.
+
+        The renderer narrows its axes for static config such as manual color
+        limits, so the cell controller inherits that here without the outer
+        plotter knowing about it.
+        """
+        return self._renderer.autoscale_axes
+
     def get_range_targets(self, data_key: ResultKey) -> RangeTargets | None:
         """Delegate per-axis target lookup to the inner renderer."""
         return self._renderer.get_range_targets(data_key)

--- a/src/ess/livedata/dashboard/plot_params.py
+++ b/src/ess/livedata/dashboard/plot_params.py
@@ -176,6 +176,35 @@ class PlotScaleParams2d(PlotScaleParams):
         description="Scale for color axis",
         title="Color Axis Scale",
     )
+    manual_color_limits: bool = pydantic.Field(
+        default=False,
+        description=(
+            "Use fixed color limits below instead of autoscaling to the data. "
+            "When enabled, the color autoscale toolbar button is removed for this "
+            "plot."
+        ),
+        title="Manual Color Limits",
+    )
+    color_min: float = pydantic.Field(
+        default=0.0,
+        description="Lower color limit (used only when manual color limits are on).",
+        title="Color Min",
+    )
+    color_max: float = pydantic.Field(
+        default=1.0,
+        description="Upper color limit (used only when manual color limits are on).",
+        title="Color Max",
+    )
+
+    @pydantic.model_validator(mode='after')
+    def _check_manual_limits(self) -> PlotScaleParams2d:
+        if not self.manual_color_limits:
+            return self
+        if self.color_max <= self.color_min:
+            raise ValueError("Color Max must be greater than Color Min.")
+        if self.color_scale == PlotScale.log and self.color_min <= 0.0:
+            raise ValueError("Color Min must be positive for a log color scale.")
+        return self
 
 
 class LayoutParams(pydantic.BaseModel):

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -437,7 +437,22 @@ class Plotter:
     """
 
     AUTOSCALE_AXES: ClassVar[frozenset[Axis]] = frozenset()
-    """Per-axis autoscale support. Override per subclass."""
+    """Per-axis autoscale capability. Override per subclass."""
+
+    _autoscale_axes_override: frozenset[Axis] | None = None
+
+    @property
+    def autoscale_axes(self) -> frozenset[Axis]:
+        """Axes for which this instance exposes autoscale controls.
+
+        Defaults to :attr:`AUTOSCALE_AXES`. An instance narrows it when a
+        static config fixes an axis (e.g. manual color limits remove ``'c'``),
+        so the cell's autoscale controller skips both the toolbar toggle and
+        the per-render range write for that axis.
+        """
+        if self._autoscale_axes_override is not None:
+            return self._autoscale_axes_override
+        return self.AUTOSCALE_AXES
 
     @property
     def is_overlayable(self) -> bool:
@@ -531,6 +546,8 @@ class Plotter:
             'logy': scale_opts.y_scale == PlotScale.log,
             'logz': scale_opts.color_scale == PlotScale.log,
         }
+        if scale_opts.manual_color_limits:
+            opts['clim'] = (scale_opts.color_min, scale_opts.color_max)
         if tick_params is not None:
             if tick_params.custom_xticks:
                 opts['xticks'] = tick_params.xticks
@@ -1130,6 +1147,8 @@ class ImagePlotter(Plotter):
         super().__init__(**kwargs)
         self._scale_opts = scale_opts
         self._base_opts = self._make_2d_base_opts(scale_opts, tick_params)
+        if scale_opts.manual_color_limits:
+            self._autoscale_axes_override = self.AUTOSCALE_AXES - {'c'}
 
     @classmethod
     def from_params(cls, params: PlotParams2d):

--- a/src/ess/livedata/dashboard/slicer_plotter.py
+++ b/src/ess/livedata/dashboard/slicer_plotter.py
@@ -284,6 +284,8 @@ class SlicerPlotter(Plotter):
         super().__init__(**kwargs)
         self._scale_opts = scale_opts
         self._base_opts = self._make_2d_base_opts(scale_opts, tick_params)
+        if scale_opts.manual_color_limits:
+            self._autoscale_axes_override = self.AUTOSCALE_AXES - {'c'}
 
     @classmethod
     def from_params(cls, params: PlotParams3d):
@@ -317,7 +319,14 @@ class SlicerPlotter(Plotter):
         data = data.get(PRIMARY, {})
         if self._normalize_to_rate:
             data = {key: _normalize_to_rate(da) for key, da in data.items()}
-        clim = self._compute_global_clim(data)
+        # With manual color limits the fixed clim is declared once in base_opts;
+        # skip the data-derived clim so it neither overrides the manual value per
+        # slice nor produces a 'c' autoscale target.
+        clim = (
+            None
+            if self._scale_opts.manual_color_limits
+            else self._compute_global_clim(data)
+        )
         use_log_scale = self._scale_opts.color_scale == PlotScale.log
         self._range_targets = {}
         if clim is not None:

--- a/src/ess/livedata/dashboard/widgets/param_widget.py
+++ b/src/ess/livedata/dashboard/widgets/param_widget.py
@@ -236,7 +236,10 @@ class ParamWidget:
             # Extract first error message for display
             error_details = e.errors()
             if error_details:
-                field_name = error_details[0].get('loc', [''])[0]
+                # Model-level validators report an empty ``loc``; only field
+                # errors carry a field name to prefix the message with.
+                loc = error_details[0].get('loc', ())
+                field_name = loc[0] if loc else ''
                 error_msg = error_details[0].get('msg', str(e))
                 return False, f"{field_name}: {error_msg}" if field_name else error_msg
             return False, str(e)
@@ -257,7 +260,8 @@ class ParamWidget:
             except pydantic.ValidationError as e:
                 error_details = e.errors()
                 if error_details:
-                    field_name = error_details[0].get('loc', [''])[0]
+                    loc = error_details[0].get('loc', ())
+                    field_name = loc[0] if loc else ''
                     if field_name in self.widgets:
                         # Apply error styling to the failing widget
                         self.widgets[field_name].styles = {

--- a/tests/dashboard/cell_autoscale_test.py
+++ b/tests/dashboard/cell_autoscale_test.py
@@ -36,7 +36,7 @@ class _FakePlotter:
     """Stand-in for a real :class:`Plotter`.
 
     Implements the minimum surface used by :class:`CellAutoscaleController`:
-    ``AUTOSCALE_AXES`` class attribute and ``iter_range_targets()``.
+    the ``autoscale_axes`` property and ``iter_range_targets()``.
     """
 
     def __init__(
@@ -44,7 +44,7 @@ class _FakePlotter:
         axes: frozenset[Axis],
         targets_by_key: dict[ResultKey, dict[Axis, tuple[float, float]]] | None = None,
     ) -> None:
-        self.AUTOSCALE_AXES = axes
+        self.autoscale_axes = axes
         self._targets = targets_by_key or {}
 
     def iter_range_targets(self):

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -333,6 +333,57 @@ class TestImagePlotter:
         result = plotter.plot(zero_data, data_key)
         assert result.vdims[0].label == 'values'
 
+    def test_manual_color_limits_pin_color_mapper(
+        self, constant_nonzero_data, data_key
+    ):
+        """Manual limits fix the rendered color mapper, ignoring the data range."""
+        from bokeh.models import LinearColorMapper
+
+        params = PlotParams2d()
+        params.plot_scale.color_scale = PlotScale.linear
+        params.plot_scale.manual_color_limits = True
+        params.plot_scale.color_min = 2.0
+        params.plot_scale.color_max = 9.0
+        plotter = plots.ImagePlotter.from_params(params)
+        fig = present_figure(plotter, {data_key: constant_nonzero_data})
+        mappers = fig.select(LinearColorMapper)
+        assert mappers
+        assert mappers[0].low == 2.0
+        assert mappers[0].high == 9.0
+
+
+class TestPlotScaleParams2dManualLimits:
+    def test_rejects_max_not_greater_than_min_when_manual(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PlotScaleParams2d(manual_color_limits=True, color_min=5.0, color_max=5.0)
+
+    def test_rejects_nonpositive_min_on_log_scale(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PlotScaleParams2d(
+                color_scale=PlotScale.log,
+                manual_color_limits=True,
+                color_min=0.0,
+                color_max=10.0,
+            )
+
+    def test_allows_nonpositive_min_on_linear_scale(self):
+        params = PlotScaleParams2d(
+            color_scale=PlotScale.linear,
+            manual_color_limits=True,
+            color_min=-5.0,
+            color_max=10.0,
+        )
+        assert params.color_min == -5.0
+
+    def test_limits_unvalidated_when_manual_off(self):
+        # Limits are ignored when manual is off, so an inverted pair is allowed.
+        params = PlotScaleParams2d(color_min=5.0, color_max=1.0)
+        assert params.manual_color_limits is False
+
 
 class TestLinePlotter:
     @pytest.fixture

--- a/tests/dashboard/plotter_range_targets_test.py
+++ b/tests/dashboard/plotter_range_targets_test.py
@@ -553,7 +553,11 @@ class TestManualColorLimitsDropAutoscaleC:
         assert plotter.autoscale_axes == frozenset({'c'})
 
     def test_slicer_manual_drops_c(self):
-        params = PlotParams3d(plot_scale=PlotScaleParams2d(manual_color_limits=True))
+        params = PlotParams3d(
+            plot_scale=PlotScaleParams2d(
+                color_scale=PlotScale.linear, manual_color_limits=True
+            )
+        )
         plotter = SlicerPlotter.from_params(params)
         assert plotter.autoscale_axes == frozenset()
 

--- a/tests/dashboard/plotter_range_targets_test.py
+++ b/tests/dashboard/plotter_range_targets_test.py
@@ -526,3 +526,63 @@ class TestCorrelationHistogramRangeTargets:
 def test_autoscale_axes_table(plotter_cls, axes):
     """Per plan section 1.4, each plotter declares its autoscalable axes."""
     assert plotter_cls.AUTOSCALE_AXES == axes
+
+
+class TestManualColorLimitsDropAutoscaleC:
+    """Manual color limits remove ``'c'`` from the effective autoscale axes.
+
+    The cell controller reads ``autoscale_axes`` (not the ``AUTOSCALE_AXES``
+    capability), so a fixed colorbar drops both the toggle and the per-render
+    color write while x/y autoscale is untouched.
+    """
+
+    def test_image_default_keeps_c(self):
+        params = PlotParams2d()
+        plotter = ImagePlotter.from_params(params)
+        assert plotter.autoscale_axes == frozenset({'x', 'y', 'c'})
+
+    def test_image_manual_drops_c(self):
+        params = PlotParams2d()
+        params.plot_scale.manual_color_limits = True
+        plotter = ImagePlotter.from_params(params)
+        assert plotter.autoscale_axes == frozenset({'x', 'y'})
+
+    def test_slicer_default_keeps_c(self):
+        params = PlotParams3d(plot_scale=PlotScaleParams2d())
+        plotter = SlicerPlotter.from_params(params)
+        assert plotter.autoscale_axes == frozenset({'c'})
+
+    def test_slicer_manual_drops_c(self):
+        params = PlotParams3d(plot_scale=PlotScaleParams2d(manual_color_limits=True))
+        plotter = SlicerPlotter.from_params(params)
+        assert plotter.autoscale_axes == frozenset()
+
+    def test_correlation_2d_delegates_to_renderer(self):
+        params = CorrelationHistogram2dParams(bins=Bin2dParams(x_bins=4, y_bins=4))
+        params.plot_scale.manual_color_limits = True
+        plotter = CorrelationHistogram2dPlotter(params=params)
+        assert plotter.autoscale_axes == frozenset({'x', 'y'})
+
+    def test_slicer_manual_skips_data_clim(self):
+        """Manual limits leave ``SlicerState.clim`` unset and emit no 'c' target."""
+        params = PlotParams3d(
+            plot_scale=PlotScaleParams2d(
+                color_scale=PlotScale.linear, manual_color_limits=True
+            )
+        )
+        plotter = SlicerPlotter.from_params(params)
+        key = _key()
+        data = sc.DataArray(
+            sc.arange('z', 0, 5 * 8 * 10, dtype='float64').fold(
+                dim='z', sizes={'z': 5, 'y': 8, 'x': 10}
+            ),
+            coords={
+                'z': sc.linspace('z', 0.0, 5.0, num=5, unit='s'),
+                'y': sc.linspace('y', 0.0, 8.0, num=8, unit='m'),
+                'x': sc.linspace('x', 0.0, 10.0, num=10, unit='m'),
+            },
+        )
+        data.data.unit = 'counts'
+        plotter.compute({PRIMARY: {key: data}})
+        assert plotter.get_cached_state().clim is None
+        assert plotter.get_range_targets(key) is None

--- a/tests/dashboard/widgets/param_widget_test.py
+++ b/tests/dashboard/widgets/param_widget_test.py
@@ -643,6 +643,26 @@ class TestValidate:
         # Widget value should remain unchanged
         assert widget.widgets["value"].value == original_value
 
+    def test_validate_handles_model_level_error(self):
+        # Model validators report an empty ``loc``; validate must not crash
+        # trying to read a field name from it.
+        class TestModel(pydantic.BaseModel):
+            low: int = 0
+            high: int = 1
+
+            @pydantic.model_validator(mode='after')
+            def _check(self):
+                if self.high <= self.low:
+                    raise ValueError("high must exceed low")
+                return self
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["high"].value = 0
+
+        is_valid, message = widget.validate()
+        assert is_valid is False
+        assert "high must exceed low" in message
+
 
 class TestSetErrorState:
     """Tests for set_error_state method."""
@@ -690,6 +710,24 @@ class TestSetErrorState:
 
         # Field should have no border
         assert widget.widgets["value"].styles.get("border") == "none"
+
+    def test_set_error_state_handles_model_level_error(self):
+        # A model-level error has no field to highlight; this must not crash.
+        class TestModel(pydantic.BaseModel):
+            low: int = 0
+            high: int = 1
+
+            @pydantic.model_validator(mode='after')
+            def _check(self):
+                if self.high <= self.low:
+                    raise ValueError("high must exceed low")
+                return self
+
+        widget = ParamWidget(TestModel)
+        widget.widgets["high"].value = 0
+        widget.set_error_state(True, "high must exceed low")
+
+        assert "high must exceed low" in widget._error_pane.object
 
 
 class TestPanel:

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -613,6 +613,10 @@ class TestComposeMixedLayers:
                 self._cached_state = None
                 self._presenters = []
 
+            @property
+            def autoscale_axes(self):
+                return self.AUTOSCALE_AXES
+
             def compute(self, data):
                 self._cached_state = data
 


### PR DESCRIPTION
## Motivation

2D plots (Image, Slicer, Flatten, 2D correlation) offered only a linear/log color scale plus an interactive color-autoscale toggle. There was no way to fix the colorbar to explicit values — useful for comparing frames on a common scale or suppressing a dominating hotspot.

## What this adds

A **Manual Color Limits** option in the 2D color-scale section of the plot config modal, with **Color Min** / **Color Max** inputs. When enabled, the fixed limits are applied to the plot and the per-cell color-autoscale toolbar button is removed, so runtime autoscaling cannot fight the user's chosen values. X/Y autoscale is unaffected.

Manual limits are validated when the config is submitted: Color Max must exceed Color Min, and Color Min must be positive on a log color scale.

## Example

<img width="836" height="692" alt="image" src="https://github.com/user-attachments/assets/4abaa5a9-931f-40fc-80b5-70ecfe08984d" />

## Design note

Effective autoscalable axes are now exposed as an instance-level `autoscale_axes` property layered over the static `AUTOSCALE_AXES` capability, letting a plotter drop the color axis at construction. This also lets the correlation plotter genuinely delegate its autoscale axes to its inner renderer, which its docstring already claimed but did not do.

## Test plan

- [x] Open a 2D plot's config, enable Manual Color Limits, set min/max, and confirm the colorbar is pinned and the color-autoscale toolbar button is gone.
- [x] Confirm X/Y autoscale toggles still work with manual color limits on.
- [x] Confirm submitting Color Max ≤ Color Min, or a non-positive Color Min on a log scale, is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
