### PR TITLE
Expire pending commands whose acknowledgement never arrives

### DIFF
--- a/src/ess/livedata/dashboard/dashboard_services.py
+++ b/src/ess/livedata/dashboard/dashboard_services.py
@@ -148,6 +148,10 @@ class DashboardServices:
             start = time.monotonic()
             try:
                 self.orchestrator.update()
+                # Expire pending commands whose acknowledgement never arrived, so
+                # a silently dropped send surfaces as an error toast rather than a
+                # workflow stuck waiting for the backend. Cheap scan of a tiny dict.
+                self.job_orchestrator.expire_pending_commands()
                 self.session_registry.cleanup_stale_sessions()
                 # Run-state poll before the flush: a commit observed here
                 # resets the affected layers' presentation, so the same pass's

--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -11,8 +11,9 @@ Coordinates workflow execution across multiple sources, handling:
 
 from __future__ import annotations
 
+import time
 import uuid
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import StrEnum, auto
@@ -46,6 +47,13 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 SourceName = str
+
+# A command acknowledgement is a fast round-trip, so a pending command that has
+# not been acknowledged within this window is treated as lost (e.g. its send was
+# silently dropped by the sink). Deliberately shorter than the 60s
+# heartbeat-staleness constants in job_service.py, which answer a different
+# question about backend liveness.
+PENDING_COMMAND_TIMEOUT_SECONDS = 30.0
 
 
 class JobConfig(BaseModel):
@@ -115,6 +123,7 @@ class JobOrchestrator:
         config_store: ConfigStore | None = None,
         instrument_config: Instrument | None = None,
         notification_queue: NotificationQueue | None = None,
+        clock: Callable[[], float] = time.time,
     ) -> None:
         """
         Initialize the job orchestrator.
@@ -137,6 +146,9 @@ class JobOrchestrator:
             Optional queue for multi-session notifications. When provided,
             command success/error notifications are pushed here instead of
             using direct callbacks.
+        clock
+            Callable returning the current time in seconds, used for command
+            expiry. Injectable to allow deterministic testing without real waits.
         """
         self._command_service = command_service
         self._workflow_registry = workflow_registry
@@ -146,7 +158,7 @@ class JobOrchestrator:
         self._notification_queue = notification_queue
 
         # Command acknowledgement tracking
-        self._pending_commands = PendingCommandTracker()
+        self._pending_commands = PendingCommandTracker(clock=clock)
 
         # Workflow state tracking
         self._workflows: dict[WorkflowId, WorkflowState] = {}
@@ -1069,4 +1081,34 @@ class JobOrchestrator:
                 result.error_count,
                 total,
                 combined_errors,
+            )
+
+    def expire_pending_commands(self) -> None:
+        """
+        Expire commands that were never acknowledged by the backend.
+
+        A command whose acknowledgement never arrives (e.g. because its send was
+        silently dropped by the sink) would otherwise leave the tracker entry
+        alive forever, with no feedback to the user. Expired commands are logged
+        and surfaced as an error notification. The workflow state and status
+        badge are left untouched.
+        """
+        expired = self._pending_commands.expire_stale(PENDING_COMMAND_TIMEOUT_SECONDS)
+        for cmd in expired:
+            spec = self._workflow_registry.get(cmd.workflow_id)
+            title = spec.title if spec else str(cmd.workflow_id)
+            logger.warning(
+                'No response from backend for %s command on workflow %s; '
+                'expired after %.0fs',
+                cmd.action,
+                title,
+                PENDING_COMMAND_TIMEOUT_SECONDS,
+            )
+            self._notify_command_error(
+                cmd.workflow_id,
+                cmd.action,
+                cmd.expected_count,
+                cmd.expected_count,
+                f"no response from backend "
+                f"(timed out after {PENDING_COMMAND_TIMEOUT_SECONDS:.0f}s)",
             )

