### PR TITLE
dashboard: Suspend hover tooltips while an ROI edit tool is active

### DIFF
--- a/src/ess/livedata/dashboard/hover_suspend.py
+++ b/src/ess/livedata/dashboard/hover_suspend.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Suspend plot hover tooltips while a Bokeh edit tool is active.
+
+The hover readout (x, y, value) obscures the plot area exactly where the user
+is drawing or dragging an ROI. This module wires the figure so that activating
+any edit tool (BoxEdit for rectangles, PolyDraw for polygons) deactivates the
+hover tools, and deactivating it restores their previous state. Merely having
+the edit tools on the toolbar does not affect hover.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+# Marks a figure as already wired, so the repeated renders of a DynamicMap do
+# not stack duplicate callbacks. Figure-scoped rather than plot-scoped because
+# HoloViews swaps the figure on kdim/Layout transitions.
+_INSTALLED_TAG = 'lt-hover-suspend'
+
+# Bokeh's ``Tool.active`` is a client-side-only property: activating a tool from
+# the toolbar never reaches the server, so the whole toggle has to live in JS.
+# Runs on every layout pass, hence the idempotency guard on the figure object.
+_SUSPEND_JS = """
+const fig = cb_obj;
+if (fig._hover_suspend_wired) { return; }
+fig._hover_suspend_wired = true;
+
+// Non-null while hover is suspended, holding the states to restore. Keeping
+// them means a user who switched hover off by hand does not get it switched
+// back on when they leave the edit tool.
+let saved = null;
+
+const update = () => {
+    const editing = edits.some((tool) => tool.active);
+    if (editing && saved === null) {
+        saved = hovers.map((hover) => hover.active);
+        for (const hover of hovers) { hover.active = false; }
+    } else if (!editing && saved !== null) {
+        hovers.forEach((hover, i) => { hover.active = saved[i]; });
+        saved = null;
+    }
+};
+
+for (const tool of edits) { tool.properties.active.change.connect(update); }
+update();
+"""
+
+
+def make_hover_suspend_hook() -> Callable[[Any, Any], None]:
+    """
+    Create a HoloViews hook suspending hover while an edit tool is active.
+
+    The hook is a no-op on figures that have no edit tool or no hover tool, so
+    it can be applied to every plot cell unconditionally.
+
+    Returns
+    -------
+    :
+        A hook function compatible with ``hv.Element.opts(hooks=[...])``.
+    """
+
+    def hook(plot: Any, element: Any) -> None:
+        del element
+        from bokeh.models import CustomJS
+        from bokeh.models.tools import EditTool, HoverTool
+
+        figure = getattr(plot, 'state', None)
+        toolbar = getattr(figure, 'toolbar', None)
+        if toolbar is None or _INSTALLED_TAG in figure.tags:
+            return
+        edits = [tool for tool in toolbar.tools if isinstance(tool, EditTool)]
+        hovers = [tool for tool in toolbar.tools if isinstance(tool, HoverTool)]
+        if not edits or not hovers:
+            return
+        # inner_width is written by BokehJS on every layout pass, giving a
+        # reliable "figure has rendered" trigger for wiring up the JS signals.
+        figure.js_on_change(
+            'inner_width',
+            CustomJS(args={'edits': edits, 'hovers': hovers}, code=_SUSPEND_JS),
+        )
+        figure.tags = [*figure.tags, _INSTALLED_TAG]
+
+    return hook

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -27,6 +27,7 @@ from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
 
 from ..cell_autoscale import CellAutoscaleController, build_controller_from_layers
 from ..format_utils import extract_error_summary
