### PR TITLE
Pause DataService delivery for plot layers without viewers

### DIFF
--- a/docs/developer/adr/0005-frame-gated-session-flush.md
+++ b/docs/developer/adr/0005-frame-gated-session-flush.md
@@ -1,6 +1,6 @@
 # ADR 0005: Frame-gated per-session plot flush
 
-- Status: accepted
+- Status: accepted (amended 2026-07-02, see bottom)
 - Deciders: Simon
 - Date: 2026-06-25
 
@@ -183,3 +183,28 @@ above, and this section should be revisited if intra-tab stagger proves visible.
   compute per batch (observed in practice) holding the loop. The result is a
   one-tick (~100 ms) stagger: acceptable and self-correcting. How often this
   happens in real traffic is unmeasured.
+
+## Amendment (2026-07-02): pull-on-frame input side
+
+The input side of the mechanism changed from push to pull (issue #1044). As a
+burst drains, `DataService` no longer extracts data and delivers it to each
+layer's subscriber; it notifies keys-only, and the orchestrator merely marks
+the affected layers dirty (per grid). `flush_frames` then pulls each dirty
+*viewed* layer's input through its extractors from the current buffer state
+(`DataService.snapshot`), rebuilds, and commits the grid as before. Dirty
+flags of unviewed layers are dropped; the 0→1 viewer transition rebuilds from
+current buffer state unconditionally.
+
+Consequences for the guarantees above:
+
+- The frame a grid's layers repaint from is now *the buffer state at flush
+  time* rather than *the drained burst's payload*. Layers of one grid are
+  pulled back-to-back on the ingestion thread with no writes in between, so
+  intra-grid coherence is unchanged.
+- A logical frame that splits across bursts now heals at the next flush by
+  construction (the pull sees whatever has arrived), rather than by a
+  one-tick stagger of stashed payloads.
+- Deferring or coalescing flushes is lossless: a pull can never observe older
+  data than a delivery would have carried. This is what makes a future
+  min-frame-interval throttle in `flush_frames` a policy choice rather than a
+  correctness question.

--- a/src/ess/livedata/dashboard/data_service.py
+++ b/src/ess/livedata/dashboard/data_service.py
@@ -47,7 +47,11 @@ class DataServiceSubscriber(ABC, Generic[K]):
         Whether the subscriber currently wants update notifications.
 
         Inactive subscribers are skipped during notification: no data is
-        extracted, copied, or delivered for them. Their extractors stay
+        extracted, copied, or delivered for them. This matters because
+        extraction runs per subscriber per update on the ingestion thread,
+        ahead of visible-plot flushes, and can be expensive — aggregating
+        extractors reduce over the buffered history on every call, which
+        dominates delivery cost for image-sized data. Their extractors stay
         registered, so buffer type and history retention are unaffected —
         buffering continues while delivery is paused. A caller reactivating
         a subscriber is responsible for refreshing it, e.g. via

--- a/src/ess/livedata/dashboard/data_service.py
+++ b/src/ess/livedata/dashboard/data_service.py
@@ -20,7 +20,21 @@ V = TypeVar('V')
 
 
 class DataServiceSubscriber(ABC, Generic[K]):
-    """Base class for data service subscribers with cached keys and extractors."""
+    """Base class for data service subscribers with cached keys and extractors.
+
+    Notifications carry no data: :py:meth:`on_updated` only reports which keys
+    changed, so a notification is O(changed keys) regardless of data size.
+    Consumers pull extracted data when (and if) they need it, via
+    :py:meth:`DataService.snapshot` — typically at frame-flush time, and only
+    for consumers that are currently displayed. Extraction can be expensive
+    (aggregating extractors reduce over the buffered history on every call,
+    which dominates cost for image-sized data), so deferring it to the pull
+    is what keeps ingestion cheap.
+
+    The subscriber's extractors still determine buffer type and history
+    retention from the moment of registration, independent of when or whether
+    the consumer pulls.
+    """
 
     def __init__(self) -> None:
         """Initialize subscriber and cache keys from extractors."""
@@ -41,27 +55,16 @@ class DataServiceSubscriber(ABC, Generic[K]):
         Returns a mapping from key to the extractor to use for that key.
         """
 
-    @property
-    def active(self) -> bool:
-        """
-        Whether the subscriber currently wants update notifications.
-
-        Inactive subscribers are skipped during notification: no data is
-        extracted, copied, or delivered for them. This matters because
-        extraction runs per subscriber per update on the ingestion thread,
-        ahead of visible-plot flushes, and can be expensive — aggregating
-        extractors reduce over the buffered history on every call, which
-        dominates delivery cost for image-sized data. Their extractors stay
-        registered, so buffer type and history retention are unaffected —
-        buffering continues while delivery is paused. A caller reactivating
-        a subscriber is responsible for refreshing it, e.g. via
-        :py:meth:`DataService.snapshot`.
-        """
-        return True
-
     @abstractmethod
-    def trigger(self, store: dict[K, Any]) -> None:
-        """Trigger the subscriber with updated data."""
+    def on_updated(self, updated_keys: set[K]) -> None:
+        """
+        Notify that some of this subscriber's keys changed (or were deleted).
+
+        Called with the intersection of the changed keys and :py:attr:`keys`.
+        Must be cheap and must not raise: it runs once per subscriber per
+        update batch on the ingestion thread. Pull data via
+        :py:meth:`DataService.snapshot` instead of computing here.
+        """
 
 
 class DataService(MutableMapping[K, V]):
@@ -74,6 +77,16 @@ class DataService(MutableMapping[K, V]):
     Uses buffers internally for storage, but presents a dict-like interface
     that returns the latest value for each key.
 
+    Notification vs. data flow
+    --------------------------
+    Notifications are keys-only: writes mark keys as updated and
+    ``subscriber.on_updated`` reports the changed keys, nothing more.
+    Consumers pull extracted data on their own schedule via
+    :py:meth:`snapshot`, which applies the subscriber's extractors and copies
+    the result out of the buffers. Every pull observes the buffer state at
+    pull time, so coalescing, deferring, or dropping notifications never
+    delivers stale data.
+
     Thread safety
     -------------
     Mutated from two threads: the background ingestion thread (via
@@ -85,19 +98,11 @@ class DataService(MutableMapping[K, V]):
     concurrent transactions on different threads flush independently and
     cannot suppress each other's root notify.
 
-    The lock is **never** held while calling ``subscriber.trigger`` (which runs
-    arbitrary compute, including Bokeh document mutation). Data handed to a
-    subscriber is copied out of the buffers under the lock first
-    (see :py:meth:`_build_subscriber_data`), so compute operates on detached
-    data and cannot observe a concurrent buffer mutation. Keeping ``trigger``
-    outside the lock also means no compute-side lock (the Bokeh document lock,
-    or ``ActiveJobRegistry``'s ingestion guard) can deadlock against this one.
-
-    A consequence is that ``trigger`` delivery is not globally ordered: the
-    initial trigger from ``register_subscriber`` and an update notification
-    from the ingestion thread may run concurrently and out of order, so a
-    subscriber can transiently receive older data after newer data (healed by
-    the next update). Subscribers must tolerate concurrent ``trigger`` calls.
+    The lock is **never** held while calling ``subscriber.on_updated``, so no
+    lock a subscriber callback takes can deadlock against this one. Extracted
+    values returned by ``snapshot`` are copied under the lock before being
+    handed out: extractors may return views aliasing a buffer's backing
+    store, which a concurrent ``update``/``drop`` would mutate.
 
     Lock ordering: ``ActiveJobRegistry.ingestion_guard`` -> ``DataService`` lock.
     The ingestion path and ``ActiveJobRegistry.cleanup`` both hold the guard
@@ -184,9 +189,9 @@ class DataService(MutableMapping[K, V]):
         Notes
         -----
         Must be called while holding ``self._lock``. Extracted values are
-        copied so callers can hand them to ``subscriber.trigger`` after
-        releasing the lock: extractors may return views aliasing the buffer's
-        backing store, which a concurrent ``update``/``drop`` would mutate.
+        copied so callers can use them after releasing the lock: extractors
+        may return views aliasing the buffer's backing store, which a
+        concurrent ``update``/``drop`` would mutate.
         """
         subscriber_data = {}
 
@@ -203,11 +208,12 @@ class DataService(MutableMapping[K, V]):
 
     def register_subscriber(self, subscriber: DataServiceSubscriber[K]) -> None:
         """
-        Register a subscriber for updates with extractor-based data access.
+        Register a subscriber for update notifications.
 
-        Triggers the subscriber immediately with existing data using its
-        extractors, unless the subscriber is currently inactive (see
-        :py:attr:`DataServiceSubscriber.active`).
+        Registers the subscriber's extractors with the buffer manager so
+        history retention covers its needs from now on. Does not notify:
+        the caller pulls existing data via :py:meth:`snapshot` if it wants
+        an initial delivery.
 
         Parameters
         ----------
@@ -223,21 +229,14 @@ class DataService(MutableMapping[K, V]):
                     extractor = subscriber.extractors[key]
                     self._buffer_manager.add_extractor(key, extractor)
 
-        # Active check and trigger outside the lock: the property may consult
-        # another component's lock, and compute must not run while holding ours.
-        if not subscriber.active:
-            return
-        with self._lock:
-            existing_data = self._build_subscriber_data(subscriber)
-        subscriber.trigger(existing_data)
-
     def snapshot(self, subscriber: DataServiceSubscriber[K]) -> dict[K, Any]:
         """
-        Extract current data for a subscriber without triggering it.
+        Extract current data for a subscriber through its extractors.
 
-        For refreshing a subscriber whose notifications were paused (see
-        :py:attr:`DataServiceSubscriber.active`): the caller delivers the
-        result itself, e.g. through a synchronous compute path.
+        The pull side of the notification protocol: call at any time after
+        an :py:meth:`DataServiceSubscriber.on_updated` notification (or on
+        demand, e.g. when a consumer becomes visible) to obtain the current
+        state of the subscriber's keys.
 
         Parameters
         ----------
@@ -275,35 +274,29 @@ class DataService(MutableMapping[K, V]):
 
     def _notify_subscribers(self, updated_keys: set[K]) -> None:
         """
-        Notify relevant subscribers about data updates.
+        Notify relevant subscribers which of their keys changed.
 
-        The subscriber data is built under the lock (copying it out of the
-        buffers), then ``trigger`` is called with the lock released so compute
-        never runs while the lock is held.
+        Keys-only: no extraction or copying happens here. ``on_updated`` is
+        called with the lock released so no lock a callback takes can nest
+        inside ours.
 
         Parameters
         ----------
         updated_keys
             The set of data keys that were updated.
         """
-        # Iterate over a snapshot: a subscriber's trigger, or a concurrent
-        # unregister from the UI thread, may mutate self._subscribers mid-loop.
-        # Without the copy the list-index iterator would silently skip the
-        # subscriber following a removed one.
+        # Iterate over a snapshot: a concurrent register/unregister from the
+        # UI thread may mutate self._subscribers mid-loop. Without the copy
+        # the list-index iterator would silently skip the subscriber
+        # following a removed one.
         with self._lock:
             subscribers = list(self._subscribers)
         for subscriber in subscribers:
-            if not (updated_keys & subscriber.keys):
+            keys = updated_keys & subscriber.keys
+            if not keys:
                 continue
             try:
-                # Checked outside self._lock: the property may consult another
-                # component's lock (e.g. the plot layer's viewer gate), which
-                # must never nest inside this one.
-                if not subscriber.active:
-                    continue
-                with self._lock:
-                    subscriber_data = self._build_subscriber_data(subscriber)
-                subscriber.trigger(subscriber_data)
+                subscriber.on_updated(keys)
             except Exception:
                 logger.exception("Failed to notify subscriber %s", subscriber)
 
@@ -346,7 +339,7 @@ class DataService(MutableMapping[K, V]):
 
     def _notify(self) -> None:
         # Some updates may have been added while notifying. Drain pending under
-        # the lock; notify (which triggers compute) without it.
+        # the lock; call subscriber callbacks without it.
         while True:
             with self._lock:
                 if not self._pending_updates:

--- a/src/ess/livedata/dashboard/data_service.py
+++ b/src/ess/livedata/dashboard/data_service.py
@@ -41,6 +41,20 @@ class DataServiceSubscriber(ABC, Generic[K]):
         Returns a mapping from key to the extractor to use for that key.
         """
 
+    @property
+    def active(self) -> bool:
+        """
+        Whether the subscriber currently wants update notifications.
+
+        Inactive subscribers are skipped during notification: no data is
+        extracted, copied, or delivered for them. Their extractors stay
+        registered, so buffer type and history retention are unaffected —
+        buffering continues while delivery is paused. A caller reactivating
+        a subscriber is responsible for refreshing it, e.g. via
+        :py:meth:`DataService.snapshot`.
+        """
+        return True
+
     @abstractmethod
     def trigger(self, store: dict[K, Any]) -> None:
         """Trigger the subscriber with updated data."""
@@ -187,7 +201,9 @@ class DataService(MutableMapping[K, V]):
         """
         Register a subscriber for updates with extractor-based data access.
 
-        Triggers the subscriber immediately with existing data using its extractors.
+        Triggers the subscriber immediately with existing data using its
+        extractors, unless the subscriber is currently inactive (see
+        :py:attr:`DataServiceSubscriber.active`).
 
         Parameters
         ----------
@@ -203,11 +219,34 @@ class DataService(MutableMapping[K, V]):
                     extractor = subscriber.extractors[key]
                     self._buffer_manager.add_extractor(key, extractor)
 
-            # Snapshot existing data using subscriber's extractors
+        # Active check and trigger outside the lock: the property may consult
+        # another component's lock, and compute must not run while holding ours.
+        if not subscriber.active:
+            return
+        with self._lock:
             existing_data = self._build_subscriber_data(subscriber)
-
-        # Trigger outside the lock: compute must not run while holding it.
         subscriber.trigger(existing_data)
+
+    def snapshot(self, subscriber: DataServiceSubscriber[K]) -> dict[K, Any]:
+        """
+        Extract current data for a subscriber without triggering it.
+
+        For refreshing a subscriber whose notifications were paused (see
+        :py:attr:`DataServiceSubscriber.active`): the caller delivers the
+        result itself, e.g. through a synchronous compute path.
+
+        Parameters
+        ----------
+        subscriber:
+            The subscriber whose extractors to apply.
+
+        Returns
+        -------
+        :
+            Extracted data, detached from the internal buffers.
+        """
+        with self._lock:
+            return self._build_subscriber_data(subscriber)
 
     def unregister_subscriber(self, subscriber: DataServiceSubscriber[K]) -> bool:
         """
@@ -250,13 +289,19 @@ class DataService(MutableMapping[K, V]):
         with self._lock:
             subscribers = list(self._subscribers)
         for subscriber in subscribers:
-            if updated_keys & subscriber.keys:
-                try:
-                    with self._lock:
-                        subscriber_data = self._build_subscriber_data(subscriber)
-                    subscriber.trigger(subscriber_data)
-                except Exception:
-                    logger.exception("Failed to notify subscriber %s", subscriber)
+            if not (updated_keys & subscriber.keys):
+                continue
+            try:
+                # Checked outside self._lock: the property may consult another
+                # component's lock (e.g. the plot layer's viewer gate), which
+                # must never nest inside this one.
+                if not subscriber.active:
+                    continue
+                with self._lock:
+                    subscriber_data = self._build_subscriber_data(subscriber)
+                subscriber.trigger(subscriber_data)
+            except Exception:
+                logger.exception("Failed to notify subscriber %s", subscriber)
 
     def __getitem__(self, key: K) -> V:
         """Get the latest value for a key."""

--- a/src/ess/livedata/dashboard/data_subscriber.py
+++ b/src/ess/livedata/dashboard/data_subscriber.py
@@ -4,7 +4,7 @@
 Data subscription and assembly for streaming plot updates.
 
 This module provides the core data flow components:
-- DataSubscriber: Connects to DataService, assembles data, invokes callback
+- DataSubscriber: Watches DataService keys, assembles pulled data by role
 - Output is always role-grouped: dict[role, dict[ResultKey, data]]
 """
 
@@ -19,11 +19,14 @@ from ess.livedata.dashboard.extractors import UpdateExtractor
 
 
 class DataSubscriber(DataServiceSubscriber[ResultKey]):
-    """Subscriber that groups data by role and invokes a callback.
+    """Subscriber that reports key updates and assembles pulled data by role.
 
-    Output shape is always ``dict[role, dict[ResultKey, data]]``. Consumers
-    that care about a single role (e.g. standard plotters using ``primary``)
-    extract it explicitly.
+    Update notifications carry no data; ``on_update`` just signals that the
+    consumer should schedule a pull. The pull applies this subscriber's
+    extractors via ``DataService.snapshot`` and is grouped with
+    :py:meth:`assemble`, whose output shape is always
+    ``dict[role, dict[ResultKey, data]]``. Consumers that care about a single
+    role (e.g. standard plotters using ``primary``) extract it explicitly.
 
     The ready_condition is built internally: requires at least one key from each role.
     """
@@ -32,8 +35,7 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
         self,
         keys_by_role: dict[str, list[ResultKey]],
         extractors: Mapping[ResultKey, UpdateExtractor],
-        on_data: Callable[[dict[str, dict[ResultKey, Any]]], None],
-        is_active: Callable[[], bool] | None = None,
+        on_update: Callable[[], None],
     ) -> None:
         """
         Initialize the subscriber.
@@ -46,14 +48,11 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
             additional roles like "x_axis", "y_axis".
         extractors
             Mapping from keys to their UpdateExtractor instances.
-        on_data
-            Callback invoked on every data update with the grouped data.
-            Called when at least one key from each role has data.
-        is_active
-            Optional callable consulted by DataService before each delivery;
-            returning False pauses delivery (buffering continues). None means
-            always active. The caller owns refreshing the consumer when the
-            gate reopens (see ``DataService.snapshot``).
+        on_update
+            Callback invoked when any of this subscriber's keys changed.
+            Must be cheap (it runs on the ingestion thread per update batch);
+            the consumer pulls data later via ``DataService.snapshot`` +
+            :py:meth:`assemble`.
         """
         self._keys_by_role = keys_by_role
         self._all_keys = {key for keys in keys_by_role.values() for key in keys}
@@ -62,8 +61,7 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
         self._key_sets_by_role = [set(keys) for keys in keys_by_role.values()]
 
         self._extractors = extractors
-        self._on_data = on_data
-        self._is_active = is_active
+        self._on_update = on_update
 
         # Initialize parent class to cache keys
         super().__init__()
@@ -77,11 +75,6 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
     def extractors(self) -> Mapping[ResultKey, UpdateExtractor]:
         """Return extractors for obtaining data views."""
         return self._extractors
-
-    @property
-    def active(self) -> bool:
-        """Whether delivery is currently wanted (see ``is_active`` in init)."""
-        return self._is_active is None or self._is_active()
 
     def _is_ready(self, available_keys: set[ResultKey]) -> bool:
         """Check if we have at least one key from each role."""
@@ -110,8 +103,6 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
                 result[role] = role_data
         return result
 
-    def trigger(self, store: dict[ResultKey, Any]) -> None:
-        """Trigger the subscriber with the current data store."""
-        assembled = self.assemble(store)
-        if assembled is not None:
-            self._on_data(assembled)
+    def on_updated(self, updated_keys: set[ResultKey]) -> None:
+        """Signal the consumer that a pull is due (see ``on_update`` in init)."""
+        self._on_update()

--- a/src/ess/livedata/dashboard/data_subscriber.py
+++ b/src/ess/livedata/dashboard/data_subscriber.py
@@ -33,6 +33,7 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
         keys_by_role: dict[str, list[ResultKey]],
         extractors: Mapping[ResultKey, UpdateExtractor],
         on_data: Callable[[dict[str, dict[ResultKey, Any]]], None],
+        is_active: Callable[[], bool] | None = None,
     ) -> None:
         """
         Initialize the subscriber.
@@ -48,6 +49,11 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
         on_data
             Callback invoked on every data update with the grouped data.
             Called when at least one key from each role has data.
+        is_active
+            Optional callable consulted by DataService before each delivery;
+            returning False pauses delivery (buffering continues). None means
+            always active. The caller owns refreshing the consumer when the
+            gate reopens (see ``DataService.snapshot``).
         """
         self._keys_by_role = keys_by_role
         self._all_keys = {key for keys in keys_by_role.values() for key in keys}
@@ -57,6 +63,7 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
 
         self._extractors = extractors
         self._on_data = on_data
+        self._is_active = is_active
 
         # Initialize parent class to cache keys
         super().__init__()
@@ -71,12 +78,27 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
         """Return extractors for obtaining data views."""
         return self._extractors
 
+    @property
+    def active(self) -> bool:
+        """Whether delivery is currently wanted (see ``is_active`` in init)."""
+        return self._is_active is None or self._is_active()
+
     def _is_ready(self, available_keys: set[ResultKey]) -> bool:
         """Check if we have at least one key from each role."""
         return all(bool(available_keys & ks) for ks in self._key_sets_by_role)
 
-    def _assemble(self, data: dict[ResultKey, Any]) -> dict[str, dict[ResultKey, Any]]:
-        """Group data by role, sorted deterministically within each role."""
+    def assemble(
+        self, store: dict[ResultKey, Any]
+    ) -> dict[str, dict[ResultKey, Any]] | None:
+        """
+        Group this subscriber's keys from ``store`` by role.
+
+        Returns None unless at least one key from each role is present.
+        Within each role, keys are sorted deterministically.
+        """
+        data = {key: store[key] for key in self._all_keys if key in store}
+        if not data or not self._is_ready(set(data.keys())):
+            return None
         result: dict[str, dict[ResultKey, Any]] = {}
         for role, role_keys in self._keys_by_role.items():
             sorted_keys = sorted(
@@ -90,9 +112,6 @@ class DataSubscriber(DataServiceSubscriber[ResultKey]):
 
     def trigger(self, store: dict[ResultKey, Any]) -> None:
         """Trigger the subscriber with the current data store."""
-        data = {key: store[key] for key in self._all_keys if key in store}
-
-        # Only invoke callback when we have data and are ready
-        if data and self._is_ready(set(data.keys())):
-            assembled = self._assemble(data)
+        assembled = self.assemble(store)
+        if assembled is not None:
             self._on_data(assembled)

--- a/src/ess/livedata/dashboard/extractors.py
+++ b/src/ess/livedata/dashboard/extractors.py
@@ -139,10 +139,10 @@ class WindowAggregatingExtractor(UpdateExtractor):
     """Extracts a window from the buffer and aggregates over the time dimension.
 
     The aggregation runs on every ``extract`` call; its cost scales with
-    window length x element size and dominates delivery cost for image-sized
-    data (milliseconds per call, vs. microseconds for a plain copy). Callers
-    that deliver per update should avoid extracting for consumers that do not
-    currently need the result (see ``DataServiceSubscriber.active``).
+    window length x element size and dominates extraction cost for image-sized
+    data (milliseconds per call, vs. microseconds for a plain copy). This is
+    why extraction is pull-based: it runs only when a displayed consumer
+    pulls a ``DataService.snapshot``, not per ingested update.
     """
 
     def __init__(

--- a/src/ess/livedata/dashboard/extractors.py
+++ b/src/ess/livedata/dashboard/extractors.py
@@ -136,7 +136,14 @@ class FullHistoryExtractor(UpdateExtractor):
 
 
 class WindowAggregatingExtractor(UpdateExtractor):
-    """Extracts a window from the buffer and aggregates over the time dimension."""
+    """Extracts a window from the buffer and aggregates over the time dimension.
+
+    The aggregation runs on every ``extract`` call; its cost scales with
+    window length x element size and dominates delivery cost for image-sized
+    data (milliseconds per call, vs. microseconds for a plain copy). Callers
+    that deliver per update should avoid extracting for consumers that do not
+    currently need the result (see ``DataServiceSubscriber.active``).
+    """
 
     def __init__(
         self,

--- a/src/ess/livedata/dashboard/plot_data_service.py
+++ b/src/ess/livedata/dashboard/plot_data_service.py
@@ -61,10 +61,10 @@ class LayerState(Enum):
 class ComputeTask:
     """A pending plotter.compute() invocation released by the layer gate.
 
-    Returned from :meth:`LayerStateMachine.stash_pending` and
-    :meth:`LayerStateMachine.set_active` when a build should run now. The
-    caller invokes the build outside any locks and reports completion via
-    ``data_arrived`` / ``error_occurred`` on the owning ``PlotDataService``.
+    Returned from :meth:`LayerStateMachine.stash_pending` when a build should
+    run now. The caller invokes the build outside any locks and reports
+    completion via ``data_arrived`` / ``error_occurred`` on the owning
+    ``PlotDataService``.
     """
 
     plotter: Plotter
@@ -90,13 +90,15 @@ class LayerStateMachine:
     Threading of the compute gate
     -----------------------------
     ``stash_pending`` is called from the data-subscriber callback on the
-    background ingestion thread; ``set_active`` is called from the per-session
-    polling thread (Bokeh main). Both return a ``ComputeTask`` when a build
-    should run; the caller invokes ``task.run()`` on its own thread (outside
-    the gate lock). So regular Kafka-delta builds execute on the bg ingestion
-    thread, while the 0→1 activation flush executes on the polling thread —
-    deliberately, so the same poll pass's component rebuild observes fresh
-    ``has_cached_state``.
+    background ingestion thread and returns a ``ComputeTask`` when a viewer is
+    watching; the caller invokes ``task.run()`` on its own thread (outside the
+    gate lock). ``set_active`` is called from the per-session polling thread
+    (Bokeh main). While no token is held, ``has_viewers`` pauses DataService
+    delivery for the layer's subscriber, so no input flows at all; on the 0→1
+    transition ``set_active`` returns True and the orchestrator refreshes the
+    layer from a fresh DataService snapshot, synchronously on the polling
+    thread — deliberately, so the same poll pass's component rebuild observes
+    fresh ``has_cached_state``.
 
     Parameters
     ----------
@@ -109,9 +111,10 @@ class LayerStateMachine:
         self._version = 0
         self._plotter: Plotter | None = None
         self._error_message: str | None = None
-        # Compute gate: tokens express viewer interest, _pending stashes the
-        # latest input while no token is held. Decoupled from lifecycle state
-        # because interest is per-(session, layer) and lifecycle is per-layer.
+        # Compute gate: tokens express viewer interest; _pending stashes the
+        # latest input, consumed when a token is held. Decoupled from lifecycle
+        # state because interest is per-(session, layer) and lifecycle is
+        # per-layer.
         self._active_tokens: set[int] = set()
         # Tokens we've already attached a weakref finalizer to, so we don't
         # register a second one on a False→True re-acquire.
@@ -254,11 +257,14 @@ class LayerStateMachine:
     ) -> ComputeTask | None:
         """Stash the latest input; return a flush task if a viewer is watching.
 
-        Called from the data-subscriber callback on every Kafka delta. When no
-        token is currently held, the input is stashed and the dirty flag is
-        set; intermediate updates collapse to last-writer-wins. When at least
-        one token is held, the returned ``ComputeTask`` should be run by the
-        caller (outside any locks) to produce the build.
+        Called from the data-subscriber callback on every Kafka delta. While
+        no token is held, delivery is paused upstream (``has_viewers`` gates
+        the DataService subscription), so this is only reached by an
+        in-flight delivery racing a pause; the input is stashed
+        last-writer-wins and superseded by the snapshot refresh on the next
+        activation. When at least one token is held, the returned
+        ``ComputeTask`` should be run by the caller (outside any locks) to
+        produce the build.
 
         Parameters
         ----------
@@ -274,13 +280,13 @@ class LayerStateMachine:
             self._dirty = True
             return self._consume_for_flush()
 
-    def set_active(self, token: object, active: bool) -> ComputeTask | None:
+    def set_active(self, token: object, active: bool) -> bool:
         """Acquire or release a viewer interest token on this layer.
 
-        On the 0→1 transition with dirty pending input, returns a
-        ``ComputeTask`` so the caller can rebuild synchronously. Releasing a
-        token does not drop the stash — it persists until the next 0→1
-        triggers a flush or a plotter replacement clears it.
+        Returns True on the 0→1 transition, i.e. when the first token is
+        acquired. Delivery was paused while no viewer was watching (see
+        ``has_viewers``), so the caller must then refresh the layer from
+        current DataService content.
 
         A ``weakref.finalize`` is attached on first acquire so the token is
         auto-released if the caller is garbage-collected without an explicit
@@ -303,9 +309,13 @@ class LayerStateMachine:
                     weakref.finalize(token, self._release_token, key)
             else:
                 self._active_tokens.discard(key)
-            if was_active or not self._active_tokens:
-                return None
-            return self._consume_for_flush()
+            return active and not was_active
+
+    @property
+    def has_viewers(self) -> bool:
+        """Whether any viewer token is held; gates DataService delivery."""
+        with self._gate_lock:
+            return bool(self._active_tokens)
 
     def _release_token(self, key: int) -> None:
         """Drop a token key from the gate (called by the weakref finalizer)."""

--- a/src/ess/livedata/dashboard/plot_data_service.py
+++ b/src/ess/livedata/dashboard/plot_data_service.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import threading
 import weakref
-from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, NewType
 from uuid import UUID
@@ -57,28 +56,6 @@ class LayerState(Enum):
     ERROR = auto()
 
 
-@dataclass(frozen=True)
-class ComputeTask:
-    """A pending plotter.compute() invocation released by the layer gate.
-
-    Returned from :meth:`LayerStateMachine.stash_pending` when a build should
-    run now. The caller invokes the build outside any locks and reports
-    completion via ``data_arrived`` / ``error_occurred`` on the owning
-    ``PlotDataService``.
-    """
-
-    plotter: Plotter
-    data: dict[str, dict[Any, Any]]
-    title_resolver: Any
-    kwargs: dict[str, Any]
-
-    def run(self) -> None:
-        """Invoke ``plotter.compute`` with the stashed input."""
-        self.plotter.compute(
-            self.data, title_resolver=self.title_resolver, **self.kwargs
-        )
-
-
 class LayerStateMachine:
     """Manages state transitions for a single plot layer.
 
@@ -87,18 +64,16 @@ class LayerStateMachine:
 
     Thread-safe: all state modifications happen through atomic operations.
 
-    Threading of the compute gate
-    -----------------------------
-    ``stash_pending`` is called from the data-subscriber callback on the
-    background ingestion thread and returns a ``ComputeTask`` when a viewer is
-    watching; the caller invokes ``task.run()`` on its own thread (outside the
-    gate lock). ``set_active`` is called from the per-session polling thread
-    (Bokeh main). While no token is held, ``has_viewers`` pauses DataService
-    delivery for the layer's subscriber, so no input flows at all; on the 0→1
-    transition ``set_active`` returns True and the orchestrator refreshes the
-    layer from a fresh DataService snapshot, synchronously on the polling
-    thread — deliberately, so the same poll pass's component rebuild observes
-    fresh ``has_cached_state``.
+    Viewer gate
+    -----------
+    Tokens express viewer interest, per (session, layer) — decoupled from
+    lifecycle state, which is per-layer. ``has_viewers`` is consulted at
+    frame-flush time on the ingestion thread: layers without viewers are
+    skipped (no extraction, no compute). ``set_active`` is called from the
+    per-session polling thread (Bokeh main); on the 0→1 transition it returns
+    True and the orchestrator rebuilds the layer from a fresh DataService
+    snapshot, synchronously on the polling thread — deliberately, so the same
+    poll pass's component rebuild observes fresh ``has_cached_state``.
 
     Parameters
     ----------
@@ -111,16 +86,10 @@ class LayerStateMachine:
         self._version = 0
         self._plotter: Plotter | None = None
         self._error_message: str | None = None
-        # Compute gate: tokens express viewer interest; _pending stashes the
-        # latest input, consumed when a token is held. Decoupled from lifecycle
-        # state because interest is per-(session, layer) and lifecycle is
-        # per-layer.
         self._active_tokens: set[int] = set()
         # Tokens we've already attached a weakref finalizer to, so we don't
         # register a second one on a False→True re-acquire.
         self._finalized_keys: set[int] = set()
-        self._pending: tuple[Any, Any, dict[str, Any]] | None = None
-        self._dirty: bool = False
         self._gate_lock = threading.Lock()
 
     @property
@@ -177,15 +146,7 @@ class LayerStateMachine:
         self._state = LayerState.WAITING_FOR_DATA
         self._error_message = None
         self._version += 1
-        # Swap the plotter and drop any input stashed for the previous plotter
-        # atomically under the gate lock. Otherwise a concurrent 0→1
-        # set_active could flush the old plotter's pending input through the
-        # new plotter. The new plotter's subscription repopulates the stash
-        # when its first delta arrives.
-        with self._gate_lock:
-            self._plotter = plotter
-            self._pending = None
-            self._dirty = False
+        self._plotter = plotter
 
     def data_arrived(self) -> None:
         """
@@ -248,45 +209,13 @@ class LayerStateMachine:
         if self._plotter is not None:
             self._plotter.mark_presenters_dirty()
 
-    def stash_pending(
-        self,
-        data: dict[str, dict[Any, Any]],
-        *,
-        title_resolver: Any = None,
-        **kwargs: Any,
-    ) -> ComputeTask | None:
-        """Stash the latest input; return a flush task if a viewer is watching.
-
-        Called from the data-subscriber callback on every Kafka delta. While
-        no token is held, delivery is paused upstream (``has_viewers`` gates
-        the DataService subscription), so this is only reached by an
-        in-flight delivery racing a pause; the input is stashed
-        last-writer-wins and superseded by the snapshot refresh on the next
-        activation. When at least one token is held, the returned
-        ``ComputeTask`` should be run by the caller (outside any locks) to
-        produce the build.
-
-        Parameters
-        ----------
-        data:
-            Role-grouped input data passed through to ``plotter.compute``.
-        title_resolver:
-            Resolver passed through to ``plotter.compute``.
-        **kwargs:
-            Extra keyword arguments passed through to ``plotter.compute``.
-        """
-        with self._gate_lock:
-            self._pending = (data, title_resolver, kwargs)
-            self._dirty = True
-            return self._consume_for_flush()
-
     def set_active(self, token: object, active: bool) -> bool:
         """Acquire or release a viewer interest token on this layer.
 
         Returns True on the 0→1 transition, i.e. when the first token is
-        acquired. Delivery was paused while no viewer was watching (see
-        ``has_viewers``), so the caller must then refresh the layer from
-        current DataService content.
+        acquired. Frame flushes skipped the layer while no viewer was
+        watching (see ``has_viewers``), so the caller must then rebuild the
+        layer from current DataService content.
 
         A ``weakref.finalize`` is attached on first acquire so the token is
         auto-released if the caller is garbage-collected without an explicit
@@ -313,7 +242,7 @@ class LayerStateMachine:
 
     @property
     def has_viewers(self) -> bool:
-        """Whether any viewer token is held; gates DataService delivery."""
+        """Whether any viewer token is held; gates frame-flush compute."""
         with self._gate_lock:
             return bool(self._active_tokens)
 
@@ -322,24 +251,6 @@ class LayerStateMachine:
         with self._gate_lock:
             self._active_tokens.discard(key)
             self._finalized_keys.discard(key)
-
-    def _consume_for_flush(self) -> ComputeTask | None:
-        # Caller holds _gate_lock.
-        if (
-            not self._active_tokens
-            or not self._dirty
-            or self._plotter is None
-            or self._pending is None
-        ):
-            return None
-        data, title_resolver, kwargs = self._pending
-        self._dirty = False
-        return ComputeTask(
-            plotter=self._plotter,
-            data=data,
-            title_resolver=title_resolver,
-            kwargs=kwargs,
-        )
 
     def has_displayable_plot(self) -> bool:
         """

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -14,6 +14,7 @@ Coordinates plot creation and management across multiple plot grids:
 from __future__ import annotations
 
 import copy
+import threading
 import traceback
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -408,9 +409,11 @@ class PlotOrchestrator:
         self._lifecycle_subscribers: dict[SubscriptionId, LifecycleSubscription] = {}
         self._data_subscriptions: dict[LayerId, Any] = {}  # DataSubscriber
         self._layer_resolvers: dict[LayerId, Any] = {}  # LayerId -> TitleResolver
-        # Per-grid compute buckets filled during a burst by ``_enqueue_compute``
-        # and drained by ``flush_frames``. Touched only on the ingestion thread.
-        self._frame_buckets: dict[GridId, list[tuple[LayerId, Any]]] = {}
+        # Layers whose DataService keys changed since the last flush, bucketed
+        # per grid. Filled by ``_mark_layer_dirty`` (any thread ending a
+        # DataService transaction), drained by ``flush_frames``.
+        self._dirty_layers: dict[GridId, set[LayerId]] = {}
+        self._dirty_lock = threading.Lock()
 
         # Parse templates (requires plotter registry, so must be done here)
         self._templates = self._parse_grid_specs(list(raw_templates))
@@ -1025,93 +1028,57 @@ class PlotOrchestrator:
                     layer.layer_id
                 )
 
-    def _stash_pending(
-        self,
-        layer_id: LayerId,
-        data: dict[str, dict[ResultKey, Any]],
-    ) -> Any:
-        """Submit input through the layer compute gate, returning a due task.
+    def _mark_layer_dirty(self, layer_id: LayerId) -> None:
+        """Record that a layer's input changed; ``flush_frames`` rebuilds it.
 
-        Stashes input on the layer state machine. A build is due (a task is
-        returned) only if at least one viewer holds an interest token. With no
-        token held, delivery is normally paused upstream and this is only
-        reached by an in-flight delivery racing a pause; the next 0→1 token
-        transition rebuilds from a fresh DataService snapshot instead (see
-        ``activate_layer``).
+        The data-subscriber callback: runs once per update batch on the
+        ingestion thread and does no extraction or compute. Dirty flags
+        coalesce, so any number of updates between flushes costs one rebuild.
         """
         if layer_id not in self._layer_to_cell:
-            return None
-        state = self._plot_data_service.get(layer_id)
-        if state is None:
-            return None
-        title_resolver = self._layer_resolvers.get(layer_id)
-        return state.stash_pending(data, title_resolver=title_resolver)
-
-    def _layer_has_viewers(self, layer_id: LayerId) -> bool:
-        """Delivery gate for a layer's data subscription (see activate_layer)."""
-        state = self._plot_data_service.get(layer_id)
-        return state is not None and state.has_viewers
+            return
+        grid_id = self._grid_of_layer(layer_id)
+        with self._dirty_lock:
+            self._dirty_layers.setdefault(grid_id, set()).add(layer_id)
 
     def _grid_of_layer(self, layer_id: LayerId) -> GridId:
         return self._cell_to_grid[self._layer_to_cell[layer_id]]
 
-    def _run_compute(
-        self,
-        layer_id: LayerId,
-        data: dict[str, dict[ResultKey, Any]],
-    ) -> None:
-        """Stash input and run a due build synchronously, committing its grid.
-
-        The synchronous path for setup-time builds (e.g. static overlays added
-        on the UI thread): compute and commit the grid inline so the layer is
-        displayed without waiting for the next ingestion flush.
-        """
-        task = self._stash_pending(layer_id, data)
-        if task is not None:
-            self._dispatch_compute_task(layer_id, task)
-            self._frame_clock.commit(self._grid_of_layer(layer_id))
-
-    def _enqueue_compute(
-        self,
-        layer_id: LayerId,
-        data: dict[str, dict[ResultKey, Any]],
-    ) -> None:
-        """Stash input and bucket a due build per grid for ``flush_frames``.
-
-        The ingestion-thread path for Kafka-delta builds. Deferring dispatch
-        out of the inline ``DataService._notify`` lets ``flush_frames`` run a
-        burst grid-by-grid and commit each grid the moment its layers finish,
-        so a session waits only on its own tab's compute.
-        """
-        task = self._stash_pending(layer_id, data)
-        if task is not None:
-            grid_id = self._grid_of_layer(layer_id)
-            self._frame_buckets.setdefault(grid_id, []).append((layer_id, task))
-
     def flush_frames(self) -> None:
-        """Run each grid's bucketed builds, committing that grid as it finishes.
+        """Rebuild each grid's dirty viewed layers, committing per grid.
 
-        Called on the ingestion thread once a burst has drained. Running
+        Called on the ingestion thread once a burst has drained. Each dirty
+        layer with a viewer is rebuilt from a fresh DataService pull; running
         grid-by-grid and committing per grid means a session showing one tab
         sees its frame the moment that grid's layers finish, rather than after
         every other visible tab's compute.
+
+        Dirty flags of layers without viewers are dropped: the 0→1 viewer
+        transition rebuilds unconditionally from current DataService content
+        (see ``activate_layer``), so nothing is lost.
         """
-        buckets = self._frame_buckets
-        self._frame_buckets = {}
-        for grid_id, tasks in buckets.items():
-            for layer_id, task in tasks:
-                self._dispatch_compute_task(layer_id, task)
-            self._frame_clock.commit(grid_id)
+        with self._dirty_lock:
+            buckets = self._dirty_layers
+            self._dirty_layers = {}
+        for grid_id, layer_ids in buckets.items():
+            computed = False
+            for layer_id in layer_ids:
+                state = self._plot_data_service.get(layer_id)
+                if state is None or not state.has_viewers:
+                    continue
+                computed |= self._pull_and_build(layer_id)
+            if computed:
+                self._frame_clock.commit(grid_id)
 
     def activate_layer(self, layer_id: LayerId, token: object, active: bool) -> None:
         """Acquire or release a viewer interest token on a layer.
 
-        While no viewer holds a token, DataService delivery is paused for the
-        layer's subscriber (no extraction, copies, or compute for hidden
-        layers); buffering continues. On the 0→1 transition the layer is
-        refreshed from a DataService snapshot, synchronously on the caller's
-        thread (the polling thread). This keeps the same poll pass's component
-        rebuild seeing fresh ``has_cached_state``.
+        While no viewer holds a token, frame flushes skip the layer (no
+        extraction or compute for hidden layers); buffering continues. On the
+        0→1 transition the layer is rebuilt from a DataService pull,
+        synchronously on the caller's thread (the polling thread). This keeps
+        the same poll pass's component rebuild seeing fresh
+        ``has_cached_state``.
         """
         state = self._plot_data_service.get(layer_id)
         if state is None:
@@ -1120,34 +1087,52 @@ class PlotOrchestrator:
             self._refresh_layer(layer_id)
 
     def _refresh_layer(self, layer_id: LayerId) -> None:
-        """Rebuild a layer from current DataService content.
+        """Rebuild a layer from current DataService content, committing its grid."""
+        if self._pull_and_build(layer_id):
+            self._frame_clock.commit(self._grid_of_layer(layer_id))
 
