### PR TITLE
Validate data-derived timestamps at the adapter boundary

### DIFF
--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -119,6 +119,10 @@ class StreamStat:
     source_name: str
     stream: str | None  # Resolved stream name, or None if unmapped
     count: int
+    # Messages whose implausibly-far-future timestamp was clamped to the wall
+    # clock (see KafkaAdapter._clamp_future). A subset of ``count``, so a
+    # stream whose every timestamp was clamped reports count == clamped.
+    clamped: int = 0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ess/livedata/core/message_batcher.py
+++ b/src/ess/livedata/core/message_batcher.py
@@ -27,9 +27,10 @@ class MessageBatch:
 # batchers' only clock, so window placement must not follow one outlier
 # arbitrarily far into the future: an over-anchored window stalls delivery
 # until wall time catches up, while an under-anchored one self-heals forward
-# as newer traffic arrives.  The cap holds regardless of where a message
-# came from: sources are not trusted to deliver sane timestamps, and the
-# batcher is the one place every message passes through.
+# as newer traffic arrives.  The adapter boundary clamps far-future
+# timestamps to an arrival estimate; this cap is defense in depth for values
+# inside the adapter's bound -- including wall-clock clamps, which land ahead
+# of the traffic when consuming a backlog -- and for non-Kafka sources.
 MAX_TIMESTAMP_AHEAD_BATCHES = 3
 
 
@@ -55,7 +56,9 @@ def plausible_anchor(timestamps: list[Timestamp], batch_length: Duration) -> Tim
     traffic is not the safe default it appears to be: a window only walks
     forward one batch length per call, so an anchor stranded in a disjoint
     past epoch takes astronomically many calls to catch up, where one
-    stranded ahead merely waits out its own distance.
+    stranded ahead merely waits out its own distance.  Resolving these is
+    the adapter boundary's job, which clamps an implausible timestamp to an
+    arrival estimate rather than weighing it against its neighbours.
     """
     ordered = sorted(timestamps)
     horizon = MAX_TIMESTAMP_AHEAD_BATCHES * batch_length
@@ -242,8 +245,8 @@ class SimpleMessageBatcher(MessageBatcher):
         a message parked implausibly far ahead advances the window on every
         call -- once per poll rather than once per batch length. The window
         then overruns the live data and comes to rest at the outlier, and
-        nothing closes a batch until wall time catches up: the #1038 wedge.
-        Refusing to advance past
+        nothing closes a batch until wall time catches up: the #1038 wedge,
+        merely bounded by the adapter's future bound. Refusing to advance past
         the frontier of the data in hand keeps the window with the traffic,
         and the frontier moves forward as real messages arrive.
 

--- a/src/ess/livedata/core/orchestrating_processor.py
+++ b/src/ess/livedata/core/orchestrating_processor.py
@@ -379,6 +379,7 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
                     window_seconds
                 )
                 self._log_stream_lag(self._stream_stats_provider.drain_lag())
+                self._log_clamped_streams(self._pending_stream_stats)
 
             logger.info(
                 'processor_metrics',
@@ -393,6 +394,26 @@ class OrchestratingProcessor(Generic[Tin, Tout]):
             self._empty_batches = 0
             self._errors_since_last_metrics = 0
             self._last_metrics_time = timestamp
+
+    def _log_clamped_streams(self, stats: StreamStats | None) -> None:
+        """Log one line per window summarizing streams with clamped timestamps.
+
+        Complements the per-stream first-occurrence warning logged where the
+        clamp happens (``KafkaAdapter._clamp_future``) with a periodic
+        overview, mirroring :meth:`_log_stream_lag`.
+        """
+        if stats is None:
+            return
+        clamped = [s for s in stats.streams if s.clamped]
+        if not clamped:
+            return
+        logger.warning(
+            'stream_timestamp_clamps',
+            streams=[
+                {'topic': s.topic, 'source': s.source_name, 'clamped': s.clamped}
+                for s in clamped
+            ],
+        )
 
     def _log_stream_lag(self, report: StreamLagReport | None) -> None:
         """Log one line per stream at a severity reflecting its lag.

--- a/src/ess/livedata/dashboard/widgets/backend_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/backend_status_widget.py
@@ -105,21 +105,34 @@ def _format_stream_stats_details(stats: StreamStats | None) -> str:
             "</details>"
         )
     unmapped_count = sum(1 for s in stats.streams if s.stream is None)
+    clamped_total = sum(s.clamped for s in stats.streams)
     summary_extra = ""
     if unmapped_count:
-        summary_extra = (
+        summary_extra += (
             f' — <span style="color: {StatusColors.ERROR}">'
             f"{unmapped_count} unmapped</span>"
+        )
+    if clamped_total:
+        summary_extra += (
+            f' — <span style="color: {StatusColors.WARNING}">'
+            f"{_format_messages(clamped_total)} clamped</span>"
         )
     rows = []
     for s in stats.streams:
         stream_cell = s.stream or (
             f'<span style="color: {StatusColors.ERROR}">unmapped</span>'
         )
+        clamped_cell = (
+            f'<span style="color: {StatusColors.WARNING}">'
+            f"{_format_messages(s.clamped)}</span>"
+            if s.clamped
+            else "0"
+        )
         rows.append(
             f"<tr><td>{escape(s.topic)}</td><td>{escape(s.source_name)}</td>"
             f"<td>{stream_cell}</td><td style='text-align:right'>"
-            f"{_format_messages(s.count)}</td></tr>"
+            f"{_format_messages(s.count)}</td><td style='text-align:right'>"
+            f"{clamped_cell}</td></tr>"
         )
     header_style = f"text-align:left; border-bottom:1px solid {Colors.BORDER}"
     count_style = f"text-align:right; border-bottom:1px solid {Colors.BORDER}"
@@ -130,6 +143,7 @@ def _format_stream_stats_details(stats: StreamStats | None) -> str:
         f'<th style="{header_style}">Source</th>'
         f'<th style="{header_style}">Stream</th>'
         f'<th style="{count_style}">Count</th>'
+        f'<th style="{count_style}">Clamped</th>'
         "</tr>" + "".join(rows) + "</table>"
     )
     return (

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -505,8 +505,9 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
         pixel_id = _vector_or_empty(event.PixelIdAsNumpy(), dtype=np.int32)
 
         # A fallback, useful in particular for testing so serialized data can be reused.
-        if reference_time.size > 0:
-            timestamp = Timestamp.from_ns(reference_time[-1])
+        reference_time_ns = int(reference_time[-1]) if reference_time.size > 0 else None
+        if reference_time_ns is not None:
+            timestamp = Timestamp.from_ns(reference_time_ns)
         else:
             timestamp = Timestamp.from_ms(message.timestamp()[1])
         timestamp = self._clamp_future(message, source_name, timestamp)
@@ -516,9 +517,14 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
                 pixel_id=pixel_id,
                 time_of_arrival=time_of_arrival,
                 unit='ns',
+                reference_time_ns=reference_time_ns,
             )
         else:
-            value = MonitorEvents(time_of_arrival=time_of_arrival, unit='ns')
+            value = MonitorEvents(
+                time_of_arrival=time_of_arrival,
+                unit='ns',
+                reference_time_ns=reference_time_ns,
+            )
         self._record_lag(message, source_name, timestamp)
         return Message(timestamp=timestamp, stream=stream, value=value)
 

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -163,6 +163,14 @@ class NullAdapter(MessageAdapter[KafkaMessage, Any]):
         raise IgnoredMessageError
 
 
+def _clamp_target_ns(message: KafkaMessage, *, bound_ns: int, now_ns: int) -> int:
+    """Broker timestamp when plausible, wall clock otherwise (see the
+    FUTURE_TIMESTAMP_BOUND_S comment for why the order matters)."""
+    kind, broker_ms = message.timestamp()
+    broker_ns = broker_ms * 1_000_000
+    return broker_ns if kind != 0 and broker_ns <= bound_ns else now_ns
+
+
 class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
     """
     Base class for Kafka adapters.
@@ -240,11 +248,7 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
         bound_ns = now_ns + self._future_bound_ns
         if timestamp.to_ns() <= bound_ns:
             return timestamp
-        kind, broker_ms = message.timestamp()
-        broker_ns = broker_ms * 1_000_000
-        # Broker timestamp when plausible, wall clock otherwise (see the
-        # FUTURE_TIMESTAMP_BOUND_S comment for why the order matters).
-        clamped_ns = broker_ns if kind != 0 and broker_ns <= bound_ns else now_ns
+        clamped_ns = _clamp_target_ns(message, bound_ns=bound_ns, now_ns=now_ns)
         topic = message.topic()
         is_first_clamp = True
         if self._stream_counter is not None:
@@ -433,7 +437,34 @@ class RunControlAdapter(MessageAdapter[KafkaMessage, Message[RunStart | RunStop]
 
     Converts timestamps from milliseconds (flatbuffer wire format) to nanoseconds
     (domain convention) at the adapter boundary.
+
+    Run start/stop times are control flow, not science data: they schedule
+    job resets that fire once data time reaches them (see
+    ``JobManager._schedule_reset``), so a far-future value would park a
+    reset that never fires and the run transition would be lost. They are
+    therefore bounded like the envelope timestamp, not passed through like
+    a payload.
     """
