### PR TITLE
Bifrost: Fix Detector Ratemeter rate display via current/cumulative outputs

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost/factories.py
+++ b/src/ess/livedata/config/instruments/bifrost/factories.py
@@ -60,7 +60,8 @@ def setup_factories(instrument: Instrument) -> None:
     )
     from scippnexus import NXdetector
 
-    from ess.livedata.handlers.accumulators import LatestValue
+    from ess.livedata.handlers.accumulation_mode import Cumulative, Current
+    from ess.livedata.handlers.accumulators import make_no_copy_accumulator_pair
     from ess.livedata.handlers.stream_processor_workflow import StreamProcessorWorkflow
 
     from .streams import detector_number
@@ -90,9 +91,8 @@ def setup_factories(instrument: Instrument) -> None:
     (
         reduction_workflow,
         DetectorRegionCounts,
-        detector_ratemeter,
+        _DetectorRegionCountsRaw,
     ) = _create_base_reduction_workflow()
-    reduction_workflow.insert(detector_ratemeter)
 
     @specs.detector_ratemeter_handle.attach_factory()
     def _detector_ratemeter_workflow(
@@ -100,11 +100,19 @@ def setup_factories(instrument: Instrument) -> None:
     ) -> StreamProcessorWorkflow:
         wf = reduction_workflow.copy()
         wf[DetectorRatemeterRegionParams] = params.region
+        cumulative, window = make_no_copy_accumulator_pair()
         return StreamProcessorWorkflow(
             wf,
             dynamic_keys={'unified_detector': NeXusData[NXdetector, SampleRun]},
-            target_keys={'detector_region_counts': DetectorRegionCounts},
-            accumulators={DetectorRegionCounts: LatestValue},
+            target_keys={
+                'detector_region_counts': DetectorRegionCounts[Current],
+                'detector_region_counts_cumulative': DetectorRegionCounts[Cumulative],
+            },
+            accumulators={
+                DetectorRegionCounts[Cumulative]: cumulative,
+                DetectorRegionCounts[Current]: window,
+            },
+            window_outputs=['detector_region_counts'],
         )
 
     # Q-map workflow factories
@@ -270,15 +278,17 @@ def _create_base_reduction_workflow():
     Returns
     -------
     reduction_workflow:
-        The base TofWorkflow configured with detector geometry.
+        The base TofWorkflow configured with detector geometry, with the
+        ratemeter providers inserted.
     DetectorRegionCounts:
-        NewType for detector region counts.
-    detector_ratemeter:
-        Function that computes detector region counts.
+        Accumulation-mode-scoped type for detector region counts.
+    DetectorRegionCountsRaw:
+        Type for the bare per-update region counts (before accumulation).
     """
     # Lazy imports
     from typing import NewType
 
+    import sciline
     from ess.reduce.nexus.types import (
         EmptyDetector,
         Filename,
@@ -289,6 +299,7 @@ def _create_base_reduction_workflow():
     from ess.spectroscopy.indirect.time_of_flight import TofWorkflow
     from scippnexus import NXdetector
 
+    from ess.livedata.handlers.accumulation_mode import AccumulationMode
     from ess.livedata.handlers.detector_data_handler import get_nexus_geometry_filename
 
     # Detector group names in the pinned (pre-2026-06-08) geometry artifact
@@ -311,21 +322,44 @@ def _create_base_reduction_workflow():
         ArcEnergy.ARC_5_0: 4,
     }
 
-    DetectorRegionCounts = NewType('DetectorRegionCounts', sc.DataArray)
+    DetectorRegionCountsRaw = NewType('DetectorRegionCountsRaw', sc.DataArray)
+
+    class DetectorRegionCounts(
+        sciline.Scope[AccumulationMode, sc.DataArray],
+        sc.DataArray,  # type: ignore[misc]
+    ):
+        """Region counts scalar, parametrized by accumulation mode.
+
+        - ``DetectorRegionCounts[Cumulative]``: accumulated since the start of the
+          run (reset only on a run transition).
+        - ``DetectorRegionCounts[Current]``: the latest update interval only
+          (cleared after each finalize).
+        """
 
     def _detector_ratemeter(
         data: RawDetector[SampleRun], region: DetectorRatemeterRegionParams
-    ) -> DetectorRegionCounts:
-        """Calculate detector count rate for selected arc and pixel range."""
+    ) -> DetectorRegionCountsRaw:
+        """Sum detector counts in the selected arc and pixel range for one update.
+
+        Emits bare per-update counts with no time coords: ``StreamProcessorWorkflow``
+        stamps ``start_time``/``end_time`` (needed for the dashboard's rate
+        normalization) on the accumulated outputs, per the window/cumulative
+        convention. Stamping here instead would suppress that (see
+        ``_add_time_coords``) and break coord matching across the accumulator sum.
+        """
         arc_idx = _arc_energy_to_index[region.arc]
         arc_data = data['arc', arc_idx]
         flat = arc_data.flatten(dims=('channel', 'pixel'), to='position')
         selected = flat['position', region.pixel_start : region.pixel_stop]
         counts = selected.sum()
-        time = selected.bins.coords['event_time_zero'].min()
-        counts.coords['time'] = time
         counts.variances = counts.values
-        return DetectorRegionCounts(counts)
+        return DetectorRegionCountsRaw(counts)
+
+    def _accumulated_region_counts(
+        counts: DetectorRegionCountsRaw,
+    ) -> DetectorRegionCounts[AccumulationMode]:
+        """Route per-update counts to the accumulation-mode-specific accumulator."""
+        return DetectorRegionCounts[AccumulationMode](counts)
 
     reduction_workflow = TofWorkflow(run_types=(SampleRun,), monitor_types=())
     # Pin detector geometry to the pre-2026-06-08 survey. The 2026-06-08 file
@@ -343,4 +377,6 @@ def _create_base_reduction_workflow():
         .reduce(func=_combine_banks)
     )
 
-    return reduction_workflow, DetectorRegionCounts, _detector_ratemeter
+    reduction_workflow.insert(_detector_ratemeter)
+    reduction_workflow.insert(_accumulated_region_counts)
+    return reduction_workflow, DetectorRegionCounts, DetectorRegionCountsRaw

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -12,7 +12,7 @@ for full instrument details.
 """
 
 from enum import StrEnum