-        Used on viewer activation: no input was delivered while the layer had
-        no viewers, so the stash (if any) is stale and is superseded by a
-        fresh pull through the subscriber's own extractors.
+    def _pull_and_build(self, layer_id: LayerId) -> bool:
+        """Pull a layer's data through its extractors and rebuild its plot.
+
+        Returns True if a build ran (also on a failed build, which transitions
+        the layer to ERROR and thus still warrants a frame commit), False if
+        the layer is gone or its data is not ready.
         """
+        if layer_id not in self._layer_to_cell:
+            return False
         subscriber = self._data_subscriptions.get(layer_id)
         if subscriber is None:
-            return
+            return False
         assembled = subscriber.assemble(self._data_service.snapshot(subscriber))
-        if assembled is not None:
-            self._run_compute(layer_id, assembled)
+        if assembled is None:
+            return False
+        return self._build_layer(layer_id, assembled)
 
-    def _dispatch_compute_task(self, layer_id: LayerId, task: Any) -> None:
-        """Run a flush task and transition the layer to READY or ERROR.
+    def _build_layer(
+        self,
+        layer_id: LayerId,
+        data: dict[str, dict[ResultKey, Any]],
+    ) -> bool:
+        """Run ``plotter.compute`` and transition the layer to READY or ERROR.
 
         Thread-agnostic: runs on whatever thread the caller is on — the bg
         ingestion thread when entered via ``flush_frames``, the polling thread