--- a/src/ess/livedata/dashboard/pending_command_tracker.py
+++ b/src/ess/livedata/dashboard/pending_command_tracker.py
@@ -8,6 +8,7 @@ sent by the frontend, enabling proper error handling and UI feedback.
 """
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -67,8 +68,18 @@ class PendingCommandTracker:
     accumulated until all expected responses are received.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, clock: Callable[[], float] = time.time) -> None:
+        """
+        Initialize the tracker.
+
+        Parameters
+        ----------
+        clock:
+            Callable returning the current time in seconds. Injectable to allow
+            deterministic testing of command expiry without real waits.
+        """
         self._pending: dict[str, PendingCommand] = {}
+        self._clock = clock
 
     def register(
         self,
@@ -94,7 +105,7 @@ class PendingCommandTracker:
         self._pending[message_id] = PendingCommand(
             workflow_id=workflow_id,
             action=action,
-            timestamp=time.time(),
+            timestamp=self._clock(),
             expected_count=expected_count,
         )
 
@@ -144,6 +155,34 @@ class PendingCommandTracker:
             )
 
         return None
+
+    def expire_stale(self, max_age_seconds: float) -> list[PendingCommand]:
+        """
+        Remove and return commands pending longer than max_age_seconds.
+
+        A command expires when no acknowledgement has arrived within the given
+        age. Expired commands are the recovery signal for sends that were
+        silently dropped by the sink and will therefore never be acknowledged.
+
+        Parameters
+        ----------
+        max_age_seconds:
+            Maximum time in seconds a command may remain pending.
+
+        Returns
+        -------
+        :
+            The expired commands that were removed from tracking.
+        """
+        now = self._clock()
+        # Snapshot: register() may insert concurrently from the UI thread while
+        # this runs on the update thread; iterating the live dict could raise.
+        expired_ids = [
+            message_id
+            for message_id, cmd in list(self._pending.items())
+            if now - cmd.timestamp > max_age_seconds
+        ]
+        return [self._pending.pop(message_id) for message_id in expired_ids]
 
     def __len__(self) -> int:
         """Return number of pending commands."""

--- a/tests/dashboard/job_orchestrator_test.py
+++ b/tests/dashboard/job_orchestrator_test.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Tests for JobOrchestrator initialization and config management."""
 
+import time
+from collections.abc import Callable
 from enum import StrEnum
 
 import pydantic
@@ -23,8 +25,15 @@ from ess.livedata.dashboard.active_job_registry import ActiveJobRegistry
 from ess.livedata.dashboard.command_service import CommandService
 from ess.livedata.dashboard.config_store import FileBackedConfigStore
 from ess.livedata.dashboard.data_service import DataService
-from ess.livedata.dashboard.job_orchestrator import JobOrchestrator
+from ess.livedata.dashboard.job_orchestrator import (
+    PENDING_COMMAND_TIMEOUT_SECONDS,
+    JobOrchestrator,
+)
 from ess.livedata.dashboard.job_service import JobService
+from ess.livedata.dashboard.notification_queue import (
+    NotificationQueue,
+    NotificationType,
+)
 from ess.livedata.fakes import FakeMessageSink
 
 
@@ -200,6 +209,8 @@ def make_orchestrator(
     fake_sink: FakeMessageSink | None = None,
     data_service: DataService | None = None,
     job_service: JobService | None = None,
+    notification_queue: NotificationQueue | None = None,
+    clock: Callable[[], float] = time.time,
 ) -> JobOrchestrator:
     """Build a JobOrchestrator from one or more WorkflowSpecs for testing."""
     registry = {spec.get_id(): spec for spec in specs}
@@ -212,6 +223,8 @@ def make_orchestrator(
         workflow_registry=registry,
         active_job_registry=ActiveJobRegistry(data_service=ds, job_service=js),
         config_store=config_store,
+        notification_queue=notification_queue,
+        clock=clock,
     )
 
 
@@ -1412,3 +1425,92 @@ class TestGetRunningWorkflowSources:
 
         orchestrator.stop_workflow(workflow_id)
         assert workflow_id not in orchestrator.get_running_workflow_sources()