+
+    def __init__(self, *, future_bound_s: float = FUTURE_TIMESTAMP_BOUND_S):
+        self._future_bound_ns = int(future_bound_s * 1_000_000_000)
+
+    def _bounded(
+        self, message: KafkaMessage, run_name: str, ts: Timestamp
+    ) -> Timestamp:
+        now_ns = time.time_ns()
+        bound_ns = now_ns + self._future_bound_ns
+        if ts.to_ns() <= bound_ns:
+            return ts
+        clamped_ns = _clamp_target_ns(message, bound_ns=bound_ns, now_ns=now_ns)
+        logger.warning(
+            'future_run_time_clamped',
+            run_name=run_name,
+            timestamp_ns=ts.to_ns(),
+            clamped_to_ns=clamped_ns,
+            bound_ns=bound_ns,
+        )
+        return Timestamp.from_ns(clamped_ns)
 
     def adapt(self, message: KafkaMessage) -> Message[RunStart | RunStop]:
         buf = message.value()
@@ -442,18 +473,26 @@ class RunControlAdapter(MessageAdapter[KafkaMessage, Message[RunStart | RunStop]
         if schema == 'pl72':
             info = run_start_pl72.deserialise_pl72(buf)
             stop_time = (
-                None if info.stop_time == 0 else Timestamp.from_ms(info.stop_time)
+                None
+                if info.stop_time == 0
+                else self._bounded(
+                    message, info.run_name, Timestamp.from_ms(info.stop_time)
+                )
             )
             value: RunStart | RunStop = RunStart(
                 run_name=info.run_name,
-                start_time=Timestamp.from_ms(info.start_time),
+                start_time=self._bounded(
+                    message, info.run_name, Timestamp.from_ms(info.start_time)
+                ),
                 stop_time=stop_time,
             )
         elif schema == '6s4t':
             info = run_stop_6s4t.deserialise_6s4t(buf)  # type: ignore[assignment]
             value = RunStop(
                 run_name=info.run_name,
-                stop_time=Timestamp.from_ms(info.stop_time),
+                stop_time=self._bounded(
+                    message, info.run_name, Timestamp.from_ms(info.stop_time)
+                ),
             )
         else:
             raise streaming_data_types.exceptions.WrongSchemaException(

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import time
 from collections.abc import Sequence
 from dataclasses import replace
 from typing import Any, Generic, Protocol, TypeVar
@@ -46,6 +47,34 @@ from .stream_mapping import InputStreamKey, StreamLUT
 from .x5f2_compat import x5f2_to_status
 
 logger = structlog.get_logger(__name__)
+
+# Data-derived timestamps further ahead of the wall clock than this have no
+# legitimate producer and are clamped. The batchers use message timestamps as
+# their only clock, so a far-future value would become that clock (#1038
+# finding 1). Clamping rather than dropping keeps the data visible: a device
+# with a broken or drifting clock -- expected to be common during
+# commissioning -- still delivers, with an arrival-time estimate standing in
+# for the bogus source time.
+#
+# The clamp target is the Kafka broker timestamp when it is itself plausible,
+# the consumer's wall clock otherwise. The distinction matters when consuming
+# a backlog: there the surrounding traffic sits at an older epoch, and a
+# wall-clock substitute would be a future outlier relative to it -- exactly
+# the input the batchers' bulk-of-traffic anchoring must then defend against
+# -- while the broker timestamp lands the message among its neighbours. The
+# wall-clock fallback covers a missing broker timestamp and the producer
+# whose host clock (which stamps CreateTime) is broken along with its payload.
+#
+# Producer skew does not set this value: NTP-synced hosts skew by
+# milliseconds (see LAG_FUTURE_TOLERANCE_S, which treats 0.1 s as already
+# anomalous), an unsynced host is typically hours out, and no future-dated
+# payload has been observed in production at all. Anything from seconds to
+# minutes would separate those cases equally well. The comparison is against
+# *this* host's wall clock, so a backend whose own clock runs slow clamps
+# everything more than (bound - error) ahead; since a misfire merely rewrites
+# a timestamp to roughly the correct value, the bound needs only modest
+# headroom for that.
+FUTURE_TIMESTAMP_BOUND_S = 30.0
 
 T = TypeVar('T')
 U = TypeVar('U')
@@ -154,10 +183,12 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
         stream_lut: StreamLUT | None = None,
         stream_kind: StreamKind,
         stream_counter: StreamCounter | None = None,
+        future_bound_s: float = FUTURE_TIMESTAMP_BOUND_S,
     ):
         self._stream_lut = stream_lut
         self._stream_kind = stream_kind
         self._stream_counter = stream_counter
+        self._future_bound_ns = int(future_bound_s * 1_000_000_000)
 
     def get_stream_id(self, topic: str, source_name: str) -> StreamId:
         if self._stream_lut is None:
@@ -176,6 +207,59 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
             self._stream_counter.record(topic, source_name, resolved)
         return stream_id
 
+    def _clamp_future(
+        self, message: KafkaMessage, source_name: str, timestamp: Timestamp
+    ) -> Timestamp:
+        """Clamp a timestamp implausibly far ahead of the wall clock.
+
+        The clamp target is the broker timestamp when plausible, the wall
+        clock otherwise. Applies to whichever timestamp ``adapt`` ultimately
+        chose, whether payload-derived or the Kafka-broker fallback -- a
+        stalled or misconfigured broker clock is just as capable of wedging
+        the batcher as a broken producer clock. Called after
+        ``get_stream_id`` so that
+        streams this service does not consume keep failing as unmapped:
+        Kafka subscription is per-topic, and a foreign producer's broken
+        clock is not this service's concern.
+
+        Only the envelope timestamp is rewritten, never the payload. The
+        envelope is livedata's transport clock -- it drives batching,
+        scheduling, and run resets, and must therefore be plausible. Payload
+        times are the device's claim and flow to science consumers
+        unmodified: a wrong device clock is then visible and attributable in
+        the data instead of silently replaced by an estimate, and consumers
+        must tolerate wrong device times anyway -- a clock running *behind*
+        passes any future bound.
+
+        Clamps are counted per stream and surfaced in the backend stream
+        stats; the first clamp per stream per stats window is also logged, so
+        a device with a broken clock is visible without a log line per
+        message.
+        """
+        now_ns = time.time_ns()
+        bound_ns = now_ns + self._future_bound_ns
+        if timestamp.to_ns() <= bound_ns:
+            return timestamp
+        kind, broker_ms = message.timestamp()
+        broker_ns = broker_ms * 1_000_000
+        # Broker timestamp when plausible, wall clock otherwise (see the
+        # FUTURE_TIMESTAMP_BOUND_S comment for why the order matters).
+        clamped_ns = broker_ns if kind != 0 and broker_ns <= bound_ns else now_ns
+        topic = message.topic()
+        is_first_clamp = True
+        if self._stream_counter is not None:
+            is_first_clamp = self._stream_counter.record_clamped(topic, source_name)
+        if is_first_clamp:
+            logger.warning(
+                'future_timestamp_clamped',
+                topic=topic,
+                source_name=source_name,
+                timestamp_ns=timestamp.to_ns(),
+                clamped_to_ns=clamped_ns,
+                bound_ns=bound_ns,
+            )
+        return Timestamp.from_ns(clamped_ns)
+
     def _record_lag(
         self, message: KafkaMessage, source_name: str, timestamp: Timestamp
     ) -> None:
@@ -193,17 +277,33 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
         )
 
 
+def _vector_or_empty(vector: Any, dtype: type) -> np.ndarray:
+    """Normalize a flatbuffers vector accessor for an absent vector.
+
+    The ev44 schema allows event vectors (reference_time, time_of_flight,
+    pixel_id) to be absent entirely, not just empty. flatbuffers-python's
+    ``*AsNumpy()`` accessors then return the Python ``int`` ``0`` instead of
+    an empty array, breaking any caller expecting ``.size`` or indexing
+    (#1038 finding 2). An absent vector is equivalent to an empty one.
+    """
+    if isinstance(vector, np.ndarray):
+        return vector
+    return np.empty(0, dtype=dtype)
+
+
 class KafkaToEv44Adapter(KafkaAdapter[eventdata_ev44.EventData]):
     schema = 'ev44'
 
     def adapt(self, message: KafkaMessage) -> Message[eventdata_ev44.EventData]:
         ev44 = eventdata_ev44.deserialise_ev44(message.value())
         stream = self.get_stream_id(topic=message.topic(), source_name=ev44.source_name)
+        reference_time = _vector_or_empty(ev44.reference_time, dtype=np.int64)
         # A fallback, useful in particular for testing so serialized data can be reused.
-        if ev44.reference_time.size > 0:
-            timestamp = Timestamp.from_ns(ev44.reference_time[-1])
+        if reference_time.size > 0:
+            timestamp = Timestamp.from_ns(reference_time[-1])
         else:
             timestamp = Timestamp.from_ms(message.timestamp()[1])
+        timestamp = self._clamp_future(message, ev44.source_name, timestamp)
         self._record_lag(message, ev44.source_name, timestamp)
         return Message(timestamp=timestamp, stream=stream, value=ev44)
 
@@ -240,14 +340,17 @@ class KafkaToDa00Adapter(KafkaAdapter[list[dataarray_da00.Variable]]):
 
     def adapt(self, message: KafkaMessage) -> Message[list[dataarray_da00.Variable]]:
         da00: dataarray_da00.da00_DataArray_t
-        da00 = dataarray_da00.deserialise_da00(message.value())  # type: ignore[reportAssignmentType]
-        key = self.get_stream_id(topic=message.topic(), source_name=da00.source_name)
+        da00 = dataarray_da00.deserialise_da00(  # type: ignore[reportAssignmentType]
+            message.value()
+        )
         # Prefer reference_time from the data variables (mirroring ev44 behavior)
         # over the opaque top-level timestamp_ns whose semantics are unspecified.
+        key = self.get_stream_id(topic=message.topic(), source_name=da00.source_name)
         ref_time = _extract_reference_time(da00.data)
         timestamp = (
             ref_time if ref_time is not None else Timestamp.from_ns(da00.timestamp_ns)
         )
+        timestamp = self._clamp_future(message, da00.source_name, timestamp)
         self._record_lag(message, da00.source_name, timestamp)
         return Message(timestamp=timestamp, stream=key, value=da00.data)
 
@@ -263,11 +366,13 @@ class KafkaToF144Adapter(KafkaAdapter[logdata_f144.ExtractedLogData]):
         *,
         stream_lut: StreamLUT | None = None,
         stream_counter: StreamCounter | None = None,
+        future_bound_s: float = FUTURE_TIMESTAMP_BOUND_S,
     ):
         super().__init__(
             stream_lut=stream_lut,
             stream_kind=StreamKind.LOG,
             stream_counter=stream_counter,
+            future_bound_s=future_bound_s,
         )
 
     def adapt(self, message: KafkaMessage) -> Message[logdata_f144.ExtractedLogData]:
