### PR TITLE
docs: draft ADR 0007 — single-writer state with versioned pull as the dashboard concurrency model

### DIFF
--- a/docs/developer/adr/0005-frame-gated-session-flush.md
+++ b/docs/developer/adr/0005-frame-gated-session-flush.md
@@ -1,6 +1,6 @@
 # ADR 0005: Frame-gated per-session plot flush
 
-- Status: accepted (amended 2026-07-02, see bottom)
+- Status: accepted (amended 2026-07-02 and 2026-07-06, see bottom)
 - Deciders: Simon
 - Date: 2026-06-25
 
@@ -72,10 +72,12 @@ of the frame just shown) and otherwise on a slow stall cadence
 ## Alternatives considered
 
 - **Push from the ingestion thread** (event-driven `pipe.send`, or
-  `doc.add_next_tick_callback` onto each captured session document). Rejected: it
-  reintroduces the cross-thread session mutation the polling architecture exists
-  to avoid. `pn.state.execute` does not help -- it targets the *current* session
-  context, useless from the ingestion thread.
+  `doc.add_next_tick_callback` carrying the payload onto each captured session
+  document). Rejected: it reintroduces the cross-thread session mutation the
+  polling architecture exists to avoid. `pn.state.execute` does not help -- it
+  targets the *current* session context, useless from the ingestion thread.
+  This rejection covers *data-carrying* push; see the 2026-07-06 amendment for
+  the data-free wake-up case.
 - **Naively lower the fixed poll period.** Rejected: each pass stays batched, but
   computes finishing in different sub-windows flush on different ticks, so
   multi-plot updates stagger.
@@ -211,3 +213,32 @@ Consequences for the guarantees above:
   data than a delivery would have carried. This is what makes a future
   min-frame-interval throttle in `flush_frames` a policy choice rather than a
   correctness question.
+
+## Amendment (2026-07-06): scope of the `add_next_tick_callback` rejection
+
+The *Alternatives considered* rejection above reads as a blanket ban on
+`doc.add_next_tick_callback` from the ingestion thread. It is not. What that
+rejection encodes is **data-carrying push and direct cross-thread mutation of
+session-bound objects**, plus `pn.state.execute`, which genuinely cannot
+resolve a session context off the session IOLoop (Panel #5488).
+
+A **data-free wake-up** is permitted: the ingestion thread may, after
+`flush_frames` commits a grid, schedule a no-argument tick on a registered
+session document. The invariant this ADR exists to protect is untouched --
+every session-bound mutation still happens inside the tick, on that session's
+IOLoop, in document context. Only the *trigger* moves from clock to event.
+
+Verified on panel 1.9.3 / bokeh 3.9.1: a background-thread
+`doc.add_next_tick_callback(tick)` runs the tick in the correct session
+context (`pn.state.curdoc` resolves; `pn.io.hold()` + `doc.models.freeze()`
+behave normally) across concurrent sessions, and scheduling into a destroyed
+document raises catchably, so stale registrations unregister lazily.
+
+Because the tick body is the existing generation-gated pass -- idempotent, and
+a no-op when nothing advanced -- a lost or duplicated wake costs nothing. That
+makes the periodic callback a safety net rather than the detection clock, so
+it can drop to ~1--2 s for the things that genuinely need a clock (heartbeat,
+notifications, freshness-pill stall aging), retiring the 100 ms tick's
+per-tick `hold`+`freeze` recompute and layer scan. Sequencing and the
+`WakeupHub` design live in #1046; the delivery model this follows from is
+ADR 0007.

--- a/docs/developer/adr/0007-single-writer-versioned-pull.md
+++ b/docs/developer/adr/0007-single-writer-versioned-pull.md
@@ -71,7 +71,14 @@ Concretely:
   consumers poll the version on their own clock (session poll, frame flush)
   and pull an immutable snapshot when it advanced. Callbacks, where they
   survive, carry no data — at most "something changed" wake-ups that
-  degrade to the next poll tick if lost.
+  degrade to the next poll tick if lost. The sanctioned instance is the
+  ingestion thread scheduling a data-free session tick via
+  `doc.add_next_tick_callback` once `flush_frames` has committed a grid: only
+  the *scheduling* crosses threads, the woken tick body runs in the owning
+  session's document context, and a lost or duplicated wake is harmless
+  because the tick is idempotent and generation-gated. ADR 0005's rejection
+  of `add_next_tick_callback` scopes to data-carrying push and to
+  `pn.state.execute`, not to wake-ups — see its 2026-07-06 amendment.
 - **Data flows by pull at display cadence.** Ingestion records what changed
   (dirty keys); extraction, copy, and compute happen when a consumer with a
   viewer pulls — not eagerly per delta on the ingestion thread. "No viewers,
@@ -94,9 +101,11 @@ Concretely:
   the audited failure mode. Locks survive, but narrowly, protecting buffer
   writes rather than delivery.
 - **Marshal all mutation onto session IOLoops** (`add_next_tick_callback`
-  everywhere). Rejected: Panel cannot resolve session context from background
-  threads (ADR 0005), fan-out to N sessions multiplies work, and shared
-  (non-session) state still needs an owner.
+  everywhere). Rejected: fan-out to N sessions multiplies the work per change,
+  the mutating thread ends up owning each session's update order, and shared
+  (non-session) state still needs a single writer regardless. Scheduling
+  itself is sound — hence the data-free wake-up above — but it is a trigger
+  mechanism, not a state-ownership model.
 - **Full actor model / message-passing rewrite.** Rejected as
   disproportionate: versioned pull achieves the same isolation for this
   system's shapes (one ingestion writer, per-session readers) with the