+from ..hover_suspend import make_hover_suspend_hook
 from ..plot_data_service import LayerState, LayerStateMachine, PlotDataService
 from ..plot_orchestrator import (
     CellId,
@@ -585,8 +586,8 @@ class CellWidget:
 
         Ensures session components exist when data is available. Sets a
         descriptive SaveTool filename on the result so that browser "Save"
-        downloads get a meaningful name, and builds the cell's autoscale
-        controller as a side effect.
+        downloads get a meaningful name, suspends hover while an ROI edit tool
+        is active, and builds the cell's autoscale controller as a side effect.
 
         Returns
         -------
@@ -646,7 +647,7 @@ class CellWidget:
         if non_overlayable:
             return result
 
-        hooks: list = []
+        hooks: list = [make_hover_suspend_hook()]
         filename = build_save_filename_from_cell(
             self._cell,
             self._deps.workflow_registry,
@@ -662,7 +663,4 @@ class CellWidget:
         if controller is not None:
             self._autoscale_controller = controller
             hooks.append(controller.make_hook())
-        if hooks:
-            result = result.opts(hooks=hooks)
-
-        return result
+        return result.opts(hooks=hooks)

--- a/tests/dashboard/hover_suspend_test.py
+++ b/tests/dashboard/hover_suspend_test.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+import pytest
+from bokeh.models.tools import BoxEditTool, HoverTool, PanTool, PolyDrawTool
+from bokeh.plotting import figure
+
+from ess.livedata.dashboard.hover_suspend import make_hover_suspend_hook
+
+
+class FakePlot:
+    """Stand-in for the HoloViews plot object, which only exposes ``state``."""
+
+    def __init__(self, state):
+        self.state = state
+
+
+def make_figure(*tools):
+    fig = figure(tools=[])
+    fig.toolbar.tools = list(tools)
+    return fig
+
+
+def callbacks(fig):
+    return fig.js_property_callbacks.get('change:inner_width', [])
+
+
+@pytest.fixture
+def hook():
+    return make_hover_suspend_hook()
+
+
+@pytest.mark.parametrize('edit_tool', [BoxEditTool, PolyDrawTool])
+def test_wires_hover_and_edit_tools(hook, edit_tool):
+    hover = HoverTool()
+    edit = edit_tool()
+    fig = make_figure(PanTool(), hover, edit)
+
+    hook(FakePlot(fig), None)
+
+    (callback,) = callbacks(fig)
+    assert callback.args['hovers'] == [hover]
+    assert callback.args['edits'] == [edit]
+
+
+def test_no_callback_without_edit_tool(hook):
+    fig = make_figure(PanTool(), HoverTool())
+
+    hook(FakePlot(fig), None)
+
+    assert callbacks(fig) == []
+
+
+def test_no_callback_without_hover_tool(hook):
+    fig = make_figure(PanTool(), BoxEditTool())
+
+    hook(FakePlot(fig), None)
+
+    assert callbacks(fig) == []
+
+
+def test_repeated_renders_do_not_stack_callbacks(hook):
+    fig = make_figure(HoverTool(), BoxEditTool())
+
+    hook(FakePlot(fig), None)
+    hook(FakePlot(fig), None)
+
+    assert len(callbacks(fig)) == 1
+
+
+def test_wires_a_freshly_swapped_figure(hook):
+    """HoloViews replaces the figure on kdim transitions; the new one needs it."""
+    hook(FakePlot(make_figure(HoverTool(), BoxEditTool())), None)
+    fig = make_figure(HoverTool(), BoxEditTool())
+
+    hook(FakePlot(fig), None)
+
+    assert len(callbacks(fig)) == 1
+
+
+def test_hook_sees_tools_of_a_rendered_holoviews_overlay(hook):
+    """The hook runs late enough to see tools contributed by all overlay layers.
+
+    The hover tool comes from the image layer and the BoxEdit tool from the ROI
+    layer, both merged onto the overlay's single figure before hooks run.
+    """
+    import holoviews as hv
+    import numpy as np
+
+    hv.extension('bokeh')
+
+    image_pipe = hv.streams.Pipe(data=np.random.default_rng(0).random((8, 8)))
+    image = hv.DynamicMap(hv.Image, streams=[image_pipe]).opts(tools=['hover'])
+    roi_pipe = hv.streams.Pipe(data=[])
+    rectangles = hv.DynamicMap(hv.Rectangles, streams=[roi_pipe])
+    hv.streams.BoxEdit(source=rectangles, num_objects=2)
+    overlay = hv.Overlay([image, rectangles]).collate()
+
+    plot = hv.renderer('bokeh').get_plot(overlay.opts(hooks=[hook]))
+
+    assert len(callbacks(plot.state)) == 1


### PR DESCRIPTION
Fixes #1063

The hover readout (x, y, value) obscures the plot area exactly where the user is drawing or dragging an ROI. Activating a rectangle or polygon edit tool now deactivates the figure's hover tools; leaving the tool restores their previous state, so hover that the user switched off by hand stays off. Merely having the edit tools on the toolbar has no effect on hover.

Bokeh's `Tool.active` is a client-side-only property — tool activation never reaches the server, and `Toolbar.active_drag` is not written back on user clicks — so nothing on the Python side can observe the edit tool becoming active. The toggle is therefore wired in JS, installed via a `CustomJS` on the figure's `inner_width`, which BokehJS writes on every layout pass and which serves as a reliable "figure has rendered" trigger.

The hook is applied to every plot cell alongside the existing SaveTool and autoscale hooks; it is a no-op on figures that carry no edit tool or no hover tool.

## Test plan

Unit tests cover the wiring, the no-op cases, and idempotency across re-renders, plus an integration test that renders a real collated HoloViews overlay and confirms the hook sees the hover tool from the image layer and the BoxEdit tool from the ROI layer on the shared figure.

The JS behaviour itself was verified against real BokehJS in headless Chromium on a standalone document: hover active initially, inactive while the edit tool is active, active again after deactivating.

Still to check manually in the dashboard:

- [x] Drawing and moving a rectangle ROI on a detector view shows no hover tooltip.
- [x] Drawing and moving a polygon ROI shows no hover tooltip.
- [x] Hover works again after deactivating the edit tool.
- [x] Hover switched off manually stays off after using an edit tool.
- [x] Hover is unaffected on a plot where the ROI tools are present but not activated.