@@ -276,6 +381,7 @@ class KafkaToF144Adapter(KafkaAdapter[logdata_f144.ExtractedLogData]):
             topic=message.topic(), source_name=log_data.source_name
         )
         timestamp = Timestamp.from_ns(log_data.timestamp_unix_ns)
+        timestamp = self._clamp_future(message, log_data.source_name, timestamp)
         return Message(timestamp=timestamp, stream=key, value=log_data)
 
 
@@ -378,11 +484,13 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
         *,
         pixellated_sources: frozenset[str] = frozenset(),
         stream_counter: StreamCounter | None = None,
+        future_bound_s: float = FUTURE_TIMESTAMP_BOUND_S,
     ):
         super().__init__(
             stream_lut=stream_lut,
             stream_kind=StreamKind.MONITOR_EVENTS,
             stream_counter=stream_counter,
+            future_bound_s=future_bound_s,
         )
         self._pixellated_sources = pixellated_sources
 
@@ -392,18 +500,20 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
         event = Event44Message.Event44Message.GetRootAs(buffer, 0)
         source_name = event.SourceName().decode("utf-8")
         stream = self.get_stream_id(topic=message.topic(), source_name=source_name)
-        reference_time = event.ReferenceTimeAsNumpy()
-        time_of_arrival = event.TimeOfFlightAsNumpy()
+        reference_time = _vector_or_empty(event.ReferenceTimeAsNumpy(), dtype=np.int64)
+        time_of_arrival = _vector_or_empty(event.TimeOfFlightAsNumpy(), dtype=np.int32)
+        pixel_id = _vector_or_empty(event.PixelIdAsNumpy(), dtype=np.int32)
 
         # A fallback, useful in particular for testing so serialized data can be reused.
         if reference_time.size > 0:
             timestamp = Timestamp.from_ns(reference_time[-1])
         else:
             timestamp = Timestamp.from_ms(message.timestamp()[1])
+        timestamp = self._clamp_future(message, source_name, timestamp)
 
         if stream.name in self._pixellated_sources:
             value: MonitorEvents | DetectorEvents = DetectorEvents(
-                pixel_id=event.PixelIdAsNumpy(),
+                pixel_id=pixel_id,
                 time_of_arrival=time_of_arrival,
                 unit='ns',
             )
@@ -461,6 +571,7 @@ class KafkaToAd00Adapter(KafkaAdapter[area_detector_ad00.ADArray]):
         ad00 = area_detector_ad00.deserialise_ad00(message.value())
         key = self.get_stream_id(topic=message.topic(), source_name=ad00.source_name)
         timestamp = Timestamp.from_ns(ad00.timestamp_ns)
+        timestamp = self._clamp_future(message, ad00.source_name, timestamp)
         self._record_lag(message, ad00.source_name, timestamp)
         return Message(timestamp=timestamp, stream=key, value=ad00)
 

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -197,6 +197,10 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
         self._stream_kind = stream_kind
         self._stream_counter = stream_counter
         self._future_bound_ns = int(future_bound_s * 1_000_000_000)
+        # Rate-limits clamp warnings when no StreamCounter is wired in (e.g.
+        # dashboard-side routes): once per stream per adapter lifetime,
+        # instead of once per message.
+        self._clamp_logged: set[tuple[str, str]] = set()
 
     def get_stream_id(self, topic: str, source_name: str) -> StreamId:
         if self._stream_lut is None:
@@ -242,7 +246,8 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
         Clamps are counted per stream and surfaced in the backend stream
         stats; the first clamp per stream per stats window is also logged, so
         a device with a broken clock is visible without a log line per
-        message.
+        message. Without a StreamCounter (e.g. dashboard-side routes) the
+        warning fires once per stream for the adapter's lifetime instead.
         """
         now_ns = time.time_ns()
         bound_ns = now_ns + self._future_bound_ns
@@ -250,9 +255,11 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
             return timestamp
         clamped_ns = _clamp_target_ns(message, bound_ns=bound_ns, now_ns=now_ns)
         topic = message.topic()
-        is_first_clamp = True
         if self._stream_counter is not None:
             is_first_clamp = self._stream_counter.record_clamped(topic, source_name)
+        else:
+            is_first_clamp = (topic, source_name) not in self._clamp_logged
+            self._clamp_logged.add((topic, source_name))
         if is_first_clamp:
             logger.warning(
                 'future_timestamp_clamped',

--- a/src/ess/livedata/kafka/stream_counter.py
+++ b/src/ess/livedata/kafka/stream_counter.py
@@ -28,6 +28,7 @@ _IGNORED_SOURCE_SUFFIXES = ('.DMOV', '.VAL')
 class _Entry:
     stream: str | None
     count: int
+    clamped: int = 0
 
 
 @dataclass(slots=True)
@@ -79,6 +80,31 @@ class StreamCounter:
         entry.count += 1
         entry.stream = stream
 
+    def record_clamped(self, topic: str, source_name: str) -> bool:
+        """Record a message whose implausibly-far-future timestamp was clamped.
+
+        Clamps are a subset of the messages counted by :meth:`record`, so a
+        stream whose timestamps are *all* clamped reports ``count == clamped``.
+        Sources with known EPICS noise suffixes and out-of-scope streams are
+        dropped, mirroring :meth:`record`.
+
+        Returns
+        -------
+        :
+            True if this is the first clamp recorded for this stream in the
+            current window, so callers can rate-limit logging to once per
+            stream per window instead of once per message.
+        """
+        if source_name.endswith(_IGNORED_SOURCE_SUFFIXES):
+            return False
+        key = (topic, source_name)
+        if key in self._out_of_scope:
+            return False
+        entry = self._counts[key]
+        is_first = entry.clamped == 0
+        entry.clamped += 1
+        return is_first
+
     def record_lag(
         self, topic: str, source_name: str, schema: str, lag_s: float
     ) -> None:
@@ -108,6 +134,7 @@ class StreamCounter:
                     source_name=source_name,
                     stream=entry.stream,
                     count=entry.count,
+                    clamped=entry.clamped,
                 )
                 for (topic, source_name), entry in sorted(self._counts.items())
             ),

--- a/src/ess/livedata/kafka/x5f2_compat.py
+++ b/src/ess/livedata/kafka/x5f2_compat.py
@@ -191,6 +191,7 @@ class StreamStatModel(pydantic.BaseModel):
     source_name: str
     stream: str | None
     count: int
+    clamped: int = 0
 
 
 class StreamStatsModel(pydantic.BaseModel):
@@ -461,6 +462,7 @@ def _stream_stats_to_model(stats: StreamStats | None) -> StreamStatsModel | None
                 source_name=s.source_name,
                 stream=s.stream,
                 count=s.count,
+                clamped=s.clamped,
             )
             for s in stats.streams
         ],
@@ -478,6 +480,7 @@ def _model_to_stream_stats(model: StreamStatsModel | None) -> StreamStats | None
                 source_name=s.source_name,
                 stream=s.stream,
                 count=s.count,
+                clamped=s.clamped,
             )
             for s in model.streams
         ),

--- a/src/ess/livedata/preprocessors/to_nxevent_data.py
+++ b/src/ess/livedata/preprocessors/to_nxevent_data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypeVar
 
 import numpy as np
@@ -20,6 +20,18 @@ def _require_single_pulse(ev44: eventdata_ev44.EventData) -> None:
         raise NotImplementedError("Processing multi-pulse messages is not supported.")
 
 
+def _single_reference_time_ns(ev44: eventdata_ev44.EventData) -> int | None:
+    """The payload's pulse time, or None if the message carries none.
+
+    An absent vector surfaces as the ``int`` ``0`` from flatbuffers-python's
+    ``*AsNumpy()`` accessors, equivalent to an empty one.
+    """
+    ref = ev44.reference_time
+    if isinstance(ref, int) or len(ref) == 0:
+        return None
+    return int(ref[-1])
+
+
 @dataclass
 class MonitorEvents:
     """
