### PR TITLE
dashboard: enable hover tool for data plotters

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -878,6 +878,12 @@ _LINE1D_LEAF_ELEMENTS: tuple[type, ...] = (
     hv.ErrorBars,
     hv.Spread,
 )
+# Element types that get a hover tool. Error elements (ErrorBars, Spread) are
+# deliberately excluded: Bokeh cannot attach a HoverTool to the Whisker glyph
+# (it raises during rendering), and the whisker/band values merely duplicate the
+# line they annotate.
+_HOVER_ELEMENTS_1D: tuple[type, ...] = (hv.Curve, hv.Scatter, hv.Histogram)
+_HOVER_ELEMENTS_2D: tuple[type, ...] = (hv.Image, hv.QuadMesh)
 
 
 def _color_error_element(el: hv.Element, color: Any) -> hv.Element:
@@ -1126,6 +1132,7 @@ class LinePlotter(Plotter):
     def style_opts(self) -> list[hv.Options]:
         return [
             *_typed_opts(_LINE1D_LEAF_ELEMENTS, **self._base_opts, **self._sizing_opts),
+            *_typed_opts(_HOVER_ELEMENTS_1D, tools=['hover']),
             *super().style_opts(),
         ]
 
@@ -1236,7 +1243,10 @@ class ImagePlotter(Plotter):
     def style_opts(self) -> list[hv.Options]:
         return [
             *_typed_opts(
-                (hv.Image, hv.QuadMesh), **self._base_opts, **self._sizing_opts
+                _HOVER_ELEMENTS_2D,
+                **self._base_opts,
+                **self._sizing_opts,
+                tools=['hover'],
             ),
             *super().style_opts(),
         ]
@@ -1268,6 +1278,11 @@ class BarsPlotter(Plotter):
         self._bars_opts: dict[str, Any] = {
             'invert_axes': horizontal,
             'show_legend': False,
+            # Pan/zoom/reset are meaningless for a categorical bar chart and the
+            # hidden toolbar makes reset unreachable; drop them and keep only an
+            # always-active hover so values can be read off each bar.
+            'default_tools': [],
+            'tools': ['hover'],
             'toolbar': None,
             'yrotation' if horizontal else 'xrotation': 45 if horizontal else 25,
         }
@@ -1501,5 +1516,6 @@ class Overlay1DPlotter(Plotter):
         # Per-slice ``color`` stays on the elements in plot(); the rest is static.
         return [
             *_typed_opts(_LINE1D_LEAF_ELEMENTS, **self._base_opts, **self._sizing_opts),
+            *_typed_opts(_HOVER_ELEMENTS_1D, tools=['hover']),
             *super().style_opts(),
         ]

--- a/src/ess/livedata/dashboard/slicer_plotter.py
+++ b/src/ess/livedata/dashboard/slicer_plotter.py
@@ -16,6 +16,7 @@ from ess.livedata.config.workflow_spec import ResultKey
 from .data_roles import PRIMARY
 from .plot_params import PlotParams3d, PlotScale, PlotScaleParams2d, TickParams
 from .plots import (
+    _HOVER_ELEMENTS_2D,
     Plotter,
     PresenterBase,
     _hv_axis_padding,
@@ -100,7 +101,10 @@ class SlicerPresenter(PresenterBase):
         """Static styling declared once on the DynamicMap (see
         :meth:`Plotter.style_opts`); the data-dependent clim stays per slice."""
         return _typed_opts(
-            (hv.Image, hv.QuadMesh), **self._base_opts, **self._sizing_opts
+            _HOVER_ELEMENTS_2D,
+            **self._base_opts,
+            **self._sizing_opts,
+            tools=['hover'],
         )
 
     def _initialize_kdims(self, state: SlicerState) -> None:


### PR DESCRIPTION
## Motivation

Plots had no hover tool, so users could not read off coordinate/value at a point. This enables hover broadly across the data plotters.

## What

Hover is now active on line, image, slicer, overlay and bar plots, and on correlation plots via their line/image renderers. Tooltips carry axis labels with units and, for images, the cell value.

Error elements (`ErrorBars`, `Spread`) are deliberately excluded: Bokeh raises when a `HoverTool` is attached to the Whisker glyph, and the whisker/band values merely duplicate the line they annotate.

Bar charts previously kept pan/zoom/reset active behind a hidden toolbar, leaving zoom usable but reset unreachable. They now expose only an always-active hover.

`FlattenPlotter` keeps its bespoke axis-decomposing hover unchanged.

## Examples

<img width="539" height="343" alt="Screenshot 2026-06-30 at 15 21 37" src="https://github.com/user-attachments/assets/851bef69-98a6-44d7-ac3c-f68ae7795bc4" />
<img width="534" height="692" alt="Screenshot 2026-06-30 at 15 21 51" src="https://github.com/user-attachments/assets/b7c338d3-2e8b-46b1-8227-8ccf1a0dc16a" />


## Test plan

- [x] Hover over a line plot (with error bars and band) shows the coordinate and value, with no hover on the error whiskers/band.
- [x] Hover over an image / slicer shows x, y and the cell value.
- [x] Hover over a bar chart shows the value; pan/zoom/reset are gone.
- [ ] Flatten plot hover still decomposes the flattened axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