+
+
+class MutableClock:
+    """Manually advanceable clock for deterministic expiry tests."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class TestPendingCommandExpiry:
+    """Test expiry of pending commands whose acknowledgement never arrives."""
+
+    def test_unacknowledged_command_produces_error_notification_after_timeout(
+        self, workflow_with_params: WorkflowSpec
+    ):
+        workflow_id = workflow_with_params.get_id()
+        clock = MutableClock()
+        queue = NotificationQueue()
+        orchestrator = make_orchestrator(
+            workflow_with_params, notification_queue=queue, clock=clock
+        )
+
+        orchestrator.stage_config(
+            workflow_id, source_name="det_1", params={}, aux_source_names={}
+        )
+        orchestrator.commit_workflow(workflow_id)
+
+        clock.advance(PENDING_COMMAND_TIMEOUT_SECONDS + 1.0)
+        orchestrator.expire_pending_commands()
+
+        errors = [
+            event
+            for event in queue.get_all_events()
+            if event.notification_type is NotificationType.ERROR
+        ]
+        assert len(errors) == 1
+        assert workflow_with_params.title in errors[0].message
+
+    def test_command_not_expired_before_timeout(
+        self, workflow_with_params: WorkflowSpec
+    ):
+        workflow_id = workflow_with_params.get_id()
+        clock = MutableClock()
+        queue = NotificationQueue()
+        orchestrator = make_orchestrator(
+            workflow_with_params, notification_queue=queue, clock=clock
+        )
+
+        orchestrator.stage_config(
+            workflow_id, source_name="det_1", params={}, aux_source_names={}
+        )
+        orchestrator.commit_workflow(workflow_id)
+
+        clock.advance(PENDING_COMMAND_TIMEOUT_SECONDS - 1.0)
+        orchestrator.expire_pending_commands()
+
+        assert queue.get_all_events() == []
+
+    def test_expired_command_notified_only_once(
+        self, workflow_with_params: WorkflowSpec
+    ):
+        workflow_id = workflow_with_params.get_id()
+        clock = MutableClock()
+        queue = NotificationQueue()
+        orchestrator = make_orchestrator(
+            workflow_with_params, notification_queue=queue, clock=clock
+        )
+
+        orchestrator.stage_config(
+            workflow_id, source_name="det_1", params={}, aux_source_names={}
+        )
+        orchestrator.commit_workflow(workflow_id)
+
+        clock.advance(PENDING_COMMAND_TIMEOUT_SECONDS + 1.0)
+        orchestrator.expire_pending_commands()
+        orchestrator.expire_pending_commands()
+
+        errors = [
+            event
+            for event in queue.get_all_events()
+            if event.notification_type is NotificationType.ERROR
+        ]
+        assert len(errors) == 1

--- a/tests/dashboard/pending_command_tracker_test.py
+++ b/tests/dashboard/pending_command_tracker_test.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for PendingCommandTracker, focused on command expiry."""
+
+import pytest
+
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.dashboard.pending_command_tracker import PendingCommandTracker
+
+
+class MutableClock:
+    """Manually advanceable clock for deterministic expiry tests."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def workflow_id() -> WorkflowId:
+    return WorkflowId(instrument="test", name="wf", version=1)
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock()
+
+
+@pytest.fixture
+def tracker(clock: MutableClock) -> PendingCommandTracker:
+    return PendingCommandTracker(clock=clock)
+
+
+def test_expire_stale_removes_only_aged_entries(
+    tracker: PendingCommandTracker, clock: MutableClock, workflow_id: WorkflowId
+) -> None:
+    tracker.register("old", workflow_id, "start")
+    clock.advance(20.0)
+    tracker.register("new", workflow_id, "stop")
+
+    clock.advance(15.0)  # "old" is now 35s, "new" is 15s
+    expired = tracker.expire_stale(max_age_seconds=30.0)
+
+    assert [cmd.action for cmd in expired] == ["start"]
+    assert len(tracker) == 1
+
+
+def test_expire_stale_returns_command_details(
+    tracker: PendingCommandTracker, clock: MutableClock, workflow_id: WorkflowId
+) -> None:
+    tracker.register("id", workflow_id, "reset", expected_count=3)
+    clock.advance(31.0)
+
+    (expired,) = tracker.expire_stale(max_age_seconds=30.0)
+
+    assert expired.workflow_id == workflow_id
+    assert expired.action == "reset"
+    assert expired.expected_count == 3
+
+
+def test_expire_stale_removes_expired_from_tracking(
+    tracker: PendingCommandTracker, clock: MutableClock, workflow_id: WorkflowId
+) -> None:
+    tracker.register("id", workflow_id, "start")
+    clock.advance(31.0)
+
+    tracker.expire_stale(max_age_seconds=30.0)
+
+    assert len(tracker) == 0
+    assert tracker.expire_stale(max_age_seconds=30.0) == []
+
+
+def test_response_after_expiry_does_not_crash(
+    tracker: PendingCommandTracker, clock: MutableClock, workflow_id: WorkflowId
+) -> None:
+    tracker.register("id", workflow_id, "start")
+    clock.advance(31.0)
+    tracker.expire_stale(max_age_seconds=30.0)
+
+    result = tracker.record_response("id", success=True)
+
+    assert result is None
+
+
+def test_non_expired_command_still_completes(
+    tracker: PendingCommandTracker, clock: MutableClock, workflow_id: WorkflowId
+) -> None:
+    tracker.register("id", workflow_id, "start", expected_count=1)
+    clock.advance(10.0)
+    tracker.expire_stale(max_age_seconds=30.0)
+
+    result = tracker.record_response("id", success=True)
+
+    assert result is not None
+    assert result.all_succeeded
+    assert len(tracker) == 0


### PR DESCRIPTION
`KafkaSink.publish_messages` silently swallows serialization and buffer-full errors, so a dropped start/stop/reset command never produces a `CommandAcknowledgement` and its `PendingCommandTracker` entry lived forever: the workflow badge showed "PENDING / Waiting for backend..." indefinitely with no feedback. This is the designated recovery signal for the send-failure mode recorded on #1042 (amendment A2), tracked on #1046 and as the #1039 low finding "pending commands never expire".

The background update loop now expires commands unacknowledged for 30s (deliberately shorter than the 60s heartbeat-staleness constants, which answer a different question), logging a warning and surfacing the existing command-error toast. Workflow state and the status badge are deliberately untouched — point fix; extend to the badge only if the failure mode shows up in practice. A late ack after expiry is ignored gracefully (pinned by test). The tracker takes an injectable clock so expiry is tested without real waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)