@@ -30,15 +42,25 @@ class MonitorEvents:
 
     Note that we keep the raw array of time of arrivals, and the unit. This is to avoid
     unnecessary copies of the data.
+
+    ``reference_time_ns`` is the payload's pulse time -- the device's claim,
+    which flows to science consumers unmodified (see
+    ``KafkaAdapter._clamp_future`` for the envelope/payload contract) -- or
+    None when the message carries none.
     """
 
     time_of_arrival: Sequence[int]
     unit: str
+    reference_time_ns: int | None = field(default=None, kw_only=True)
 
     @staticmethod
     def from_ev44(ev44: eventdata_ev44.EventData) -> MonitorEvents:
         _require_single_pulse(ev44)
-        return MonitorEvents(time_of_arrival=ev44.time_of_flight, unit='ns')
+        return MonitorEvents(
+            time_of_arrival=ev44.time_of_flight,
+            unit='ns',
+            reference_time_ns=_single_reference_time_ns(ev44),
+        )
 
 
 @dataclass
@@ -66,7 +88,10 @@ class DetectorEvents(MonitorEvents):
     def from_ev44(ev44: eventdata_ev44.EventData) -> DetectorEvents:
         _require_single_pulse(ev44)
         return DetectorEvents(
-            pixel_id=ev44.pixel_id, time_of_arrival=ev44.time_of_flight, unit='ns'
+            pixel_id=ev44.pixel_id,
+            time_of_arrival=ev44.time_of_flight,
+            unit='ns',
+            reference_time_ns=_single_reference_time_ns(ev44),
         )
 
 
@@ -129,6 +154,16 @@ class _WeightsBuffer:
 
 
 class ToNXevent_data(Accumulator[Events, sc.DataArray]):
+    """Accumulates event chunks into an NXevent_data-shaped binned DataArray.
+
+    ``event_time_zero`` is the payload's pulse time (the device's claim,
+    passed through unmodified), with the envelope timestamp as fallback for
+    messages that carry no pulse time. The two differ when the envelope was
+    clamped at the adapter boundary: absolute event times from a device with
+    a broken clock are then wrong by the device's clock error, visibly,
+    rather than silently replaced by an arrival estimate off the pulse grid.
+    """
+
     def __init__(self):
         self._chunks: list[Events] = []
         self._timestamps: list[int] = []
@@ -150,7 +185,8 @@ class ToNXevent_data(Accumulator[Events, sc.DataArray]):
         elif self._have_event_id != isinstance(data, DetectorEvents):
             # This should never happen, but we check to be safe.
             raise ValueError("Inconsistent event_id")
-        self._timestamps.append(timestamp.to_ns())
+        ref_ns = data.reference_time_ns
+        self._timestamps.append(ref_ns if ref_ns is not None else timestamp.to_ns())
         self._chunks.append(data)
         return True
 

--- a/tests/core/message_batcher_test.py
+++ b/tests/core/message_batcher_test.py
@@ -41,7 +41,8 @@ class TestPlausibleAnchor:
         return plausible_anchor(stamps, self.BATCH_LENGTH).to_ns() / 1e9
 
     def test_single_timestamp_is_its_own_anchor(self):
-        """One message carries no evidence against itself."""
+        """One message carries no evidence against itself; clamping an
+        implausible lone value is the adapter boundary's job."""
         assert self.anchor(500.0) == 500.0
 
     def test_contiguous_traffic_keeps_its_maximum(self):
@@ -63,7 +64,7 @@ class TestPlausibleAnchor:
         """With one message on each side there is nothing to weigh. Anchoring
         behind the traffic is the worse failure -- the window walks forward
         only one batch length per call, so a disjoint past epoch never catches
-        up."""
+        up -- and clamping an implausible lone value is the adapter's job."""
         assert self.anchor(100.0, 1e6) == 1e6
 
     def test_gap_just_within_horizon_stays_connected(self):
@@ -853,8 +854,8 @@ class TestSimpleBatcherFutureTimestampLiveness:
     live data and comes to rest at the outlier; from there nothing closes a
     batch until wall time catches up (#1038 finding 1, #1047).
 
-    The batcher cannot assume anything upstream sanitized timestamps, so this
-    band must be survivable on its own.
+    The band tested here sits inside the adapter boundary's future bound, so
+    it is what actually reaches the batcher in production.
     """
 
     RATE_HZ = 14

--- a/tests/dashboard/widgets/backend_status_widget_test.py
+++ b/tests/dashboard/widgets/backend_status_widget_test.py
@@ -142,3 +142,23 @@ class TestFormatStreamStatsDetails:
         html = _format_stream_stats_details(stats)
         assert "<b>bad</b>" not in html
         assert "&lt;b&gt;" in html
+
+    def test_clamped_count_is_flagged(self) -> None:
+        stats = StreamStats(
+            window_seconds=30.0,
+            streams=(
+                StreamStat(
+                    topic="t", source_name="src", stream="s", count=10, clamped=4
+                ),
+            ),
+        )
+        html = _format_stream_stats_details(stats)
+        assert "4 clamped" in html
+
+    def test_no_clamped_summary_when_all_zero(self) -> None:
+        stats = StreamStats(
+            window_seconds=30.0,
+            streams=(StreamStat(topic="t", source_name="src", stream="s", count=10),),
+        )
+        html = _format_stream_stats_details(stats)
+        assert "clamped" not in html

--- a/tests/helpers/hostile_wire.py
+++ b/tests/helpers/hostile_wire.py
@@ -8,13 +8,11 @@ serialized payloads that a broken or misconfigured upstream producer could
 emit, in two families:
 
 - **Malformed**: payloads that fail to decode or violate the schema's
-  structural assumptions (garbage bytes, truncated flatbuffers, absent event
-  vectors). These exercise the per-message containment in
-  ``AdaptingMessageSource``.
+  structural assumptions (garbage bytes, truncated flatbuffers). These
+  exercise the per-message containment in ``AdaptingMessageSource``.
 - **Well-formed but insane**: payloads that decode fine but carry data-derived
   values no sane producer would send, e.g. timestamps centuries in the future.
-  These exercise (currently: document the absence of) validation at the
-  adapter boundary — see #1038 and #1047.
+  These exercise the validation at the adapter boundary — see #1038 and #1047.
 
 Used by ``tests/kafka/adapter_robustness_test.py`` (adapter-level containment
 and timestamp-bound invariants) and
@@ -220,7 +218,6 @@ def malformed_corpus(source_name: str) -> dict[str, bytes]:
         'truncated_ev44': truncated(
             ev44_events(source_name, reference_time_ns=REALISTIC_EPOCH_NS)
         ),
-        'ev44_without_event_vectors': ev44_without_event_vectors(source_name),
         'wrong_schema_f144': f144_log(source_name, timestamp_ns=REALISTIC_EPOCH_NS),
         'unmapped_source': ev44_events(
             'not_a_known_source', reference_time_ns=REALISTIC_EPOCH_NS

--- a/tests/kafka/adapter_robustness_test.py
+++ b/tests/kafka/adapter_robustness_test.py
@@ -7,15 +7,12 @@ Two invariants, driven by the corpus in ``tests/helpers/hostile_wire``:
 1. **Containment** (holds today, guarded here against regression): a payload
    that cannot be adapted is dropped by ``AdaptingMessageSource`` without the
    exception escaping and without affecting subsequent messages.
-2. **Timestamp sanity** (does not hold today — strict xfail): data-derived
-   timestamps should be bounded against the wall clock before crossing the
-   adapter boundary, because the batcher uses them as its only clock and a
-   single far-future value wedges the whole service (#1038 finding 1). These
-   tests are the acceptance criterion for the boundary-validation layer
-   proposed in #1047: when it lands, the xfails flip to XPASS (strict, so
-   pytest will insist the markers are removed). Any resolution — dropping,
-   clamping, or falling back to the Kafka broker timestamp — satisfies the
-   assertion as written.
+2. **Timestamp sanity**: data-derived timestamps are bounded against the wall
+   clock before crossing the adapter boundary, because the batcher uses them
+   as its only clock and a single far-future value would otherwise wedge the
+   whole service (#1038 finding 1). ``KafkaAdapter._clamp_future`` implements
+   this as a clamp to the wall clock; these tests are agnostic between that,
+   rejecting, and falling back to the Kafka broker timestamp.
 """
 
 from __future__ import annotations
@@ -101,11 +98,6 @@ def test_ev44_mismatched_event_vectors_accepted_on_plain_monitor_path() -> None:
     assert len(adapted.value.time_of_arrival) == 10
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='#1038 finding 2: absent event vectors raise deep in the adapter '
-    'and the message is dropped instead of using the Kafka-timestamp fallback',
-)
 def test_ev44_without_event_vectors_falls_back_to_kafka_timestamp() -> None:
     payload = hostile_wire.ev44_without_event_vectors(SOURCE)
     message = _kafka_message(payload, timestamp_ms=5678)
