### PR TITLE
Return a snapshot from JobService.job_statuses

### DIFF
--- a/src/ess/livedata/dashboard/job_service.py
+++ b/src/ess/livedata/dashboard/job_service.py
@@ -38,8 +38,13 @@ class JobService:
 
     @property
     def job_statuses(self) -> dict[JobId, JobStatus]:
-        """Access to all stored job statuses."""
-        return self._job_statuses
+        """Snapshot of all stored job statuses.
+
+        Returns a copy: ``status_updated`` runs on the ingestion thread, so
+        handing out the live dict would let UI-thread callers iterate it while
+        a heartbeat inserts a new key.
+        """
+        return dict(self._job_statuses)
 
     def status_updated(self, job_status: JobStatus) -> None:
         """Update the stored job status and record timestamp."""

--- a/tests/dashboard/job_service_test.py
+++ b/tests/dashboard/job_service_test.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for JobService."""
+
+from ess.livedata.config.workflow_spec import JobId, WorkflowId
+from ess.livedata.core.job import JobState, JobStatus
+from ess.livedata.dashboard.job_service import JobService
+
+
+def make_status(source_name: str, job_number: int = 1) -> JobStatus:
+    return JobStatus(
+        job_id=JobId(source_name=source_name, job_number=job_number),
+        workflow_id=WorkflowId(instrument='test', name='wf', version=1),
+        state=JobState.active,
+    )
+
+
+def test_job_statuses_returns_snapshot_decoupled_from_updates() -> None:
+    service = JobService()
+    first = make_status('det_1')
+    service.status_updated(first)
+
+    snapshot = service.job_statuses
+    service.status_updated(make_status('det_2'))
+
+    assert snapshot == {first.job_id: first}
+    assert len(service.job_statuses) == 2


### PR DESCRIPTION
Fixes #1079: the property handed out the live dict while `status_updated` mutates it on the ingestion thread, so a UI-thread caller iterating it could hit `RuntimeError: dictionary changed size during iteration` when a heartbeat lands mid-pass. The sole consumer (`WorkflowStatusWidget._compute_status`) only iterates, so a shallow copy suffices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)