### PR TITLE
Remove departed subscribers' extractors from buffer retention

### DIFF
--- a/src/ess/livedata/dashboard/data_service.py
+++ b/src/ess/livedata/dashboard/data_service.py
@@ -263,6 +263,16 @@ class DataService(MutableMapping[K, V]):
         """
         Unregister a subscriber, stopping it from receiving updates.
 
+        Drops the subscriber's extractors from buffer retention: each affected
+        buffer is reconfigured to the surviving subscribers' requirements, so
+        retention cannot ratchet up over repeated register/unregister cycles.
+        Buffer type never downgrades here (sticky-upward, see
+        :py:meth:`TemporalBufferManager.set_extractors`), so buffered history
+        survives an unregister/re-register cycle on the same key. The cycle is
+        not atomic, though: if a surviving subscriber needs a shorter timespan,
+        an append landing between unregister and re-register may trim history
+        to that shorter window.
+
         Parameters
         ----------
         subscriber:
@@ -276,9 +286,14 @@ class DataService(MutableMapping[K, V]):
         with self._lock:
             try:
                 self._subscribers.remove(subscriber)
-                return True
             except ValueError:
                 return False
+            for key in subscriber.keys:
+                if key in self._buffer_manager:
+                    self._buffer_manager.set_extractors(
+                        key, self._get_extractors(key), allow_downgrade=False
+                    )
+            return True
 
     def _notify_subscribers(self, updated_keys: set[K]) -> None:
         """