-from typing import Literal
+from typing import ClassVar, Literal
 
 import pydantic
 import scipp as sc
@@ -23,7 +23,7 @@ from ess.livedata.config import (
     instrument_registry,
     name_streams,
 )
-from ess.livedata.config.workflow_spec import WorkflowOutputsBase
+from ess.livedata.config.workflow_spec import OutputView, WorkflowOutputsBase
 from ess.livedata.handlers.detector_view_specs import SpectrumViewSpec
 from ess.livedata.handlers.monitor_workflow_specs import (
     TOAOnlyMonitorDataParams,
@@ -96,13 +96,42 @@ def _make_3d_template() -> sc.DataArray:
 class DetectorRatemeterOutputs(WorkflowOutputsBase):
     """Outputs for detector ratemeter workflow."""
 
+    output_views: ClassVar[tuple[OutputView, ...]] = (
+        OutputView(
+            name='detector_region_counts',
+            title='Detector Region Counts',
+            streams={
+                'since_start': 'detector_region_counts_cumulative',
+                'per_update': 'detector_region_counts',
+            },
+            description=(
+                'Counts for the selected arc and pixel range. With "since run '
+                'start" shows the count accumulated since the start of the run; '
+                'with "latest update" or a window, shows recent counts. Display '
+                'as a rate (counts/s) via the plot Rate option.'
+            ),
+            params=('region',),
+        ),
+    )
+
     detector_region_counts: sc.DataArray = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.scalar(0, unit='counts'),
             coords={'time': sc.scalar(0, unit='ns')},
         ),
         title='Detector Region Counts',
-        description='Total counts for the selected arc and pixel range.',
+        description=(
+            'Counts for the selected arc and pixel range, for the latest update '
+            'interval only. Resets each update interval.'
+        ),
+    )
+    detector_region_counts_cumulative: sc.DataArray = pydantic.Field(
+        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
+        title='Detector Region Counts',
+        description=(
+            'Counts for the selected arc and pixel range, accumulated since the '
+            'start of the run.'
+        ),
     )
 
 
