### PR TITLE
Drop previous-JobSet tracking and persistence

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -84,7 +84,7 @@ python -m ess.livedata.dashboard.reduction --instrument dummy --transport fake \
 Add `--auto-start` (requires `--transport fake`) to commit every staged workflow on
 launch so plots render with no interaction. Regenerate a fixture by configuring via the
 UI, then copying the persisted `workflow_configs.yaml` (strip the runtime
-`current_job`/`previous_job` keys, keep `jobs`) and `plot_configs.yaml` from the config
+`current_job` key, keep `jobs`) and `plot_configs.yaml` from the config
 dir back into the fixture; `ui_config_fixtures_test.py` guards against drift.
 
 **Shadow DOM selectors.** Tool buttons and rows live in per-widget *open* shadow roots.

--- a/src/ess/livedata/dashboard/active_job_registry.py
+++ b/src/ess/livedata/dashboard/active_job_registry.py
@@ -164,18 +164,15 @@ class ActiveJobRegistry:
             if dropped is not None:
                 self._job_service.remove_jobs_by_number(dropped.job_number)
 
-    def restore(
-        self,
-        workflow_id: WorkflowId,
-        *,
-        current: Generation | None,
-        last: Generation | None = None,
-    ) -> None:
-        """Restore persisted generations without acquiring the lock.
+    def restore(self, workflow_id: WorkflowId, *, current: Generation) -> None:
+        """Restore the persisted current generation without acquiring the lock.
 
-        Used during initialization when no other threads are running.
+        Used during initialization when no other threads are running. Only
+        ``current`` survives a dashboard restart: a stopped backend job no
+        longer heartbeats, so there is nothing a restored ``last`` generation
+        would admit.
         """
-        self._generations[workflow_id] = _GenerationRecord(current=current, last=last)
+        self._generations[workflow_id] = _GenerationRecord(current=current)
 
     def resolve_config(
         self, workflow_id: WorkflowId, job_number: JobNumber

--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -98,7 +98,6 @@ class WorkflowState:
     """State for an active workflow, including transitions."""
 
     current: JobSet | None = None
-    previous: JobSet | None = None
     staged_jobs: dict[SourceName, JobConfig] = field(default_factory=dict)
     version: int = 0
     stopped_reason: StoppedReason | None = None
@@ -238,21 +237,9 @@ class JobOrchestrator:
                             e,
                         )
 
-                if previous_data := config_data.get('previous_job'):
-                    try:
-                        state.previous = JobSet.model_validate(previous_data)
-                    except (KeyError, ValueError, TypeError) as e:
-                        logger.warning(
-                            'Failed to restore previous job for workflow %s: %s',
-                            workflow_id,
-                            e,
-                        )
-
-                if state.current is not None or state.previous is not None:
+                if state.current is not None:
                     self._active_job_registry.restore(
-                        workflow_id,
-                        current=_generation_of(state.current),
-                        last=_generation_of(state.previous),
+                        workflow_id, current=_generation_of(state.current)
                     )
 
             self._workflows[workflow_id] = state
@@ -393,7 +380,6 @@ class JobOrchestrator:
                 for job_id in state.current.job_ids()
             )
             logger.debug('Will stop %d old jobs in batch', len(state.current.jobs))
-            state.previous = state.current
 
         # Send workflow configs to all staged sources
         # Note: Currently all jobs use same params, but aux_source_names may
@@ -494,9 +480,6 @@ class JobOrchestrator:
         # Add active job state
         if state.current is not None:
             config_dict['current_job'] = state.current.model_dump(mode='json')
-
-        if state.previous is not None:
-            config_dict['previous_job'] = state.previous.model_dump(mode='json')
 
         # Persist if we have something to save
         if config_dict:
@@ -740,25 +723,6 @@ class JobOrchestrator:
             aux_source_names=first_job.aux_source_names,
         )
 
-    def get_previous_job_number(self, workflow_id: WorkflowId) -> JobNumber | None:
-        """
-        Get the job number of the previous job for a workflow.
-
-        Parameters
-        ----------
-        workflow_id
-            The workflow to query.
-
-        Returns
-        -------
-        :
-            The job number if there's a previous job, None otherwise.
-        """
-        state = self._workflows.get(workflow_id)
-        if state is None or state.previous is None:
-            return None
-        return state.previous.job_number
-
     def stop_workflow(self, workflow_id: WorkflowId) -> bool:
         """
         Stop all jobs for a workflow.
@@ -792,10 +756,10 @@ class JobOrchestrator:
     ) -> None:
         """Clear active job state, persist, and notify subscribers.
 
-        The just-stopped job becomes state.previous. Its buffered data stays
-        under the workflow's stable keys — nothing is evicted on stop — so
-        plots created while the workflow is stopped still display its last
-        results; the next commit's generation flip clears them.
+        The just-stopped job's buffered data stays under the workflow's
+        stable keys — nothing is evicted on stop — so plots created while
+        the workflow is stopped still display its last results; the next
+        commit's generation flip clears them.
         """
         state = self._workflows[workflow_id]
 
@@ -803,7 +767,6 @@ class JobOrchestrator:
             for job_id in state.current.job_ids():
                 self._job_states.pop(job_id, None)
             self._active_job_registry.deactivate(workflow_id)
-            state.previous = state.current
             state.current = None
         state.stopped_reason = reason
 

--- a/tests/dashboard/active_job_registry_test.py
+++ b/tests/dashboard/active_job_registry_test.py
@@ -204,18 +204,10 @@ class TestRestore:
         assert registry.is_current(_workflow_id, job_number)
         assert registry.resolve_config(_workflow_id, job_number) == {"a": 1}
 
-    def test_restored_last_is_known_but_not_current(self):
+    def test_unrestored_workflow_admits_nothing(self):
         registry, _ds, _js = _make_registry()