-        when entered via ``activate_layer`` or the synchronous ``_run_compute``
-        setup path. See ``LayerStateMachine`` for the gate's threading contract.
+        when entered via ``activate_layer``, the UI thread for setup-time
+        static-overlay builds.
         """
+        state = self._plot_data_service.get(layer_id)
+        if state is None or state.plotter is None:
+            return False
         try:
-            task.run()
+            state.plotter.compute(
+                data, title_resolver=self._layer_resolvers.get(layer_id)
+            )
             self._plot_data_service.data_arrived(layer_id)
         except Exception:
             error_msg = traceback.format_exc()
             self._logger.exception('Failed to compute state for layer_id=%s', layer_id)
             self._plot_data_service.error_occurred(layer_id, error_msg)
+        return True
 
     def _subscribe_layer(self, grid_id: GridId, cell_id: CellId, layer: Layer) -> None:
         """
@@ -1180,9 +1165,11 @@ class PlotOrchestrator:
 
         if config.is_static():
             # Static overlay: create plot immediately without subscription.
+            # Built unconditionally (no viewer gate): there is no data
+            # subscription to pull from later, and the build is a one-off.
             plotter = self._create_and_register_plotter(layer_id, config)
-            if plotter is not None:
-                self._run_compute(layer_id, {})
+            if plotter is not None and self._build_layer(layer_id, {}):
+                self._frame_clock.commit(self._grid_of_layer(layer_id))
             cell = self._grids[grid_id].cells[cell_id]
             self._notify_cell_updated(grid_id, cell_id, cell)
             self._persist_to_store()
@@ -1256,16 +1243,18 @@ class PlotOrchestrator:
 
         self._layer_resolvers[layer_id] = self._build_title_resolver(layer_id)
 
-        # Set up data pipeline - _enqueue_compute buckets builds as data arrives
+        # Set up data pipeline - updates mark the layer dirty; flush_frames
+        # pulls and rebuilds. The immediate mark covers a restart with data
+        # already present, so the plot shows without waiting for a new delta.
         try:
             subscriber = self._plotting_controller.setup_pipeline(
                 keys_by_role=ready.keys_by_role,
                 plot_name=config.plot_name,
                 params=config.params,
-                on_data=lambda data: self._enqueue_compute(layer_id, data),
-                is_active=lambda: self._layer_has_viewers(layer_id),
+                on_update=lambda: self._mark_layer_dirty(layer_id),
             )
             self._data_subscriptions[layer_id] = subscriber
+            self._mark_layer_dirty(layer_id)
         except Exception:
             error_msg = traceback.format_exc()
             self._logger.exception(

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -1034,10 +1034,17 @@ class PlotOrchestrator:
         The data-subscriber callback: runs once per update batch on the
         ingestion thread and does no extraction or compute. Dirty flags
         coalesce, so any number of updates between flushes costs one rebuild.
+
+        ``DataService`` notifies from a snapshot of its subscriber list taken
+        before the callbacks run, so the UI thread may remove this layer while
+        the notification is in flight. The grid lookup therefore tolerates the
+        mappings changing underneath it; dropping the mark is correct, since a
+        removed layer has no state left for ``flush_frames`` to rebuild.
         """
-        if layer_id not in self._layer_to_cell:
+        try:
+            grid_id = self._grid_of_layer(layer_id)
+        except KeyError:
             return
-        grid_id = self._grid_of_layer(layer_id)
         with self._dirty_lock:
             self._dirty_layers.setdefault(grid_id, set()).add(layer_id)
 

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -406,7 +406,7 @@ class PlotOrchestrator:
         self._layer_subscriptions: dict[LayerId, LayerSubscription] = {}
         self._layer_to_cell: dict[LayerId, CellId] = {}
         self._lifecycle_subscribers: dict[SubscriptionId, LifecycleSubscription] = {}
-        self._data_subscriptions: dict[LayerId, Any] = {}  # DataServiceSubscriber
+        self._data_subscriptions: dict[LayerId, Any] = {}  # DataSubscriber
         self._layer_resolvers: dict[LayerId, Any] = {}  # LayerId -> TitleResolver
         # Per-grid compute buckets filled during a burst by ``_enqueue_compute``
         # and drained by ``flush_frames``. Touched only on the ingestion thread.
@@ -1033,9 +1033,11 @@ class PlotOrchestrator:
         """Submit input through the layer compute gate, returning a due task.
 
         Stashes input on the layer state machine. A build is due (a task is
-        returned) only if at least one viewer holds an interest token;
-        otherwise the latest input is retained and rebuilt on the next 0→1
-        token transition (see ``activate_layer``).
+        returned) only if at least one viewer holds an interest token. With no
+        token held, delivery is normally paused upstream and this is only
+        reached by an in-flight delivery racing a pause; the next 0→1 token
+        transition rebuilds from a fresh DataService snapshot instead (see
+        ``activate_layer``).
         """
         if layer_id not in self._layer_to_cell:
             return None
@@ -1044,6 +1046,11 @@ class PlotOrchestrator:
             return None
         title_resolver = self._layer_resolvers.get(layer_id)
         return state.stash_pending(data, title_resolver=title_resolver)
+
+    def _layer_has_viewers(self, layer_id: LayerId) -> bool:
+        """Delivery gate for a layer's data subscription (see activate_layer)."""
+        state = self._plot_data_service.get(layer_id)
+        return state is not None and state.has_viewers
 
     def _grid_of_layer(self, layer_id: LayerId) -> GridId:
         return self._cell_to_grid[self._layer_to_cell[layer_id]]