@@ -322,7 +351,12 @@ detector_ratemeter_handle = instrument.register_spec(
     name='detector_ratemeter',
     version=1,
     title='Detector Ratemeter',
-    description='Counts for a selected arc and pixel range.',
+    description=(
+        'Counts for a selected arc and pixel range, as a current (per-update) '
+        'and a cumulative output. Both carry the time bounds needed to display '
+        'a rate (counts/s) via the plot Rate option. The cumulative count '
+        'resets only on a run transition.'
+    ),
     source_names=['unified_detector'],
     params=DetectorRatemeterParams,
     outputs=DetectorRatemeterOutputs,

--- a/tests/bifrost_test.py
+++ b/tests/bifrost_test.py
@@ -16,6 +16,7 @@ from ess.livedata.config.instruments.bifrost import specs
 from ess.livedata.config.instruments.bifrost.factories import (
     _create_base_reduction_workflow,
 )
+from ess.livedata.core.timestamp import Timestamp
 
 
 @pytest.fixture
@@ -23,14 +24,15 @@ def bifrost_workflow():
     """
     Create and configure the base reduction workflow for tests.
 
-    Returns a tuple of (workflow, DetectorRegionCounts) where the workflow
-    has the detector_ratemeter function already inserted.
+    Returns ``(workflow, DetectorRegionCountsRaw)``. The workflow has the
+    ratemeter providers inserted; the raw per-update counts are what the sciline
+    graph computes directly (accumulation into current/cumulative views happens
+    in ``StreamProcessorWorkflow``, not in the bare graph).
     """
-    workflow, DetectorRegionCounts, detector_ratemeter = (
+    workflow, _DetectorRegionCounts, DetectorRegionCountsRaw = (
         _create_base_reduction_workflow()
     )
-    workflow.insert(detector_ratemeter)
-    return workflow, DetectorRegionCounts
+    return workflow, DetectorRegionCountsRaw
 
 
 @pytest.mark.slow
@@ -139,7 +141,7 @@ class TestDetectorRatemeter:
 
     def test_ratemeter_sums_events_in_selected_arc(self, bifrost_workflow):
         """Test that ratemeter correctly sums events in the selected arc."""
-        reduction_workflow, DetectorRegionCounts = bifrost_workflow
+        reduction_workflow, DetectorRegionCountsRaw = bifrost_workflow
         # Create test data with 100 events in arc 2
         nexus_data = _make_test_event_data(arc_events={2: 100})
 
@@ -154,7 +156,7 @@ class TestDetectorRatemeter:
         wf[specs.DetectorRatemeterRegionParams] = region_params
 
         # Compute result
-        result = wf.compute(DetectorRegionCounts)
+        result = wf.compute(DetectorRegionCountsRaw)
 
         # Check that we get the expected count
         assert result.value == 100
@@ -162,7 +164,7 @@ class TestDetectorRatemeter:
 
     def test_ratemeter_with_pixel_range_selection(self, bifrost_workflow):
         """Test that pixel range selection works correctly."""
-        reduction_workflow, DetectorRegionCounts = bifrost_workflow
+        reduction_workflow, DetectorRegionCountsRaw = bifrost_workflow
         # Create test data with events evenly distributed across arc 0
         nexus_data = _make_test_event_data(arc_events={0: 900})
 
@@ -176,14 +178,14 @@ class TestDetectorRatemeter:
         wf[NeXusData[NXdetector, SampleRun]] = nexus_data
         wf[specs.DetectorRatemeterRegionParams] = region_params
 
-        result = wf.compute(DetectorRegionCounts)
+        result = wf.compute(DetectorRegionCountsRaw)
 
         # Should get approximately half the events (allowing some tolerance)
         assert 400 <= result.value <= 500
 
     def test_ratemeter_with_different_arcs(self, bifrost_workflow):
         """Test that arc selection correctly isolates events."""
-        reduction_workflow, DetectorRegionCounts = bifrost_workflow
+        reduction_workflow, DetectorRegionCountsRaw = bifrost_workflow
         # Create test data with different event counts per arc
         nexus_data = _make_test_event_data(arc_events={0: 50, 2: 150, 4: 200})
 
@@ -197,27 +199,87 @@ class TestDetectorRatemeter:
         wf[NeXusData[NXdetector, SampleRun]] = nexus_data
         wf[specs.DetectorRatemeterRegionParams] = region_params
 
-        result = wf.compute(DetectorRegionCounts)
+        result = wf.compute(DetectorRegionCountsRaw)
         assert result.value == 200
 
-    def test_ratemeter_includes_time_coordinate(self, bifrost_workflow):
-        """Test that the result includes a time coordinate."""
-        reduction_workflow, DetectorRegionCounts = bifrost_workflow
+    def test_ratemeter_raw_counts_carry_no_time_coords(self, bifrost_workflow):
+        """Per-update counts are bare: time coords are stamped on accumulation.
+
+        Stamping a ``time`` coord here would suppress the ``start_time``/
+        ``end_time`` the dashboard's rate normalization needs (see
+        ``_add_time_coords``) and break coord matching across the accumulator sum.
+        """
+        reduction_workflow, DetectorRegionCountsRaw = bifrost_workflow
         nexus_data = _make_test_event_data(arc_events={1: 50})
 
         wf = reduction_workflow.copy()
-        region_params = specs.DetectorRatemeterRegionParams(
-            arc=specs.ArcEnergy.ARC_3_2,  # Arc index 1
+        wf[NeXusData[NXdetector, SampleRun]] = nexus_data
+        wf[specs.DetectorRatemeterRegionParams] = specs.DetectorRatemeterRegionParams(
+            arc=specs.ArcEnergy.ARC_3_2,
             pixel_start=0,
             pixel_stop=900,
         )
-        wf[NeXusData[NXdetector, SampleRun]] = nexus_data
-        wf[specs.DetectorRatemeterRegionParams] = region_params
 
-        result = wf.compute(DetectorRegionCounts)
+        result = wf.compute(DetectorRegionCountsRaw)
 
-        assert 'time' in result.coords
-        assert result.coords['time'].unit == 'ns'
+        assert result.unit == 'counts'
+        assert 'time' not in result.coords
+        assert 'start_time' not in result.coords
+        assert 'end_time' not in result.coords
+
+    @pytest.mark.slow
+    def test_ratemeter_current_output_normalizes_to_rate(self):
+        """The current output carries the time bounds needed for counts/s.
+
+        Drives the real ``StreamProcessorWorkflow`` (as the production factory
+        builds it) and checks the current output can be normalized to a rate,
+        while the cumulative output defers its time bounds to the job layer.
+        """
+        from ess.livedata.dashboard.plots import _normalize_to_rate
+        from ess.livedata.handlers.accumulation_mode import Cumulative, Current
+        from ess.livedata.handlers.accumulators import make_no_copy_accumulator_pair
+        from ess.livedata.handlers.stream_processor_workflow import (
+            StreamProcessorWorkflow,
+        )
+
+        reduction_workflow, DetectorRegionCounts, _ = _create_base_reduction_workflow()
+        wf = reduction_workflow.copy()
+        wf[specs.DetectorRatemeterRegionParams] = specs.DetectorRatemeterRegionParams(
+            arc=specs.ArcEnergy.ARC_5_0, pixel_start=0, pixel_stop=900
+        )
+        cumulative, window = make_no_copy_accumulator_pair()
+        workflow = StreamProcessorWorkflow(
+            wf,
+            dynamic_keys={'unified_detector': NeXusData[NXdetector, SampleRun]},
+            target_keys={
+                'detector_region_counts': DetectorRegionCounts[Current],
+                'detector_region_counts_cumulative': DetectorRegionCounts[Cumulative],
+            },
+            accumulators={
+                DetectorRegionCounts[Cumulative]: cumulative,
+                DetectorRegionCounts[Current]: window,
+            },
+            window_outputs=['detector_region_counts'],
+        )
+        workflow.build()
+        workflow.accumulate(
+            {'unified_detector': _make_test_event_data(arc_events={4: 100})},
+            start_time=Timestamp.from_ns(0),
+            end_time=Timestamp.from_ns(2_000_000_000),  # 2 s window
+        )
+        results = workflow.finalize()
+
+        current = results['detector_region_counts']
+        assert current.value == 100
+        assert {'time', 'start_time', 'end_time'} <= set(current.coords)
+        rate = _normalize_to_rate(current)
+        assert rate.unit == 'counts/s'
+        assert rate.value == 50  # 100 counts / 2 s
+
+        # Cumulative defers time bounds to the job layer (_add_time_coords).
+        cumulative_out = results['detector_region_counts_cumulative']
+        assert cumulative_out.value == 100
+        assert 'start_time' not in cumulative_out.coords
 
 
 class TestUnifiedDetectorViewLayout:


### PR DESCRIPTION
## Problem

Enabling a plot's Rate option ("counts per second") on the Bifrost **Detector Ratemeter** left the value in raw counts and the column header showing `counts` rather than `counts/s`. Regular detector/monitor "total" outputs were unaffected.

The ratemeter emitted a single `counts` output and hand-stamped only a scalar `time` coord. That coord caused `_add_time_coords` to skip `start_time`/`end_time`, so `_normalize_to_rate` found no duration to divide by and silently returned the data unchanged — no division, unit stayed `counts`.

## Fix

Restructure the ratemeter to the same current+cumulative output pattern already used by the monitor and detector-view workflows. A bare per-update provider feeds an accumulation-mode-scoped output accumulated via `make_no_copy_accumulator_pair`. The current output is a `window_output`, so `StreamProcessorWorkflow` stamps `time`/`start_time`/`end_time` from the update window; the cumulative output receives the job span via `_add_time_coords`. Both outputs stay `counts`, so the plot Rate option divides each by the appropriate duration (window vs. whole run) to give the correct `counts/s`.

An `OutputView` pairs the two streams under the existing view name, so the shipped grid template cells resolve unchanged and gain the standard "since run start" / "latest update" toggle. The cumulative count resets only on a run transition.

## Test plan

- [x] Unit + slow tests pass; new integration test drives the real `StreamProcessorWorkflow` and confirms the current output normalizes to `counts/s`, cumulative defers its time bounds to the job layer
- [x] Grid-template and workflow-spec validation pass
- [x] Bifrost dashboard: open the Detector Ratemeter, enable the plot Rate option, confirm the Table header reads `counts/s` and the value is divided by the window duration
- [x] Confirm the bars and timeseries cells still render as before
