### PR TITLE
Drop streams on unauthorized Kafka topics in PROD

### DIFF
--- a/src/ess/livedata/config/__init__.py
+++ b/src/ess/livedata/config/__init__.py
@@ -2,7 +2,14 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
 from .instrument import Instrument, SourceMetadata, instrument_registry
-from .stream import ContextBinding, Device, F144Stream, Stream, name_streams
+from .stream import (
+    ContextBinding,
+    Device,
+    F144Stream,
+    Stream,
+    filter_authorized_streams,
+    name_streams,
+)
 
 __all__ = [
     'ContextBinding',
@@ -11,6 +18,7 @@ __all__ = [
     'Instrument',
     'SourceMetadata',
     'Stream',
+    'filter_authorized_streams',
     'instrument_registry',
     'name_streams',
 ]

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -17,7 +17,12 @@ from typing import Literal
 import pydantic
 import scipp as sc
 
-from ess.livedata.config import Instrument, instrument_registry, name_streams
+from ess.livedata.config import (
+    Instrument,
+    filter_authorized_streams,
+    instrument_registry,
+    name_streams,
+)
 from ess.livedata.config.workflow_spec import WorkflowOutputsBase
 from ess.livedata.handlers.detector_view_specs import SpectrumViewSpec
 from ess.livedata.handlers.monitor_workflow_specs import (
@@ -230,7 +235,7 @@ monitors = [
 ]
 
 
-streams = name_streams(PARSED_STREAMS)
+streams = name_streams(filter_authorized_streams(PARSED_STREAMS))
 
 # Create instrument
 instrument = Instrument(

--- a/src/ess/livedata/config/instruments/dream/specs.py
+++ b/src/ess/livedata/config/instruments/dream/specs.py
@@ -13,6 +13,7 @@ from ess.livedata import parameter_models
 from ess.livedata.config import (
     Instrument,
     SourceMetadata,
+    filter_authorized_streams,
     instrument_registry,
     name_streams,
 )
@@ -110,7 +111,7 @@ instrument = Instrument(
         'overlap_chopper',
         'T0_chopper',
     ],
-    streams=name_streams(PARSED_STREAMS),
+    streams=name_streams(filter_authorized_streams(PARSED_STREAMS)),
     source_metadata={
         'mantle_detector': SourceMetadata(
             title='Mantle',

--- a/src/ess/livedata/config/instruments/estia/specs.py
+++ b/src/ess/livedata/config/instruments/estia/specs.py
@@ -11,6 +11,7 @@ from ess.livedata import parameter_models
 from ess.livedata.config import (
     Instrument,
     SourceMetadata,
+    filter_authorized_streams,
     instrument_registry,
     name_streams,
 )
@@ -185,7 +186,7 @@ class EstiaReflectometryReductionOutputs(WorkflowOutputsBase):
     )
 
 
-streams = name_streams(PARSED_STREAMS)
+streams = name_streams(filter_authorized_streams(PARSED_STREAMS))
 
 instrument = Instrument(
     name='estia',

--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -13,6 +13,7 @@ from ess.livedata import parameter_models
 from ess.livedata.config import (
     Instrument,
     SourceMetadata,
+    filter_authorized_streams,
     instrument_registry,
     name_streams,
 )
@@ -176,7 +177,7 @@ detector_names = [f'loki_detector_{bank}' for bank in range(9)]
 # f144 streams come from streams_parsed.py (auto-generated from the LOKI
 # geometry file). The detector carriage readback is the position dependency of
 # loki_detector_0 (depends_on -> /entry/instrument/detector_carriage/value).
-streams = name_streams(PARSED_STREAMS)
+streams = name_streams(filter_authorized_streams(PARSED_STREAMS))
 
 # Create instrument
 instrument = Instrument(

--- a/src/ess/livedata/config/instruments/nmx/specs.py
+++ b/src/ess/livedata/config/instruments/nmx/specs.py
@@ -4,7 +4,12 @@
 NMX instrument spec registration.
 """
 
-from ess.livedata.config import Instrument, instrument_registry, name_streams
+from ess.livedata.config import (
+    Instrument,
+    filter_authorized_streams,
+    instrument_registry,
+    name_streams,
+)
 from ess.livedata.config.workflow_spec import DETECTORS
 from ess.livedata.handlers.detector_view_specs import (
     DetectorROIAuxSources,
@@ -26,7 +31,7 @@ instrument = Instrument(
     name='nmx',
     detector_names=detector_names,
     monitors=['monitor1', 'monitor2'],
-    streams=name_streams(PARSED_STREAMS),
+    streams=name_streams(filter_authorized_streams(PARSED_STREAMS)),
 )
 
 # Register instrument

--- a/src/ess/livedata/config/instruments/odin/specs.py
+++ b/src/ess/livedata/config/instruments/odin/specs.py
@@ -4,7 +4,12 @@
 ODIN instrument spec registration.
 """
 
-from ess.livedata.config import Instrument, instrument_registry, name_streams
+from ess.livedata.config import (
+    Instrument,
+    filter_authorized_streams,
+    instrument_registry,
+    name_streams,
+)
 from ess.livedata.handlers.monitor_workflow_specs import (
     TOAOnlyMonitorDataParams,
     register_monitor_workflow_specs,
@@ -17,7 +22,7 @@ instrument = Instrument(
     name='odin',
     detector_names=['timepix3'],
     monitors=['monitor1', 'monitor2'],
-    streams=name_streams(PARSED_STREAMS),
+    streams=name_streams(filter_authorized_streams(PARSED_STREAMS)),
 )
 
 instrument_registry.register(instrument)

--- a/src/ess/livedata/config/instruments/tbl/specs.py
+++ b/src/ess/livedata/config/instruments/tbl/specs.py
@@ -7,6 +7,7 @@ TBL workflow spec registration.
 from ess.livedata.config import (
     Instrument,
     SourceMetadata,
+    filter_authorized_streams,
     instrument_registry,
     name_streams,
 )
@@ -35,7 +36,7 @@ instrument = Instrument(
     name='tbl',
     detector_names=detector_names,
     monitors=monitor_names,
-    streams=name_streams(PARSED_STREAMS),
+    streams=name_streams(filter_authorized_streams(PARSED_STREAMS)),
     source_metadata={
         'timepix3_detector': SourceMetadata(title='Timepix3'),
         'multiblade_detector': SourceMetadata(title='Multiblade'),

--- a/src/ess/livedata/config/stream.py
+++ b/src/ess/livedata/config/stream.py
@@ -309,6 +309,46 @@ def _detect_devices(parsed: dict[str, Stream]) -> dict[str, _DetectedDevice]:
     return devices
 
 
+#: Kafka topic suffixes with a PROD ACL grant for f144 log streams, plus
+#: ``tn_data_general`` which is authorized outright. PROD topic authorization
+#: is temporarily incomplete; entries in a ``streams_parsed`` module whose
+#: topic falls outside this set are dropped by :func:`filter_authorized_streams`
+#: so instruments do not attempt to subscribe to a topic they cannot read.
+_AUTHORIZED_TOPIC_SUFFIXES: tuple[str, ...] = ('_choppers', '_motion', '_sample_env')
+_AUTHORIZED_TOPICS: frozenset[str] = frozenset({'tn_data_general'})
+
+
+def filter_authorized_streams(parsed: dict[str, Stream]) -> dict[str, Stream]:
+    """Drop streams whose Kafka topic lacks a PROD ACL grant.
+
+    Temporary workaround for an incomplete PROD topic authorization list:
+    keeps only entries whose ``topic`` is ``tn_data_general`` or ends in
+    ``_choppers``, ``_motion``, or ``_sample_env``. Remove this filtering
+    once PROD ACLs cover the full topic set used by ``streams_parsed``
+    modules.
+
+    Parameters
+    ----------
+    parsed:
+        Path-keyed stream dict, typically the ``PARSED_STREAMS`` imported
+        from an instrument's auto-generated ``streams_parsed`` module.
+
+    Returns
+    -------
+    :
+        The subset of ``parsed`` whose topic is authorized.
+    """
+    return {
+        path: stream
+        for path, stream in parsed.items()
+        if stream.topic in _AUTHORIZED_TOPICS
+        or (
+            stream.topic is not None
+            and stream.topic.endswith(_AUTHORIZED_TOPIC_SUFFIXES)
+        )
+    }
+
+
 def name_streams(
     parsed: dict[str, Stream],
     *,

--- a/tests/config/stream_test.py
+++ b/tests/config/stream_test.py
@@ -6,12 +6,17 @@ from __future__ import annotations
 
 import pytest
 
-from ess.livedata.config import Device, F144Stream, name_streams
+from ess.livedata.config import (
+    Device,
+    F144Stream,
+    filter_authorized_streams,
+    name_streams,
+)
 from ess.livedata.config.stream import Stream, suggest_names
 
 
-def _parsed(path: str, *, source: str = 'src') -> F144Stream:
-    return F144Stream(nexus_path=path, source=source, topic='topic', units='mm')
+def _parsed(path: str, *, source: str = 'src', topic: str = 'topic') -> F144Stream:
+    return F144Stream(nexus_path=path, source=source, topic=topic, units='mm')
 
 
 class TestSuggestNames:
@@ -370,3 +375,36 @@ class TestDeviceDetection:
         result = name_streams(parsed)
         assert isinstance(result['a/motor'], Device)
         assert isinstance(result['b/motor'], Device)
+
+
+class TestFilterAuthorizedStreams:
+    @pytest.mark.parametrize(
+        'topic',
+        [
+            'loki_choppers',
+            'loki_motion',
+            'loki_sample_env',
+            'tn_data_general',
+        ],
+    )
+    def test_keeps_authorized_topic(self, topic: str) -> None:
+        parsed = {'/entry/instrument/a/value': _parsed('a', topic=topic)}
+        assert filter_authorized_streams(parsed) == parsed
+
+    @pytest.mark.parametrize(
+        'topic',
+        [
+            'loki_misc_devices',
+            'loki_nicos_devices',
+        ],
+    )
+    def test_drops_unauthorized_topic(self, topic: str) -> None:
+        parsed = {'/entry/instrument/a/value': _parsed('a', topic=topic)}
+        assert filter_authorized_streams(parsed) == {}
+
+    def test_keeps_only_authorized_subset(self) -> None:
+        parsed = {
+            '/a/value': _parsed('a', topic='loki_motion'),
+            '/b/value': _parsed('b', topic='loki_nicos_devices'),
+        }
+        assert filter_authorized_streams(parsed) == {'/a/value': parsed['/a/value']}


### PR DESCRIPTION
## Summary
- PROD is currently missing topic ACL grants for some Kafka topics referenced by `<instrument>/streams_parsed.py`, so instruments would fail to subscribe to them.
- Adds a global (non per-instrument) allow-list — `<instr>_choppers`, `<instr>_motion`, `<instr>_sample_env`, and `tn_data_general` — and drops any `streams_parsed.py` entries on topics outside it before stream naming.
- Offending topics currently found: `dream_nicos_devices`, `loki_misc_devices`, `loki_nicos_devices`, `odin_misc_devices`, `odin_nicos_devices`, `tbl_misc_devices`, `tbl_nicos_devices`.
- This is a temporary workaround, to be reverted once PROD ACLs cover the full topic set.

## Test plan
Full unit test suite and ruff pass locally with this change.