@@ -1099,16 +1106,32 @@ class PlotOrchestrator:
     def activate_layer(self, layer_id: LayerId, token: object, active: bool) -> None:
         """Acquire or release a viewer interest token on a layer.
 
-        On the 0→1 transition with pending input, the stashed build is run
-        synchronously on the caller's thread (the polling thread). This keeps
-        the same poll pass's component rebuild seeing fresh ``has_cached_state``.
+        While no viewer holds a token, DataService delivery is paused for the
+        layer's subscriber (no extraction, copies, or compute for hidden
+        layers); buffering continues. On the 0→1 transition the layer is
+        refreshed from a DataService snapshot, synchronously on the caller's
+        thread (the polling thread). This keeps the same poll pass's component
+        rebuild seeing fresh ``has_cached_state``.
         """
         state = self._plot_data_service.get(layer_id)
         if state is None:
             return
-        task = state.set_active(token, active)
-        if task is not None:
-            self._dispatch_compute_task(layer_id, task)
+        if state.set_active(token, active):
+            self._refresh_layer(layer_id)
+
+    def _refresh_layer(self, layer_id: LayerId) -> None:
+        """Rebuild a layer from current DataService content.
+
+        Used on viewer activation: no input was delivered while the layer had
+        no viewers, so the stash (if any) is stale and is superseded by a
+        fresh pull through the subscriber's own extractors.
+        """
+        subscriber = self._data_subscriptions.get(layer_id)
+        if subscriber is None:
+            return
+        assembled = subscriber.assemble(self._data_service.snapshot(subscriber))
+        if assembled is not None:
+            self._run_compute(layer_id, assembled)
 
     def _dispatch_compute_task(self, layer_id: LayerId, task: Any) -> None:
         """Run a flush task and transition the layer to READY or ERROR.
@@ -1240,6 +1263,7 @@ class PlotOrchestrator:
                 plot_name=config.plot_name,
                 params=config.params,
                 on_data=lambda data: self._enqueue_compute(layer_id, data),
+                is_active=lambda: self._layer_has_viewers(layer_id),
             )
             self._data_subscriptions[layer_id] = subscriber
         except Exception:

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -12,7 +12,7 @@ from ess.livedata.config.workflow_spec import (
     WorkflowSpec,
 )
 
-from .data_service import DataServiceSubscriber
+from .data_subscriber import DataSubscriber
 from .extractors import (
     LatestValueExtractor,
     UpdateExtractor,
@@ -178,7 +178,8 @@ class PlottingController:
         plot_name: str,
         params: dict | pydantic.BaseModel,
         on_data: Callable[[dict[ResultKey, Any]], None],
-    ) -> DataServiceSubscriber[ResultKey]:
+        is_active: Callable[[], bool] | None = None,
+    ) -> DataSubscriber:
         """
         Set up data pipeline for any plot type.
 
@@ -199,6 +200,9 @@ class PlottingController:
             Callback invoked on every data update with role-grouped data
             (dict[role, dict[ResultKey, DataArray]]). Called when at least one
             key from each role has data.
+        is_active
+            Optional delivery gate consulted before each update; see
+            :py:class:`DataSubscriber`. None means always active.
 
         Returns
         -------
@@ -224,6 +228,7 @@ class PlottingController:
             keys_by_role=keys_by_role,
             on_data=on_data,
             extractors=extractors,
+            is_active=is_active,
         )
 
     def create_plotter(

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Hashable
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import pydantic
 
@@ -177,8 +177,7 @@ class PlottingController:
         keys_by_role: dict[str, list[ResultKey]],
         plot_name: str,
         params: dict | pydantic.BaseModel,
-        on_data: Callable[[dict[ResultKey, Any]], None],
-        is_active: Callable[[], bool] | None = None,
+        on_update: Callable[[], None],
     ) -> DataSubscriber:
         """
         Set up data pipeline for any plot type.
@@ -196,13 +195,9 @@ class PlottingController:
             Name of the plotter to use.
         params
             Plotter parameters as a dict or validated Pydantic model.
-        on_data
-            Callback invoked on every data update with role-grouped data
-            (dict[role, dict[ResultKey, DataArray]]). Called when at least one
-            key from each role has data.
-        is_active
-            Optional delivery gate consulted before each update; see
-            :py:class:`DataSubscriber`. None means always active.
+        on_update
+            Callback invoked when any of the keys changed; see
+            :py:class:`DataSubscriber`.
 
         Returns
         -------
@@ -226,9 +221,8 @@ class PlottingController:
         extractors = create_extractors_from_params(all_keys, window, spec)
         return self._stream_manager.make_stream(
             keys_by_role=keys_by_role,
-            on_data=on_data,
+            on_update=on_update,
             extractors=extractors,
-            is_active=is_active,
         )
 
     def create_plotter(

--- a/src/ess/livedata/dashboard/stream_manager.py
+++ b/src/ess/livedata/dashboard/stream_manager.py
@@ -22,15 +22,15 @@ class StreamManager:
     def make_stream(
         self,
         keys_by_role: dict[str, list[ResultKey]],
-        on_data: Callable[[dict[str, dict[ResultKey, Any]]], None],
+        on_update: Callable[[], None],
         extractors: dict[ResultKey, Any] | None = None,
-        is_active: Callable[[], bool] | None = None,
     ) -> DataSubscriber:
         """
         Create a data stream for the given result keys organized by role.
 
-        Registers a subscriber that groups data by role and invokes the
-        callback with ``dict[role, dict[ResultKey, data]]``.
+        Registers a subscriber whose ``on_update`` callback fires when any of
+        the keys change. The consumer pulls role-grouped data via
+        ``subscriber.assemble(data_service.snapshot(subscriber))``.
 
         Parameters
         ----------
@@ -38,15 +38,12 @@ class StreamManager:
             Dict mapping role names to lists of ResultKeys. For standard plots,
             this is {"primary": [keys...]}. For correlation plots, includes
             additional roles like "x_axis", "y_axis".
-        on_data
-            Callback invoked on every data update with the grouped data.
-            Called when at least one key from each role has data.
+        on_update
+            Callback invoked when any of the keys changed; see
+            :py:class:`DataSubscriber`.
         extractors
             Optional dict mapping keys to UpdateExtractor instances. If not
             provided, uses LatestValueExtractor for all keys.
-        is_active
-            Optional delivery gate consulted before each update; see
-            :py:class:`DataSubscriber`. None means always active.
 
         Returns
         -------
@@ -67,8 +64,7 @@ class StreamManager:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=on_data,
-            is_active=is_active,
+            on_update=on_update,
         )
         self.data_service.register_subscriber(subscriber)
         return subscriber

--- a/src/ess/livedata/dashboard/stream_manager.py
+++ b/src/ess/livedata/dashboard/stream_manager.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from ess.livedata.config.workflow_spec import ResultKey
 
-from .data_service import DataService, DataServiceSubscriber
+from .data_service import DataService
 from .data_subscriber import DataSubscriber
 
 
@@ -24,7 +24,8 @@ class StreamManager:
         keys_by_role: dict[str, list[ResultKey]],
         on_data: Callable[[dict[str, dict[ResultKey, Any]]], None],
         extractors: dict[ResultKey, Any] | None = None,
-    ) -> DataServiceSubscriber[ResultKey]:
+        is_active: Callable[[], bool] | None = None,
+    ) -> DataSubscriber:
         """
         Create a data stream for the given result keys organized by role.
 
@@ -43,6 +44,9 @@ class StreamManager:
         extractors
             Optional dict mapping keys to UpdateExtractor instances. If not
             provided, uses LatestValueExtractor for all keys.
+        is_active
+            Optional delivery gate consulted before each update; see
+            :py:class:`DataSubscriber`. None means always active.
 
         Returns
         -------
@@ -64,6 +68,7 @@ class StreamManager:
             keys_by_role=keys_by_role,
             extractors=extractors,
             on_data=on_data,
+            is_active=is_active,
         )
         self.data_service.register_subscriber(subscriber)
         return subscriber

--- a/tests/dashboard/active_job_registry_test.py
+++ b/tests/dashboard/active_job_registry_test.py
@@ -138,7 +138,7 @@ class TestCleanup:
         ds[key_a] = sc.scalar(1.0)
         ds[key_b] = sc.scalar(2.0)
 
-        triggers: list[set[ResultKey]] = []
+        notifications: list[set[ResultKey]] = []
 
         class RecordingSubscriber(DataServiceSubscriber):
             @property
@@ -148,13 +148,13 @@ class TestCleanup:
                     key_b: LatestValueExtractor(),
                 }
 
-            def trigger(self, store):
-                triggers.append(set(store.keys()))
+            def on_updated(self, updated_keys: set[ResultKey]) -> None:
+                notifications.append(updated_keys)
 
         ds.register_subscriber(RecordingSubscriber())
-        triggers.clear()  # discard initial trigger from registration
 
         registry.cleanup(job_number)
 
         # Every notification must show either both keys or neither — never one.
-        assert all(t in ({key_a, key_b}, set()) for t in triggers), triggers
+        # After cleanup both keys are deleted, so we see them marked as updated
+        assert all(t in ({key_a, key_b}, set()) for t in notifications), notifications

--- a/tests/dashboard/data_service_test.py
+++ b/tests/dashboard/data_service_test.py
@@ -1416,3 +1416,73 @@ class TestThreadSafety:
         sub.explode = False
         service["key1"] = make_test_data(2, time=2.0)
         assert triggered == [2]
+
+
+class GatedSubscriber(DataServiceSubscriber[str]):
+    """Subscriber whose delivery is gated by a mutable ``active`` flag."""
+
+    def __init__(self, extractor=None) -> None:
+        self._extractors = {"key1": extractor or LatestValueExtractor()}
+        self.active_flag = True
+        self.triggered: list[dict[str, Any]] = []
+        super().__init__()
+
+    @property
+    def extractors(self):
+        return self._extractors
+
+    @property
+    def active(self) -> bool:
+        return self.active_flag
+
+    def trigger(self, store: dict[str, Any]) -> None:
+        if store:  # ignore the empty initial trigger from registration
+            self.triggered.append(store)
+
+
+class TestInactiveSubscribers:
+    """Delivery is paused for inactive subscribers; buffering continues."""
+
+    def test_inactive_subscriber_is_not_triggered_on_update(self):
+        service = DataService[str, int]()
+        sub = GatedSubscriber()
+        service.register_subscriber(sub)
+        sub.active_flag = False
+        service["key1"] = make_test_data(1)
+        assert sub.triggered == []
+        sub.active_flag = True
+        service["key1"] = make_test_data(2)
+        assert [s["key1"].value for s in sub.triggered] == [2]
+
+    def test_register_skips_initial_trigger_when_inactive(self):
+        service = DataService[str, int]()
+        service["key1"] = make_test_data(1)
+        sub = GatedSubscriber()
+        sub.active_flag = False
+        service.register_subscriber(sub)
+        assert sub.triggered == []
+
+    def test_snapshot_returns_data_regardless_of_active(self):
+        service = DataService[str, int]()
+        service["key1"] = make_test_data(1, time=1.0)
+        sub = GatedSubscriber()
+        sub.active_flag = False
+        service.register_subscriber(sub)
+        snapshot = service.snapshot(sub)
+        assert snapshot["key1"].value == 1
+        assert sub.triggered == []  # snapshot does not trigger
+
+    def test_buffering_continues_while_inactive(self):
+        """History accumulates for a paused history subscriber, so a snapshot
+        on reactivation sees everything that arrived in the meantime."""
+        from ess.livedata.dashboard.extractors import FullHistoryExtractor
+
+        service = DataService[str, int]()
+        sub = GatedSubscriber(extractor=FullHistoryExtractor())
+        service.register_subscriber(sub)
+        sub.active_flag = False
+        for i in range(3):
+            service["key1"] = make_test_data(i, time=float(i))
+        assert sub.triggered == []
+        snapshot = service.snapshot(sub)
+        assert snapshot["key1"].sizes["time"] == 3

--- a/tests/dashboard/data_service_test.py
+++ b/tests/dashboard/data_service_test.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable
-from typing import Any
 
 import pytest
 import scipp as sc
@@ -24,12 +23,11 @@ def make_test_data(value: int, time: float = 0.0) -> sc.DataArray:
 class FakePipe:
     """Fake pipe for testing."""
 
-    def __init__(self, data: Any = None) -> None:
-        self.init_data = data
-        self.sent_data: list[dict[str, Any]] = []
+    def __init__(self) -> None:
+        self.notifications: list[set[str]] = []
 
-    def send(self, data: Any) -> None:
-        self.sent_data.append(data)
+    def record_keys(self, updated_keys: set[str]) -> None:
+        self.notifications.append(updated_keys)
 
 
 class SimpleTestSubscriber(DataServiceSubscriber[str]):
@@ -38,7 +36,7 @@ class SimpleTestSubscriber(DataServiceSubscriber[str]):
     def __init__(self, keys: set[str]) -> None:
         self._keys_set = keys
         self._extractors = {key: LatestValueExtractor() for key in keys}
-        self._pipe: FakePipe | None = None
+        self._pipe = FakePipe()
         super().__init__()
 
     @property
@@ -47,29 +45,22 @@ class SimpleTestSubscriber(DataServiceSubscriber[str]):
 
     @property
     def pipe(self) -> FakePipe:
-        if self._pipe is None:
-            raise RuntimeError("Pipe not yet created")
         return self._pipe
 
-    def trigger(self, store: dict[str, Any]) -> None:
-        # Filter to only subscribed keys
-        data = {key: store[key] for key in self._keys_set if key in store}
-        if self._pipe is None:
-            self._pipe = FakePipe(data)
-        else:
-            self._pipe.send(data)
+    def on_updated(self, updated_keys: set[str]) -> None:
+        self._pipe.record_keys(updated_keys)
 
 
 def create_test_subscriber(keys: set[str]) -> tuple[SimpleTestSubscriber, Callable]:
     """
     Create a test subscriber with the given keys.
 
-    Returns the subscriber and a callable to get the pipe after it's created.
+    Returns the subscriber and a callable to get the pipe.
     """
     subscriber = SimpleTestSubscriber(keys)
 
     def get_pipe() -> FakePipe:
-        """Get the pipe (created on first trigger)."""
+        """Get the pipe."""
         return subscriber.pipe
 
     return subscriber, get_pipe
@@ -116,8 +107,9 @@ def test_setitem_without_subscribers_no_error(data_service: DataService[str, int
 def test_register_subscriber_adds_to_list(data_service: DataService[str, int]):
     subscriber, get_pipe = create_test_subscriber({"key1"})
     data_service.register_subscriber(subscriber)
-    # Verify pipe was created and subscriber was added
-    _ = get_pipe()  # Ensure pipe exists
+    # Registration does not trigger notification
+    pipe = get_pipe()
+    assert len(pipe.notifications) == 0
 
 
 def test_unregister_subscriber_removes_from_list(data_service: DataService[str, int]):
@@ -130,8 +122,7 @@ def test_unregister_subscriber_removes_from_list(data_service: DataService[str, 
     # Subscriber should no longer receive updates
     data_service["key1"] = make_test_data(42)
     pipe = get_pipe()
-    # Only received data from initial registration trigger, not the new update
-    assert len(pipe.sent_data) == 0
+    assert len(pipe.notifications) == 0
 
 
 def test_unregister_nonexistent_subscriber_returns_false(
@@ -151,7 +142,7 @@ def test_unregister_during_notification_does_not_skip_other_subscribers(
     """A subscriber removed mid-notification must not cause a sibling to be skipped.
 
     Reproduces the list-index skip: notifying iterates the subscriber list, and a
