### PR TITLE
Route tab-to-grid lookups through the tabbed-grid list

### DIFF
--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -280,13 +280,35 @@ class PlotGridTabs:
                 cell=cell,
             )
 
+    def _tabbed_grid_ids(self) -> list[GridId]:
+        """GridIds that currently have a tab, in tab order.
+
+        Disabled grids keep a widget in ``_grid_widgets`` (preserving state
+        across re-enable) but have no tab. Positional lookups between a Bokeh
+        tab index and a GridId must go through this list, never through
+        ``_grid_widgets`` directly, or a disabled grid preceding an enabled one
+        skews the mapping. Membership is read from the live tabs -- the grid
+        panels actually appended -- so it stays correct even mid-removal, when
+        the orchestrator has already dropped the grid being removed.
+        """
+        panel_to_grid = {
+            id(grid.panel): grid_id for grid_id, grid in self._grid_widgets.items()
+        }
+        tabbed: list[GridId] = []
+        for tab in self._tabs[self._static_tabs_count :]:
+            grid_id = panel_to_grid.get(id(tab))
+            if grid_id is not None:
+                tabbed.append(grid_id)
+        return tabbed
+
     def _remove_grid_tab(self, grid_id: GridId) -> None:
         """Remove a grid tab."""
         if grid_id not in self._grid_widgets:
             return
 
-        tab_index = list(self._grid_widgets.keys()).index(grid_id)
-        self._tabs.pop(self._static_tabs_count + tab_index)
+        tabbed = self._tabbed_grid_ids()
+        if grid_id in tabbed:
+            self._tabs.pop(self._static_tabs_count + tabbed.index(grid_id))
         del self._grid_widgets[grid_id]
 
     def _get_active_grid_id(self) -> GridId | None:
@@ -304,9 +326,9 @@ class PlotGridTabs:
         if self._current_modal is not None:
             return None
         grid_idx = self._tabs.active - self._static_tabs_count
-        grid_keys = list(self._grid_widgets.keys())
-        if 0 <= grid_idx < len(grid_keys):
-            return grid_keys[grid_idx]
+        tabbed = self._tabbed_grid_ids()
+        if 0 <= grid_idx < len(tabbed):
+            return tabbed[grid_idx]
         return None
 
     def _on_grid_created(self, grid_id: GridId, grid_config: PlotGridConfig) -> None:
@@ -317,9 +339,9 @@ class PlotGridTabs:
         """
         self._reconcile_grid_tabs()
 
-        if grid_id in self._grid_widgets:
-            tab_index = list(self._grid_widgets.keys()).index(grid_id)
-            self._tabs.active = self._static_tabs_count + tab_index
+        tabbed = self._tabbed_grid_ids()
+        if grid_id in tabbed:
+            self._tabs.active = self._static_tabs_count + tabbed.index(grid_id)
 
     def _on_grid_removed(self, grid_id: GridId) -> None:
         """Handle grid removal from orchestrator."""

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -865,3 +865,70 @@ class TestDisabledGridTabs:
         static = plot_grid_tabs._static_tabs_count
         grid_titles = plot_grid_tabs.tabs._names[static:]
         assert grid_titles == ['Beta', 'Alpha']
+
+    def test_active_grid_id_resolves_correctly_with_first_grid_disabled(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """Active tab maps to the right grid when the first grid is disabled.
+
+        A disabled grid preceding enabled ones must not skew the tab->grid
+        mapping: it has no tab, so the first visible grid tab is the first
+        *enabled* grid, not the first entry in ``_grid_widgets``.
+        """
+        id_a = plot_orchestrator.add_grid(title='A', nrows=2, ncols=2)
+        id_b = plot_orchestrator.add_grid(title='B', nrows=2, ncols=2)
+        id_c = plot_orchestrator.add_grid(title='C', nrows=2, ncols=2)
+
+        plot_orchestrator.set_grid_enabled(id_a, enabled=False)
+
+        static = plot_grid_tabs._static_tabs_count
+        # Two visible grid tabs: B then C.
+        assert plot_grid_tabs.tabs._names[static:] == ['B', 'C']
+
+        plot_grid_tabs.tabs.active = static
+        assert plot_grid_tabs._get_active_grid_id() == id_b
+
+        plot_grid_tabs.tabs.active = static + 1
+        assert plot_grid_tabs._get_active_grid_id() == id_c
+
+    def test_active_grid_id_resolves_correctly_with_middle_grid_disabled(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """Active tab maps to the right grid when a middle grid is disabled."""
+        id_a = plot_orchestrator.add_grid(title='A', nrows=2, ncols=2)
+        id_b = plot_orchestrator.add_grid(title='B', nrows=2, ncols=2)
+        id_c = plot_orchestrator.add_grid(title='C', nrows=2, ncols=2)
+
+        plot_orchestrator.set_grid_enabled(id_b, enabled=False)
+
+        static = plot_grid_tabs._static_tabs_count
+        assert plot_grid_tabs.tabs._names[static:] == ['A', 'C']
+
+        plot_grid_tabs.tabs.active = static
+        assert plot_grid_tabs._get_active_grid_id() == id_a
+
+        plot_grid_tabs.tabs.active = static + 1
+        assert plot_grid_tabs._get_active_grid_id() == id_c
+
+    def test_removing_grid_after_disabled_grid_removes_right_tab(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """Removing an enabled grid preceded by a disabled one pops its tab.
+
+        With the first grid disabled, the positional tab index of a later grid
+        differs from its index in ``_grid_widgets``; removal must pop the tab
+        that actually belongs to the removed grid.
+        """
+        id_a = plot_orchestrator.add_grid(title='A', nrows=2, ncols=2)
+        plot_orchestrator.add_grid(title='B', nrows=2, ncols=2)
+        id_c = plot_orchestrator.add_grid(title='C', nrows=2, ncols=2)
+
+        plot_orchestrator.set_grid_enabled(id_a, enabled=False)
+
+        static = plot_grid_tabs._static_tabs_count
+        assert plot_grid_tabs.tabs._names[static:] == ['B', 'C']
+
+        plot_orchestrator.remove_grid(id_c)
+
+        # C's tab is gone; B remains.
+        assert plot_grid_tabs.tabs._names[static:] == ['B']


### PR DESCRIPTION
Fixes #1071: disabled grids keep their widget in `_grid_widgets` (preserving state across re-enable) but have no tab, so positional lookups indexing `list(_grid_widgets.keys())` skewed once a disabled grid preceded an enabled one — the visible tab resolved to the wrong grid, silently freezing its plots (`update_pipe` never ran for the grid actually on screen), and removing a grid could pop the wrong tab. Three positional call sites were affected (`_get_active_grid_id`, `_remove_grid_tab`, and `_on_grid_created`'s auto-switch, one more than the issue named); all now go through a single helper listing grids that actually have tabs.

Tab membership is derived from the live tab panels rather than the orchestrator's enabled flag: `remove_grid` drops the grid from the orchestrator before `on_grid_removed` fires, so the enabled flag is already gone for the grid whose tab must still be popped (this broke the removal path in a first attempt using the flag).

New tests disable the first/middle grid of three — the existing suite only ever disabled the last one, which happens not to skew; that gap is why this escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)