### PR TITLE
Default to sciline NaiveScheduler in backend services

### DIFF
--- a/docs/developer/design/backend-service-architecture.md
+++ b/docs/developer/design/backend-service-architecture.md
@@ -207,5 +207,5 @@ Services use `ExitStack` for automatic resource cleanup on service exit or error
 
 ## Building Services with DataServiceBuilder
 
-`DataServiceBuilder` constructs services consistently with `OrchestratingProcessor` by default. For command-line services, `DataServiceRunner` (see `service_factory.py`) wraps a builder and adds standard CLI arguments (`--instrument`, `--dev`, `--log-level`, `--sync-scheduler`, `--job-threads`). Services can publish initialization messages on startup for workflow specifications or configuration values.
+`DataServiceBuilder` constructs services consistently with `OrchestratingProcessor` by default. For command-line services, `DataServiceRunner` (see `service_factory.py`) wraps a builder and adds standard CLI arguments (`--instrument`, `--dev`, `--log-level`, `--scheduler`, `--job-threads`). The `--scheduler` option selects the scheduler sciline uses for workflow execution (default `naive`, which avoids per-cycle dask overhead; see `ess.livedata.core.sciline_scheduler`). Services can publish initialization messages on startup for workflow specifications or configuration values.
 

--- a/src/ess/livedata/core/sciline_scheduler.py
+++ b/src/ess/livedata/core/sciline_scheduler.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Process-wide selection of the scheduler sciline uses for workflow execution.
+
+Backend services execute reduction workflows via
+:class:`ess.reduce.streaming.StreamProcessor`, which calls
+``sciline.Pipeline.compute()`` on internal pipeline copies without exposing a
+``scheduler`` argument. Sciline picks its default scheduler at task-graph
+construction time: dask's threaded scheduler when ``dask`` is importable
+(always, since essreduce depends on it), otherwise
+:class:`sciline.scheduler.NaiveScheduler`.
+
+For live-data workflows the dask machinery is pure overhead: graphs are small
+(tens of nodes), run once per ~1 s batch, and parallelism happens at the job
+level, not within a graph. Benchmarks (monitor and detector-view workflows)
+show dask adds ~1-3 ms per accumulate+finalize cycle (~40 us per graph node
+per compute call) over the naive scheduler, with no benefit since production
+runs dask with a synchronous executor anyway.
+
+Since neither essreduce nor sciline offers a hook to change the default,
+:func:`configure_sciline_scheduler` overrides the selection site in
+``sciline.task_graph``. A startup probe verifies the override took effect so
+that a sciline refactor breaks service startup loudly instead of silently
+reverting to the dask scheduler.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, NewType, get_args
+
+import sciline
+import sciline.task_graph
+from sciline.scheduler import DaskScheduler, NaiveScheduler, Scheduler
+
+SchedulerMode = Literal['naive', 'dask-sync', 'dask-threaded']
+SCHEDULER_MODES: tuple[str, ...] = get_args(SchedulerMode)
+
+# The factory sciline's TaskGraph instantiates when no scheduler is given.
+# Captured at import time so the override can be applied repeatedly (tests)
+# and composed from a known-good baseline.
+_ORIGINAL_DASK_SCHEDULER = sciline.task_graph.DaskScheduler
+
+
+def configure_sciline_scheduler(mode: SchedulerMode) -> None:
+    """Select the scheduler sciline uses when none is passed explicitly.
+
+    Applies to every ``Pipeline.compute()`` in this process, in particular the
+    calls ``StreamProcessor`` makes internally, which cannot be reached via a
+    ``scheduler`` argument.
+
+    Parameters
+    ----------
+    mode:
+        - ``'naive'``: sciline's :class:`~sciline.scheduler.NaiveScheduler`.
+          Sequential, no dask involvement. Fastest for the small graphs used
+          in live-data workflows.
+        - ``'dask-sync'``: dask's threaded scheduler with a synchronous
+          executor, i.e. task execution on the calling thread (the previous
+          production default, ``--sync-scheduler``).
+        - ``'dask-threaded'``: dask's threaded scheduler with its regular
+          thread pool. Subject to GIL contention with job-level threading.
+    """
+    if mode not in SCHEDULER_MODES:
+        raise ValueError(f"Unknown scheduler mode: {mode!r}. Use {SCHEDULER_MODES}.")
+
+    import dask
+
+    if mode == 'naive':
+        sciline.task_graph.DaskScheduler = NaiveScheduler
+        _verify_default_scheduler(NaiveScheduler)
+    elif mode == 'dask-sync':
+        from dask.local import SynchronousExecutor
+
+        sciline.task_graph.DaskScheduler = _ORIGINAL_DASK_SCHEDULER
+        dask.config.set(pool=SynchronousExecutor())
+        _verify_default_scheduler(DaskScheduler)
+    else:  # 'dask-threaded'
+        sciline.task_graph.DaskScheduler = _ORIGINAL_DASK_SCHEDULER
+        dask.config.set(pool=None)
+        _verify_default_scheduler(DaskScheduler)
+
+
+_Probe = NewType('_Probe', int)
+
+
+def _verify_default_scheduler(expected: type[Scheduler]) -> None:
+    """Check that a pipeline built without an explicit scheduler uses `expected`.
+
+    The override patches a name in a sciline-internal module; if a sciline
+    update stops routing default-scheduler selection through that name (or
+    renames the attribute inspected here), this raises at service startup
+    rather than letting workflows silently fall back to the dask scheduler.
+    """
+    task_graph = sciline.Pipeline([], params={_Probe: _Probe(0)}).get(_Probe)
+    scheduler = getattr(task_graph, '_scheduler', None)
+    if not isinstance(scheduler, expected):
+        raise RuntimeError(
+            f"Failed to configure sciline's default scheduler: expected "
+            f"{expected.__name__}, but a probe pipeline selected "
+            f"{type(scheduler).__name__}. The sciline internals targeted by "
+            f"ess.livedata.core.sciline_scheduler have likely changed; update "
+            f"the override to match the installed sciline version."
+        )