-    trigger (or, in production, a concurrent UI-thread teardown) removes a
+    notification (or, in production, a concurrent UI-thread teardown) removes a
     subscriber positioned before one not yet visited. A raw list-index iterator
     would then skip the following subscriber.
     """
@@ -168,8 +159,8 @@ def test_unregister_during_notification_does_not_skip_other_subscribers(
         def extractors(self):
             return self._extractors
 
-        def trigger(self, store: dict[str, Any]) -> None:
-            if "key1" not in store:
+        def on_updated(self, updated_keys: set[str]) -> None:
+            if "key1" not in updated_keys:
                 return
             triggered.append(self.name)
             if self.target is not None:
@@ -185,7 +176,6 @@ def test_unregister_during_notification_does_not_skip_other_subscribers(
     for sub in (first, middle, last):
         data_service.register_subscriber(sub)
 
-    triggered.clear()
     data_service["key1"] = make_test_data(42)
 
     assert triggered == ["first", "middle", "last"]
@@ -198,8 +188,10 @@ def test_setitem_notifies_matching_subscriber(data_service: DataService[str, int
     data_service["key1"] = make_test_data(42)
 
     pipe = get_pipe()
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key1"].value == 42
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1"}
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 42
 
 
 def test_setitem_ignores_non_matching_subscriber(data_service: DataService[str, int]):
@@ -209,7 +201,7 @@ def test_setitem_ignores_non_matching_subscriber(data_service: DataService[str, 
     data_service["key1"] = make_test_data(42)
 
     pipe = get_pipe()
-    assert len(pipe.sent_data) == 0
+    assert len(pipe.notifications) == 0
 
 
 def test_setitem_notifies_multiple_matching_subscribers(
@@ -226,9 +218,9 @@ def test_setitem_notifies_multiple_matching_subscribers(
     data_service["key1"] = make_test_data(42)
 
     pipe1, pipe2, pipe3 = get_pipe1(), get_pipe2(), get_pipe3()
-    assert len(pipe1.sent_data) == 1
-    assert len(pipe2.sent_data) == 1
-    assert len(pipe3.sent_data) == 0
+    assert len(pipe1.notifications) == 1
+    assert len(pipe2.notifications) == 1
+    assert len(pipe3.notifications) == 0
 
 
 def test_setitem_multiple_updates_notify_separately(
@@ -241,10 +233,12 @@ def test_setitem_multiple_updates_notify_separately(
     data_service["key2"] = make_test_data(84)
 
     pipe = get_pipe()
-    assert len(pipe.sent_data) == 2
-    assert pipe.sent_data[0]["key1"].value == 42
-    assert pipe.sent_data[1]["key1"].value == 42
-    assert pipe.sent_data[1]["key2"].value == 84
+    assert len(pipe.notifications) == 2
+    assert pipe.notifications[0] == {"key1"}
+    assert pipe.notifications[1] == {"key2"}
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 42
+    assert snapshot["key2"].value == 84
 
 
 def test_transaction_batches_notifications(data_service: DataService[str, int]):
@@ -256,12 +250,14 @@ def test_transaction_batches_notifications(data_service: DataService[str, int]):
         data_service["key1"] = make_test_data(42)
         data_service["key2"] = make_test_data(84)
         # No notifications yet
-        assert len(pipe.sent_data) == 0
+        assert len(pipe.notifications) == 0
 
     # Single notification after transaction
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key1"].value == 42
-    assert pipe.sent_data[0]["key2"].value == 84
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1", "key2"}
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 42
+    assert snapshot["key2"].value == 84
 
 
 def test_transaction_nested_batches_correctly(data_service: DataService[str, int]):
@@ -273,16 +269,18 @@ def test_transaction_nested_batches_correctly(data_service: DataService[str, int
         data_service["key1"] = make_test_data(42)
         with data_service.transaction():
             data_service["key2"] = make_test_data(84)
-            assert len(pipe.sent_data) == 0
+            assert len(pipe.notifications) == 0
         # Still in outer transaction
-        assert len(pipe.sent_data) == 0
+        assert len(pipe.notifications) == 0
         data_service["key3"] = make_test_data(126)
 
     # Single notification after all transactions
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key1"].value == 42
-    assert pipe.sent_data[0]["key2"].value == 84
-    assert pipe.sent_data[0]["key3"].value == 126
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1", "key2", "key3"}
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 42
+    assert snapshot["key2"].value == 84
+    assert snapshot["key3"].value == 126
 
 
 def test_transaction_exception_still_notifies(data_service: DataService[str, int]):
@@ -299,8 +297,10 @@ def test_transaction_exception_still_notifies(data_service: DataService[str, int
 
     # Notification should still happen
     pipe = get_pipe()
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key1"].value == 42
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1"}
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 42
 
 
 def test_dictionary_operations_work(
@@ -336,7 +336,7 @@ def test_update_method_triggers_notifications(data_service: DataService[str, int
 
     # Should trigger notifications for each key
     pipe = get_pipe()
-    assert len(pipe.sent_data) == 2
+    assert len(pipe.notifications) == 2
 
 
 def test_clear_removes_all_data(
@@ -382,9 +382,11 @@ def test_subscriber_gets_full_data_dict(data_service: DataService[str, int]):
     data_service["existing"] = make_test_data(999)
     data_service["key1"] = make_test_data(42)
 
-    # Subscriber should get the full data dict
+    # Subscriber should get notified with matching keys
     pipe = get_pipe()
-    assert pipe.sent_data[-1]["key1"].value == 42
+    assert {"key1"} in pipe.notifications
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 42
 
 
 def test_subscriber_only_gets_subscribed_keys(data_service: DataService[str, int]):
@@ -397,15 +399,18 @@ def test_subscriber_only_gets_subscribed_keys(data_service: DataService[str, int
     data_service["key3"] = make_test_data(126)
     data_service["unrelated"] = make_test_data(999)  # Not subscribed to this key
 
-    # Subscriber should only receive data for keys it's interested in
+    # Subscriber should only receive notifications for keys it's interested in
     pipe = get_pipe()
-    last_data = pipe.sent_data[-1]
-    assert last_data["key1"].value == 42
-    assert last_data["key3"].value == 126
+    assert {"key1"} in pipe.notifications
+    assert {"key3"} in pipe.notifications
+    assert {"key2"} not in pipe.notifications
+    assert {"unrelated"} not in pipe.notifications
 
-    # Verify unrelated keys are not included
-    assert "key2" not in last_data
-    assert "unrelated" not in last_data
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 42
+    assert snapshot["key3"].value == 126
+    assert "key2" not in snapshot
+    assert "unrelated" not in snapshot
 
 
 def test_empty_transaction_no_notifications(data_service: DataService[str, int]):
@@ -416,7 +421,7 @@ def test_empty_transaction_no_notifications(data_service: DataService[str, int])
     with data_service.transaction():
         pass  # No changes
 
-    assert len(pipe.sent_data) == 0
+    assert len(pipe.notifications) == 0
 
 
 def test_delitem_notifies_subscribers(data_service: DataService[str, int]):
@@ -427,15 +432,18 @@ def test_delitem_notifies_subscribers(data_service: DataService[str, int]):
     data_service["key1"] = make_test_data(42)
     data_service["key2"] = make_test_data(84)
     pipe = get_pipe()
-    pipe.sent_data.clear()  # Clear previous notifications
+    pipe.notifications.clear()  # Clear previous notifications
 
     # Delete a key
     del data_service["key1"]
 
-    # Should notify with remaining data
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key2"].value == 84
+    # Should notify about the deleted key
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1"}
     assert "key1" not in data_service
+    snapshot = data_service.snapshot(subscriber)
+    assert "key1" not in snapshot
+    assert snapshot["key2"].value == 84
 
 
 def test_delitem_in_transaction_batches_notifications(
@@ -448,17 +456,20 @@ def test_delitem_in_transaction_batches_notifications(
     data_service["key1"] = make_test_data(42)
     data_service["key2"] = make_test_data(84)
     pipe = get_pipe()
-    pipe.sent_data.clear()  # Clear previous notifications
+    pipe.notifications.clear()  # Clear previous notifications
 
     with data_service.transaction():
         del data_service["key1"]
         data_service["key2"] = make_test_data(99)
         # No notifications yet
-        assert len(pipe.sent_data) == 0
+        assert len(pipe.notifications) == 0
 
     # Single notification after transaction
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key2"].value == 99
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1", "key2"}
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key2"].value == 99
+    assert "key1" not in snapshot
 
 
 def test_transaction_set_then_del_same_key(data_service: DataService[str, int]):
@@ -468,18 +479,21 @@ def test_transaction_set_then_del_same_key(data_service: DataService[str, int]):
     # Add some initial data
     data_service["key2"] = make_test_data(84)
     pipe = get_pipe()
-    pipe.sent_data.clear()
+    pipe.notifications.clear()
 
     with data_service.transaction():
         data_service["key1"] = make_test_data(42)  # Set key1
         del data_service["key1"]  # Then delete key1
         # No notifications yet
-        assert len(pipe.sent_data) == 0
+        assert len(pipe.notifications) == 0
 
-    # After transaction: key1 should not exist, only key2 should be in notification
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key2"].value == 84
+    # After transaction: key1 should not exist, but it was in the pending set
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1"}
     assert "key1" not in data_service
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key2"].value == 84
+    assert "key1" not in snapshot
 
 
 def test_transaction_del_then_set_same_key(data_service: DataService[str, int]):
@@ -490,18 +504,20 @@ def test_transaction_del_then_set_same_key(data_service: DataService[str, int]):
     data_service["key1"] = make_test_data(42)
     data_service["key2"] = make_test_data(84)
     pipe = get_pipe()
-    pipe.sent_data.clear()
+    pipe.notifications.clear()
 
     with data_service.transaction():
         del data_service["key1"]  # Delete key1
         data_service["key1"] = make_test_data(99)  # Then set key1 to new value
         # No notifications yet
-        assert len(pipe.sent_data) == 0
+        assert len(pipe.notifications) == 0
 
     # After transaction: key1 should have the new value
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key1"].value == 99
-    assert pipe.sent_data[0]["key2"].value == 84
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1"}
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 99
+    assert snapshot["key2"].value == 84
     assert data_service["key1"].value == 99
 
 
@@ -512,7 +528,7 @@ def test_transaction_multiple_operations_same_key(data_service: DataService[str,
     # Add initial data
     data_service["key1"] = make_test_data(10)
     pipe = get_pipe()
-    pipe.sent_data.clear()
+    pipe.notifications.clear()
 
     with data_service.transaction():
         data_service["key1"] = make_test_data(20)  # Update
@@ -520,11 +536,13 @@ def test_transaction_multiple_operations_same_key(data_service: DataService[str,
         del data_service["key1"]  # Delete
         data_service["key1"] = make_test_data(40)  # Set again
         # No notifications yet
-        assert len(pipe.sent_data) == 0
+        assert len(pipe.notifications) == 0
 
     # After transaction: key1 should have final value
-    assert len(pipe.sent_data) == 1
-    assert pipe.sent_data[0]["key1"].value == 40
+    assert len(pipe.notifications) == 1
+    assert pipe.notifications[0] == {"key1"}
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 40
     assert data_service["key1"].value == 40
 
 
@@ -546,15 +564,17 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    derived_value = store["input"].value * 2
-                    self._service["derived"] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        derived_value = snapshot["input"].value * 2
+                        self._service["derived"] = make_test_data(derived_value)
 
         subscriber = UpdatingSubscriber({"input"}, service)
         service.register_subscriber(subscriber)
 
-        # This should trigger the subscriber, which updates "derived"
+        # This should notify the subscriber, which updates "derived"
         service["input"] = make_test_data(10)
 
         assert service["input"].value == 10
@@ -575,10 +595,12 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    derived_value = store["input"].value * 2
-                    self._service["derived"] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        derived_value = snapshot["input"].value * 2
+                        self._service["derived"] = make_test_data(derived_value)
 
         subscriber = UpdatingSubscriber({"input"}, service)
         service.register_subscriber(subscriber)
@@ -613,11 +635,13 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    key = f"derived_{self._multiplier}x"
-                    derived_value = store["input"].value * self._multiplier
-                    self._service[key] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        key = f"derived_{self._multiplier}x"
+                        derived_value = snapshot["input"].value * self._multiplier
+                        self._service[key] = make_test_data(derived_value)
 
         sub1 = MultiplierSubscriber({"input"}, service, 2)
         sub2 = MultiplierSubscriber({"input"}, service, 3)
@@ -647,10 +671,12 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    derived_value = store["input"].value * 2
-                    self._service["level1"] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        derived_value = snapshot["input"].value * 2
+                        self._service["level1"] = make_test_data(derived_value)
 
         class SecondLevelSubscriber(DataServiceSubscriber[str]):
             def __init__(self, service: DataService[str, int]):
@@ -665,10 +691,12 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "level1" in store:
-                    derived_value = store["level1"].value * 3
-                    self._service["level2"] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "level1" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "level1" in snapshot:
+                        derived_value = snapshot["level1"].value * 3
+                        self._service["level2"] = make_test_data(derived_value)
 
         sub1 = FirstLevelSubscriber(service)
         sub2 = SecondLevelSubscriber(service)
@@ -698,10 +726,12 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    derived_value = store["input"].value * 2
-                    self._service["level1"] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        derived_value = snapshot["input"].value * 2
+                        self._service["level1"] = make_test_data(derived_value)
 
         class SecondLevelSubscriber(DataServiceSubscriber[str]):
             def __init__(self, service: DataService[str, int]):
@@ -716,10 +746,12 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "level1" in store:
-                    derived_value = store["level1"].value * 3
-                    self._service["level2"] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "level1" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "level1" in snapshot:
+                        derived_value = snapshot["level1"].value * 3
+                        self._service["level2"] = make_test_data(derived_value)
 
         sub1 = FirstLevelSubscriber(service)
         sub2 = SecondLevelSubscriber(service)
@@ -756,13 +788,15 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    input_value = store["input"].value
-                    with self._service.transaction():
-                        self._service["double"] = make_test_data(input_value * 2)
-                        self._service["triple"] = make_test_data(input_value * 3)
-                        self._service["square"] = make_test_data(input_value**2)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        input_value = snapshot["input"].value
+                        with self._service.transaction():
+                            self._service["double"] = make_test_data(input_value * 2)
+                            self._service["triple"] = make_test_data(input_value * 3)
+                            self._service["square"] = make_test_data(input_value**2)
 
         subscriber = MultiUpdateSubscriber(service)
         service.register_subscriber(subscriber)
@@ -792,10 +826,12 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    derived_value = store["input"].value * 10
-                    self._service["existing"] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        derived_value = snapshot["input"].value * 10
+                        self._service["existing"] = make_test_data(derived_value)
 
         subscriber = OverwriteSubscriber(service)
         service.register_subscriber(subscriber)
@@ -823,14 +859,18 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
+            def on_updated(self, updated_keys: set[str]) -> None:
                 update_count["count"] += 1
                 if update_count["count"] < 5:  # Prevent infinite recursion in test
-                    if "input" in store and "output" not in store:
-                        derived_value = store["input"].value + 1
+                    snapshot = self._service.snapshot(self)
+                    if "input" in updated_keys and "output" not in snapshot:
+                        derived_value = snapshot["input"].value + 1
                         self._service["output"] = make_test_data(derived_value)
-                    elif "output" in store and store["output"].value < 10:
-                        derived_value = store["output"].value + 1
+                    elif (
+                        "output" in updated_keys
+                        and snapshot.get("output", make_test_data(0)).value < 10
+                    ):
+                        derived_value = snapshot["output"].value + 1
                         self._service["output"] = make_test_data(derived_value)
 
         subscriber = CircularSubscriber(service)
@@ -861,8 +901,8 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "trigger" in store and "to_delete" in self._service:
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "trigger" in updated_keys and "to_delete" in self._service:
                     del self._service["to_delete"]
                     self._service["deleted_flag"] = make_test_data(1)
 
@@ -892,14 +932,18 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    input_value = store["input"].value
-                    with self._service.transaction():
-                        self._service["derived1"] = make_test_data(input_value * 2)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        input_value = snapshot["input"].value
                         with self._service.transaction():
-                            self._service["derived2"] = make_test_data(input_value * 3)
-                        self._service["derived3"] = make_test_data(input_value * 4)
+                            self._service["derived1"] = make_test_data(input_value * 2)
+                            with self._service.transaction():
+                                self._service["derived2"] = make_test_data(
+                                    input_value * 3
+                                )
+                            self._service["derived3"] = make_test_data(input_value * 4)
 
         subscriber = ComplexSubscriber(service)
         service.register_subscriber(subscriber)
@@ -938,10 +982,12 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if self._input_key in store:
-                    derived_value = store[self._input_key].value + 1
-                    self._service[self._output_key] = make_test_data(derived_value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if self._input_key in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if self._input_key in snapshot:
+                        derived_value = snapshot[self._input_key].value + 1
+                        self._service[self._output_key] = make_test_data(derived_value)
 
         # Create a chain: input -> step1 -> step2 -> step3
         sub1 = ChainSubscriber("input", "step1", service)
@@ -976,19 +1022,21 @@ class TestDataServiceUpdatingSubscribers:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, int]) -> None:
-                if "input" in store:
-                    input_value = store["input"].value
-                    # Immediate update
-                    self._service["immediate"] = make_test_data(input_value * 2)
-                    # Transaction update
-                    with self._service.transaction():
-                        self._service["transactional1"] = make_test_data(
-                            input_value * 3
-                        )
-                        self._service["transactional2"] = make_test_data(
-                            input_value * 4
-                        )
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if "input" in updated_keys:
+                    snapshot = self._service.snapshot(self)
+                    if "input" in snapshot:
+                        input_value = snapshot["input"].value
+                        # Immediate update
+                        self._service["immediate"] = make_test_data(input_value * 2)
+                        # Transaction update
+                        with self._service.transaction():
+                            self._service["transactional1"] = make_test_data(
+                                input_value * 3
+                            )
+                            self._service["transactional2"] = make_test_data(
+                                input_value * 4
+                            )
 
         subscriber = MixedSubscriber(service)
         service.register_subscriber(subscriber)
@@ -1018,7 +1066,7 @@ class TestNotifySubscriberErrorIsolation:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, Any]) -> None:
+            def on_updated(self, updated_keys: set[str]) -> None:
                 if self._armed:
                     raise RuntimeError("subscriber failed")
 
@@ -1032,8 +1080,9 @@ class TestNotifySubscriberErrorIsolation:
         service["key1"] = make_test_data(42)
 
         pipe = get_pipe()
-        assert len(pipe.sent_data) == 1
-        assert pipe.sent_data[0]["key1"].value == 42
+        assert len(pipe.notifications) == 1
+        snapshot = service.snapshot(good)
+        assert snapshot["key1"].value == 42
 
     def test_failing_extractor_does_not_block_subsequent_subscribers(self):
         service = DataService[str, int]()
@@ -1063,7 +1112,7 @@ class TestNotifySubscriberErrorIsolation:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, Any]) -> None:
+            def on_updated(self, updated_keys: set[str]) -> None:
                 pass
 
         extractor = BrokenExtractor()
@@ -1077,8 +1126,9 @@ class TestNotifySubscriberErrorIsolation:
         service["key1"] = make_test_data(42)
 
         pipe = get_pipe()
-        assert len(pipe.sent_data) == 1
-        assert pipe.sent_data[0]["key1"].value == 42
+        assert len(pipe.notifications) == 1
+        snapshot = service.snapshot(good)
+        assert snapshot["key1"].value == 42
 
 
 class TestExtractorBasedSubscription:
@@ -1098,15 +1148,15 @@ class TestExtractorBasedSubscription:
             def __init__(self, keys: set[str], extractor):
                 self._keys_set = keys
                 self._extractor = extractor
-                self.received_data: list[dict] = []
+                self.notification_keys: list[set[str]] = []
                 super().__init__()
 
             @property
             def extractors(self) -> dict:
                 return dict.fromkeys(self._keys_set, self._extractor)
 
-            def trigger(self, data: dict) -> None:
-                self.received_data.append(data)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                self.notification_keys.append(updated_keys)
 
         # Create service
         service = DataService()
@@ -1133,13 +1183,14 @@ class TestExtractorBasedSubscription:
             )
 
         # Both subscribers should have received all updates
-        # sub1: 1 initial trigger + 1 update before sub2 registration + 10 after = 12
-        assert len(sub1.received_data) == 12
-        # sub2: 1 initial trigger on registration (with copied data) + 10 updates = 11
-        assert len(sub2.received_data) == 11
+        # sub1: 1 update before sub2 registration + 10 after = 11
+        assert len(sub1.notification_keys) == 11
+        # sub2: 10 updates after registration = 10
+        assert len(sub2.notification_keys) == 10
 
         # sub1 should get latest value only (unwrapped)
-        last_from_sub1 = sub1.received_data[-1]["data"]
+        snapshot1 = service.snapshot(sub1)
+        last_from_sub1 = snapshot1["data"]
         assert last_from_sub1.ndim == 0  # Scalar (unwrapped)
         assert last_from_sub1.value == 11
 
@@ -1147,7 +1198,8 @@ class TestExtractorBasedSubscription:
         # When sub2 registered, buffer switched from SingleValueBuffer to
         # TemporalBuffer, copying the first data point, then receiving 10 more
         # updates = 11 total
-        last_from_sub2 = sub2.received_data[-1]["data"]
+        snapshot2 = service.snapshot(sub2)
+        last_from_sub2 = snapshot2["data"]
         assert last_from_sub2.sizes == {'time': 11}
 
     def test_multiple_keys_with_different_extractors(self):
@@ -1162,7 +1214,7 @@ class TestExtractorBasedSubscription:
 
         class MultiKeySubscriber(DataServiceSubscriber[str]):
             def __init__(self):
-                self.received_data: list[dict] = []
+                self.notification_keys: list[set[str]] = []
                 super().__init__()
 
             @property
@@ -1172,8 +1224,8 @@ class TestExtractorBasedSubscription:
                     "history": FullHistoryExtractor(),
                 }
 
-            def trigger(self, data: dict) -> None:
-                self.received_data.append(data)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                self.notification_keys.append(updated_keys)
 
         service = DataService()
         subscriber = MultiKeySubscriber()
@@ -1192,10 +1244,10 @@ class TestExtractorBasedSubscription:
 
         # Should have received updates (batched in transaction would be less,
         # but here each setitem triggers separately)
-        assert len(subscriber.received_data) > 0
+        assert len(subscriber.notification_keys) > 0
 
-        # Check last received data
-        last_data = subscriber.received_data[-1]
+        # Check last received data via snapshot
+        last_data = service.snapshot(subscriber)
 
         # "latest" should be unwrapped scalar
         if "latest" in last_data:
@@ -1228,11 +1280,11 @@ class TestThreadSafety:
         # Distinct objects: the returned value is copied, not a buffer view.
         assert service["key1"] is not service["key1"]
 
-    def test_trigger_runs_without_holding_lock(self):
-        """A subscriber's trigger must not block other threads' locked ops.
+    def test_on_updated_runs_without_holding_lock(self):
+        """A subscriber's on_updated must not block other threads' locked ops.
 
-        Proves the lock is released around ``trigger``: while one subscriber is
-        mid-trigger, another thread can complete a ``__setitem__`` (which needs
+        Proves the lock is released around ``on_updated``: while one subscriber is
+        mid-notification, another thread can complete a ``__setitem__`` (which needs
         the lock) on an unrelated key.
         """
         service = DataService[str, int]()
