### PR TITLE
Cap inactive backend worker entries per kind

### DIFF
--- a/src/ess/livedata/dashboard/service_registry.py
+++ b/src/ess/livedata/dashboard/service_registry.py
@@ -17,6 +17,11 @@ logger = structlog.get_logger(__name__)
 # Timeout threshold for considering a worker stale (30 seconds in nanoseconds)
 SERVICE_HEARTBEAT_TIMEOUT_NS = 30_000_000_000
 
+# Max inactive (stopped/stale) workers kept per (instrument, service_name). A
+# crash-looping service mints a fresh worker_id on every restart, so without
+# this cap its terminal heartbeats would accumulate indefinitely.
+DEFAULT_MAX_INACTIVE_WORKERS_PER_KIND = 3
+
 
 def make_worker_key(status: ServiceStatus) -> str:
     """Create a unique key for a worker from its status."""
@@ -35,10 +40,12 @@ class ServiceRegistry:
         self,
         *,
         heartbeat_timeout_ns: int = SERVICE_HEARTBEAT_TIMEOUT_NS,
+        max_inactive_workers_per_kind: int = DEFAULT_MAX_INACTIVE_WORKERS_PER_KIND,
     ) -> None:
         self._worker_statuses: dict[str, ServiceStatus] = {}
         self._worker_timestamps: dict[str, int] = {}
         self._heartbeat_timeout_ns = heartbeat_timeout_ns
+        self._max_inactive_workers_per_kind = max_inactive_workers_per_kind
 
     @property
     def worker_statuses(self) -> dict[str, ServiceStatus]:
@@ -64,6 +71,28 @@ class ServiceRegistry:
                 status = replace(status, stream_stats=previous.stream_stats)
         self._worker_statuses[worker_key] = status
         self._worker_timestamps[worker_key] = time.time_ns()
+        self._prune_inactive_workers(status.instrument, status.service_name)
+
+    def _prune_inactive_workers(self, instrument: str, service_name: str) -> None:
+        """Drop the oldest inactive workers once a kind exceeds its cap.
+
+        Only ``stopped``/stale entries are pruned, and only among those
+        sharing ``instrument`` and ``service_name`` with the just-updated
+        status; active workers are never removed automatically.
+        """
+        same_kind_inactive = []
+        for key in self.get_inactive_worker_keys():
+            status = self._worker_statuses[key]
+            if status.instrument == instrument and status.service_name == service_name:
+                same_kind_inactive.append(key)
+
+        excess = len(same_kind_inactive) - self._max_inactive_workers_per_kind
+        if excess <= 0:
+            return
+
+        same_kind_inactive.sort(key=lambda key: self._worker_timestamps[key])
+        for key in same_kind_inactive[:excess]:
+            self.remove_worker(key)
 
     def remove_worker(self, worker_key: str) -> None:
         """Remove a worker from tracking."""

--- a/tests/dashboard/service_registry_test.py
+++ b/tests/dashboard/service_registry_test.py
@@ -412,3 +412,96 @@ class TestServiceRegistry:
         assert removed == 2
         assert len(registry.worker_statuses) == 1
         assert make_worker_key(fresh) in registry.worker_statuses
+
+    def test_prunes_oldest_inactive_worker_once_kind_exceeds_cap(self) -> None:
+        """A crash-looping service mints a new worker_id per restart; only the
+        most recent ``max_inactive_workers_per_kind`` terminal heartbeats
+        should be kept."""
+        registry = ServiceRegistry(max_inactive_workers_per_kind=2)
+
+        for i in range(4):
+            registry.status_updated(
+                ServiceStatus(
+                    instrument="dream",
+                    service_name="crash_looper",
+                    worker_id=f"worker{i}",
+                    state=ServiceState.stopped,
+                    started_at=Timestamp.from_ns(1000),
+                    active_job_count=0,
+                )
+            )
+            time.sleep(0.01)
+
+        assert len(registry.worker_statuses) == 2
+        remaining_ids = {key.split(":")[-1] for key in registry.worker_statuses}
+        assert remaining_ids == {"worker2", "worker3"}
+
+    def test_pruning_does_not_remove_active_workers(self) -> None:
+        registry = ServiceRegistry(max_inactive_workers_per_kind=2)
+        running = ServiceStatus(
+            instrument="dream",
+            service_name="crash_looper",
+            worker_id="running_worker",
+            state=ServiceState.running,
+            started_at=Timestamp.from_ns(1000),
+            active_job_count=1,
+        )
+        registry.status_updated(running)
+
+        for i in range(4):
+            registry.status_updated(
+                ServiceStatus(
+                    instrument="dream",
+                    service_name="crash_looper",
+                    worker_id=f"stopped{i}",
+                    state=ServiceState.stopped,
+                    started_at=Timestamp.from_ns(1000),
+                    active_job_count=0,
+                )
+            )
+
+        assert make_worker_key(running) in registry.worker_statuses
+        inactive_count = len([k for k in registry.worker_statuses if "stopped" in k])
+        assert inactive_count == 2
+
+    def test_pruning_is_scoped_per_kind(self) -> None:
+        """Inactive workers of one service_name must not count against the
+        cap of a different service_name, nor a different instrument."""
+        registry = ServiceRegistry(max_inactive_workers_per_kind=1)
+
+        for i in range(3):
+            registry.status_updated(
+                ServiceStatus(
+                    instrument="dream",
+                    service_name="service_a",
+                    worker_id=f"a{i}",
+                    state=ServiceState.stopped,
+                    started_at=Timestamp.from_ns(1000),
+                    active_job_count=0,
+                )
+            )
+        registry.status_updated(
+            ServiceStatus(
+                instrument="dream",
+                service_name="service_b",
+                worker_id="b0",
+                state=ServiceState.stopped,
+                started_at=Timestamp.from_ns(1000),
+                active_job_count=0,
+            )
+        )
+        registry.status_updated(
+            ServiceStatus(
+                instrument="loki",
+                service_name="service_a",
+                worker_id="loki0",
+                state=ServiceState.stopped,
+                started_at=Timestamp.from_ns(1000),
+                active_job_count=0,
+            )
+        )
+
+        assert len(registry.worker_statuses) == 3
+        assert "dream:service_a:a2" in registry.worker_statuses
+        assert "dream:service_b:b0" in registry.worker_statuses
+        assert "loki:service_a:loki0" in registry.worker_statuses


### PR DESCRIPTION
## Summary
- A crash-looping backend service mints a fresh `worker_id` (UUID) on every process restart, so `ServiceRegistry` accumulated a permanent new entry per restart, only ever cleared via the manual "Clear stopped workers" button — flooding the Backend Workers widget.
- `ServiceRegistry.status_updated` now auto-prunes the oldest `stopped`/stale entries once a given `(instrument, service_name)` kind exceeds a small cap (default 3), keeping the most recently seen ones. Active (`running`/`starting`) workers are never pruned automatically.

## Test plan
- [x] Added unit tests in `tests/dashboard/service_registry_test.py` covering oldest-first pruning under a restart loop, active workers being exempt, and per-kind/per-instrument scoping.