@@ -120,7 +129,11 @@ Concretely:
   instead of re-deriving interleavings per PR.
 - Worst-case freshness is bounded by the consumer's poll cadence (100 ms
   session tick; see ADR 0005 for why this does not add visible latency over
-  push).
+  push). Where a wake-up backs the poll, the bound tightens to data cadence
+  plus milliseconds and the poll becomes a safety net: the 100 ms fast tick —
+  and with it the per-tick `hold`+`freeze` recompute and O(grids×cells×layers)
+  layer scan (#1055 Target 3, #1044 scalability note) — can then be retired
+  rather than optimized.
 - Cost: dirty-flag/version bookkeeping replaces eager delivery, and
   during migration both mechanisms coexist — the migration is sequenced so
   each step deletes more push machinery than it adds pull machinery.

--- a/docs/developer/adr/0007-single-writer-versioned-pull.md
+++ b/docs/developer/adr/0007-single-writer-versioned-pull.md
@@ -6,13 +6,20 @@
 
 ## Context
 
-The dashboard runs on three kinds of threads: the shared ingestion thread
+The dashboard runs on two kinds of threads: the shared ingestion thread
 (`DashboardServices._update_loop`, draining Kafka and driving orchestrator
-updates at ~50 ms), each session's Tornado/Bokeh IOLoop (UI callbacks and the
-100 ms session poll, under that session's document lock), and the polling
-thread paths that run layer activation. Session-bound objects (`Pipe`,
-`DynamicMap`, Bokeh documents) may only be mutated on their own session's
-IOLoop — a hard constraint established in ADR 0005.
+updates at ~50 ms), and each session's Tornado/Bokeh IOLoop (UI callbacks and
+the 100 ms session poll, under that session's document lock). Layer activation
+runs on the latter — the poll pass calls `LayerStateMachine.set_active`, so
+activation flushes and Kafka-delta builds enter the same gate from opposite
+threads. Session-bound objects (`Pipe`, `DynamicMap`, Bokeh documents) may only
+be mutated on their own session's IOLoop — a hard constraint established in
+ADR 0005.
+
+One path crosses that boundary by design: the stale-session reaper runs on the
+ingestion thread (`SessionRegistry.cleanup_stale_sessions`), so
+`SessionUpdater` cleanup handlers execute off their own session's IOLoop and
+must be safe there.
 
 Historically, state changes propagated between these threads by two competing
 mechanisms:

--- a/docs/developer/adr/0007-single-writer-versioned-pull.md
+++ b/docs/developer/adr/0007-single-writer-versioned-pull.md
@@ -32,13 +32,15 @@ mechanisms:
 
 The 2026-07 audits (#1039, #1044; standalone issues #1040, #955; assessment
 #1042) showed the two mechanisms have sharply different defect profiles.
-Every confirmed cross-thread race, session leak, and category of compute waste
-was located in push machinery: registration racing ingestion, notify loops
-iterating live sets mutated by the UI thread, cross-session document mutation
-outside the document lock, the viewer gate and stash bolted onto the push path
-along with their documented races, and the rebinding chain that exists only to
-push "the job key changed" to consumers. The code built on versioned pull was
-audited clean. The same failure was fixed once before (#1007), in push code.
+Every confirmed cross-thread race and session leak was located in push
+machinery, and the audited compute waste concentrated in its delivery path:
+registration racing ingestion, notify loops iterating live sets mutated by
+the UI thread, cross-session document mutation outside the document lock, the
+viewer gate and stash bolted onto the push path along with their documented
+races, and the rebinding chain that exists only to push "the job key changed"
+to consumers. The code built on versioned pull had no concurrency findings
+(it has ordinary bugs like any code — e.g. buffer edge cases — but no races).
+The same failure was fixed once before (#1007), in push code.
 
 The structural reason: under push, thread-safety is a per-call-site
 obligation. Each new entry point (add-layer-while-running, heartbeat
@@ -101,9 +103,10 @@ Concretely:
   rebinding chain is deleted via stable keys (#1042 Option B); grid widgets
   move to version polling and reaper teardown moves to the owning IOLoop
   (#1040, #955).
-- Audited races #1039-2/3/9 and the session-leak items #1039-5/11 are removed
+- Audited races #1039-2/3/9 and the session-leak item #1039-11 are removed
   structurally rather than guarded; field symptoms #789 and #714 are expected
-  to resolve (verify after landing).
+  to resolve (verify after landing). (#1039-5 is a deterministic
+  index-mapping bug, not a race — it is fixed directly, outside this program.)
 - New features inherit safety by construction: a new consumer polls a version
   and pulls a snapshot; a new producer bumps a version. Review can enforce a
   simple rule — "who is the single writer, and where is the version?" —

--- a/docs/developer/adr/0007-single-writer-versioned-pull.md
+++ b/docs/developer/adr/0007-single-writer-versioned-pull.md
@@ -1,6 +1,6 @@
 # ADR 0007: Single-writer state with versioned pull as the dashboard concurrency model
 
-- Status: proposed
+- Status: accepted
 - Deciders: Simon
 - Date: 2026-07-05
 

--- a/docs/developer/adr/0007-single-writer-versioned-pull.md
+++ b/docs/developer/adr/0007-single-writer-versioned-pull.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Deciders: Simon
-- Date: 2026-07-05
+- Date: 2026-07-20
 
 ## Context
 

--- a/docs/developer/adr/0007-single-writer-versioned-pull.md
+++ b/docs/developer/adr/0007-single-writer-versioned-pull.md
@@ -1,0 +1,116 @@
+# ADR 0007: Single-writer state with versioned pull as the dashboard concurrency model
+
+- Status: proposed
+- Deciders: Simon
+- Date: 2026-07-05
+
+## Context
+
+The dashboard runs on three kinds of threads: the shared ingestion thread
+(`DashboardServices._update_loop`, draining Kafka and driving orchestrator
+updates at ~50 ms), each session's Tornado/Bokeh IOLoop (UI callbacks and the
+100 ms session poll, under that session's document lock), and the polling
+thread paths that run layer activation. Session-bound objects (`Pipe`,
+`DynamicMap`, Bokeh documents) may only be mutated on their own session's
+IOLoop — a hard constraint established in ADR 0005.
+
+Historically, state changes propagated between these threads by two competing
+mechanisms:
+
+1. **Synchronous push**: callbacks fanning out from the mutating thread,
+   carrying data or lifecycle events — `DataService` extracting and
+   delivering per subscriber inside ingestion (`_notify`), the
+   `JobOrchestrator` subscription registry notifying `LayerSubscription` /
+   `PlotOrchestrator` on job changes, and `PlotOrchestrator` lifecycle
+   notifications rebuilding every session's grid widgets from the mutating
+   session's thread.
+2. **Versioned pull**: a single writer updates authoritative state and bumps a
+   version counter; each consumer polls the version on its own clock and pulls
+   a snapshot when it changed — the pattern prescribed in
+   `.claude/rules/dashboard-widgets.md`, followed by the workflow-status
+   widgets, and (since ADR 0005) by the frame-gated session flush.
+
+The 2026-07 audits (#1039, #1044; standalone issues #1040, #955; assessment
+#1042) showed the two mechanisms have sharply different defect profiles.
+Every confirmed cross-thread race, session leak, and category of compute waste
+was located in push machinery: registration racing ingestion, notify loops
+iterating live sets mutated by the UI thread, cross-session document mutation
+outside the document lock, the viewer gate and stash bolted onto the push path
+along with their documented races, and the rebinding chain that exists only to
+push "the job key changed" to consumers. The code built on versioned pull was
+audited clean. The same failure was fixed once before (#1007), in push code.
+
+The structural reason: under push, thread-safety is a per-call-site
+obligation. Each new entry point (add-layer-while-running, heartbeat
+deactivation, the stale-session reaper) must remember every guard, and the
+audit trail shows each one independently missed some. Under versioned pull,
+safety is a property of the pattern: the writer is single, the version bump is
+atomic, and consumers read snapshots on their own thread.
+
+## Decision
+
+Single-writer state with versioned pull is the dashboard's concurrency and
+delivery model. Push is the exception and requires explicit justification.
+
+Concretely:
+
+- **Every piece of shared state has exactly one writing thread.** Other
+  threads request changes by enqueueing for the owner or mutating via a
+  narrowly-scoped, documented lock — never by direct multi-step mutation.
+- **State changes are observed by version, not by callback.** A writer bumps a
+  monotonic version (per key, grid, or subsystem as granularity requires);
+  consumers poll the version on their own clock (session poll, frame flush)
+  and pull an immutable snapshot when it advanced. Callbacks, where they
+  survive, carry no data — at most "something changed" wake-ups that
+  degrade to the next poll tick if lost.
+- **Data flows by pull at display cadence.** Ingestion records what changed
+  (dirty keys); extraction, copy, and compute happen when a consumer with a
+  viewer pulls — not eagerly per delta on the ingestion thread. "No viewers,
+  no work" is the default, not a gate.
+- **Session-bound mutation happens only on the owning session's IOLoop**
+  (reaffirming ADR 0005), including teardown paths such as the stale-session
+  reaper.
+- **Subscription identity is stable.** Keys a consumer subscribes under must
+  not embed ephemeral tokens (e.g. per-commit `job_number`); generation
+  discrimination is a filter at the ingest boundary, not part of consumer
+  identity. (Assessment: #1042, Option B.)
+
+## Alternatives considered
+
+- **Keep push, add locks** (the direction of the standalone lock/gate fixes,
+  e.g. serializing `DataService`, guarding `PlotOrchestrator` topology).
+  Rejected as the end state: each lock protects one call-site pattern, the
+  lock-ordering surface grows (`ingestion_guard` → service lock → document
+  lock), and nothing prevents the next feature from bypassing the guards —
+  the audited failure mode. Locks survive, but narrowly, protecting buffer
+  writes rather than delivery.
+- **Marshal all mutation onto session IOLoops** (`add_next_tick_callback`
+  everywhere). Rejected: Panel cannot resolve session context from background
+  threads (ADR 0005), fan-out to N sessions multiplies work, and shared
+  (non-session) state still needs an owner.
+- **Full actor model / message-passing rewrite.** Rejected as
+  disproportionate: versioned pull achieves the same isolation for this
+  system's shapes (one ingestion writer, per-session readers) with the
+  patterns already proven in the codebase.
+
+## Consequences
+
+- The three push planes converge on the model (tracked in #1046):
+  data delivery inverts to pull-on-frame (#1045, subsuming the viewer gate
+  #1043 and shrinking the #1009 lock to buffer writes); the job-identity
+  rebinding chain is deleted via stable keys (#1042 Option B); grid widgets
+  move to version polling and reaper teardown moves to the owning IOLoop
+  (#1040, #955).
+- Audited races #1039-2/3/9 and the session-leak items #1039-5/11 are removed
+  structurally rather than guarded; field symptoms #789 and #714 are expected
+  to resolve (verify after landing).
+- New features inherit safety by construction: a new consumer polls a version
+  and pulls a snapshot; a new producer bumps a version. Review can enforce a
+  simple rule — "who is the single writer, and where is the version?" —
+  instead of re-deriving interleavings per PR.
+- Worst-case freshness is bounded by the consumer's poll cadence (100 ms
+  session tick; see ADR 0005 for why this does not add visible latency over
+  push).
+- Cost: dirty-flag/version bookkeeping replaces eager delivery, and
+  during migration both mechanisms coexist — the migration is sequenced so
+  each step deletes more push machinery than it adds pull machinery.

--- a/docs/developer/adr/index.md
+++ b/docs/developer/adr/index.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-Lightweight records of load-bearing design decisions and their rationale. Each ADR captures one decision, immutable once accepted; superseding decisions get a new ADR that links back. Format follows [scipp's ADR convention](https://github.com/scipp/scipp/tree/main/docs/development/adr).
+Lightweight records of load-bearing design decisions and their rationale. Each ADR captures one decision. Accepted text is not rewritten: corrections and extensions land as a dated amendment section at the bottom, flagged in the status line, so the original stays readable as the reasoning of its time — an amended passage may gain a pointer to the amendment, nothing more. Reversing or replacing a decision gets a new ADR that links back. Format follows [scipp's ADR convention](https://github.com/scipp/scipp/tree/main/docs/development/adr).
 
 ```{toctree}
 ---


### PR DESCRIPTION
Draft ADR consolidating the root cause behind the audit bug clusters, per the analysis in #1046.

The 2026-07 audits (#1039, #1044, plus #1040, #955, and the assessment in #1042) located essentially every confirmed cross-thread race, session leak, and category of compute waste in one kind of code: synchronous push machinery (callbacks fanning out across threads and sessions carrying data or lifecycle events), while the code built on the version-polling pattern from `.claude/rules/dashboard-widgets.md` was audited clean. This ADR proposes making single-writer state + versioned pull the explicit, default concurrency and delivery model for the dashboard, so the three in-flight proposals (#1045 pull-on-frame, #1042 Option B, #1040's polling direction) are recognized as one architectural move and future features inherit the safe pattern by construction.

Status is `proposed` — this PR is meant as the concrete text to discuss and amend; the sequencing/execution program lives in #1046.

Refs #1046. Related: #1039, #1040, #1042, #1044, #955, #1043, #1045, #1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXpjcjaNvus3Qb1WEJefvQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXpjcjaNvus3Qb1WEJefvQ)_