@@ -1249,21 +1301,21 @@ class TestThreadSafety:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, Any]) -> None:
-                if store:  # block only on a real data update, not the empty register
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if updated_keys:  # block only on a real update
                     entered.set()
                     release.wait(timeout=5)
 
         service.register_subscriber(BlockingSubscriber())
 
-        # Ingestion thread enters trigger and blocks there.
+        # Ingestion thread enters on_updated and blocks there.
         ingest = threading.Thread(
             target=lambda: service.__setitem__("key1", make_test_data(1))
         )
         ingest.start()
-        assert entered.wait(timeout=5), "trigger was not entered"
+        assert entered.wait(timeout=5), "on_updated was not entered"
 
-        # While trigger is blocked, an unrelated locked op must still complete.
+        # While on_updated is blocked, an unrelated locked op must still complete.
         other_done = threading.Event()
 
         def other() -> None:
@@ -1272,7 +1324,9 @@ class TestThreadSafety:
 
         other_thread = threading.Thread(target=other)
         other_thread.start()
-        assert other_done.wait(timeout=5), "lock held during trigger blocked a writer"
+        assert other_done.wait(timeout=5), (
+            "lock held during on_updated blocked a writer"
+        )
 
         release.set()
         ingest.join(timeout=5)
@@ -1312,7 +1366,7 @@ class TestThreadSafety:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, Any]) -> None:
+            def on_updated(self, updated_keys: set[str]) -> None:
                 pass
 
         def churn() -> None:
@@ -1354,9 +1408,11 @@ class TestThreadSafety:
             def extractors(self):
                 return self._extractors
 
-            def trigger(self, store: dict[str, Any]) -> None:
-                if store:
-                    triggered.append(store["key1"].value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if updated_keys:
+                    snapshot = service.snapshot(self)
+                    if "key1" in snapshot:
+                        triggered.append(snapshot["key1"].value)
 
         service.register_subscriber(RecordingSubscriber())
 
@@ -1402,9 +1458,11 @@ class TestThreadSafety:
                     raise RuntimeError("boom")
                 return super().keys
 
-            def trigger(self, store: dict[str, Any]) -> None:
-                if store:
-                    triggered.append(store["key1"].value)
+            def on_updated(self, updated_keys: set[str]) -> None:
+                if updated_keys:
+                    snapshot = service.snapshot(self)
+                    if "key1" in snapshot:
+                        triggered.append(snapshot["key1"].value)
 
         sub = ExplodingKeysSubscriber()
         service.register_subscriber(sub)
@@ -1418,71 +1476,25 @@ class TestThreadSafety:
         assert triggered == [2]
 
 
-class GatedSubscriber(DataServiceSubscriber[str]):
-    """Subscriber whose delivery is gated by a mutable ``active`` flag."""
-
-    def __init__(self, extractor=None) -> None:
-        self._extractors = {"key1": extractor or LatestValueExtractor()}
-        self.active_flag = True
-        self.triggered: list[dict[str, Any]] = []
-        super().__init__()
-
-    @property
-    def extractors(self):
-        return self._extractors
-
-    @property
-    def active(self) -> bool:
-        return self.active_flag
-
-    def trigger(self, store: dict[str, Any]) -> None:
-        if store:  # ignore the empty initial trigger from registration
-            self.triggered.append(store)
+def test_snapshot_returns_data_after_registration(data_service: DataService[str, int]):
+    """Snapshot returns existing data even if subscriber hasn't received updates."""
+    data_service["key1"] = make_test_data(42, time=1.0)
+    subscriber, _ = create_test_subscriber({"key1"})
+    data_service.register_subscriber(subscriber)
+    snapshot = data_service.snapshot(subscriber)
+    assert snapshot["key1"].value == 42
 
 
-class TestInactiveSubscribers:
-    """Delivery is paused for inactive subscribers; buffering continues."""
+def test_buffering_continues_after_registration():
+    """History accumulates from the moment of registration."""
+    from ess.livedata.dashboard.extractors import FullHistoryExtractor
 
-    def test_inactive_subscriber_is_not_triggered_on_update(self):
-        service = DataService[str, int]()
-        sub = GatedSubscriber()
-        service.register_subscriber(sub)
-        sub.active_flag = False
-        service["key1"] = make_test_data(1)
-        assert sub.triggered == []
-        sub.active_flag = True
-        service["key1"] = make_test_data(2)
-        assert [s["key1"].value for s in sub.triggered] == [2]
-
-    def test_register_skips_initial_trigger_when_inactive(self):
-        service = DataService[str, int]()
-        service["key1"] = make_test_data(1)
-        sub = GatedSubscriber()
-        sub.active_flag = False
-        service.register_subscriber(sub)
-        assert sub.triggered == []
-
-    def test_snapshot_returns_data_regardless_of_active(self):
-        service = DataService[str, int]()
-        service["key1"] = make_test_data(1, time=1.0)
-        sub = GatedSubscriber()
-        sub.active_flag = False
-        service.register_subscriber(sub)
-        snapshot = service.snapshot(sub)
-        assert snapshot["key1"].value == 1
-        assert sub.triggered == []  # snapshot does not trigger
-
-    def test_buffering_continues_while_inactive(self):
-        """History accumulates for a paused history subscriber, so a snapshot
-        on reactivation sees everything that arrived in the meantime."""
-        from ess.livedata.dashboard.extractors import FullHistoryExtractor
-
-        service = DataService[str, int]()
-        sub = GatedSubscriber(extractor=FullHistoryExtractor())
-        service.register_subscriber(sub)
-        sub.active_flag = False
-        for i in range(3):
-            service["key1"] = make_test_data(i, time=float(i))
-        assert sub.triggered == []
-        snapshot = service.snapshot(sub)
-        assert snapshot["key1"].sizes["time"] == 3
+    service = DataService[str, int]()
+    subscriber = SimpleTestSubscriber({"key1"})
+    # Replace extractor with FullHistoryExtractor
+    subscriber._extractors = {"key1": FullHistoryExtractor()}
+    service.register_subscriber(subscriber)
+    for i in range(3):
+        service["key1"] = make_test_data(i, time=float(i))
+    snapshot = service.snapshot(subscriber)
+    assert snapshot["key1"].sizes["time"] == 3

--- a/tests/dashboard/data_subscriber_test.py
+++ b/tests/dashboard/data_subscriber_test.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any
 
 import pytest
 
@@ -51,15 +50,13 @@ class TestDataSubscriberSingleRole:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: None,
+            on_update=lambda: None,
         )
 
         assert subscriber.keys == {key1, key2}
 
-    def test_on_data_called_with_grouped_data(self, make_result_key):
-        """on_data receives role-grouped data even for a single role."""
-        received_data: list[Any] = []
-
+    def test_assemble_returns_grouped_data(self, make_result_key):
+        """assemble returns role-grouped data even for a single role."""
         key1 = make_result_key('detector1')
         key2 = make_result_key('detector2')
         keys_by_role = {'primary': [key1, key2]}
@@ -68,20 +65,18 @@ class TestDataSubscriberSingleRole:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: received_data.append(d),
+            on_update=lambda: None,
         )
 
-        subscriber.trigger({key1: 'value1', key2: 'value2'})
+        data = subscriber.assemble({key1: 'value1', key2: 'value2'})
 
-        assert len(received_data) == 1
-        primary = received_data[0]['primary']
+        assert data is not None
+        primary = data['primary']
         assert primary[key1] == 'value1'
         assert primary[key2] == 'value2'
 
-    def test_multiple_triggers_call_on_data_each_time(self, make_result_key):
-        """Test that each trigger calls on_data."""
-        received_data: list[Any] = []
-
+    def test_assemble_multiple_stores_with_different_data(self, make_result_key):
+        """Test assemble with different store values."""
         key = make_result_key('detector')
         keys_by_role = {'primary': [key]}
         extractors = {key: LatestValueExtractor()}
@@ -89,22 +84,19 @@ class TestDataSubscriberSingleRole:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: received_data.append(d),
+            on_update=lambda: None,
         )
 
-        subscriber.trigger({key: 'value1'})
-        subscriber.trigger({key: 'value2'})
-        subscriber.trigger({key: 'value3'})
+        data1 = subscriber.assemble({key: 'value1'})
+        data2 = subscriber.assemble({key: 'value2'})
+        data3 = subscriber.assemble({key: 'value3'})
 
-        assert len(received_data) == 3
-        assert received_data[0]['primary'][key] == 'value1'
-        assert received_data[1]['primary'][key] == 'value2'
-        assert received_data[2]['primary'][key] == 'value3'
+        assert data1['primary'][key] == 'value1'
+        assert data2['primary'][key] == 'value2'
+        assert data3['primary'][key] == 'value3'
 
     def test_partial_data_included(self, make_result_key):
         """Test that partial data is included in assembly."""
