### PR TITLE
Enable wavelength-LUT workflow for TBL

### DIFF
--- a/src/ess/livedata/config/instruments/tbl/specs.py
+++ b/src/ess/livedata/config/instruments/tbl/specs.py
@@ -36,6 +36,9 @@ instrument = Instrument(
     name='tbl',
     detector_names=detector_names,
     monitors=monitor_names,
+    # Bandwidth choppers feeding the wavelength-LUT cascade, in beam order
+    # (source -> sample): bwc_2 sits at 14.5 m from the source, bwc_1 at 15.5 m.
+    choppers=['bwc_2', 'bwc_1'],
     streams=name_streams(filter_authorized_streams(PARSED_STREAMS)),
     source_metadata={
         'timepix3_detector': SourceMetadata(title='Timepix3'),

--- a/src/ess/livedata/handlers/detector_data_handler.py
+++ b/src/ess/livedata/handlers/detector_data_handler.py
@@ -78,6 +78,7 @@ _registry = {
     'geometry-bifrost-2026-06-08.nxs': 'md5:31d0aa10243e29a14aac0655454ff205',
     'geometry-odin-2025-09-25.nxs': 'md5:5615a6203813b4ab84a191f7478ceb3c',
     'geometry-tbl-2025-12-03.nxs': 'md5:040a70659155eb386245755455ee3e62',
+    'geometry-tbl-2026-07-01.nxs': 'md5:81535e5468a6907e47b97c4cb8e1fd3c',
     'geometry-estia-2025-12-16.nxs': 'md5:07d33010189a50ee46ee5f649f848ca5',
 }
 


### PR DESCRIPTION
## What & why

Enables the wavelength lookup-table workflow for TBL. Declaring the two bandwidth choppers on the instrument auto-wires the LUT spec, its factory, the per-chopper setpoint context bindings, and the `ChopperSynthesizer` in the timeseries service.

The chopper f144 streams (`bwc_*/rotation_speed_setpoint`, `bwc_*/delay` in ns, etc.) were already declared with the right names and units, and match the `tbl_choppers` sources seen in PROD. The blocker was the geometry artifact: the previously registered `geometry-tbl-2025-12-03.nxs` carried the `bwc_1`/`bwc_2` `NXdisk_chopper` groups with position only (no slit geometry), so the chopper cascade could not be built.

A new artifact `geometry-tbl-2026-07-01.nxs`, generated from a coda file with full chopper geometry (slit edges, radius, slit height) plus the `NXsource` at −30 m, is registered here and uploaded to the `geometry-v0` release.

Choppers are declared in beam order (source → sample): `bwc_2` at 14.5 m from the source, `bwc_1` at 15.5 m.

## Verification

- End-to-end: built the LUT workflow against the new geometry, fed setpoints (14 Hz, 0 ns delay) plus the cascade trigger. Produces `wavelength_lut` (254×287, 0.03–15 Å) and `chopper_cascade_bands` at distances [0.0 source, 14.5 bwc_2, 15.5 bwc_1] m.
- `pytest tests/config` (LUT/factory/output validation): 508 passed.
- Clean pooch fetch of the new artifact from the release verifies (md5 matches registry).
