### PR TITLE
tests: hostile-wire liveness harness and multi-session browser smoke test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ python -m venv .venv && source .venv/bin/activate && pip install -e ".[test]"
 - Tests in `tests/` mirror `src/ess/livedata/` structure, files follow `*_test.py`
 - All unit tests run without Kafka -- use fakes from `fakes.py`
 - `pytest` uses `--import-mode=importlib`
+- Robustness harnesses: `tests/helpers/hostile_wire.py` is the corpus of
+  malformed/insane wire payloads consumed by the adapter- and service-level
+  robustness tests (add new corruption modes there). Known holes are strict
+  `xfail`s referencing their issue; fixing the issue flips them loudly.
+- `pytest -m browser` runs local Playwright UI tests (fake backend, e.g. the
+  multi-session smoke test); excluded from the default run and CI.
 
 ```sh
 python -m pytest                      # fast tests only (~25s)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ addopts = """
 --strict-markers
 --import-mode=importlib
 --benchmark-skip
--m "not integration and not slow"
+-m "not integration and not slow and not browser"
 -ra
 """
 testpaths = "tests"
@@ -112,6 +112,7 @@ markers = [
   "instrument: Specify instrument name for parameterized tests",
   "services: Specify which services to use in integration_env fixture (monitor, detector, or reduction)",
   "slow: Slow tests (>2s) excluded by default, run in CI via tox",
+  "browser: Browser-driven (Playwright) UI tests; run locally, excluded from CI",
 ]
 filterwarnings = [
   "error",

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -15,6 +15,9 @@ Two ways to use it:
           dash.goto_tab("Detectors")
           dash.screenshot("plots.png")
 
+  For multi-session scenarios (state is process-global, widgets per-session),
+  :meth:`Dashboard.connect_many` opens n isolated sessions on one server.
+
 * As a **CLI** against a running server, or self-launching a Kafka-free fake
   backend seeded from the committed dummy fixture::
 
@@ -36,6 +39,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import socket
 import subprocess
@@ -48,6 +52,7 @@ from pathlib import Path
 from urllib.error import URLError
 
 from playwright.sync_api import (
+    Browser,
     Page,
     sync_playwright,
 )
@@ -63,6 +68,23 @@ DEFAULT_URL = f"http://localhost:{DEFAULT_PORT}"
 # Time for Bokeh models to settle / the first refresh tick to rebuild rows after
 # load, before any click. See the "cold start" window in the rule file.
 SETTLE_MS = 5000
+# Override the Chromium binary when the installed playwright package does not
+# match the browsers available on disk (e.g. a preprovisioned container).
+_CHROMIUM_ENV = "PLAYWRIGHT_CHROMIUM_EXECUTABLE"
+
+
+def _launch_browser(playwright) -> Browser:
+    executable = os.environ.get(_CHROMIUM_ENV)
+    return playwright.chromium.launch(executable_path=executable or None)
+
+
+def _open_session(browser: Browser, url: str, settle_ms: int) -> Page:
+    """One dashboard session: an isolated context, loaded and settled."""
+    context = browser.new_context(viewport={"width": 1600, "height": 1000})
+    page = context.new_page()
+    page.goto(url, wait_until="networkidle")
+    page.wait_for_timeout(settle_ms)
+    return page
 
 
 class Dashboard:
@@ -76,12 +98,30 @@ class Dashboard:
     def connect(cls, url: str = DEFAULT_URL, *, settle_ms: int = SETTLE_MS):
         """Open a browser on a running dashboard, waiting for it to settle."""
         with sync_playwright() as p:
-            browser = p.chromium.launch()
-            page = browser.new_page(viewport={"width": 1600, "height": 1000})
-            page.goto(url, wait_until="networkidle")
-            page.wait_for_timeout(settle_ms)
+            browser = _launch_browser(p)
             try:
-                yield cls(page)
+                yield cls(_open_session(browser, url, settle_ms))
+            finally:
+                browser.close()
+
+    @classmethod
+    @contextmanager
+    def connect_many(
+        cls, n: int, url: str = DEFAULT_URL, *, settle_ms: int = SETTLE_MS
+    ):
+        """Open ``n`` independent sessions on the same running dashboard.
+
+        Each session gets its own isolated browser context -- own websocket,
+        own Bokeh session -- like ``n`` separate users. Sessions connect
+        sequentially, so the returned list is ordered oldest first; use this
+        to script late-joiner scenarios (dashboard state is process-global,
+        widgets are per-session, so "renders in one session but not another"
+        is the classic multi-session regression).
+        """
+        with sync_playwright() as p:
+            browser = _launch_browser(p)
+            try:
+                yield [cls(_open_session(browser, url, settle_ms)) for _ in range(n)]
             finally:
                 browser.close()
 

--- a/tests/dashboard/multisession_smoke_test.py
+++ b/tests/dashboard/multisession_smoke_test.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Multi-session smoke test: every session sees plots and keeps receiving data.
+
+Dashboard state (orchestrators, DataService, plot layers) is process-global
+while widgets and Bokeh documents are per-session, so the classic regression
+class is asymmetry between sessions: a plot renders in one session but not
+another (#789), a late joiner sees stale or missing data, or activity in one
+session stalls delivery to another. Until now this was only covered by the
+recurring manual test-plan item "check with 2+ browser sessions" (e.g. the
+manual checklists in #1009 and #1043).
+
+This drives the Kafka-free fake backend (seeded from the committed dummy
+fixture, updating at 1 Hz) with two Playwright sessions and walks the manual
+checklist once: a late-joining session must see the same tabs and populated
+plots, both sessions must keep receiving updates, and tab switching in one
+session must disturb neither. It is deliberately behavioral -- it observes
+rendered ColumnDataSource contents, not internals -- so it stays valid across
+delivery-mechanism refactors (#1045, #1046).
+
+Runs locally via ``pytest -m browser`` (excluded from the default run and CI;
+skips cleanly where Playwright is absent).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+pytest.importorskip("playwright.sync_api")
+from drive_dashboard import Dashboard, _fake_dashboard  # noqa: E402
+
+# How long to watch for a data update before declaring a session stalled. The
+# fake backend emits at 1 Hz, so this is a generous margin.
+_UPDATE_WINDOW_MS = 6000
+
+# Fingerprint of all rendered ColumnDataSource data in the page: source and
+# column-length counts plus a value checksum (sampling nested/typed arrays, so
+# image payloads contribute). Any data update changes it.
+_DATA_FINGERPRINT_JS = """() => {
+  let sources = 0, length = 0, checksum = 0;
+  const sample = (column) => {
+    for (let i = 0; i < Math.min(column.length, 64); i++) {
+      const v = column[i];
+      if (typeof v === 'number' && Number.isFinite(v)) checksum += v;
+      else if (v && typeof v.length === 'number') sample(v);
+    }
+  };
+  for (const doc of (window.Bokeh && Bokeh.documents) || []) {
+    for (const m of Array.from(doc._all_models.values())) {
+      if (m.type === 'ColumnDataSource') {
+        sources++;
+        for (const column of Object.values(m.data)) {
+          length += column.length;
+          sample(column);
+        }
+      }
+    }
+  }
+  return {sources, length, checksum};
+}"""
+
+
+def _fingerprint(dash: Dashboard) -> dict:
+    return dash.page.evaluate(_DATA_FINGERPRINT_JS)
+
+
+def _assert_updating(dash: Dashboard, label: str) -> None:
+    before = _fingerprint(dash)
+    dash.page.wait_for_timeout(_UPDATE_WINDOW_MS)
+    after = _fingerprint(dash)
+    assert after != before, f"{label} stopped receiving data updates: {before}"
+
+
+@pytest.mark.browser
+def test_two_sessions_see_plots_and_keep_receiving_updates():
+    with (
+        _fake_dashboard("dummy", 5032) as url,
+        Dashboard.connect_many(2, url) as (
+            first,
+            second,
+        ),
+    ):
+        # The late joiner (second) must see the same UI as the first session.
+        assert second.tab_names() == first.tab_names()
+        assert "Detectors" in second.tab_names()
+
+        first.goto_tab("Detectors")
+        second.goto_tab("Detectors")
+
+        # Both sessions render populated plots, including the session that
+        # joined after the workflows were already running.
+        for label, dash in [("first session", first), ("second session", second)]:
+            fp = _fingerprint(dash)
+            assert fp["sources"] > 0, f"{label} rendered no data sources"
+            assert fp["length"] > 0, f"{label} rendered only empty data sources"
+
+        # Both sessions keep receiving live updates.
+        _assert_updating(first, "first session")
+        _assert_updating(second, "second session")
+
+        # Tab switching in one session must not stall delivery to either: the
+        # switching session must resume on return, the other must be unaffected.
+        second.goto_tab("Workflows")
+        second.goto_tab("Detectors")
+        _assert_updating(second, "second session after tab switch")
+        _assert_updating(first, "first session while other session switched tabs")

--- a/tests/helpers/hostile_wire.py
+++ b/tests/helpers/hostile_wire.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Corpus of hostile wire-level payloads for boundary-robustness testing.
+
+The backend trusts values decoded from Kafka payloads (most critically
+timestamps, which serve as the batcher's clock). This module provides
+serialized payloads that a broken or misconfigured upstream producer could
+emit, in two families:
+
+- **Malformed**: payloads that fail to decode or violate the schema's
+  structural assumptions (garbage bytes, truncated flatbuffers, absent event
+  vectors). These exercise the per-message containment in
+  ``AdaptingMessageSource``.
+- **Well-formed but insane**: payloads that decode fine but carry data-derived
+  values no sane producer would send, e.g. timestamps centuries in the future.
+  These exercise (currently: document the absence of) validation at the
+  adapter boundary — see #1038 and #1047.
+
+Used by ``tests/kafka/adapter_robustness_test.py`` (adapter-level containment
+and timestamp-bound invariants) and
+``tests/services/hostile_input_liveness_test.py`` (service-level liveness).
+Add new corruption modes here so both layers pick them up.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from streaming_data_types import (
+    area_detector_ad00,
+    dataarray_da00,
+    eventdata_ev44,
+    logdata_f144,
+)
+from streaming_data_types.fbschemas.eventdata_ev44 import Event44Message
+
+# 2200-01-01 in nanoseconds since epoch: decodes fine, but is beyond any
+# plausible wall clock or test-data timestamp. A single message carrying this
+# as its data-derived timestamp is the reproduced trigger for the batcher
+# wedge in #1038 (finding 1).
+FAR_FUTURE_NS = 7_258_118_400 * 1_000_000_000
+
+# 2026-01-01: a fixed, deterministic "realistic" base time for good messages.
+REALISTIC_EPOCH_NS = 1_767_225_600 * 1_000_000_000
+
+
+def ev44_events(
+    source_name: str,
+    *,
+    reference_time_ns: int | None,
+    n_events: int = 10,
+    seed: int = 0,
+) -> bytes:
+    """Well-formed ev44 event data with an explicit data-derived timestamp.
+
+    Parameters
+    ----------
+    source_name:
+        Source name stored in the payload.
+    reference_time_ns:
+        Value for ``reference_time[-1]``, which the adapters use as the
+        message timestamp. ``None`` leaves the vector empty so adapters fall
+        back to the Kafka message timestamp.
+    n_events:
+        Number of events in the payload.
+    seed:
+        Seed for the event time-of-arrival values.
+
+    Returns
+    -------
+    :
+        Serialized ev44 payload.
+    """
+    rng = np.random.default_rng(seed)
+    time_of_arrival = rng.uniform(0, 70_000_000, n_events).astype(np.int32)
+    reference_time = [] if reference_time_ns is None else [reference_time_ns]
+    return eventdata_ev44.serialise_ev44(
+        source_name=source_name,
+        message_id=0,
+        reference_time=reference_time,
+        reference_time_index=0,
+        time_of_flight=time_of_arrival,
+        pixel_id=np.zeros(n_events, dtype=np.int32),
+    )
+
+
+def ev44_without_event_vectors(source_name: str) -> bytes:
+    """ev44 payload whose event vectors are absent (not just empty).
+
+    ``serialise_ev44`` always writes the vectors, but the flatbuffer schema
+    does not require them, so other producers can omit them. The
+    flatbuffers-python accessors then return scalar ``0`` instead of an empty
+    array, which trips code expecting ``.size``/``len()`` — see #1038
+    (finding 2).
+    """
+    import flatbuffers
+
+    builder = flatbuffers.Builder(64)
+    builder.ForceDefaults(True)
+    source = builder.CreateString(source_name)
+    Event44Message.Event44MessageStart(builder)
+    Event44Message.Event44MessageAddMessageId(builder, 0)
+    Event44Message.Event44MessageAddSourceName(builder, source)
+    data = Event44Message.Event44MessageEnd(builder)
+    builder.Finish(data, file_identifier=eventdata_ev44.FILE_IDENTIFIER)
+    return bytes(builder.Output())
+
+
+def f144_log(source_name: str, *, timestamp_ns: int, value: float = 1.0) -> bytes:
+    """Well-formed f144 log datum with an explicit data-derived timestamp."""
+    return logdata_f144.serialise_f144(
+        source_name=source_name, value=value, timestamp_unix_ns=timestamp_ns
+    )
+
+
+def da00_array(
+    source_name: str,
+    *,
+    timestamp_ns: int,
+    reference_time_ns: int | None = None,
+    reference_time_dtype: type = np.int64,
+) -> bytes:
+    """Well-formed da00 data array, optionally with a reference_time variable.
+
+    Parameters
+    ----------
+    source_name:
+        Source name stored in the payload.
+    timestamp_ns:
+        Top-level ``timestamp_ns`` (the fallback timestamp).
+    reference_time_ns:
+        If given, a ``reference_time`` variable is included; adapters prefer
+        its last value over ``timestamp_ns``.
+    reference_time_dtype:
+        Dtype of the reference_time data. Dtypes other than int64/uint64 are
+        rejected by ``_extract_reference_time`` (fallback to ``timestamp_ns``).
+    """
+    variables = [
+        dataarray_da00.Variable(
+            name='signal',
+            data=np.arange(4, dtype=np.float64),
+            axes=['x'],
+            unit='counts',
+        )
+    ]
+    if reference_time_ns is not None:
+        variables.append(
+            dataarray_da00.Variable(
+                name='reference_time',
+                data=np.array([reference_time_ns], dtype=reference_time_dtype),
+                axes=['time'],
+                unit='ns',
+            )
+        )
+    return dataarray_da00.serialise_da00(
+        source_name=source_name, timestamp_ns=timestamp_ns, data=variables
+    )
+
+
+def ad00_frame(source_name: str, *, timestamp_ns: int) -> bytes:
+    """Well-formed ad00 area-detector frame with an explicit timestamp."""
+    return area_detector_ad00.serialise_ad00(
+        source_name=source_name,
+        unique_id=1,
+        timestamp_ns=timestamp_ns,
+        data=np.zeros((2, 2), dtype=np.uint16),
+    )
+
+
+def garbage_bytes() -> bytes:
+    """Deterministic bytes that are not a flatbuffer of any schema."""
+    return bytes(range(256)) * 4
+
+
+def truncated(payload: bytes, keep: int = 12) -> bytes:
+    """Truncate a valid payload so the schema id survives but the body breaks.
+
+    Flatbuffer schema identifiers live at bytes 4:8, so ``keep >= 8`` keeps
+    schema routing working while decoding fails.
+    """
+    return payload[:keep]
+
+
+def malformed_corpus(source_name: str) -> dict[str, bytes]:
+    """All malformed payloads, keyed by case id.
+
+    Every entry must be *contained* by the adapter layer: dropped (possibly
+    with a logged error) without the exception escaping and without affecting
+    the handling of subsequent messages.
+    """
+    return {
+        'garbage': garbage_bytes(),
+        'empty': b'',
+        'truncated_ev44': truncated(
+            ev44_events(source_name, reference_time_ns=REALISTIC_EPOCH_NS)
+        ),
+        'ev44_without_event_vectors': ev44_without_event_vectors(source_name),
+        'wrong_schema_f144': f144_log(source_name, timestamp_ns=REALISTIC_EPOCH_NS),
+        'unmapped_source': ev44_events(
+            'not_a_known_source', reference_time_ns=REALISTIC_EPOCH_NS
+        ),
+    }

--- a/tests/helpers/hostile_wire.py
+++ b/tests/helpers/hostile_wire.py
@@ -42,6 +42,12 @@ FAR_FUTURE_NS = 7_258_118_400 * 1_000_000_000
 # 2026-01-01: a fixed, deterministic "realistic" base time for good messages.
 REALISTIC_EPOCH_NS = 1_767_225_600 * 1_000_000_000
 
+# ~1938 (negative nanosecond epoch): physically impossible as a data timestamp.
+# Note there is deliberately no "too old" analogue of the far-future adapter
+# invariant: consuming a Kafka backlog makes genuinely old timestamps
+# legitimate, so pre-epoch values are exercised for service *liveness* only.
+PRE_EPOCH_NS = -(10**18)
+
 
 def ev44_events(
     source_name: str,
@@ -103,6 +109,27 @@ def ev44_without_event_vectors(source_name: str) -> bytes:
     data = Event44Message.Event44MessageEnd(builder)
     builder.Finish(data, file_identifier=eventdata_ev44.FILE_IDENTIFIER)
     return bytes(builder.Output())
+
+
+def ev44_mismatched_event_vectors(
+    source_name: str, *, reference_time_ns: int, n_events: int = 10
+) -> bytes:
+    """ev44 payload whose per-event vectors disagree in length.
+
+    ``time_of_flight`` carries ``n_events`` entries but ``pixel_id`` only half
+    as many. The schema cannot express which is authoritative, so consumers
+    must not index one by the other's length. Not in :func:`malformed_corpus`:
+    the plain (non-pixellated) monitor path deliberately ignores ``pixel_id``
+    and *accepts* this payload, so "must be dropped" is not its contract.
+    """
+    return eventdata_ev44.serialise_ev44(
+        source_name=source_name,
+        message_id=0,
+        reference_time=[reference_time_ns],
+        reference_time_index=0,
+        time_of_flight=np.arange(n_events, dtype=np.int32),
+        pixel_id=np.zeros(n_events // 2, dtype=np.int32),
+    )
 
 
 def f144_log(source_name: str, *, timestamp_ns: int, value: float = 1.0) -> bytes:

--- a/tests/kafka/adapter_robustness_test.py
+++ b/tests/kafka/adapter_robustness_test.py
@@ -87,6 +87,20 @@ def test_malformed_payload_is_contained_and_does_not_affect_next_message(
     assert adapted[0].timestamp == Timestamp.from_ns(GOOD_TIME_NS)
 
 
+def test_ev44_mismatched_event_vectors_accepted_on_plain_monitor_path() -> None:
+    """Pins current behavior: for non-pixellated monitors ``pixel_id`` is
+    ignored, so a payload with disagreeing vector lengths adapts cleanly and
+    all time-of-arrival entries survive. (The detector path, where the
+    mismatch matters, is tracked in #1054.)
+    """
+    payload = hostile_wire.ev44_mismatched_event_vectors(
+        SOURCE, reference_time_ns=GOOD_TIME_NS
+    )
+    adapted = _monitor_adapter().adapt(_kafka_message(payload))
+    assert adapted.timestamp == Timestamp.from_ns(GOOD_TIME_NS)
+    assert len(adapted.value.time_of_arrival) == 10
+
+
 @pytest.mark.xfail(
     strict=True,
     reason='#1038 finding 2: absent event vectors raise deep in the adapter '

--- a/tests/kafka/adapter_robustness_test.py
+++ b/tests/kafka/adapter_robustness_test.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Adapter-boundary robustness against hostile wire payloads.
+
+Two invariants, driven by the corpus in ``tests/helpers/hostile_wire``:
+
+1. **Containment** (holds today, guarded here against regression): a payload
+   that cannot be adapted is dropped by ``AdaptingMessageSource`` without the
+   exception escaping and without affecting subsequent messages.
+2. **Timestamp sanity** (does not hold today — strict xfail): data-derived
+   timestamps should be bounded against the wall clock before crossing the
+   adapter boundary, because the batcher uses them as its only clock and a
+   single far-future value wedges the whole service (#1038 finding 1). These
+   tests are the acceptance criterion for the boundary-validation layer
+   proposed in #1047: when it lands, the xfails flip to XPASS (strict, so
+   pytest will insist the markers are removed). Any resolution — dropping,
+   clamping, or falling back to the Kafka broker timestamp — satisfies the
+   assertion as written.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+import pytest
+
+from ess.livedata.core.message import StreamKind
+from ess.livedata.core.timestamp import Timestamp
+from ess.livedata.kafka.message_adapter import (
+    AdaptingMessageSource,
+    FakeKafkaMessage,
+    KafkaAdapter,
+    KafkaMessage,
+    KafkaToAd00Adapter,
+    KafkaToDa00Adapter,
+    KafkaToEv44Adapter,
+    KafkaToF144Adapter,
+    KafkaToMonitorEventsAdapter,
+)
+from ess.livedata.kafka.stream_mapping import InputStreamKey
+from tests.helpers import hostile_wire
+
+TOPIC = 'dummy_beam_monitor'
+SOURCE = 'monitor1'
+GOOD_TIME_NS = hostile_wire.REALISTIC_EPOCH_NS
+
+# Data-derived timestamps further than this ahead of the wall clock have no
+# legitimate producer; they must not cross the adapter boundary unmodified.
+FUTURE_TOLERANCE_NS = 24 * 3600 * 1_000_000_000
+
+
+class ListSource:
+    """Message source yielding a fixed list of raw Kafka messages once."""
+
+    def __init__(self, messages: Sequence[KafkaMessage]) -> None:
+        self._messages = list(messages)
+
+    def get_messages(self) -> Sequence[KafkaMessage]:
+        messages, self._messages = self._messages, []
+        return messages
+
+
+def _monitor_adapter() -> KafkaToMonitorEventsAdapter:
+    lut = {InputStreamKey(topic=TOPIC, source_name=SOURCE): SOURCE}
+    return KafkaToMonitorEventsAdapter(lut)
+
+
+def _kafka_message(payload: bytes, timestamp_ms: int = 1234) -> FakeKafkaMessage:
+    return FakeKafkaMessage(
+        value=payload, topic=TOPIC, timestamp=timestamp_ms, timestamp_type=1
+    )
+
+
+@pytest.mark.parametrize('case', sorted(hostile_wire.malformed_corpus(SOURCE)))
+def test_malformed_payload_is_contained_and_does_not_affect_next_message(
+    case: str,
+) -> None:
+    payloads = hostile_wire.malformed_corpus(SOURCE)
+    good = hostile_wire.ev44_events(SOURCE, reference_time_ns=GOOD_TIME_NS)
+    source = AdaptingMessageSource(
+        source=ListSource([_kafka_message(payloads[case]), _kafka_message(good)]),
+        adapter=_monitor_adapter(),
+    )
+    adapted = source.get_messages()
+    assert len(adapted) == 1
+    assert adapted[0].timestamp == Timestamp.from_ns(GOOD_TIME_NS)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='#1038 finding 2: absent event vectors raise deep in the adapter '
+    'and the message is dropped instead of using the Kafka-timestamp fallback',
+)
+def test_ev44_without_event_vectors_falls_back_to_kafka_timestamp() -> None:
+    payload = hostile_wire.ev44_without_event_vectors(SOURCE)
+    message = _kafka_message(payload, timestamp_ms=5678)
+    adapted = _monitor_adapter().adapt(message)
+    assert adapted.timestamp == Timestamp.from_ms(5678)
+
+
+def _far_future_cases() -> list[tuple[str, KafkaAdapter, bytes]]:
+    """One (adapter, payload) pair per data-derived timestamp entry point."""
+    far = hostile_wire.FAR_FUTURE_NS
+    return [
+        (
+            'ev44',
+            KafkaToEv44Adapter(stream_kind=StreamKind.DETECTOR_EVENTS),
+            hostile_wire.ev44_events(SOURCE, reference_time_ns=far),
+        ),
+        (
+            'ev44_monitor',
+            _monitor_adapter(),
+            hostile_wire.ev44_events(SOURCE, reference_time_ns=far),
+        ),
+        (
+            'f144',
+            KafkaToF144Adapter(),
+            hostile_wire.f144_log(SOURCE, timestamp_ns=far),
+        ),
+        (
+            'da00_reference_time',
+            KafkaToDa00Adapter(stream_kind=StreamKind.MONITOR_COUNTS),
+            hostile_wire.da00_array(
+                SOURCE, timestamp_ns=GOOD_TIME_NS, reference_time_ns=far
+            ),
+        ),
+        (
+            'da00_timestamp_ns',
+            KafkaToDa00Adapter(stream_kind=StreamKind.MONITOR_COUNTS),
+            hostile_wire.da00_array(SOURCE, timestamp_ns=far),
+        ),
+        (
+            'ad00',
+            KafkaToAd00Adapter(stream_kind=StreamKind.AREA_DETECTOR),
+            hostile_wire.ad00_frame(SOURCE, timestamp_ns=far),
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ('adapter', 'payload'),
+    [pytest.param(a, p, id=name) for name, a, p in _far_future_cases()],
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason='#1038 finding 1 / #1047: data-derived timestamps cross the '
+    'adapter boundary unvalidated; a single far-future value wedges the '
+    'batcher service-wide',
+)
+def test_far_future_data_timestamp_does_not_cross_adapter_boundary(
+    adapter: KafkaAdapter, payload: bytes
+) -> None:
+    source = AdaptingMessageSource(
+        source=ListSource([_kafka_message(payload)]), adapter=adapter
+    )
+    bound = time.time_ns() + FUTURE_TOLERANCE_NS
+    for message in source.get_messages():
+        assert message.timestamp.to_ns() <= bound
+
+
+def test_da00_non_int64_reference_time_falls_back_to_timestamp_ns() -> None:
+    """The existing dtype guard: int32 reference_time cannot hold nanosecond
+    epochs, so the adapter must ignore it in favor of the top-level timestamp.
+    """
+    import numpy as np
+
+    payload = hostile_wire.da00_array(
+        SOURCE,
+        timestamp_ns=GOOD_TIME_NS,
+        reference_time_ns=12345,
+        reference_time_dtype=np.int32,
+    )
+    adapter = KafkaToDa00Adapter(stream_kind=StreamKind.MONITOR_COUNTS)
+    adapted = adapter.adapt(_kafka_message(payload))
+    assert adapted.timestamp == Timestamp.from_ns(GOOD_TIME_NS)

--- a/tests/services/hostile_input_liveness_test.py
+++ b/tests/services/hostile_input_liveness_test.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Service liveness under hostile wire input, with production batching.
+
+Most service-level tests run with ``NaiveMessageBatcher``, which emits every
+poll as a batch and therefore cannot detect the most severe corruption class
+found in the backend audit (#1038): inputs that stall the *production*
+batcher, silently stopping all output service-wide while the process looks
+healthy. This harness runs the monitor service with the production-default
+``AdaptiveMessageBatcher`` (wrapping ``SimpleMessageBatcher``, which uses
+data-derived timestamps as its only clock) and asserts one invariant:
+
+    After consuming any single hostile payload, the service still publishes
+    results for subsequent well-formed data.
+
+Payloads come from ``tests/helpers/hostile_wire``. Cases the current code
+survives are regression guards; the reproduced wedge (#1038 finding 1) is a
+strict xfail that doubles as the acceptance test for the adapter-boundary
+validation proposed in #1047.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from ess.livedata.config import instrument_registry, workflow_spec
+from ess.livedata.config.workflow_spec import JobId
+from ess.livedata.core.message import StreamKind
+from ess.livedata.core.message_batcher import AdaptiveMessageBatcher
+from ess.livedata.services.monitor_data import make_monitor_service_builder
+from tests.helpers import hostile_wire
+from tests.helpers.livedata_app import LivedataApp
+
+SOURCE = 'monitor1'
+SECOND_NS = 1_000_000_000
+
+
+def _monitor_workflow_id(instrument: str) -> workflow_spec.WorkflowId:
+    config = instrument_registry[instrument]
+    for wid, spec in config.workflow_factory.items():
+        if spec.group.name == 'monitor_data':
+            return wid
+    raise ValueError(f'No monitor_data workflow for {instrument}')
+
+
+class MonitorServiceHarness:
+    """Monitor service with production batching and a running workflow.
+
+    Publishes well-formed monitor events with steadily advancing data-derived
+    timestamps (the batcher's clock) and observes published workflow results.
+    """
+
+    def __init__(self) -> None:
+        builder = make_monitor_service_builder(instrument='dummy')
+        # Production default; LivedataApp would otherwise install the naive
+        # batcher, which hides batching-level failure modes.
+        builder.message_batcher = AdaptiveMessageBatcher()
+        self.app = LivedataApp.from_service_builder(
+            builder, use_naive_message_batcher=False
+        )
+        self._time_ns = hostile_wire.REALISTIC_EPOCH_NS
+        self._seed = 0
+        workflow_config = workflow_spec.WorkflowConfig(
+            identifier=_monitor_workflow_id('dummy'),
+            job_id=JobId(source_name=SOURCE, job_number=uuid.uuid4()),
+        )
+        self.app.publish_config_message(workflow_config)
+        self.app.step()
+
+    def publish_payload(self, payload: bytes) -> None:
+        """Queue a raw payload on the monitor topic without stepping."""
+        self.app.publish_data(topic=self.app.monitor_topic, time=0, data=payload)
+
+    def publish_good(self) -> None:
+        """Queue a well-formed event message one second after the previous."""
+        self._time_ns += SECOND_NS
+        self._seed += 1
+        self.publish_payload(
+            hostile_wire.ev44_events(
+                SOURCE, reference_time_ns=self._time_ns, seed=self._seed
+            )
+        )
+
+    def result_count(self) -> int:
+        return sum(
+            1
+            for m in self.app.sink.messages
+            if m.stream.kind == StreamKind.LIVEDATA_DATA
+        )
+
+    def run_good_cycles(self, n: int) -> int:
+        """Publish+process n good messages; return results gained."""
+        before = self.result_count()
+        for _ in range(n):
+            self.publish_good()
+            self.app.step()
+        return self.result_count() - before
+
+
+@pytest.fixture
+def harness() -> MonitorServiceHarness:
+    return MonitorServiceHarness()
+
+
+def assert_service_live(harness: MonitorServiceHarness, cycles: int = 10) -> None:
+    """The service publishes new results as well-formed data keeps arriving.
+
+    The production batcher holds back the trailing batch until later data
+    closes it, so we require growth over the window, not one result per cycle.
+    """
+    assert harness.run_good_cycles(cycles) > 0
+
+
+def test_baseline_service_is_live(harness: MonitorServiceHarness) -> None:
+    """Harness sanity: without hostile input, results flow."""
+    harness.publish_good()
+    harness.app.step()
+    assert_service_live(harness)
+
+
+@pytest.mark.parametrize('case', sorted(hostile_wire.malformed_corpus(SOURCE)))
+def test_malformed_payload_does_not_stall_service(
+    harness: MonitorServiceHarness, case: str
+) -> None:
+    """Malformed payloads are contained per-message; output keeps flowing."""
+    harness.publish_good()
+    harness.app.step()
+    harness.publish_payload(hostile_wire.malformed_corpus(SOURCE)[case])
+    harness.app.step()
+    assert_service_live(harness)
+
+
+def test_far_future_timestamp_mid_stream_does_not_stall_service(
+    harness: MonitorServiceHarness,
+) -> None:
+    """A far-future timestamp *after* the first batch degrades the batcher
+    (the message lingers as a pending future message) but must not stop
+    output. Guards the boundary of the wedge in #1038 finding 1.
+    """
+    harness.run_good_cycles(3)
+    harness.publish_payload(
+        hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.FAR_FUTURE_NS)
+    )
+    harness.app.step()
+    assert_service_live(harness)
+
+
+def test_ancient_timestamp_mid_stream_does_not_stall_service(
+    harness: MonitorServiceHarness,
+) -> None:
+    """A near-epoch timestamp mid-stream counts as a late message; it lands in
+    the current batch and must not disturb batch progression.
+    """
+    harness.run_good_cycles(3)
+    harness.publish_payload(hostile_wire.ev44_events(SOURCE, reference_time_ns=1))
+    harness.app.step()
+    assert_service_live(harness)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason='#1038 finding 1 / #1047: a far-future data timestamp in the first '
+    'consumed batch becomes the batch boundary, after which no batch is ever '
+    'emitted — the service goes silent while appearing healthy',
+)
+def test_far_future_timestamp_in_first_batch_does_not_stall_service(
+    harness: MonitorServiceHarness,
+) -> None:
+    harness.publish_payload(
+        hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.FAR_FUTURE_NS)
+    )
+    harness.publish_good()
+    harness.app.step()
+    assert_service_live(harness, cycles=20)

--- a/tests/services/hostile_input_liveness_test.py
+++ b/tests/services/hostile_input_liveness_test.py
@@ -73,13 +73,17 @@ class MonitorServiceHarness:
         """Queue a raw payload on the monitor topic without stepping."""
         self.app.publish_data(topic=self.app.monitor_topic, time=0, data=payload)
 
+    def next_time_ns(self) -> int:
+        """Advance and return the data clock, for hand-built in-sequence payloads."""
+        self._time_ns += SECOND_NS
+        return self._time_ns
+
     def publish_good(self) -> None:
         """Queue a well-formed event message one second after the previous."""
-        self._time_ns += SECOND_NS
         self._seed += 1
         self.publish_payload(
             hostile_wire.ev44_events(
-                SOURCE, reference_time_ns=self._time_ns, seed=self._seed
+                SOURCE, reference_time_ns=self.next_time_ns(), seed=self._seed
             )
         )
 
@@ -147,14 +151,53 @@ def test_far_future_timestamp_mid_stream_does_not_stall_service(
     assert_service_live(harness)
 
 
+@pytest.mark.parametrize(
+    'timestamp_ns',
+    [1, hostile_wire.PRE_EPOCH_NS],
+    ids=['near_epoch', 'pre_epoch'],
+)
 def test_ancient_timestamp_mid_stream_does_not_stall_service(
-    harness: MonitorServiceHarness,
+    harness: MonitorServiceHarness, timestamp_ns: int
 ) -> None:
-    """A near-epoch timestamp mid-stream counts as a late message; it lands in
-    the current batch and must not disturb batch progression.
+    """An ancient (even pre-epoch) timestamp mid-stream counts as a late
+    message; it lands in the current batch and must not disturb progression.
     """
     harness.run_good_cycles(3)
-    harness.publish_payload(hostile_wire.ev44_events(SOURCE, reference_time_ns=1))
+    harness.publish_payload(
+        hostile_wire.ev44_events(SOURCE, reference_time_ns=timestamp_ns)
+    )
+    harness.app.step()
+    assert_service_live(harness)
+
+
+def test_pre_epoch_timestamp_in_first_batch_does_not_stall_service(
+    harness: MonitorServiceHarness,
+) -> None:
+    """The mirror of the far-future wedge: an initial batch opening at a
+    pre-epoch time only stretches the first batch backwards; subsequent
+    batches align to the newest data and output must keep flowing.
+    """
+    harness.publish_payload(
+        hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.PRE_EPOCH_NS)
+    )
+    harness.publish_good()
+    harness.app.step()
+    assert_service_live(harness)
+
+
+def test_mismatched_event_vectors_do_not_stall_service(
+    harness: MonitorServiceHarness,
+) -> None:
+    """Disagreeing time_of_flight/pixel_id lengths adapt on the monitor path
+    (pixel_id is unused there); nothing downstream may index one vector by
+    the other's length.
+    """
+    harness.run_good_cycles(3)
+    harness.publish_payload(
+        hostile_wire.ev44_mismatched_event_vectors(
+            SOURCE, reference_time_ns=harness.next_time_ns()
+        )
+    )
     harness.app.step()
     assert_service_live(harness)
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ isolated_build = true
 deps = -r requirements/test.txt
 setenv =
   JUPYTER_PLATFORM_DIRS = 1
-# Override pyproject.toml addopts to include slow tests in CI
-commands = pytest -m "not integration" {posargs}
+# Override pyproject.toml addopts: include slow tests, still skip browser tests
+commands = pytest -m "not integration and not browser" {posargs}
 
 [testenv:integration]
 description = Run integration tests (requires Kafka to be running)
@@ -21,16 +21,16 @@ deps = -r requirements/nightly.txt
 setenv =
   PIP_INDEX_URL = https://pypi.anaconda.org/scipp-nightly-wheels/simple
   PIP_EXTRA_INDEX_URL = https://pypi.org/simple
-# Override pyproject.toml addopts to include slow tests in CI
-commands = pytest -m "not integration" {posargs}
+# Override pyproject.toml addopts: include slow tests, still skip browser tests
+commands = pytest -m "not integration and not browser" {posargs}
 
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.
 deps =
   -r requirements/basetest.txt
   esslivedata
-# Override pyproject.toml addopts to include slow tests in CI
-commands = pytest -m "not integration" {posargs}
+# Override pyproject.toml addopts: include slow tests, still skip browser tests
+commands = pytest -m "not integration and not browser" {posargs}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
## Motivation

Two validation gaps let whole classes of errors through untested, both aimed at boundaries the ongoing dashboard restructuring (#1046) will not move:

1. **The backend's worst known error class is invisible to the test suite.** Service-level tests run with `NaiveMessageBatcher`, so the production `AdaptiveMessageBatcher` — which the audit (#1038) showed is permanently wedged by a single far-future data timestamp, silencing the entire service — is never exercised. Nothing feeds malformed or insane payloads through the real adapter wiring.
2. **Multi-session dashboard behavior is manual-only.** Nearly every concurrency PR carries the same unchecked item ("manual: check with 2+ browser sessions", e.g. #1009, #1043), and #789 is exactly that regression class in the field.

## What

**Hostile-wire corpus + liveness harness** (runs in CI, ~7 s total):

- `tests/helpers/hostile_wire.py`: reusable corpus of hostile payloads in two families — *malformed* (garbage, truncated flatbuffers, hand-built ev44 with absent event vectors, wrong schema, unmapped source) and *well-formed but insane* (far-future data timestamps for all four data schemas, pre-epoch timestamps, disagreeing `time_of_flight`/`pixel_id` lengths). New corruption modes get added here and both test layers pick them up.
- `tests/kafka/adapter_robustness_test.py`: pins the existing per-message containment in `AdaptingMessageSource` (regression guards, pass today) and the accepted-by-design cases (mismatched vectors on the plain monitor path, da00 dtype fallback), plus strict `xfail`s asserting data-derived timestamps must not cross the adapter boundary unbounded.
- `tests/services/hostile_input_liveness_test.py`: runs the monitor service with the production-default batcher and asserts one invariant — after consuming any single hostile payload, the service still publishes results for subsequent well-formed data. The reproduced #1038-finding-1 wedge is a strict `xfail`; the surviving variants (mid-stream future timestamp, ancient/pre-epoch timestamps mid-stream and in the first batch, mismatched vectors, all malformed cases) pass and pin current containment behavior.

The strict `xfail`s double as **ready-made acceptance tests for #1047**: when the adapter-boundary validation lands they flip loudly to XPASS and pytest forces the markers' removal, so the known holes cannot silently rot. Any resolution shape (drop, clamp, broker-timestamp fallback) satisfies the assertions as written. There is deliberately no "too old" analogue of the far-future invariant — backlog consumption makes genuinely old timestamps legitimate, so pre-epoch values are exercised for liveness only.

Scope note: this PR contains only cases with an unambiguous contract and a verified reproduction. Extensions needing a contract decision or behavior characterization first (timeseries/f144 path, rate-aware batcher, multi-pulse ev44, NaN f144, detector service) are tracked in #1054 with the reasoning spelled out there.

**Multi-session browser smoke test** (local-only, `pytest -m browser`, ~60 s):

- `Dashboard.connect_many(n)` in `scripts/drive_dashboard.py` opens n isolated sessions (own context/websocket/Bokeh session) on one server, ordered oldest-first for late-joiner scenarios. The Chromium binary is overridable via `PLAYWRIGHT_CHROMIUM_EXECUTABLE` for containers whose playwright package doesn't match the provisioned browsers.
- `tests/dashboard/multisession_smoke_test.py` drives the Kafka-free fake backend with two sessions and walks the manual checklist once: the late joiner sees the same tabs and populated plots, both sessions keep receiving data updates (fingerprinting rendered `ColumnDataSource` contents), and tab switching in one session stalls neither. Deliberately behavioral — it observes rendered data, not internals — so it stays valid across the delivery-mechanism refactors (#1045, #1046) and can help verify them.
- New `browser` pytest marker, excluded from the default run and the CI tox envs. The marker definition and exclusions mirror the in-flight #1030 exactly, so the branches merge cleanly in either order.

## Test plan

- [x] `adapter_robustness_test.py` + `hostile_input_liveness_test.py`: 20 passed, 8 xfailed (~6 s); the wedge xfail was verified to reproduce end-to-end (output frozen forever vs. steady growth in an unpoisoned control).
- [x] `pytest -m browser tests/dashboard/multisession_smoke_test.py` passes against the fake backend; `drive_dashboard.py --launch --map` still works after the `connect` refactor.
- [x] Full fast suite green (3912 passed, 8 xfailed); the only failures are pre-existing environmental ones (blocked `pooch` downloads for dream/estia data in the sandbox).
- [ ] Optional reviewer check: run `pytest -m browser` on a dev machine with Playwright installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYME35Uh2EmdyEhmhjcXYM