-        received_data: list[Any] = []
-
         key1 = make_result_key('detector1')
         key2 = make_result_key('detector2')
         keys_by_role = {'primary': [key1, key2]}
@@ -113,20 +105,18 @@ class TestDataSubscriberSingleRole:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: received_data.append(d),
+            on_update=lambda: None,
         )
 
         # Only provide data for key1
-        subscriber.trigger({key1: 'value1'})
+        data = subscriber.assemble({key1: 'value1'})
 
-        primary = received_data[0]['primary']
+        primary = data['primary']
         assert key1 in primary
         assert key2 not in primary
 
     def test_keys_sorted_deterministically(self, workflow_id):
         """Test that keys are sorted deterministically in output."""
-        received_data: list[Any] = []
-
         # Create keys with specific ordering
         job_a = JobId(source_name='a_detector', job_number=uuid.uuid4())
         job_b = JobId(source_name='b_detector', job_number=uuid.uuid4())
@@ -140,12 +130,12 @@ class TestDataSubscriberSingleRole:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: received_data.append(d),
+            on_update=lambda: None,
         )
 
-        subscriber.trigger({key_a: 'value_a', key_b: 'value_b'})
+        data = subscriber.assemble({key_a: 'value_a', key_b: 'value_b'})
 
-        result_keys = list(received_data[0]['primary'].keys())
+        result_keys = list(data['primary'].keys())
         # Should be sorted alphabetically by source_name
         assert result_keys[0].job_id.source_name == 'a_detector'
         assert result_keys[1].job_id.source_name == 'b_detector'
@@ -156,8 +146,6 @@ class TestDataSubscriberMultiRole:
 
     def test_multi_role_assembles_grouped_dict(self, make_result_key):
         """Multiple roles output dict[str, dict[ResultKey, data]]."""
-        received_data: list[Any] = []
-
         primary_key = make_result_key('detector')
         x_axis_key = make_result_key('position')
         keys_by_role = {'primary': [primary_key], 'x_axis': [x_axis_key]}
@@ -166,13 +154,15 @@ class TestDataSubscriberMultiRole:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: received_data.append(d),
+            on_update=lambda: None,
         )
 
-        subscriber.trigger({primary_key: 'detector_data', x_axis_key: 'position_data'})
+        data = subscriber.assemble(
+            {primary_key: "detector_data", x_axis_key: "position_data"}
+        )
 
-        # Should receive grouped dict
-        data = received_data[0]
+        # Should return grouped dict
+        assert data is not None
         assert 'primary' in data
         assert 'x_axis' in data
         assert data['primary'][primary_key] == 'detector_data'
@@ -195,7 +185,7 @@ class TestDataSubscriberMultiRole:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: None,
+            on_update=lambda: None,
         )
 
         assert subscriber.keys == {primary_key, x_axis_key, y_axis_key}
@@ -204,10 +194,8 @@ class TestDataSubscriberMultiRole:
 class TestDataSubscriberReadyCondition:
     """Test on_data callback behavior with role-based ready condition."""
 
-    def test_single_role_fires_when_any_data_available(self, make_result_key):
-        """Single role fires on_data when any key has data."""
-        callback_invoked: list[Any] = []
-
+    def test_single_role_assemble_with_partial_data(self, make_result_key):
+        """Single role assemble succeeds when any key has data."""
         key1 = make_result_key('detector1')
         key2 = make_result_key('detector2')
         keys_by_role = {'primary': [key1, key2]}
@@ -216,19 +204,20 @@ class TestDataSubscriberReadyCondition:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: callback_invoked.append(d),
+            on_update=lambda: None,
         )
 
-        # Trigger with only one key
-        subscriber.trigger({key1: 'value1'})
+        # assemble with only one key
+        result = subscriber.assemble({key1: 'value1'})
 
-        # Should fire (at least one key from the one role)
-        assert len(callback_invoked) == 1
+        # Should succeed (at least one key from the one role)
+        assert result is not None
+        assert 'primary' in result
+        assert key1 in result['primary']
+        assert key2 not in result['primary']
 
     def test_multi_role_requires_data_from_each_role(self, make_result_key):
-        """Multi-role requires at least one key from EACH role to fire."""
-        callback_invoked: list[Any] = []
-
+        """Multi-role assemble returns None until all roles have data."""
         primary_key = make_result_key('detector')
         x_axis_key = make_result_key('position')
         keys_by_role = {'primary': [primary_key], 'x_axis': [x_axis_key]}
@@ -237,21 +226,23 @@ class TestDataSubscriberReadyCondition:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: callback_invoked.append(d),
+            on_update=lambda: None,
         )
 
-        # Trigger with only primary - should NOT fire
-        subscriber.trigger({primary_key: 'detector_data'})
-        assert len(callback_invoked) == 0
+        # assemble with only primary - should return None
+        result = subscriber.assemble({primary_key: 'detector_data'})
+        assert result is None
 
-        # Trigger with both roles - should fire
-        subscriber.trigger({primary_key: 'detector_data', x_axis_key: 'position_data'})
-        assert len(callback_invoked) == 1
+        # assemble with both roles - should return grouped data
+        result = subscriber.assemble(
+            {primary_key: "detector_data", x_axis_key: "position_data"}
+        )
+        assert result is not None
+        assert 'primary' in result
+        assert 'x_axis' in result
 
-    def test_no_callback_with_empty_data(self, make_result_key):
-        """on_data does not fire when there's no data."""
-        callback_invoked: list[Any] = []
-
+    def test_assemble_returns_none_with_empty_data(self, make_result_key):
+        """assemble returns None when there's no data."""
         key = make_result_key('detector')
         keys_by_role = {'primary': [key]}
         extractors = {key: LatestValueExtractor()}
@@ -259,11 +250,11 @@ class TestDataSubscriberReadyCondition:
         subscriber = DataSubscriber(
             keys_by_role=keys_by_role,
             extractors=extractors,
-            on_data=lambda d: callback_invoked.append(d),
+            on_update=lambda: None,
         )
 
-        # Trigger with empty store
-        subscriber.trigger({})
+        # assemble with empty store
+        result = subscriber.assemble({})
 
-        # Should not fire
-        assert len(callback_invoked) == 0
+        # Should return None
+        assert result is None

--- a/tests/dashboard/plot_data_service_test.py
+++ b/tests/dashboard/plot_data_service_test.py
@@ -249,30 +249,33 @@ class TestLayerComputeGate:
         task.run()
         assert plotter.compute_calls == [({'k': 1}, {'title_resolver': None})]
 
-    def test_stash_then_set_active_flushes_on_zero_to_one_transition(self):
-        state, plotter = self._ready_state()
-        token = _Token()
-        state.set_active(token, False)
-        state.stash_pending({'k': 1})
-        assert plotter.compute_calls == []
-        task = state.set_active(token, True)
-        assert task is not None
-        task.run()
-        assert plotter.compute_calls == [({'k': 1}, {'title_resolver': None})]
-
-    def test_only_zero_to_one_transition_returns_a_task(self):
+    def test_set_active_reports_only_zero_to_one_transition(self):
         state, _plotter = self._ready_state()
         token = _Token()
-        state.set_active(token, True)
-        state.stash_pending({'k': 1}).run()
-        # Re-asserting True after the flush returns None (no pending dirty).
-        assert state.set_active(token, True) is None
+        assert state.set_active(token, True) is True
+        # Re-asserting True is not a transition.
+        assert state.set_active(token, True) is False
+        state.set_active(token, False)
+        assert state.set_active(token, True) is True
+
+    def test_has_viewers_tracks_token_count(self):
+        state, _plotter = self._ready_state()
+        t1, t2 = _Token(), _Token()
+        assert not state.has_viewers
+        state.set_active(t1, True)
+        state.set_active(t2, True)
+        assert state.has_viewers
+        state.set_active(t1, False)
+        assert state.has_viewers
+        state.set_active(t2, False)
+        assert not state.has_viewers
 
     def test_multiple_tokens_keep_active_until_last_released(self):
         state, plotter = self._ready_state()
         t1, t2 = _Token(), _Token()
-        state.set_active(t1, True)
-        state.set_active(t2, True)
+        assert state.set_active(t1, True) is True
+        # Second token while already active is not a transition.
+        assert state.set_active(t2, True) is False
         task = state.stash_pending({'k': 1})
         assert task is not None
         task.run()
@@ -287,33 +290,12 @@ class TestLayerComputeGate:
         # Only the first two computes ran; the third is stashed.
         assert [d for d, _ in plotter.compute_calls] == [{'k': 1}, {'k': 2}]
 
-    def test_intermediate_updates_collapse_to_latest(self):
-        state, plotter = self._ready_state()
-        token = _Token()
-        state.set_active(token, False)
-        for i in range(5):
-            state.stash_pending({'k': i})
-        task = state.set_active(token, True)
-        assert task is not None
-        task.run()
-        assert plotter.compute_calls == [({'k': 4}, {'title_resolver': None})]
-
     def test_release_of_unknown_token_is_noop(self):
         state, _plotter = self._ready_state()
         # Releasing a token never seen does not raise or change anything.
         unknown = _Token()
-        assert state.set_active(unknown, False) is None
-
-    def test_pending_cleared_when_plotter_replaced(self):
-        state, _old = self._ready_state()
-        token = _Token()
-        state.set_active(token, False)
-        state.stash_pending({'k': 1})  # stashed for old plotter
-        new_plotter = FakePlotter()
-        state.job_started(new_plotter)  # replaces plotter, clears stash
-        # New plotter activation must not re-run the old plotter's pending input.
-        assert state.set_active(token, True) is None
-        assert new_plotter.compute_calls == []
+        assert state.set_active(unknown, False) is False
+        assert not state.has_viewers
 
     def test_stash_returns_no_task_before_job_started(self):
         state = LayerStateMachine()
@@ -335,4 +317,5 @@ class TestLayerComputeGate:
         del token
         gc.collect()
         # Gate is now closed (no active tokens) → next stash returns None.
+        assert not state.has_viewers
         assert state.stash_pending({'k': 2}) is None

--- a/tests/dashboard/plot_data_service_test.py
+++ b/tests/dashboard/plot_data_service_test.py
@@ -226,8 +226,13 @@ class _Token:
     """Weakref-compatible stand-in for a viewer (real callers are SessionLayer)."""
 
 
-class TestLayerComputeGate:
-    """Tests for the lazy compute gate on LayerStateMachine."""
+class TestLayerViewerGate:
+    """Tests for the viewer gate on LayerStateMachine.
+
+    The gate tracks viewer interest tokens. On 0→1 transition (first viewer),
+    the orchestrator rebuilds the layer from DataService; on 1→0 (last
+    viewer released), the layer is skipped at frame flushes.
+    """
 
     def _ready_state(self) -> tuple[LayerStateMachine, FakePlotter]:
         state = LayerStateMachine()
@@ -235,30 +240,18 @@ class TestLayerComputeGate:
         state.job_started(plotter)
         return state, plotter
 
-    def test_stash_without_active_token_does_not_flush(self):
-        state, plotter = self._ready_state()
-        assert state.stash_pending({'k': 1}) is None
-        assert plotter.compute_calls == []
-
-    def test_set_active_then_stash_flushes_immediately(self):
-        state, plotter = self._ready_state()
-        token = _Token()
-        state.set_active(token, True)
-        task = state.stash_pending({'k': 1})
-        assert task is not None
-        task.run()
-        assert plotter.compute_calls == [({'k': 1}, {'title_resolver': None})]
-
-    def test_set_active_reports_only_zero_to_one_transition(self):
+    def test_set_active_reports_zero_to_one_transition(self):
+        """set_active returns True on the 0→1 transition only."""
         state, _plotter = self._ready_state()
         token = _Token()
         assert state.set_active(token, True) is True
-        # Re-asserting True is not a transition.
+        # Re-activating the same token is not a transition.
         assert state.set_active(token, True) is False
         state.set_active(token, False)
         assert state.set_active(token, True) is True
 
-    def test_has_viewers_tracks_token_count(self):
+    def test_has_viewers_tracks_active_tokens(self):
+        """has_viewers reflects whether any viewer holds a token."""
         state, _plotter = self._ready_state()
         t1, t2 = _Token(), _Token()
         assert not state.has_viewers
@@ -270,52 +263,38 @@ class TestLayerComputeGate:
         state.set_active(t2, False)
         assert not state.has_viewers
 
-    def test_multiple_tokens_keep_active_until_last_released(self):
-        state, plotter = self._ready_state()
+    def test_multiple_tokens_keep_layer_active(self):
+        """Layer stays active while any viewer holds a token."""
+        state, _plotter = self._ready_state()
         t1, t2 = _Token(), _Token()
         assert state.set_active(t1, True) is True
         # Second token while already active is not a transition.
         assert state.set_active(t2, True) is False
-        task = state.stash_pending({'k': 1})
-        assert task is not None
-        task.run()
-        # Release one; still active — stash flushes immediately.
+        assert state.has_viewers
+        # Release one; still active (t2 holds it).
         state.set_active(t1, False)
-        task = state.stash_pending({'k': 2})
-        assert task is not None
-        task.run()
-        # Release the second; gate closes, next stash returns None.
+        assert state.has_viewers
+        # Release the second; gate closes.
         state.set_active(t2, False)
-        assert state.stash_pending({'k': 3}) is None
-        # Only the first two computes ran; the third is stashed.
-        assert [d for d, _ in plotter.compute_calls] == [{'k': 1}, {'k': 2}]
+        assert not state.has_viewers
 
     def test_release_of_unknown_token_is_noop(self):
+        """Releasing a token never acquired is safe."""
         state, _plotter = self._ready_state()
-        # Releasing a token never seen does not raise or change anything.
         unknown = _Token()
         assert state.set_active(unknown, False) is False
         assert not state.has_viewers
 
-    def test_stash_returns_no_task_before_job_started(self):
-        state = LayerStateMachine()
-        token = _Token()
-        state.set_active(token, True)
-        # No plotter yet → no flush.
-        assert state.stash_pending({'k': 1}) is None
-
     def test_token_auto_released_on_garbage_collection(self):
-        """Safety net: if the caller is gc'd without releasing, the gate closes."""
+        """Finalizer closes gate if caller is gc'd without explicit release."""
         import gc
 
         state, _plotter = self._ready_state()
         token = _Token()
         state.set_active(token, True)
-        # Active: stash flushes immediately.
-        assert state.stash_pending({'k': 1}) is not None
+        assert state.has_viewers
         # Drop the only reference and force gc; finalizer must release the key.
         del token
         gc.collect()
-        # Gate is now closed (no active tokens) → next stash returns None.
+        # Gate is now closed.
         assert not state.has_viewers
-        assert state.stash_pending({'k': 2}) is None

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -209,6 +209,7 @@ class FakePlottingController:
         plot_name: str,
         params,
         on_data,
+        is_active=None,
     ):
         """Set up data pipeline using real StreamManager (unified interface)."""
         from ess.livedata.dashboard.data_roles import PRIMARY