@@ -155,12 +147,6 @@ def _far_future_cases() -> list[tuple[str, KafkaAdapter, bytes]]:
 @pytest.mark.parametrize(
     ('adapter', 'payload'),
     [pytest.param(a, p, id=name) for name, a, p in _far_future_cases()],
-)
-@pytest.mark.xfail(
-    strict=True,
-    reason='#1038 finding 1 / #1047: data-derived timestamps cross the '
-    'adapter boundary unvalidated; a single far-future value wedges the '
-    'batcher service-wide',
 )
 def test_far_future_data_timestamp_does_not_cross_adapter_boundary(
     adapter: KafkaAdapter, payload: bytes

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -1287,6 +1287,28 @@ class TestFutureTimestampGuard:
         assert result.value.timestamp_unix_ns == timestamp_unix_ns
         assert result.value.value == 1.0
 
+    def test_clamp_warning_without_counter_fires_once_per_stream(self) -> None:
+        """Adapters without a StreamCounter (e.g. dashboard-side routes) must
+        not warn per message: a producer with a broken clock sends thousands
+        of messages per stats window."""
+        from structlog.testing import capture_logs
+
+        def make_message(source_name: str) -> FakeKafkaMessage:
+            payload = logdata_f144.serialise_f144(
+                source_name=source_name,
+                value=1.0,
+                timestamp_unix_ns=_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60),
+            )
+            return FakeKafkaMessage(value=payload, topic="sensors")
+
+        adapter = KafkaToF144Adapter()
+        with capture_logs() as captured:
+            adapter.adapt(make_message("temperature1"))
+            adapter.adapt(make_message("temperature1"))
+            adapter.adapt(make_message("temperature2"))
+        clamps = [c for c in captured if c["event"] == "future_timestamp_clamped"]
+        assert [c["source_name"] for c in clamps] == ["temperature1", "temperature2"]
+
     def test_within_bound_da00_timestamp_is_accepted_unchanged(self) -> None:
         timestamp_ns = _future_ns(5)
         payload = dataarray_da00.serialise_da00(

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import time
+
 import numpy as np
 import pytest
 import scipp as sc
@@ -11,6 +13,7 @@ from streaming_data_types import (
 )
 from streaming_data_types.exceptions import WrongSchemaException
 
+from ess.livedata.core.job import StreamStat
 from ess.livedata.core.message import (
     COMMANDS_STREAM_ID,
     RESPONSES_STREAM_ID,
@@ -21,6 +24,7 @@ from ess.livedata.core.message import (
 )
 from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.kafka.message_adapter import (
+    FUTURE_TIMESTAMP_BOUND_S,
     Ad00ToScippAdapter,
     AdaptingMessageSource,
     ChainedAdapter,
@@ -42,6 +46,7 @@ from ess.livedata.kafka.message_adapter import (
     ResponsesAdapter,
     RouteBySchemaAdapter,
     RouteByTopicAdapter,
+    UnmappedStreamError,
 )
 from ess.livedata.kafka.stream_counter import StreamCounter
 from ess.livedata.preprocessors.to_nxevent_data import DetectorEvents
@@ -1144,3 +1149,306 @@ class TestAdapterLagRecording:
         adapter.adapt(message)
 
         assert counter.drain_lag() is None
+
+
+def _future_ns(offset_s: float) -> int:
+    return time.time_ns() + int(offset_s * 1_000_000_000)
+
+
+def _assert_clamped_to_now(timestamp_ns: int, *, before_ns: int) -> None:
+    """The clamped timestamp is the adapter's wall clock at adapt time."""
+    assert before_ns <= timestamp_ns <= time.time_ns()
+
+
+class TestFutureTimestampGuard:
+    """A data-derived timestamp too far ahead of the wall clock is clamped.
+
+    Within-bound future timestamps must pass through unchanged -- the guard
+    only clamps implausible values, not all future data (replays and normal
+    facility clock skew are legitimate).
+    """
+
+    def test_within_bound_ev44_timestamp_is_accepted_unchanged(self) -> None:
+        reference_time = _future_ns(5)
+        payload = eventdata_ev44.serialise_ev44(
+            source_name="monitor1",
+            message_id=0,
+            reference_time=[reference_time],
+            reference_time_index=0,
+            time_of_flight=[123456],
+            pixel_id=[1],
+        )
+        message = FakeKafkaMessage(value=payload, topic="monitors")
+        adapter = KafkaToEv44Adapter(stream_kind=StreamKind.MONITOR_EVENTS)
+        result = adapter.adapt(message)
+        assert result.timestamp.to_ns() == reference_time
+        assert result.value.time_of_flight == [123456]
+
+    def test_beyond_bound_ev44_timestamp_is_clamped(self) -> None:
+        payload = eventdata_ev44.serialise_ev44(
+            source_name="monitor1",
+            message_id=0,
+            reference_time=[_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)],
+            reference_time_index=0,
+            time_of_flight=[123456],
+            pixel_id=[1],
+        )
+        message = FakeKafkaMessage(value=payload, topic="monitors")
+        adapter = KafkaToEv44Adapter(stream_kind=StreamKind.MONITOR_EVENTS)
+        before_ns = time.time_ns()
+        result = adapter.adapt(message)
+        _assert_clamped_to_now(result.timestamp.to_ns(), before_ns=before_ns)
+        assert result.value.time_of_flight == [123456]
+
+    def test_within_bound_monitor_timestamp_is_accepted_unchanged(self) -> None:
+        reference_time = _future_ns(5)
+        payload = eventdata_ev44.serialise_ev44(
+            source_name="monitor1",
+            message_id=0,
+            reference_time=[reference_time],
+            reference_time_index=0,
+            time_of_flight=[123456],
+            pixel_id=[1],
+        )
+        message = FakeKafkaMessage(value=payload, topic="monitors")
+        adapter = KafkaToMonitorEventsAdapter(
+            stream_lut={
+                InputStreamKey(topic="monitors", source_name="monitor1"): "monitor1"
+            }
+        )
+        result = adapter.adapt(message)
+        assert result.timestamp.to_ns() == reference_time
+        assert result.value.time_of_arrival == [123456]
+
+    def test_beyond_bound_monitor_timestamp_is_clamped(self) -> None:
+        payload = eventdata_ev44.serialise_ev44(
+            source_name="monitor1",
+            message_id=0,
+            reference_time=[_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)],
+            reference_time_index=0,
+            time_of_flight=[123456],
+            pixel_id=[1],
+        )
+        message = FakeKafkaMessage(value=payload, topic="monitors")
+        adapter = KafkaToMonitorEventsAdapter(
+            stream_lut={
+                InputStreamKey(topic="monitors", source_name="monitor1"): "monitor1"
+            }
+        )
+        before_ns = time.time_ns()
+        result = adapter.adapt(message)
+        _assert_clamped_to_now(result.timestamp.to_ns(), before_ns=before_ns)
+        assert result.value.time_of_arrival == [123456]
+
+    def test_unmapped_stream_is_reported_as_unmapped_not_clamped(self) -> None:
+        """Kafka subscription is per-topic, so a service sees sources it does
+        not consume. A foreign producer's broken clock must not surface as an
+        error in a service that ignores its data."""
+        payload = eventdata_ev44.serialise_ev44(
+            source_name="foreign",
+            message_id=0,
+            reference_time=[_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)],
+            reference_time_index=0,
+            time_of_flight=[123456],
+            pixel_id=[1],
+        )
+        message = FakeKafkaMessage(value=payload, topic="monitors")
+        adapter = KafkaToMonitorEventsAdapter(stream_lut={})
+        with pytest.raises(UnmappedStreamError):
+            adapter.adapt(message)
+
+    def test_within_bound_f144_timestamp_is_accepted_unchanged(self) -> None:
+        timestamp_unix_ns = _future_ns(5)
+        payload = logdata_f144.serialise_f144(
+            source_name="temperature1", value=1.0, timestamp_unix_ns=timestamp_unix_ns
+        )
+        message = FakeKafkaMessage(value=payload, topic="sensors")
+        result = KafkaToF144Adapter().adapt(message)
+        assert result.timestamp.to_ns() == timestamp_unix_ns
+        assert result.value.timestamp_unix_ns == timestamp_unix_ns
+        assert result.value.value == 1.0
+
+    def test_beyond_bound_f144_clamp_leaves_payload_untouched(self) -> None:
+        """The clamp rewrites only the envelope timestamp. The payload is the
+        device's claim and flows to science consumers unmodified, so a wrong
+        device clock is visible in the data instead of silently replaced."""
+        timestamp_unix_ns = _future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)
+        payload = logdata_f144.serialise_f144(
+            source_name="temperature1", value=1.0, timestamp_unix_ns=timestamp_unix_ns
+        )
+        message = FakeKafkaMessage(value=payload, topic="sensors")
+        before_ns = time.time_ns()
+        result = KafkaToF144Adapter().adapt(message)
+        _assert_clamped_to_now(result.timestamp.to_ns(), before_ns=before_ns)
+        assert result.value.timestamp_unix_ns == timestamp_unix_ns
+        assert result.value.value == 1.0
+
+    def test_within_bound_da00_timestamp_is_accepted_unchanged(self) -> None:
+        timestamp_ns = _future_ns(5)
+        payload = dataarray_da00.serialise_da00(
+            source_name="instrument",
+            timestamp_ns=timestamp_ns,
+            data=[
+                dataarray_da00.Variable(
+                    name="signal", data=np.array([1.0]), unit="counts"
+                )
+            ],
+        )
+        message = FakeKafkaMessage(value=payload, topic="instrument")
+        adapter = KafkaToDa00Adapter(stream_kind=StreamKind.MONITOR_COUNTS)
+        result = adapter.adapt(message)
+        assert result.timestamp.to_ns() == timestamp_ns
+        assert len(result.value) == 1
+
+    def test_beyond_bound_da00_timestamp_is_clamped(self) -> None:
+        payload = dataarray_da00.serialise_da00(
+            source_name="instrument",
+            timestamp_ns=_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60),
+            data=[
+                dataarray_da00.Variable(
+                    name="signal", data=np.array([1.0]), unit="counts"
+                )
+            ],
+        )
+        message = FakeKafkaMessage(value=payload, topic="instrument")
+        adapter = KafkaToDa00Adapter(stream_kind=StreamKind.MONITOR_COUNTS)
+        before_ns = time.time_ns()
+        result = adapter.adapt(message)
+        _assert_clamped_to_now(result.timestamp.to_ns(), before_ns=before_ns)
+        assert len(result.value) == 1
+
+    def test_within_bound_ad00_timestamp_is_accepted_unchanged(self) -> None:
+        timestamp_ns = _future_ns(5)
+        payload = area_detector_ad00.serialise_ad00(
+            source_name="area_detector",
+            unique_id=42,
+            timestamp_ns=timestamp_ns,
+            data=np.array([[1.0, 2.0], [3.0, 4.0]]),
+        )
+        message = FakeKafkaMessage(value=payload, topic="detectors")
+        adapter = KafkaToAd00Adapter(stream_kind=StreamKind.AREA_DETECTOR)
+        result = adapter.adapt(message)
+        assert result.timestamp.to_ns() == timestamp_ns
+        assert result.stream.name == "area_detector"
+
+    def test_beyond_bound_ad00_timestamp_is_clamped(self) -> None:
+        payload = area_detector_ad00.serialise_ad00(
+            source_name="area_detector",
+            unique_id=42,
+            timestamp_ns=_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60),
+            data=np.array([[1.0, 2.0], [3.0, 4.0]]),
+        )
+        message = FakeKafkaMessage(value=payload, topic="detectors")
+        adapter = KafkaToAd00Adapter(stream_kind=StreamKind.AREA_DETECTOR)
+        before_ns = time.time_ns()
+        result = adapter.adapt(message)
+        _assert_clamped_to_now(result.timestamp.to_ns(), before_ns=before_ns)
+        assert result.stream.name == "area_detector"
+
+    def test_custom_bound_via_ctor_kwarg_clamps_tighter(self) -> None:
+        """A caller-supplied bound overrides the module default: this offset
+        is comfortably within the default and clamped only by the tighter
+        bound."""
+        payload = eventdata_ev44.serialise_ev44(
+            source_name="monitor1",
+            message_id=0,
+            reference_time=[_future_ns(5)],
+            reference_time_index=0,
+            time_of_flight=[1],
+            pixel_id=[1],
+        )
+        message = FakeKafkaMessage(value=payload, topic="monitors")
+        adapter = KafkaToEv44Adapter(
+            stream_kind=StreamKind.MONITOR_EVENTS, future_bound_s=1.0
+        )
+        before_ns = time.time_ns()
+        result = adapter.adapt(message)
+        _assert_clamped_to_now(result.timestamp.to_ns(), before_ns=before_ns)
+
+    def test_clamp_prefers_plausible_broker_timestamp_over_wall_clock(self) -> None:
+        """When consuming a backlog the wall clock is ahead of the surrounding
+        traffic; the broker CreateTime lands the message among its neighbours
+        instead of turning it into a future outlier for the batcher."""
+        broker_time_ms = (time.time_ns() - 3600 * 1_000_000_000) // 1_000_000
+        timestamp_unix_ns = _future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)
+        payload = logdata_f144.serialise_f144(
+            source_name="temperature1", value=1.0, timestamp_unix_ns=timestamp_unix_ns
+        )
+        message = FakeKafkaMessage(
+            value=payload, topic="sensors", timestamp=broker_time_ms, timestamp_type=1
+        )
+        result = KafkaToF144Adapter().adapt(message)
+        assert result.timestamp == Timestamp.from_ms(broker_time_ms)
+        assert result.value.timestamp_unix_ns == timestamp_unix_ns
+
+    def test_clamp_falls_back_to_wall_clock_for_insane_broker_timestamp(self) -> None:
+        """A producer whose host clock stamps both the payload and CreateTime
+        offers no plausible broker time; the wall clock is the last resort."""
+        broker_time_ms = _future_ns(FUTURE_TIMESTAMP_BOUND_S + 60) // 1_000_000
+        payload = logdata_f144.serialise_f144(
+            source_name="temperature1",
+            value=1.0,
+            timestamp_unix_ns=_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60),
+        )
+        message = FakeKafkaMessage(
+            value=payload, topic="sensors", timestamp=broker_time_ms, timestamp_type=1
+        )
+        before_ns = time.time_ns()
+        result = KafkaToF144Adapter().adapt(message)
+        _assert_clamped_to_now(result.timestamp.to_ns(), before_ns=before_ns)
+
+    def test_clamp_is_recorded_in_stream_counter(self) -> None:
+        counter = StreamCounter()
+        payload = eventdata_ev44.serialise_ev44(
+            source_name="monitor1",
+            message_id=0,
+            reference_time=[_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)],
+            reference_time_index=0,
+            time_of_flight=[1],
+            pixel_id=[1],
+        )
+        message = FakeKafkaMessage(value=payload, topic="monitors")
+        adapter = KafkaToEv44Adapter(
+            stream_kind=StreamKind.MONITOR_EVENTS, stream_counter=counter
+        )
+        adapter.adapt(message)
+
+        stats = counter.drain(window_seconds=30.0)
+        # Clamps are a subset of received messages, so a stream whose every
+        # timestamp was clamped reports count == clamped.
+        assert stats.streams == (
+            StreamStat(
+                topic="monitors",
+                source_name="monitor1",
+                stream="monitor1",
+                count=1,
+                clamped=1,
+            ),
+        )
+
+    def test_warning_logged_only_on_first_clamp_per_stream_per_window(self) -> None:
+        from structlog.testing import capture_logs
+
+        counter = StreamCounter()
+        payload = eventdata_ev44.serialise_ev44(
+            source_name="monitor1",
+            message_id=0,
+            reference_time=[_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)],
+            reference_time_index=0,
+            time_of_flight=[1],
+            pixel_id=[1],
+        )
+        adapter = KafkaToEv44Adapter(
+            stream_kind=StreamKind.MONITOR_EVENTS, stream_counter=counter
+        )
+        with capture_logs() as captured:
+            adapter.adapt(FakeKafkaMessage(value=payload, topic="monitors"))
+            adapter.adapt(FakeKafkaMessage(value=payload, topic="monitors"))
+
+        clamp_logs = [
+            log for log in captured if log['event'] == 'future_timestamp_clamped'
+        ]
+        assert len(clamp_logs) == 1
+
+        stats = counter.drain(window_seconds=30.0)
+        assert stats.streams[0].clamped == 2