--- a/src/ess/livedata/dashboard/temporal_buffer_manager.py
+++ b/src/ess/livedata/dashboard/temporal_buffer_manager.py
@@ -135,7 +135,13 @@ class TemporalBufferManager(Mapping[K, BufferProtocol[sc.DataArray]], Generic[K]
         state.extractors.append(extractor)
         self._reconfigure_buffer_if_needed(key, state)
 
-    def set_extractors(self, key: K, extractors: Sequence[UpdateExtractor]) -> None:
+    def set_extractors(
+        self,
+        key: K,
+        extractors: Sequence[UpdateExtractor],
+        *,
+        allow_downgrade: bool = True,
+    ) -> None:
         """
         Replace all extractors for an existing buffer.
 
@@ -144,22 +150,27 @@ class TemporalBufferManager(Mapping[K, BufferProtocol[sc.DataArray]], Generic[K]
         - Temporal→Single: Last time slice is copied to the new buffer
         - Other transitions: Data is discarded
 
-        Useful for reconfiguring buffers when subscribers change, e.g., when
-        a subscriber is removed and we need to downgrade from Temporal to
-        SingleValue buffer.
-
         Parameters
         ----------
         key:
             Key identifying the buffer to update.
         extractors:
             New sequence of extractors that will use this buffer.
+        allow_downgrade:
+            If False, the Temporal→Single transition is skipped: buffer type
+            is sticky-upward. Use on subscriber removal, where a transient
+            survivors-empty (or latest-only) state must not collapse buffered
+            history to a single slice — an unregister/re-register cycle on the
+            same key (e.g. a plot reconfiguration) would otherwise wipe
+            timeseries history that the backend never resends.
         """
         state = self._states[key]
         state.extractors = list(extractors)
-        self._reconfigure_buffer_if_needed(key, state)
+        self._reconfigure_buffer_if_needed(key, state, allow_downgrade=allow_downgrade)
 
-    def _reconfigure_buffer_if_needed(self, key: K, state: _BufferState) -> None:
+    def _reconfigure_buffer_if_needed(
+        self, key: K, state: _BufferState, *, allow_downgrade: bool = True
+    ) -> None:
         """
         Check if buffer type needs to change and handle migration.
 
@@ -169,10 +180,17 @@ class TemporalBufferManager(Mapping[K, BufferProtocol[sc.DataArray]], Generic[K]
             Key identifying the buffer.
         state:
             Buffer state to reconfigure.
+        allow_downgrade:
+            If False, keep a TemporalBuffer even when the extractors no
+            longer require one (see :py:meth:`set_extractors`).
         """
         # Check if we need to switch buffer type
         new_buffer = self._create_buffer_for_extractors(state.extractors)
-        if not isinstance(new_buffer, type(state.buffer)):
+        if not allow_downgrade and isinstance(new_buffer, SingleValueBuffer):
+            # Sticky-upward: keep the current buffer (and its history); a
+            # downgrade would keep only the last time slice.
+            pass
+        elif not isinstance(new_buffer, type(state.buffer)):
             # Handle data migration for Single->Temporal transition
             if isinstance(state.buffer, SingleValueBuffer) and isinstance(
                 new_buffer, TemporalBuffer
@@ -277,7 +295,9 @@ class TemporalBufferManager(Mapping[K, BufferProtocol[sc.DataArray]], Generic[K]
         extractors:
             Sequence of extractors to gather requirements from.
         """
-        # Compute maximum required timespan
+        # With no extractors, previous requirements are retained: shrinking to
+        # zero would let an append trim history during a transient
+        # unregister/re-register cycle (e.g. a plot reconfiguration).
         if extractors:
             max_timespan = max(e.get_required_timespan() for e in extractors)
             buffer.set_required_timespan(max_timespan)

--- a/tests/dashboard/data_service_test.py
+++ b/tests/dashboard/data_service_test.py
@@ -1554,3 +1554,58 @@ def test_buffering_continues_after_registration():
         service["key1"] = make_test_data(i, time=float(i))
     snapshot = service.snapshot(subscriber)
     assert snapshot["key1"].sizes["time"] == 3
+
+
+class TestUnregisterExtractorSymmetry:
+    """Unregistering drops a subscriber's extractors from buffer retention.
+
+    Without this symmetry, extractor lists (and the retention they pin) grow
+    without bound over repeated register/unregister cycles on a long-lived key.
+    """
+
+    @staticmethod
+    def _history_subscriber() -> SimpleTestSubscriber:
+        from ess.livedata.dashboard.extractors import FullHistoryExtractor
+
+        subscriber = SimpleTestSubscriber({"key1"})
+        subscriber._extractors = {"key1": FullHistoryExtractor()}
+        return subscriber
+
+    def test_history_preserved_across_unregister_reregister_cycle(self):
+        """A plot-edit style unregister/re-register must not wipe history."""
+        service = DataService[str, int]()
+        sub1 = self._history_subscriber()
+        service.register_subscriber(sub1)
+        for i in range(3):
+            service["key1"] = make_test_data(i, time=float(i))
+
+        service.unregister_subscriber(sub1)
+        sub2 = self._history_subscriber()
+        service.register_subscriber(sub2)
+
+        snapshot = service.snapshot(sub2)
+        assert snapshot["key1"].sizes["time"] == 3
+
+    def test_unregister_releases_retention_requirement(self):
+        """A departed subscriber's timespan no longer pins the buffer."""
+        from ess.livedata.dashboard.temporal_buffers import TemporalBuffer
+
+        service = DataService[str, int]()
+        latest = SimpleTestSubscriber({"key1"})
+        service.register_subscriber(latest)
+        service["key1"] = make_test_data(0, time=0.0)
+
+        for _ in range(20):
+            history = self._history_subscriber()
+            service.register_subscriber(history)
+            assert service._buffer_manager["key1"].get_required_timespan() == float(
+                "inf"
+            )
+            service.unregister_subscriber(history)
+            # Retention shrinks to the surviving LatestValueExtractor; the
+            # buffer stays temporal (sticky-upward). Extractor count is the
+            # leak observable, unreachable through the public API.
+            buffer = service._buffer_manager["key1"]
+            assert buffer.get_required_timespan() == 0.0
+            assert isinstance(buffer, TemporalBuffer)
+            assert len(service._buffer_manager._states["key1"].extractors) == 1

--- a/tests/dashboard/temporal_buffer_manager_test.py
+++ b/tests/dashboard/temporal_buffer_manager_test.py
@@ -357,3 +357,51 @@ class TestTemporalBufferManagerWithRealData:
         assert result is not None
         assert 'time' in result.dims
         assert result.sizes['time'] == 3
+
+
+def _timed(value: float, time: float) -> sc.DataArray:
+    return sc.DataArray(
+        sc.scalar(value, unit='counts'),
+        coords={'time': sc.scalar(time, unit='s')},
+    )
+
+
+class TestSetExtractorsWithoutDowngrade:
+    """Sticky-upward buffer type on subscriber removal (allow_downgrade=False)."""
+
+    def test_keeps_temporal_buffer_and_history(self):
+        manager = TemporalBufferManager()
+        manager.create_buffer('test', [FullHistoryExtractor()])
+        for i in range(3):
+            manager.update_buffer('test', _timed(float(i), float(i)))
+
+        manager.set_extractors('test', [LatestValueExtractor()], allow_downgrade=False)
+
+        assert isinstance(manager['test'], TemporalBuffer)
+        result = manager.get_buffered_data('test')
+        assert result is not None
+        assert result.sizes['time'] == 3
+
+    def test_empty_extractors_keep_buffer_type_and_requirements(self):
+        manager = TemporalBufferManager()
+        manager.create_buffer(
+            'test', [WindowAggregatingExtractor(window_duration_seconds=60.0)]
+        )
+        manager.update_buffer('test', _timed(1.0, 0.0))
+
+        manager.set_extractors('test', [], allow_downgrade=False)
+
+        assert isinstance(manager['test'], TemporalBuffer)
+        assert manager['test'].get_required_timespan() == 60.0
+        assert manager.get_buffered_data('test') is not None
+
+    def test_timespan_shrinks_to_surviving_extractors(self):
+        manager = TemporalBufferManager()
+        window = WindowAggregatingExtractor(window_duration_seconds=60.0)
+        manager.create_buffer('test', [FullHistoryExtractor(), window])
+        assert manager['test'].get_required_timespan() == float('inf')
+
+        manager.set_extractors('test', [window], allow_downgrade=False)
+
+        assert isinstance(manager['test'], TemporalBuffer)
+        assert manager['test'].get_required_timespan() == 60.0


### PR DESCRIPTION
Part of #1044 (extractor-removal symmetry), sequenced as the prerequisite for #1042 Option B slice (i) per the corrected amendment A1 on that issue.

`DataService.unregister_subscriber` removed the subscriber from the notification list but left its extractors in `_BufferState.extractors` forever, so extractor lists grow and max retention ratchets up over repeated register/unregister cycles on a long-lived key. Today this is bounded because every commit mints fresh keys and old buffers die at cleanup; under the stable dashboard keys of #1042 slice (i) buffers become immortal and the growth unbounded over multi-day operation, so this must land first.

Naive symmetric removal (`set_extractors` with the survivors) would regress plot edits: an unregister/re-register cycle on the same key passes through a survivors-empty state whose Temporal→Single downgrade keeps only the last time slice, wiping timeseries history the backend never resends (delta emission). The unregister path therefore applies survivor extractors with the type downgrade disabled — buffer type is sticky-upward for the buffer's lifetime (resets at buffer deletion) — and empty-survivor states retain previous retention requirements, since shrinking to zero would let an append trim history inside the transient cycle.

Known residual window (documented in the docstring, accepted for now): the unregister/re-register cycle is not atomic, so if a surviving subscriber needs a shorter timespan than the re-registering one, an append landing in the gap may trim history to the shorter window. Making the cycle atomic is plot-orchestrator API surgery that #1042 slices (ii)+ reshape anyway.

## Test plan

- New regression test: unregister/re-register cycle on a populated timeseries key preserves full history (fails on the naive fix).
- Retention shrinks to survivors and extractor count stays constant over repeated cycles; empty-survivor state keeps buffer type and requirements.
- Existing concurrent ingestion/subscriber-churn stress test now exercises the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