@@ -231,6 +232,7 @@ class FakePlottingController:
         return self._stream_manager.make_stream(
             keys_by_role,
             on_data=on_data,
+            is_active=is_active,
         )
 
     def create_plotter(
@@ -2577,6 +2579,61 @@ class TestPersistenceRoundTrip:
 
         raw = config_store.get('plot_grids')
         assert 'enabled' not in raw['grids'][0]
+
+
+class TestDeliveryPausedForHiddenLayers:
+    """Layers without a viewer token receive no deliveries or computes;
+    activation refreshes them from current DataService content."""
+
+    def test_hidden_layer_skips_compute_and_refreshes_on_activation(
+        self,
+        plot_orchestrator,
+        workflow_id,
+        workflow_spec,
+        job_orchestrator,
+        fake_plotting_controller,
+        fake_data_service,
+    ):
+        import scipp as sc
+
+        from ess.livedata.config.workflow_spec import JobId, ResultKey
+
+        job_ids = commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
+        job_number = job_ids[0].job_number
+
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=1, ncols=1)
+        config = make_plot_config(
+            workflow_id, source_names=['monitor_0'], output_name='output_a'
+        )
+        cell_id = plot_orchestrator.add_cell(grid_id, DEFAULT_GEOMETRY)
+        layer_id = plot_orchestrator.add_layer(cell_id, config)
+        # No viewer token acquired: the layer sits on a hidden tab.
+
+        key = ResultKey(
+            workflow_id=workflow_id,
+            job_id=JobId(source_name='monitor_0', job_number=job_number),
+            output_name='output_a',
+        )
+        fake_data_service[key] = sc.scalar(1.0)
+        fake_data_service[key] = sc.scalar(2.0)
+        plot_orchestrator.flush_frames()
+
+        (plotter,) = fake_plotting_controller.created_plotters
+        assert plotter.compute_calls == []
+
+        # Activation refreshes from DataService: one compute, latest value.
+        viewer = _Viewer()
+        plot_orchestrator.activate_layer(layer_id, viewer, True)
+        assert len(plotter.compute_calls) == 1
+        ((role_data,),) = [plotter.compute_calls[0]['data'].values()]
+        (value,) = role_data.values()
+        assert value.value == 2.0
+
+        # Releasing the last token pauses delivery again.
+        plot_orchestrator.activate_layer(layer_id, viewer, False)
+        fake_data_service[key] = sc.scalar(3.0)
+        plot_orchestrator.flush_frames()
+        assert len(plotter.compute_calls) == 1
 
 
 class TestFrameGeneration:

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -208,8 +208,7 @@ class FakePlottingController:
         keys_by_role,
         plot_name: str,
         params,
-        on_data,
-        is_active=None,
+        on_update,
     ):
         """Set up data pipeline using real StreamManager (unified interface)."""
         from ess.livedata.dashboard.data_roles import PRIMARY
@@ -231,8 +230,7 @@ class FakePlottingController:
         # Use real StreamManager for subscription (avoids duplicating logic)
         return self._stream_manager.make_stream(
             keys_by_role,
-            on_data=on_data,
-            is_active=is_active,
+            on_update=on_update,
         )
 
     def create_plotter(

--- a/tests/dashboard/stream_manager_test.py
+++ b/tests/dashboard/stream_manager_test.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any
 
 import pytest
 import scipp as sc
@@ -69,37 +68,43 @@ class TestStreamManager:
         key = make_key(workflow_id)
         keys_by_role = {'primary': [key]}
 
-        manager.make_stream(keys_by_role, on_data=lambda d: None)
+        manager.make_stream(keys_by_role, on_update=lambda: None)
 
         assert len(data_service._subscribers) == 1
 
     def test_single_source_data_flow(self, data_service, sample_data, workflow_id):
         """Test data flow with a single source."""
         manager = StreamManager(data_service=data_service)
-        received_data: list[Any] = []
+        updates: list[None] = []
 
         key = make_key(workflow_id)
         keys_by_role = {'primary': [key]}
 
-        manager.make_stream(keys_by_role, on_data=lambda d: received_data.append(d))
+        subscriber = manager.make_stream(
+            keys_by_role, on_update=lambda: updates.append(None)
+        )
 
         # Publish data
         data_service[key] = sample_data
 
-        # Verify data received (grouped by role)
-        assert len(received_data) == 1
-        assert_dict_equal_with_scipp(received_data[0]['primary'], {key: sample_data})
+        # Verify on_update fired and data can be assembled (grouped by role)
+        assert len(updates) == 1
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
+        assert_dict_equal_with_scipp(result['primary'], {key: sample_data})
 
     def test_multiple_sources_data_flow(self, data_service, sample_data, workflow_id):
         """Test data flow with multiple sources in single role."""
         manager = StreamManager(data_service=data_service)
-        received_data: list[Any] = []
+        updates: list[None] = []
 
         key1 = make_key(workflow_id, "source1")
         key2 = make_key(workflow_id, "source2")
         keys_by_role = {'primary': [key1, key2]}
 
-        manager.make_stream(keys_by_role, on_data=lambda d: received_data.append(d))
+        subscriber = manager.make_stream(
+            keys_by_role, on_update=lambda: updates.append(None)
+        )
 
         # Publish data for both keys
         sample_data2 = sc.DataArray(
@@ -108,35 +113,44 @@ class TestStreamManager:
         )
 
         data_service[key1] = sample_data
-        data_service[key2] = sample_data2
+        # First update - has only key1
+        assert len(updates) == 1
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
+        assert_dict_equal_with_scipp(result['primary'], {key1: sample_data})
 
-        # Should receive data for both keys
-        assert len(received_data) == 2
-        # First call has only key1
-        assert_dict_equal_with_scipp(received_data[0]['primary'], {key1: sample_data})
-        # Second call has both keys
+        data_service[key2] = sample_data2
+        # Second update - has both keys
+        assert len(updates) == 2
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
         assert_dict_equal_with_scipp(
-            received_data[1]['primary'],
+            result['primary'],
             {key1: sample_data, key2: sample_data2},
         )
 
     def test_partial_data_updates(self, data_service, sample_data, workflow_id):
         """Test handling of partial data updates when only some keys have data."""
         manager = StreamManager(data_service=data_service)
-        received_data: list[Any] = []
+        updates: list[None] = []
 
         key1 = make_key(workflow_id, "source1")
         key2 = make_key(workflow_id, "source2")
         keys_by_role = {'primary': [key1, key2]}
 
-        manager.make_stream(keys_by_role, on_data=lambda d: received_data.append(d))
+        subscriber = manager.make_stream(
+            keys_by_role, on_update=lambda: updates.append(None)
+        )
 
         # Send data for only one key
         data_service[key1] = sample_data
 
-        # Should receive partial data (grouped by role)
-        assert len(received_data) == 1
-        primary = received_data[0]['primary']
+        # Should trigger on_update, assemble returns partial data (grouped by role)
+        assert len(updates) == 1
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
+        assert result is not None
+        primary = result['primary']
         assert key1 in primary
         assert key2 not in primary
         assert_identical(primary[key1], sample_data)
@@ -144,46 +158,50 @@ class TestStreamManager:
     def test_stream_independence(self, data_service, sample_data, workflow_id):
         """Test that multiple streams operate independently."""
         manager = StreamManager(data_service=data_service)
-        received_data1: list[Any] = []
-        received_data2: list[Any] = []
+        updates1: list[None] = []
+        updates2: list[None] = []
 
         # Create two independent streams with different keys
         key1 = make_key(workflow_id, "source1")
         key2 = make_key(workflow_id, "source2")
 
         manager.make_stream(
-            {'primary': [key1]}, on_data=lambda d: received_data1.append(d)
+            {'primary': [key1]}, on_update=lambda: updates1.append(None)
         )
         manager.make_stream(
-            {'primary': [key2]}, on_data=lambda d: received_data2.append(d)
+            {'primary': [key2]}, on_update=lambda: updates2.append(None)
         )
 
         # Send data for key1
         data_service[key1] = sample_data
 
-        # Only stream1 should receive data
-        assert len(received_data1) == 1
-        assert len(received_data2) == 0
+        # Only stream1 should receive update
+        assert len(updates1) == 1
+        assert len(updates2) == 0
 
         # Send data for key2
         data_service[key2] = sample_data
 
-        # Now stream2 should also have data, stream1 unchanged
-        assert len(received_data1) == 1
-        assert len(received_data2) == 1
+        # Now stream2 should also have update, stream1 unchanged
+        assert len(updates1) == 1
+        assert len(updates2) == 1
 
     def test_incremental_updates(self, data_service, sample_data, workflow_id):
-        """Test that incremental updates flow through correctly."""
+        """Test incremental updates trigger on_update and assemble reflects changes."""
         manager = StreamManager(data_service=data_service)
-        received_data: list[Any] = []
+        updates: list[None] = []
 
         key = make_key(workflow_id)
-        manager.make_stream(
-            {'primary': [key]}, on_data=lambda d: received_data.append(d)
+        subscriber = manager.make_stream(
+            {'primary': [key]}, on_update=lambda: updates.append(None)
         )
 
         # Send initial data
         data_service[key] = sample_data
+        assert len(updates) == 1
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
+        assert_dict_equal_with_scipp(result['primary'], {key: sample_data})
 
         # Send updated data
         updated_data = sc.DataArray(
@@ -191,38 +209,37 @@ class TestStreamManager:
             coords={'x': sc.array(dims=['x'], values=[70, 80, 90])},
         )
         data_service[key] = updated_data
-
-        # Should receive both updates (grouped by role)
-        assert len(received_data) == 2
-        assert_dict_equal_with_scipp(received_data[0]['primary'], {key: sample_data})
-        assert_dict_equal_with_scipp(received_data[1]['primary'], {key: updated_data})
+        assert len(updates) == 2
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
+        assert_dict_equal_with_scipp(result['primary'], {key: updated_data})
 
     def test_unrelated_key_filtering(self, data_service, sample_data, workflow_id):
         """Test that unrelated keys are filtered out."""
         manager = StreamManager(data_service=data_service)
-        received_data: list[Any] = []
+        updates: list[None] = []
 
         target_key = make_key(workflow_id, "target")
         unrelated_key = make_key(workflow_id, "unrelated")
 
-        manager.make_stream(
-            {'primary': [target_key]}, on_data=lambda d: received_data.append(d)
+        subscriber = manager.make_stream(
+            {'primary': [target_key]}, on_update=lambda: updates.append(None)
         )
 
         # Publish data for unrelated key
         data_service[unrelated_key] = sample_data
 
-        # Should not receive any data
-        assert len(received_data) == 0
+        # Should not trigger on_update (unrelated key)
+        assert len(updates) == 0
 
         # Publish data for target key
         data_service[target_key] = sample_data
 
-        # Should receive data now (grouped by role)
-        assert len(received_data) == 1
-        assert_dict_equal_with_scipp(
-            received_data[0]['primary'], {target_key: sample_data}
-        )
+        # Should trigger on_update and assemble should return data
+        assert len(updates) == 1
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
+        assert_dict_equal_with_scipp(result['primary'], {target_key: sample_data})
 
 
 class TestStreamManagerMultiRole:
@@ -233,13 +250,15 @@ class TestStreamManagerMultiRole:
     ):
         """Multiple roles output grouped dict[str, dict[ResultKey, data]]."""
         manager = StreamManager(data_service=data_service)
-        received_data: list[Any] = []
+        updates: list[None] = []
 
         primary_key = make_key(workflow_id, "detector")
         x_axis_key = make_key(workflow_id, "position")
         keys_by_role = {'primary': [primary_key], 'x_axis': [x_axis_key]}
 
-        manager.make_stream(keys_by_role, on_data=lambda d: received_data.append(d))
+        subscriber = manager.make_stream(
+            keys_by_role, on_update=lambda: updates.append(None)
+        )
 
         position_data = sc.DataArray(
             data=sc.array(dims=['t'], values=[1.0, 2.0, 3.0]),
@@ -248,31 +267,42 @@ class TestStreamManagerMultiRole:
         data_service[primary_key] = sample_data
         data_service[x_axis_key] = position_data
 
-        # Last call should have grouped structure
-        last_data = received_data[-1]
-        assert 'primary' in last_data
-        assert 'x_axis' in last_data
-        assert_identical(last_data['primary'][primary_key], sample_data)
-        assert_identical(last_data['x_axis'][x_axis_key], position_data)
+        # After both updates, assemble should return grouped structure
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
+        assert result is not None
+        assert 'primary' in result
+        assert 'x_axis' in result
+        assert_identical(result['primary'][primary_key], sample_data)
+        assert_identical(result['x_axis'][x_axis_key], position_data)
 
     def test_multi_role_waits_for_all_roles(
         self, data_service, sample_data, workflow_id
     ):
-        """Multi-role stream waits for data from each role before firing callback."""
+        """Multi-role stream waits for all role data before assemble returns."""
         manager = StreamManager(data_service=data_service)
-        received_data: list[Any] = []
+        updates: list[None] = []
 
         primary_key = make_key(workflow_id, "detector")
         x_axis_key = make_key(workflow_id, "position")
         keys_by_role = {'primary': [primary_key], 'x_axis': [x_axis_key]}
 
-        manager.make_stream(keys_by_role, on_data=lambda d: received_data.append(d))
+        subscriber = manager.make_stream(
+            keys_by_role, on_update=lambda: updates.append(None)
+        )
 
-        # Only primary data - should NOT fire (multi-role requires all roles)
+        # Only primary data - on_update should fire but assemble returns None
         data_service[primary_key] = sample_data
-        assert len(received_data) == 0
+        assert len(updates) == 1
+        snapshot = data_service.snapshot(subscriber)
+        assert subscriber.assemble(snapshot) is None
 
-        # Add x_axis data - should fire
+        # Add x_axis data - assemble should now return data
         position_data = sc.DataArray(data=sc.array(dims=['t'], values=[1.0, 2.0]))
         data_service[x_axis_key] = position_data
-        assert len(received_data) == 1
+        assert len(updates) == 2
+        snapshot = data_service.snapshot(subscriber)
+        result = subscriber.assemble(snapshot)
+        assert result is not None
+        assert 'primary' in result
+        assert 'x_axis' in result


### PR DESCRIPTION
Stacked on #1009.

## Motivation

Data subscriptions in the dashboard are process-global: one `DataSubscriber` per plot layer, shared by all sessions. On every `DataService` update, extract + copy + assemble + stash ran for every subscribed layer on every tab — only `plotter.compute` was gated on viewer interest. A dashboard with many tabs paid delivery costs for all of them even with nobody looking, on the ingestion thread and ahead of visible-tab frame flushes, and each hidden layer pinned a copied, assembled input dict in its stash indefinitely.

## What changed

The subscription's two roles are now split. Buffering (extractors drive buffer type and history retention) keeps running for hidden layers, so a timeseries is complete when its tab is opened. Delivery is gated per subscriber: `DataService` consults a new `active` property before extracting, and `DataSubscriber` derives it from the layer gate's viewer-token count — so tokens released by the weakref finalizer pause delivery too, with no mirrored flag that could go stale.

On the 0→1 viewer transition the layer is refreshed synchronously from a `DataService` snapshot through the subscriber's own extractors, reusing the synchronous `_run_compute` path. This preserves the same-poll-pass `has_cached_state` contract for tab switches and keeps `_frame_buckets` ingestion-thread-only. `LayerStateMachine.set_active` accordingly reports the transition as a bool instead of flushing the (now stale) stash; the stash remains as the handoff for the active delivery path.

## Performance impact

Measured per-delivery cost (extract + copy per layer per update, devcontainer CPU, realistic shapes):

| Layer type | per update |
| --- | --- |
| 0D latest value | 0.005 ms |
| Timeseries full history (10k–100k points) | ~0.25 ms |
| Image latest value (128²–1024²) | 0.04–0.18 ms |
| Image with time-window aggregation (256², ~10-frame window) | ~4 ms |

Plain copies are memcpy-bound and nearly free; the dominant cost is `WindowAggregatingExtractor`, which reduces over the buffered window on every delivery and scales with window length × image size. For a typical deployment (5–10 tabs × 5–10 layers of mixed types, ~1 Hz updates, 1–3 sessions each viewing one tab, so 70–90% of layers hidden) this saves roughly 20–80 ms/s of ingestion-thread CPU; windowed-image-heavy configurations or higher update rates scale that to hundreds of ms/s. Session count itself is a non-factor since subscriptions are process-global.

Beyond CPU: delivery ran serially on the ingestion thread ahead of `flush_frames`, so every visible-tab frame previously waited on all hidden tabs' delivery — that per-burst latency is removed from the plots someone is actually watching. Each hidden layer also pinned one assembled, copied input (0.1–8 MB for images) in its stash indefinitely; the stash is now only populated transiently.

## Test plan

- Unit tests cover paused delivery, snapshot refresh, buffering-while-paused, gate transitions, and an end-to-end orchestrator flow (hidden layer skips compute, activation computes the latest value, releasing the last token pauses again).
- Verified in the running dashboard (fake transport, Playwright): a tab hidden since startup receives zero deliveries and fills immediately on first activation; after a hidden dwell it shows fresh data (moved peak, grown counts); visible tabs update live; rapid tab churn produces no notification or compute errors in the server log.
- [ ] Manual check against a real backend: switch between tabs with active workflows in 2+ browser sessions; hidden tabs must fill immediately on switch and timeseries must cover the hidden period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