--- a/tests/kafka/message_adapter_test.py
+++ b/tests/kafka/message_adapter_test.py
@@ -1221,10 +1221,13 @@ class TestFutureTimestampGuard:
         assert result.value.time_of_arrival == [123456]
 
     def test_beyond_bound_monitor_timestamp_is_clamped(self) -> None:
+        """Only the envelope is clamped; the payload keeps the device's claimed
+        pulse time (see KafkaAdapter._clamp_future for the contract)."""
+        reference_time_ns = _future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)
         payload = eventdata_ev44.serialise_ev44(
             source_name="monitor1",
             message_id=0,
-            reference_time=[_future_ns(FUTURE_TIMESTAMP_BOUND_S + 60)],
+            reference_time=[reference_time_ns],
             reference_time_index=0,
             time_of_flight=[123456],
             pixel_id=[1],
@@ -1239,6 +1242,7 @@ class TestFutureTimestampGuard:
         result = adapter.adapt(message)
         _assert_clamped_to_now(result.timestamp.to_ns(), before_ns=before_ns)
         assert result.value.time_of_arrival == [123456]
+        assert result.value.reference_time_ns == reference_time_ns
 
     def test_unmapped_stream_is_reported_as_unmapped_not_clamped(self) -> None:
         """Kafka subscription is per-topic, so a service sees sources it does

--- a/tests/kafka/run_control_adapter_test.py
+++ b/tests/kafka/run_control_adapter_test.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import time
+
 import pytest
 from streaming_data_types import run_start_pl72, run_stop_6s4t
 from streaming_data_types.exceptions import WrongSchemaException
@@ -82,6 +84,43 @@ class TestRunControlAdapter:
         stop_msg = adapter.adapt(_make_run_stop_message())
         assert start_msg.stream == RUN_CONTROL_STREAM_ID
         assert stop_msg.stream == RUN_CONTROL_STREAM_ID
+
+    def test_far_future_run_times_are_bounded(self):
+        """Run times schedule resets that fire when data time reaches them; a
+        far-future value would park a reset that never fires, losing the run
+        transition. Bounded like the envelope, with the same broker-time
+        preference."""
+        far_future_ms = (time.time_ns() + 3600 * 1_000_000_000) // 1_000_000
+        broker_time_ms = 1_700_000_000_000
+        buf = run_start_pl72.serialise_pl72(
+            job_id='fw-job-1',
+            filename='/data/run_42.nxs',
+            start_time=far_future_ms,
+            stop_time=far_future_ms + 1,
+            run_name='run_42',
+        )
+        message = FakeKafkaMessage(
+            value=buf,
+            topic='inst_filewriter',
+            timestamp=broker_time_ms,
+            timestamp_type=1,
+        )
+        msg = RunControlAdapter().adapt(message)
+        assert isinstance(msg.value, RunStart)
+        assert msg.value.start_time == Timestamp.from_ms(broker_time_ms)
+        assert msg.value.stop_time == Timestamp.from_ms(broker_time_ms)
+
+    def test_far_future_stop_time_falls_back_to_wall_clock(self):
+        far_future_ms = (time.time_ns() + 3600 * 1_000_000_000) // 1_000_000
+        buf = run_stop_6s4t.serialise_6s4t(
+            job_id='fw-job-1', run_name='run_42', stop_time=far_future_ms
+        )
+        message = FakeKafkaMessage(value=buf, topic='inst_filewriter')
+        before_ns = time.time_ns()
+        msg = RunControlAdapter().adapt(message)
+        after_ns = time.time_ns()
+        assert isinstance(msg.value, RunStop)
+        assert before_ns <= msg.value.stop_time.to_ns() <= after_ns
 
     def test_raises_on_unknown_schema(self):
         adapter = RunControlAdapter()

--- a/tests/kafka/status_message_test.py
+++ b/tests/kafka/status_message_test.py
@@ -1069,3 +1069,40 @@ class TestStreamStatsX5F2RoundTrip:
         assert isinstance(result, ServiceStatus)
         assert result.stream_stats is not None
         assert result.stream_stats.streams[0].count == 42
+
+    def test_round_trip_preserves_clamped(self):
+        """The clamped count survives the x5f2 round trip alongside count,
+        including a stream whose every message was clamped (count=0)."""
+        stats = StreamStats(
+            window_seconds=30.0,
+            streams=(
+                StreamStat(
+                    topic="t1", source_name="s1", stream="s1", count=42, clamped=3
+                ),
+                StreamStat(
+                    topic="t2", source_name="s2", stream=None, count=0, clamped=5
+                ),
+            ),
+        )
+        original = make_service_status(stream_stats=stats)
+
+        x5f2_data = service_status_to_x5f2(original)
+        converted = x5f2_to_service_status(x5f2_data)
+
+        assert converted.stream_stats is not None
+        assert converted.stream_stats.streams[0] == stats.streams[0]
+        assert converted.stream_stats.streams[1] == stats.streams[1]
+
+    def test_round_trip_defaults_clamped_to_zero(self):
+        """StreamStat constructed without clamped still round-trips as 0."""
+        stats = StreamStats(
+            window_seconds=30.0,
+            streams=(StreamStat(topic="t1", source_name="s1", stream="s1", count=1),),
+        )
+        original = make_service_status(stream_stats=stats)
+
+        x5f2_data = service_status_to_x5f2(original)
+        converted = x5f2_to_service_status(x5f2_data)
+
+        assert converted.stream_stats is not None
+        assert converted.stream_stats.streams[0].clamped == 0

--- a/tests/kafka/stream_counter_test.py
+++ b/tests/kafka/stream_counter_test.py
@@ -133,6 +133,88 @@ class TestStreamCounter:
         assert stats.streams[0].topic == "other_topic"
 
 
+class TestStreamCounterClamped:
+    def test_record_clamped_creates_entry_with_zero_count(self) -> None:
+        """A stream whose timestamps are all clamped must still be visible."""
+        counter = StreamCounter()
+        counter.record_clamped("topic_a", "source_1")
+        stats = counter.drain(window_seconds=30.0)
+        assert stats.streams == (
+            StreamStat(
+                topic="topic_a",
+                source_name="source_1",
+                stream=None,
+                count=0,
+                clamped=1,
+            ),
+        )
+
+    def test_record_clamped_accumulates(self) -> None:
+        counter = StreamCounter()
+        counter.record_clamped("topic_a", "source_1")
+        counter.record_clamped("topic_a", "source_1")
+        counter.record_clamped("topic_a", "source_1")
+        stats = counter.drain(window_seconds=30.0)
+        assert stats.streams[0].clamped == 3
+
+    def test_record_and_record_clamped_share_the_same_entry(self) -> None:
+        counter = StreamCounter()
+        counter.record("topic_a", "source_1", "stream_1")
+        counter.record_clamped("topic_a", "source_1")
+        stats = counter.drain(window_seconds=30.0)
+        assert stats.streams == (
+            StreamStat(
+                topic="topic_a",
+                source_name="source_1",
+                stream="stream_1",
+                count=1,
+                clamped=1,
+            ),
+        )
+
+    def test_record_clamped_returns_true_on_first_call_in_window(self) -> None:
+        counter = StreamCounter()
+        assert counter.record_clamped("topic_a", "source_1") is True
+
+    def test_record_clamped_returns_false_on_subsequent_calls_in_window(self) -> None:
+        counter = StreamCounter()
+        counter.record_clamped("topic_a", "source_1")
+        assert counter.record_clamped("topic_a", "source_1") is False
+
+    def test_record_clamped_is_first_again_after_drain(self) -> None:
+        counter = StreamCounter()
+        counter.record_clamped("topic_a", "source_1")
+        counter.drain(window_seconds=30.0)
+        assert counter.record_clamped("topic_a", "source_1") is True
+
+    def test_first_clamp_is_per_stream(self) -> None:
+        counter = StreamCounter()
+        assert counter.record_clamped("topic_a", "source_1") is True
+        assert counter.record_clamped("topic_a", "source_2") is True
+
+    def test_drain_resets_clamped(self) -> None:
+        counter = StreamCounter()
+        counter.record_clamped("topic_a", "source_1")
+        counter.drain(window_seconds=30.0)
+        stats = counter.drain(window_seconds=30.0)
+        assert stats.streams == ()
+
+    def test_ignores_epics_noise_suffixes(self) -> None:
+        counter = StreamCounter()
+        assert counter.record_clamped("motion", "PV.DMOV") is False
+        assert counter.record_clamped("motion", "PV.VAL") is False
+        stats = counter.drain(window_seconds=30.0)
+        assert stats.streams == ()
+
+    def test_drops_out_of_scope_streams(self) -> None:
+        counter = StreamCounter(
+            out_of_scope=[InputStreamKey(topic="logs", source_name="other_pv.RBV")]
+        )
+        assert counter.record_clamped("logs", "other_pv.RBV") is False
+        stats = counter.drain(window_seconds=30.0)
+        assert stats.streams == ()
+
+
 class TestStreamCounterLag:
     def test_drain_lag_empty_returns_none(self) -> None:
         assert StreamCounter().drain_lag() is None

--- a/tests/preprocessors/to_nxevent_data_test.py
+++ b/tests/preprocessors/to_nxevent_data_test.py
@@ -25,6 +25,22 @@ def test_MonitorEvents_from_ev44() -> None:
     monitor_events = MonitorEvents.from_ev44(ev44)
     assert monitor_events.time_of_arrival == [1, 2, 3]
     assert monitor_events.unit == 'ns'
+    assert monitor_events.reference_time_ns is None
+
+
+@pytest.mark.parametrize('events_cls', [MonitorEvents, DetectorEvents])
+def test_from_ev44_captures_payload_pulse_time(
+    events_cls: type[MonitorEvents],
+) -> None:
+    ev44 = eventdata_ev44.EventData(
+        source_name='ignored',
+        message_id=0,
+        reference_time=[123_000],
+        reference_time_index=[0],
+        pixel_id=[1, 1, 1],
+        time_of_flight=[1, 2, 3],
+    )
+    assert events_cls.from_ev44(ev44).reference_time_ns == 123_000
 
 
 @pytest.mark.parametrize('events_cls', [MonitorEvents, DetectorEvents])
@@ -75,6 +91,25 @@ def test_MonitorEvents_ToNXevent_data() -> None:
     assert empty_events.sizes == {'event_time_zero': 0}
     to_nx.release_buffers()
     assert_identical(empty_events, events[0:0])
+
+
+def test_event_time_zero_prefers_payload_pulse_time_over_envelope() -> None:
+    """The payload's pulse time is the device's claim and flows through
+    unmodified; the envelope may have been clamped at the adapter boundary
+    and only stands in when the payload carries no pulse time."""
+    to_nx = ToNXevent_data()
+    to_nx.add(
+        Timestamp.from_ns(500),
+        MonitorEvents(time_of_arrival=[1], unit='ns', reference_time_ns=71_000_000),
+    )
+    to_nx.add(Timestamp.from_ns(1000), MonitorEvents(time_of_arrival=[2], unit='ns'))
+    events = to_nx.get()
+    assert_identical(
+        events.coords['event_time_zero'],
+        sc.epoch(unit='ns')
+        + sc.array(dims=['event_time_zero'], values=[71_000_000, 1000], unit='ns'),
+    )
+    to_nx.release_buffers()
 
 
 def test_DetectorEvents_ToNXevent_data() -> None:

--- a/tests/services/hostile_input_liveness_test.py
+++ b/tests/services/hostile_input_liveness_test.py
@@ -38,6 +38,7 @@ from ess.livedata.core.message_batcher import (
     SimpleMessageBatcher,
 )
 from ess.livedata.core.rate_aware_batcher import RateAwareMessageBatcher
+from ess.livedata.kafka.message_adapter import FakeKafkaMessage
 from ess.livedata.services.monitor_data import make_monitor_service_builder
 from tests.helpers import hostile_wire
 from tests.helpers.livedata_app import LivedataApp
@@ -80,9 +81,27 @@ class MonitorServiceHarness:
         self.app.publish_config_message(workflow_config)
         self.app.step()
 
-    def publish_payload(self, payload: bytes) -> None:
-        """Queue a raw payload on the monitor topic without stepping."""
-        self.app.publish_data(topic=self.app.monitor_topic, time=0, data=payload)
+    def publish_payload(
+        self, payload: bytes, *, broker_time_ms: int | None = None
+    ) -> None:
+        """Queue a raw payload on the monitor topic without stepping.
+
+        Without ``broker_time_ms`` the message carries no broker timestamp
+        (``TIMESTAMP_NOT_AVAILABLE``), which forces the adapter's future-clamp
+        onto its wall-clock fallback. Real Kafka messages always carry a
+        CreateTime; pass one to exercise the broker-timestamp clamp target.
+        """
+        if broker_time_ms is None:
+            self.app.publish_data(topic=self.app.monitor_topic, time=0, data=payload)
+        else:
+            self.app.consumer.add_message(
+                FakeKafkaMessage(
+                    value=payload,
+                    topic=self.app.monitor_topic,
+                    timestamp=broker_time_ms,
+                    timestamp_type=1,
+                )
+            )
 
     def next_time_ns(self) -> int:
         """Advance and return the data clock, for hand-built in-sequence payloads."""
@@ -155,10 +174,13 @@ def test_far_future_timestamp_mid_stream_does_not_stall_service(
 ) -> None:
     """A far-future timestamp *after* the first batch must not stop output.
 
-    The batchers must refuse to let the insane value steer window placement,
-    however far ahead it sits. The rate-aware batcher may stay silent for up
-    to ``_REANCHOR_STALLED_CALLS`` polls before re-anchoring, so the liveness
-    window must exceed that.
+    The adapter clamps the insane value to the wall clock. The harness data
+    timeline is a fixed epoch, so the clamped timestamp is still months ahead
+    of the stream *from the batcher's point of view* -- this test therefore
+    exercises the batcher-level in-band outlier defence end-to-end, the band
+    the adapter bound cannot cover. The rate-aware batcher may stay silent
+    for up to ``_REANCHOR_STALLED_CALLS`` polls before re-anchoring, so the
+    liveness window must exceed that.
     """
     harness.run_good_cycles(3)
     harness.publish_payload(
@@ -219,41 +241,24 @@ def test_mismatched_event_vectors_do_not_stall_service(
     assert_service_live(harness)
 
 
-@pytest.mark.parametrize(
-    'harness',
-    [
-        pytest.param(
-            SimpleMessageBatcher,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason='#1038 finding 1 / #1047: a lone far-future timestamp in '
-                'the startup backlog wins plausible_anchor\'s tie-break (one '
-                'message on each side carries no evidence), anchors the first '
-                'batch boundary, and the simple batcher has no recovery path — '
-                'the service goes silent while appearing healthy. Telling a '
-                'lone outlier from real traffic needs arrival-time evidence, '
-                'i.e. validation where messages enter (#1047).',
-            ),
-        ),
-        pytest.param(RateAwareMessageBatcher),
-    ],
-    indirect=True,
-    ids=['simple', 'rate_aware'],
-)
 def test_far_future_timestamp_in_first_batch_does_not_stall_service(
     harness: MonitorServiceHarness,
 ) -> None:
     """The startup backlog is where a far-future timestamp is most dangerous:
     it would anchor the first batch boundary, and every real message would
-    then look early forever. With only one good message beside the outlier,
-    ``plausible_anchor`` has no bulk of traffic to weigh against it, so the
-    first anchor lands on the outlier. The rate-aware batcher recovers by
-    re-anchoring once the buffered traffic unanimously contradicts the
-    window; the simple batcher stays wedged (see the xfail).
+    then look early forever. Two independent layers prevent it — the adapter
+    boundary clamps the timestamp, and the batchers anchor on a plausible
+    timestamp rather than the maximum.
+
+    The message carries a broker CreateTime in the harness's data epoch, as
+    in production consuming a backlog: the clamp must land the message among
+    its neighbours rather than at the wall clock, where it would re-poison
+    the first anchor from within the adapter's bound.
     """
     harness.publish_payload(
-        hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.FAR_FUTURE_NS)
+        hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.FAR_FUTURE_NS),
+        broker_time_ms=hostile_wire.REALISTIC_EPOCH_NS // 1_000_000,
     )
     harness.publish_good()
     harness.app.step()
-    assert_service_live(harness, cycles=60)
+    assert_service_live(harness, cycles=20)


### PR DESCRIPTION
## Why

The batcher hardening keeps services alive against pathological timestamps, but it cannot resolve every case: a lone far-future timestamp in the startup backlog is indistinguishable from real traffic without arrival-time evidence, and the simple batcher wedges on it (the strict xfail from #1122). The adapter boundary has that evidence — it sees the broker `CreateTime` and the consuming host's wall clock — so validation belongs there.

## What changed

Data-derived envelope timestamps implausibly far ahead of the wall clock (bound: 30 s; NTP skew is milliseconds, a broken clock is hours out, and three days of production logs contain no future-dated payload at all) are clamped at the adapter boundary. The clamp target is the broker `CreateTime` when itself plausible, the consumer's wall clock as a last resort — the order matters when consuming a backlog, where a wall-clock substitute would be a future outlier relative to the surrounding traffic and re-poison the batchers from within the bound.

The change establishes an explicit contract: **the envelope timestamp is livedata's transport clock** (batching, scheduling, run resets) and may be clamped freely, while **payload times are the device's claim** and reach science consumers unmodified. A wrong device clock stays visible and attributable in the data instead of being silently replaced by an estimate; consumers must tolerate wrong device times regardless, since a clock running behind passes any future bound. Concretely:

- No payload is rewritten on clamp, including f144.
- `event_time_zero` is now built from the payload's `reference_time` (threaded through the `Events` dataclasses) instead of inheriting the envelope, closing the path by which the clamp used to rewrite pulse times covertly. The envelope stands in only for messages carrying no pulse time.
- pl72/6s4t run start/stop times are the exception that proves the rule: they are control flow (they schedule job resets that fire when data time reaches them, so a far-future value would park a reset that never fires and lose the run transition) and are bounded like the envelope.

Clamping rather than dropping keeps data flowing during commissioning, when devices with broken clocks are expected. For a clamped ev44 stream this is a degraded mode with a known taxonomy: physics based on `event_time_offset` (most live reduction) is unaffected; correlation with slow f144 metadata holds at arrival-time accuracy while consumption is live; pulse-precision correlation is unrecoverable — no timestamp policy can restore it once the producer clock is broken.

Clamps are counted per stream and surfaced in the backend stream stats at warning severity, with a clamped-message column in the backend status widget. Adapters without a `StreamCounter` (dashboard-side routes) log once per stream instead of once per message.

While in the adapter, ev44 payloads whose event vectors are absent rather than empty now reach the broker-timestamp fallback intended for them, instead of dying on an `AttributeError` and being dropped (#1038 finding 2).

## Notes for review

An unmapped stream sending far-future timestamps is reported as unmapped rather than as a clamp: Kafka subscription is per-topic, and a foreign producer's broken clock should not raise warnings in a service that ignores its data.

A known residual hole: a message whose payload timestamp and `CreateTime` are both insane, consumed mid-backlog, degrades to the wall-clock fallback and is then a future outlier relative to the backlog's epoch; the rate-aware batcher recovers via re-anchoring, the simple batcher stays silent until catch-up completes.

A possible follow-up, deliberately not in scope: estimating a per-stream clock offset and clamping to `timestamp - offset`, which would preserve the pulse grid and upgrade coarse correlation to near-exact for constant-offset clocks.

Closes #1047. Also resolves findings 1 and 2 of #1038.

## Test plan

The strict xfail acceptance tests from #1053 and from #1122 now pass and their markers are removed. The far-future liveness tests exercise both clamp targets end-to-end. Adapter-level tests assert delivery with the clamped envelope, untouched payloads, the broker-time-vs-wall-clock cascade, run-time bounding, and once-per-stream warning rate-limiting without a counter.

- [ ] Backend status widget: confirm the clamped-message column and its summary badge render sensibly for a stream with clamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