--- a/src/ess/livedata/service_factory.py
+++ b/src/ess/livedata/service_factory.py
@@ -23,6 +23,11 @@ from .core.message_batcher import (
 )
 from .core.orchestrating_processor import OrchestratingProcessor
 from .core.rate_aware_batcher import RateAwareMessageBatcher
+from .core.sciline_scheduler import (
+    SCHEDULER_MODES,
+    SchedulerMode,
+    configure_sciline_scheduler,
+)
 from .core.service import Service
 from .kafka import KafkaTopic
 from .kafka import consumer as kafka_consumer
@@ -238,6 +243,31 @@ class DataServiceBuilder(Generic[Traw, Tin, Tout]):
         )
 
 
+def _resolve_scheduler_mode(
+    *, scheduler: SchedulerMode | None, sync_scheduler: bool | None
+) -> SchedulerMode:
+    """Resolve --scheduler, honoring the deprecated --sync-scheduler flag.
+
+    An explicit --scheduler always wins. Otherwise --sync-scheduler /
+    --no-sync-scheduler select the pre-existing dask behaviors so existing
+    deployment configurations keep working unchanged.
+    """
+    if scheduler is not None:
+        if sync_scheduler is not None:
+            logger.warning(
+                "sync_scheduler_ignored",
+                reason="--scheduler given; deprecated --sync-scheduler ignored",
+            )
+        return scheduler
+    if sync_scheduler is not None:
+        logger.warning(
+            "sync_scheduler_deprecated",
+            hint="use --scheduler=dask-sync or --scheduler=dask-threaded",
+        )
+        return 'dask-sync' if sync_scheduler else 'dask-threaded'
+    return 'naive'
+
+
 class DataServiceRunner:
     def __init__(
         self,
@@ -248,11 +278,22 @@ class DataServiceRunner:
         self._make_builder = make_builder
         self._parser = Service.setup_arg_parser(description=f'{pretty_name} Service')
         self._parser.add_argument(
+            '--scheduler',
+            choices=list(SCHEDULER_MODES),
+            default=None,
+            help='Scheduler used by sciline to execute workflow graphs.'
+            ' "naive" (default) runs providers sequentially without dask,'
+            ' avoiding per-cycle dask overhead; "dask-sync" is dask\'s threaded'
+            ' scheduler with a synchronous executor (the previous default);'
+            ' "dask-threaded" uses a real thread pool (GIL contention likely).',
+        )
+        self._parser.add_argument(
             '--sync-scheduler',
             action=argparse.BooleanOptionalAction,
-            default=True,
-            help='Use synchronous dask scheduler instead of threaded'
-            ' (reduces GIL contention)',
+            default=None,
+            help='Deprecated, use --scheduler. --sync-scheduler maps to'
+            ' --scheduler=dask-sync, --no-sync-scheduler to'
+            ' --scheduler=dask-threaded.',
         )
         self._parser.add_argument(
             '--job-threads',
@@ -291,13 +332,11 @@ class DataServiceRunner:
     ) -> NoReturn:
         args = vars(self._parser.parse_args())
 
-        sync_scheduler = args.pop('sync_scheduler')
-        if sync_scheduler:
-            import dask
-            from dask.local import SynchronousExecutor
-
-            dask.config.set(pool=SynchronousExecutor())
-            logger.info("dask_scheduler", mode="synchronous")
+        scheduler_mode = _resolve_scheduler_mode(
+            scheduler=args.pop('scheduler'), sync_scheduler=args.pop('sync_scheduler')
+        )
+        configure_sciline_scheduler(scheduler_mode)
+        logger.info("sciline_scheduler", mode=scheduler_mode)
 
         # Configure logging with parsed arguments
         log_level = getattr(logging, args.pop('log_level'))

--- a/tests/core/sciline_scheduler_test.py
+++ b/tests/core/sciline_scheduler_test.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import threading
+from typing import NewType
+
+import dask
+import pytest
+import sciline
+import sciline.task_graph
+from sciline.scheduler import DaskScheduler, NaiveScheduler
+
+from ess.livedata.core.sciline_scheduler import (
+    SCHEDULER_MODES,
+    configure_sciline_scheduler,
+)
+
+A = NewType('A', int)
+B = NewType('B', int)
+Result = NewType('Result', int)
+
+
+@pytest.fixture(autouse=True)
+def _restore_scheduler_config():
+    """Undo the process-global scheduler override and dask pool config."""
+    original = sciline.task_graph.DaskScheduler
+    yield
+    sciline.task_graph.DaskScheduler = original
+    dask.config.set(pool=None)
+
+
+def _make_pipeline() -> sciline.Pipeline:
+    def provider_a() -> A:
+        return A(1)
+
+    def provider_b() -> B:
+        return B(2)
+
+    def provider_result(a: A, b: B) -> Result:
+        return Result(a + b)
+
+    return sciline.Pipeline(providers=[provider_a, provider_b, provider_result])
+
+
+def _default_scheduler(pipeline: sciline.Pipeline):
+    return pipeline.get(Result)._scheduler
+
+
+def test_naive_mode_selects_naive_scheduler_by_default() -> None:
+    configure_sciline_scheduler('naive')
+    assert isinstance(_default_scheduler(_make_pipeline()), NaiveScheduler)
+
+
+def test_dask_modes_select_dask_scheduler_by_default() -> None:
+    configure_sciline_scheduler('dask-sync')
+    assert isinstance(_default_scheduler(_make_pipeline()), DaskScheduler)
+    configure_sciline_scheduler('dask-threaded')
+    assert isinstance(_default_scheduler(_make_pipeline()), DaskScheduler)
+
+
+def test_modes_can_be_switched_back_and_forth() -> None:
+    configure_sciline_scheduler('naive')
+    configure_sciline_scheduler('dask-sync')
+    assert isinstance(_default_scheduler(_make_pipeline()), DaskScheduler)
+    configure_sciline_scheduler('naive')
+    assert isinstance(_default_scheduler(_make_pipeline()), NaiveScheduler)
+
+
+def test_unknown_mode_raises() -> None:
+    with pytest.raises(ValueError, match='Unknown scheduler mode'):
+        configure_sciline_scheduler('threaded')  # type: ignore[arg-type]
+
+
+def test_scheduler_modes_cover_cli_choices() -> None:
+    assert SCHEDULER_MODES == ('naive', 'dask-sync', 'dask-threaded')
+
+
+@pytest.mark.parametrize('mode', ['naive', 'dask-sync'])
+def test_compute_runs_on_calling_thread_and_yields_correct_result(mode) -> None:
+    """Both non-threaded modes execute providers on the calling thread.
+
+    This verifies end-to-end that the configuration reaches
+    ``Pipeline.compute()`` calls that do not pass a scheduler explicitly --
+    the call shape used by ``ess.reduce.streaming.StreamProcessor``.
+    """
+    configure_sciline_scheduler(mode)
+
+    task_threads: list[int | None] = []
+
+    def provider_a() -> A:
+        task_threads.append(threading.current_thread().ident)
+        return A(1)
+
+    def provider_b() -> B:
+        task_threads.append(threading.current_thread().ident)
+        return B(2)
+
+    def provider_result(a: A, b: B) -> Result:
+        task_threads.append(threading.current_thread().ident)
+        return Result(a + b)
+
+    pl = sciline.Pipeline(providers=[provider_a, provider_b, provider_result])
+    result = pl.compute(Result)
+
+    assert result == 3
+    assert len(task_threads) == 3
+    calling_thread = threading.current_thread().ident
+    assert all(tid == calling_thread for tid in task_threads)
+
+
+def test_explicit_scheduler_argument_still_wins() -> None:
+    configure_sciline_scheduler('naive')
+    pl = _make_pipeline()
+    scheduler = DaskScheduler(dask.get)
+    assert pl.get(Result, scheduler=scheduler)._scheduler is scheduler
+
+
+def test_verification_raises_when_override_is_ineffective() -> None:
+    """If sciline stops selecting via task_graph.DaskScheduler, fail loudly.
+
+    Simulated by asserting a scheduler that the (unpatched) default selection
+    does not produce: with dask installed sciline picks DaskScheduler, so
+    verifying for NaiveScheduler must raise.
+    """
+    from ess.livedata.core.sciline_scheduler import _verify_default_scheduler
+
+    sciline.task_graph.DaskScheduler = DaskScheduler  # ensure unpatched selection
+    with pytest.raises(RuntimeError, match='Failed to configure'):
+        _verify_default_scheduler(NaiveScheduler)

--- a/tests/service_factory_test.py
+++ b/tests/service_factory_test.py
@@ -1,47 +1,64 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-import threading
-from typing import NewType
-
-import dask
 import pytest
-import sciline
 
-from ess.livedata.service_factory import DataServiceRunner
+from ess.livedata.service_factory import DataServiceRunner, _resolve_scheduler_mode
 
 
 def _make_runner() -> DataServiceRunner:
     return DataServiceRunner(pretty_name='test', make_builder=lambda **kw: None)
 
 
-@pytest.fixture(autouse=True)
-def _clean_dask_pool_config():
-    """Ensure dask pool config is reset after each test."""
-    yield
-    dask.config.set(pool=None)
+def test_scheduler_flag_defaults_to_none_resolving_to_naive():
+    runner = _make_runner()
+    args = runner.parser.parse_args(['--instrument', 'dummy'])
+    assert args.scheduler is None
+    assert (
+        _resolve_scheduler_mode(scheduler=args.scheduler, sync_scheduler=None)
+        == 'naive'
+    )
 
 
-def test_sync_scheduler_flag_is_registered():
+@pytest.mark.parametrize('mode', ['naive', 'dask-sync', 'dask-threaded'])
+def test_scheduler_flag_accepts_all_modes(mode):
+    runner = _make_runner()
+    args = runner.parser.parse_args(['--scheduler', mode, '--instrument', 'dummy'])
+    assert args.scheduler == mode
+
+
+def test_scheduler_flag_rejects_unknown_mode():
+    runner = _make_runner()
+    with pytest.raises(SystemExit):
+        runner.parser.parse_args(['--scheduler', 'bogus', '--instrument', 'dummy'])
+
+
+def test_deprecated_sync_scheduler_flag_still_parses():
     runner = _make_runner()
     args = runner.parser.parse_args(['--sync-scheduler', '--instrument', 'dummy'])
     assert args.sync_scheduler is True
-
-
-def test_sync_scheduler_flag_defaults_to_true():
-    runner = _make_runner()
-    args = runner.parser.parse_args(['--instrument', 'dummy'])
-    assert args.sync_scheduler is True
-
-
-def test_sync_scheduler_can_be_disabled():
-    runner = _make_runner()
     args = runner.parser.parse_args(['--no-sync-scheduler', '--instrument', 'dummy'])
     assert args.sync_scheduler is False
+    args = runner.parser.parse_args(['--instrument', 'dummy'])
+    assert args.sync_scheduler is None
 
 
-A = NewType('A', int)
-B = NewType('B', int)
-Result = NewType('Result', int)
+def test_resolve_scheduler_mode_defaults_to_naive():
+    assert _resolve_scheduler_mode(scheduler=None, sync_scheduler=None) == 'naive'
+
+
+def test_resolve_scheduler_mode_maps_deprecated_flag_to_dask_modes():
+    assert _resolve_scheduler_mode(scheduler=None, sync_scheduler=True) == 'dask-sync'
+    assert (
+        _resolve_scheduler_mode(scheduler=None, sync_scheduler=False) == 'dask-threaded'
+    )
+
+
+def test_resolve_scheduler_mode_explicit_scheduler_wins_over_deprecated_flag():
+    assert _resolve_scheduler_mode(scheduler='naive', sync_scheduler=True) == 'naive'
+    assert (
+        _resolve_scheduler_mode(scheduler='dask-threaded', sync_scheduler=True)
+        == 'dask-threaded'
+    )
 
 
 def test_job_threads_flag_is_registered():
@@ -66,36 +83,3 @@ def test_check_flag_is_registered():
     runner = _make_runner()
     args = runner.parser.parse_args(['--check', '--instrument', 'dummy'])
     assert args.check is True
-
-
-def test_sciline_with_sync_pool_runs_on_calling_thread():
-    """Setting dask pool to SynchronousExecutor makes sciline run on the calling thread.
-
-    This verifies that the ``--sync-scheduler`` mechanism actually takes effect
-    end-to-end through sciline's DaskScheduler.
-    """
-    from dask.local import SynchronousExecutor
-
-    dask.config.set(pool=SynchronousExecutor())
-
-    task_threads: list[int] = []
-
-    def provider_a() -> A:
-        task_threads.append(threading.current_thread().ident)
-        return A(1)
-
-    def provider_b() -> B:
-        task_threads.append(threading.current_thread().ident)
-        return B(2)
-
-    def provider_result(a: A, b: B) -> Result:
-        task_threads.append(threading.current_thread().ident)
-        return Result(a + b)
-
-    pl = sciline.Pipeline(providers=[provider_a, provider_b, provider_result])
-    result = pl.compute(Result)
-
-    assert result == 3
-    calling_thread = threading.current_thread().ident
-    assert len(task_threads) == 3
-    assert all(tid == calling_thread for tid in task_threads)


### PR DESCRIPTION
## Motivation

Sciline silently selects dask's threaded scheduler for every `Pipeline.compute()` whenever dask is importable — and it is always importable, since both esslivedata and essreduce depend on it. `StreamProcessor` computes on internal `Pipeline` copies and offers no `scheduler` argument, so backend jobs have been paying the dask graph-conversion and dispatch machinery on every `accumulate()` and `finalize()` (twice per job per ~1 s batch) without any way to opt out — and without any benefit, since production ran dask on a synchronous executor anyway (parallelism happens at the job level via `--job-threads`).

Benchmarked per-cycle cost (accumulate + finalize, median, warm):

| scheduler | monitor wf (14-node graph, 10k events) | detector view 128×128 (29-node graph, ~100k events) |
|---|---|---|
| dask threaded + sync pool (previous default) | 3.6 ms | 14.8 ms |
| dask threaded + real thread pool | 5.2 ms (p90 spikes ≫) | 16.8 ms |
| sciline `NaiveScheduler` | **2.6 ms** | **12.6 ms** |

The dask overhead is ~40 µs of pure bookkeeping per graph node per compute call. With `NaiveScheduler`, every job's per-batch latency drops by ~1–3 ms; outputs are byte-identical (verified with `sc.identical` across all monitor and detector-view targets).

## Approach

Per-instance injection is impossible without changing essreduce (`StreamProcessor.__init__` builds fresh plain `sciline.Pipeline()` objects internally, so a `Pipeline` subclass does not survive), and removing the dask dependency wouldn't help either (essreduce's metadata pulls it back in, and sciline auto-picks it whenever importable). The remaining seam is sciline's default-scheduler selection site.