-        job_number = uuid.uuid4()
 
-        registry.restore(
-            _workflow_id,
-            current=None,
-            last=Generation(job_number=job_number, config={}),
-        )
-
-        assert not registry.is_current(_workflow_id, job_number)
-        assert registry.is_known_job(job_number)
+        assert not registry.is_current(_workflow_id, uuid.uuid4())
 
 
 class TestRecordStale:

--- a/tests/dashboard/job_orchestrator_test.py
+++ b/tests/dashboard/job_orchestrator_test.py
@@ -1020,7 +1020,7 @@ class TestJobOrchestratorStop:
             params={"threshold": 50.0, "mode": "custom"},
             aux_source_names={},
         )
-        job_ids = orchestrator.commit_workflow(workflow_id)
+        orchestrator.commit_workflow(workflow_id)
 
         # Verify active job is in config store
         assert 'current_job' in config_store[str(workflow_id)]
@@ -1028,14 +1028,10 @@ class TestJobOrchestratorStop:
         # Stop the workflow
         orchestrator.stop_workflow(workflow_id)
 
-        # Verify current_job is removed from config store
+        # Verify current_job is removed from config store; the stopped job
+        # itself is not persisted (retention does not survive a restart)
         assert 'current_job' not in config_store[str(workflow_id)]
-
-        # Verify previous_job is in config store
-        assert 'previous_job' in config_store[str(workflow_id)]
-        assert config_store[str(workflow_id)]['previous_job']['job_number'] == str(
-            job_ids[0].job_number
-        )
+        assert 'previous_job' not in config_store[str(workflow_id)]
 
     def test_stop_workflow_allows_immediate_restart(
         self,

--- a/tests/integration/job_state_persistence_test.py
+++ b/tests/integration/job_state_persistence_test.py
@@ -79,15 +79,12 @@ def test_active_job_persisted_and_restored(tmp_path) -> None:
         assert restored_active['monitor1'].params == custom_params.model_dump()
 
 
-def test_job_transition_persists_previous_job(tmp_path) -> None:
+def test_recommit_persists_only_current_job(tmp_path) -> None:
     """
-    Test that stopping old jobs and starting new ones persists both states.
+    Committing over a running job replaces the persisted current job.
 
-    When committing a workflow that already has an active job:
-    1. Old job moves to 'previous'
-    2. New job becomes 'current'
-    3. Both current and previous are persisted
-    4. After restoration, both current and previous are restored
+    Only the current job survives a dashboard restart; the replaced job is
+    not persisted (its retained data does not survive a restart either).
     """
     workflow_id = WorkflowId(
         instrument='dummy',
@@ -100,12 +97,11 @@ def test_job_transition_persists_previous_job(tmp_path) -> None:
         instrument='dummy', dev=True, transport='none', config_dir=tmp_path
     ) as backend1:
         # Start first job
-        job_ids_1 = backend1.workflow_controller.start_workflow(
+        backend1.workflow_controller.start_workflow(
             workflow_id=workflow_id,
             source_names=source_names,
             config=MonitorDataParams(),
         )
-        first_job_number = job_ids_1[0].job_number
 
         # Start second job (stops first)
         job_ids_2 = backend1.workflow_controller.start_workflow(
@@ -119,31 +115,17 @@ def test_job_transition_persists_previous_job(tmp_path) -> None:
         )
         second_job_number = job_ids_2[0].job_number
 
-        # Verify state in first backend using public API
         current_job_number = backend1.job_orchestrator.get_active_job_number(
             workflow_id
         )
-        previous_job_number = backend1.job_orchestrator.get_previous_job_number(
-            workflow_id
-        )
         assert current_job_number == second_job_number
-        assert previous_job_number == first_job_number
 
     # Restore in second backend
     with DashboardBackend(
         instrument='dummy', dev=True, transport='none', config_dir=tmp_path
     ) as backend2:
-        # Both current and previous should be restored
         restored_current = backend2.job_orchestrator.get_active_job_number(workflow_id)
-        restored_previous = backend2.job_orchestrator.get_previous_job_number(
-            workflow_id
-        )
-
-        assert restored_current is not None
         assert restored_current == second_job_number
-
-        assert restored_previous is not None
-        assert restored_previous == first_job_number
 
 
 def test_corrupted_job_state_does_not_break_restoration(tmp_path) -> None:


### PR DESCRIPTION
Part of #1042 (Option B, Wave 3 on #1046, slice iv). Stacked on #1064.

The previous-JobSet machinery existed to let `LayerSubscription` replay a stopped workflow's job to late-created layers. With static plot creation (#1064) retention is free — a stopped workflow's data stays under its stable keys and any new layer binds to it directly — so `WorkflowState.previous`, `get_previous_job_number`, and the `previous_job` persistence key have no remaining consumers.

`ActiveJobRegistry.restore` now takes only the current generation. Rationale for dropping restored-`last`: after a dashboard restart the only thing a `last` generation could do is admit status heartbeats of a job stopped before the restart — but a stopped backend job no longer heartbeats, and the retained data (in-memory) did not survive the restart either. The *runtime* `last` generation is untouched: `begin_generation`/`deactivate` still rotate into it, backing provenance stamps (`resolve_config`) and the just-replaced-job status filter.

`current_job` persistence and `restore` stay — they are how a dashboard restart re-recognizes a running backend job, until heartbeat adoption (slice v, Wave 5, gated on D8).

## Test plan

- `test_stop_workflow_persists_stopped_state` now pins that a stop leaves neither `current_job` nor `previous_job` in the store.
- Integration test rewritten: recommit persists only the new current job; restart restores it.
- Full suite and the `restart_cleanup_test.py -m ""` race gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
