### PR TITLE
Read cell title from TextInput.value, not value_input

### DIFF
--- a/src/ess/livedata/dashboard/widgets/cell_properties_modal.py
+++ b/src/ess/livedata/dashboard/widgets/cell_properties_modal.py
@@ -106,13 +106,11 @@ class CellPropertiesModal:
         self.modal.open = True
 
     def _build(self) -> pn.Modal:
-        self._add_layer_button = pn.widgets.Button(
-            name='Add layer…', button_type='default'
-        )
+        self._add_layer_button = pn.widgets.Button(label='Add layer…', color='default')
         self._add_layer_button.on_click(lambda _: self._on_add())
-        save_button = pn.widgets.Button(name='Save', button_type='primary')
+        save_button = pn.widgets.Button(label='Save', color='primary')
         save_button.on_click(lambda _: self._finish(save=True))
-        cancel_button = pn.widgets.Button(name='Cancel')
+        cancel_button = pn.widgets.Button(label='Cancel')
         cancel_button.on_click(lambda _: self._finish(save=False))
 
         modal = pn.Modal(
@@ -141,7 +139,11 @@ class CellPropertiesModal:
         return modal
 
     def _persist_title(self) -> None:
-        new_title = (self._text.value_input or '').strip() or None
+        # ``value`` (not ``value_input``) reflects the field's current displayed
+        # content: it is set from the constructor's pre-fill and, unlike
+        # ``value_input``, syncs on blur even without a keystroke -- which is
+        # what happens as focus leaves the field when Save/Add layer is clicked.
+        new_title = (self._text.value or '').strip() or None
         self._orchestrator.set_cell_title(self._cell_id, new_title)
 
     def _close(self) -> None:

--- a/tests/dashboard/widgets/cell_properties_modal_test.py
+++ b/tests/dashboard/widgets/cell_properties_modal_test.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for CellPropertiesModal title persistence.
+
+Regression coverage for issue 1072: the title field is pre-filled via
+``TextInput.value``, but Panel only mirrors typed keystrokes into
+``value_input`` -- it does not seed ``value_input`` from ``value`` on
+construction. Reading ``value_input`` in ``_persist_title`` therefore saw an
+empty string whenever the modal was saved without the user touching the
+field, erasing any existing custom title.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from uuid import uuid4
+
+import pydantic
+import pytest
+
+from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
+from ess.livedata.dashboard.plot_orchestrator import CellGeometry, CellId, PlotCell
+from ess.livedata.dashboard.widgets.cell_properties_modal import CellPropertiesModal
+
+EXISTING_TITLE = 'Existing Title'
+
+
+class FakePlottingController:
+    """Stand-in for PlottingController.
+
+    ``CellPropertiesModal`` only queries the plotting controller while
+    rendering layer rows, which none of these title-persistence tests
+    exercise (the fixture cell has no layers); raising on use turns any
+    unexpected call into a loud test failure instead of a silent fake.
+    """
+
+    def is_overlayable(self, plot_name: str, params: dict | pydantic.BaseModel) -> bool:
+        raise AssertionError('unexpected call for a cell with no layers')
+
+
+class FakeOrchestrator:
+    """Orchestrator fake exposing only what CellPropertiesModal calls.
+
+    Mirrors ``PlotOrchestrator.set_cell_title``'s normalization (falsy title
+    becomes ``None``) so tests can assert on the resulting ``PlotCell``
+    state directly, the same way callers observe persistence in production.
+    """
+
+    def __init__(self, cell: PlotCell) -> None:
+        self._cell = cell
+
+    def get_cell(self, cell_id: CellId) -> PlotCell:
+        return self._cell
+
+    def set_cell_title(self, cell_id: CellId, title: str | None) -> None:
+        self._cell.user_title = title or None
+
+
+@pytest.fixture
+def cell_id() -> CellId:
+    return CellId(uuid4())
+
+
+@pytest.fixture
+def cell() -> PlotCell:
+    return PlotCell(
+        geometry=CellGeometry(row=0, col=0, row_span=1, col_span=1),
+        layers=[],
+        user_title=EXISTING_TITLE,
+    )
+
+
+@pytest.fixture
+def orchestrator(cell: PlotCell) -> FakeOrchestrator:
+    return FakeOrchestrator(cell)
+
+
+@pytest.fixture
+def workflow_registry() -> Mapping[WorkflowId, WorkflowSpec]:
+    return {}
+
+
+@pytest.fixture
+def modal(
+    orchestrator: FakeOrchestrator,
+    workflow_registry: Mapping[WorkflowId, WorkflowSpec],
+    cell_id: CellId,
+) -> CellPropertiesModal:
+    return CellPropertiesModal(
+        orchestrator=orchestrator,
+        workflow_registry=workflow_registry,
+        plotting_controller=FakePlottingController(),
+        cell_id=cell_id,
+        current_title=EXISTING_TITLE,
+        has_user_title=True,
+        on_add_layer=lambda cell_id: None,
+        on_close=lambda: None,
+    )
+
+
+class TestPersistTitle:
+    def test_save_without_typing_preserves_existing_title(
+        self,
+        modal: CellPropertiesModal,
+        orchestrator: FakeOrchestrator,
+        cell_id: CellId,
+    ) -> None:
+        """Opening the modal and saving without touching the field is a no-op.
+
+        The field is pre-filled via ``value`` only; ``value_input`` stays at
+        Panel's default (``''``) until a keystroke lands in the browser.
+        """
+        modal._persist_title()
+        assert orchestrator.get_cell(cell_id).user_title == EXISTING_TITLE
+
+    def test_typed_text_persists(
+        self,
+        modal: CellPropertiesModal,
+        orchestrator: FakeOrchestrator,
+        cell_id: CellId,
+    ) -> None:
+        """A real edit is saved.
+
+        A keystroke updates ``value_input``; focus then leaving the field
+        (e.g. clicking Save) updates ``value``. Set both here, in that
+        order, to match what production sees by the time the Save button's
+        callback runs.
+        """
+        modal._text.value_input = 'New Title'
+        modal._text.value = 'New Title'
+        modal._persist_title()
+        assert orchestrator.get_cell(cell_id).user_title == 'New Title'
+
+    def test_clearing_field_persists_none(
+        self,
+        modal: CellPropertiesModal,
+        orchestrator: FakeOrchestrator,
+        cell_id: CellId,
+    ) -> None:
+        """Deleting all text and saving clears the custom title."""
+        modal._text.value_input = ''
+        modal._text.value = ''
+        modal._persist_title()
+        assert orchestrator.get_cell(cell_id).user_title is None


### PR DESCRIPTION
Fixes #1072: saving the cell-properties modal (or adding a layer) without typing in the title field erased the existing custom title, because `value_input` only populates on real keystrokes while the pre-fill lives in `value`. Reading `value` covers untouched, edited, and cleared fields; the `value_input or value` fallback was rejected since it would break clearing (empty `value_input` is falsy and would fall through to the stale title).

Also switches the modal's buttons to the `label=`/`color=` Button API — the deprecated kwargs warn on Panel 1.9.3 and `filterwarnings=error` made the modal unconstructable in tests, which is why it had none. New test file pins the regression plus the typed and cleared cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)