### PR TITLE
Refresh recency on config-store key update

### DIFF
--- a/src/ess/livedata/dashboard/config_store.py
+++ b/src/ess/livedata/dashboard/config_store.py
@@ -88,6 +88,9 @@ class InMemoryConfigStore(UserDict[str, dict[str, Any]]):
         if not isinstance(key, str):
             raise TypeError(f"ConfigStore keys must be str, got {type(key).__name__}")
         with self._lock:
+            # Drop any existing entry first so re-insertion below moves the key
+            # to the end, keeping insertion order aligned with recency of use.
+            self.data.pop(key, None)
             super().__setitem__(key, value)
 
             # Automatic LRU eviction if limit exceeded
@@ -155,6 +158,9 @@ class FileBackedConfigStore(UserDict[str, dict[str, Any]]):
         if not isinstance(key, str):
             raise TypeError(f"ConfigStore keys must be str, got {type(key).__name__}")
         with self._lock:
+            # Drop any existing entry first so re-insertion below moves the key
+            # to the end, keeping insertion order aligned with recency of use.
+            self.data.pop(key, None)
             super().__setitem__(key, value)
 
             # Automatic LRU eviction if limit exceeded

--- a/tests/dashboard/config_store_test.py
+++ b/tests/dashboard/config_store_test.py
@@ -140,6 +140,25 @@ class TestInMemoryConfigStore:
             )
             assert str(wf_id) in store
 
+    def test_lru_eviction_refreshes_on_update(self):
+        """Test that updating a key marks it as recently used, not just inserted."""
+        store = InMemoryConfigStore(max_configs=3)
+
+        store['A'] = {'params': {'value': 'a1'}}
+        store['B'] = {'params': {'value': 'b'}}
+        store['C'] = {'params': {'value': 'c'}}
+
+        # A is touched again, so it becomes the most recently used entry.
+        store['A'] = {'params': {'value': 'a2'}}
+
+        # Exceeding max_configs evicts the single least recently used key.
+        store['D'] = {'params': {'value': 'd'}}
+
+        assert store['A'] == {'params': {'value': 'a2'}}
+        assert 'B' not in store
+        assert 'C' in store
+        assert 'D' in store
+
     def test_no_max_configs(self):
         """Test store without max_configs limit."""
         store = InMemoryConfigStore(max_configs=None)
@@ -294,6 +313,25 @@ class TestFileBackedConfigStore:
                 version=1,
             )
             assert str(wf_id) in store
+
+    def test_lru_eviction_refreshes_on_update(self, temp_config_file):
+        """Test that updating a key marks it as recently used, not just inserted."""
+        store = FileBackedConfigStore(temp_config_file, max_configs=3)
+
+        store['A'] = {'params': {'value': 'a1'}}
+        store['B'] = {'params': {'value': 'b'}}
+        store['C'] = {'params': {'value': 'c'}}
+
+        # A is touched again, so it becomes the most recently used entry.
+        store['A'] = {'params': {'value': 'a2'}}
+
+        # Exceeding max_configs evicts the single least recently used key.
+        store['D'] = {'params': {'value': 'd'}}
+
+        assert store['A'] == {'params': {'value': 'a2'}}
+        assert 'B' not in store
+        assert 'C' in store
+        assert 'D' in store
 
     def test_corrupted_file_handling(
         self, temp_config_file, workflow_id_1, config_value_1


### PR DESCRIPTION
Fixes #1076: both config stores document LRU eviction but evicted by plain dict insertion order, which is unchanged when an existing key is updated in place — so a config edited moments ago could be evicted ahead of entries untouched for days. Pop-before-reinsert moves the updated key to the end of iteration order. `OrderedDict` was deliberately avoided: `yaml.safe_dump` in the file-backed store dispatches on `type(data)` and would not serialize it. Regression tests for both store classes fail on the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)