### PR TITLE
Remove dead WorkflowController data_service dependency

### DIFF
--- a/src/ess/livedata/dashboard/dashboard_services.py
+++ b/src/ess/livedata/dashboard/dashboard_services.py
@@ -261,7 +261,6 @@ class DashboardServices:
         self.workflow_controller = WorkflowController(
             job_orchestrator=self.job_orchestrator,
             workflow_registry=self.processor_factory,
-            data_service=self.data_service,
             instrument_config=self.instrument_config,
         )
 

--- a/src/ess/livedata/dashboard/workflow_controller.py
+++ b/src/ess/livedata/dashboard/workflow_controller.py
@@ -13,14 +13,12 @@ import pydantic
 import structlog
 
 from ess.livedata.config.workflow_spec import (
-    DataKey,
     JobId,
     WorkflowId,
     WorkflowSpec,
 )
 
 from .configuration_adapter import ConfigurationState
-from .data_service import DataService
 from .job_orchestrator import JobOrchestrator
 from .workflow_configuration_adapter import WorkflowConfigurationAdapter
 
@@ -54,7 +52,6 @@ class WorkflowController:
         *,
         job_orchestrator: JobOrchestrator,
         workflow_registry: Mapping[WorkflowId, WorkflowSpec],
-        data_service: DataService[DataKey, object] | None = None,
         instrument_config: Instrument | None = None,
     ) -> None:
         """
@@ -66,8 +63,6 @@ class WorkflowController:
             Shared job orchestrator for workflow lifecycle management.
         workflow_registry
             Registry of available workflows and their specifications.
-        data_service
-            Optional data service for cleaning up workflow data keys.
         instrument_config
             Optional instrument configuration for source metadata lookup.
         """
@@ -76,7 +71,6 @@ class WorkflowController:
 
         # Extend registry with correlation histogram specs if controller provided
         self._workflow_registry = dict(workflow_registry)
-        self._data_service = data_service
 
     def start_workflow(
         self,

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -62,19 +62,6 @@ def plot_orchestrator(
 
 
 @pytest.fixture
-def workflow_controller(job_orchestrator, workflow_registry, data_service):
-    """Create a WorkflowController for testing."""
-    from ess.livedata.dashboard.workflow_controller import WorkflowController
-
-    return WorkflowController(
-        job_orchestrator=job_orchestrator,
-        workflow_registry=workflow_registry,
-        data_service=data_service,
-        correlation_histogram_controller=None,
-    )
-
-
-@pytest.fixture
 def workflow_status_widget(job_orchestrator, job_service):
     """Create a WorkflowStatusListWidget for testing."""
     return WorkflowStatusListWidget(


### PR DESCRIPTION
Trivial cleanup flagged in the #1042 Wave 3 handoff: `WorkflowController` stored a `DataService` it never used (dead since before slice (i)). Also deletes an unused fixture in `plot_grid_tabs_test.py` that would have raised `TypeError` if exercised (stale `correlation_histogram_controller` argument).

🤖 Generated with [Claude Code](https://claude.com/claude-code)