New module `ess.livedata.core.sciline_scheduler`:
- `configure_sciline_scheduler(mode)` overrides `sciline.task_graph.DaskScheduler`, the factory `TaskGraph` instantiates when no scheduler is passed — this is sciline's documented default-selection behavior, redirected process-wide.
- Because this patches a sciline-internal name, a **startup probe** builds a trivial pipeline and verifies the expected scheduler was actually selected, so a future sciline refactor breaks service startup loudly instead of silently reverting to dask.

CLI (`DataServiceRunner`):
- New `--scheduler {naive,dask-sync,dask-threaded}`, default `naive`.
- `dask-sync` reproduces the previous default exactly (threaded scheduler + `SynchronousExecutor` pool), `dask-threaded` the previous `--no-sync-scheduler`, so production can A/B or roll back without a code change.
- The deprecated `--sync-scheduler`/`--no-sync-scheduler` flags still parse and map to the two dask modes (with a deprecation warning), so existing deployment configurations keep working; an explicit `--scheduler` wins.

## Notes

- If sciline later ships an improved scheduler upstream, it can be added as another mode here — in the current release (25.11.1) only `NaiveScheduler` and `DaskScheduler` exist.
- `NaiveScheduler` holds intermediate results until the computation finishes rather than freeing them eagerly; irrelevant at our graph sizes (14–29 nodes).
- Two `tests/services/data_reduction_test.py` DREAM failures and two `registered_workflow_factories_test.py` roundtrip failures in my environment are pre-existing (blocked external download of instrument data files; they fail identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuFKpNkobLPnbg62B4TNnc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuFKpNkobLPnbg62B4TNnc)_