### PR TITLE
Share live ROI state across sessions instead of republishing per session

### DIFF
--- a/src/ess/livedata/dashboard/roi_request_plots.py
+++ b/src/ess/livedata/dashboard/roi_request_plots.py
@@ -17,7 +17,8 @@ ROI request plotters follow the two-stage compute/present pattern:
    forwards the raw data. Called once when data arrives.
 
 2. create_presenter(): Creates a presenter with HoloViews config and an edit
-   handler callback. The callback captures per-session ROI state in a closure.
+   handler callback. The callback reads and updates the plotter's live ROI
+   state, which is shared across all sessions.
 
 3. Presenter.__init__(): Creates session-bound Pipe, DynamicMap, and edit
    streams. Each browser session gets its own presenter instance.
@@ -31,6 +32,7 @@ comparison, skip logic, publishing) stays in the plotter via the edit callback.
 
 from __future__ import annotations
 
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, runtime_checkable
@@ -549,6 +551,13 @@ class BaseROIRequestPlotter(Plotter, ABC, Generic[ROIType, ParamsType, Converter
         self._index_offset = self._get_index_offset()
         self._initial_rois: dict[int, ROIType] = self._parse_initial_geometry()
 
+        # Live ROI state shared across all sessions of this plotter. Sessions'
+        # edit handlers read and update this under _roi_lock; new presenters are
+        # seeded from it so a session opened after edits sees the current ROIs.
+        self._current_rois: dict[int, ROIType] = dict(self._initial_rois)
+        self._published_initial = False
+        self._roi_lock = threading.Lock()
+
         # Data-dependent state (set during compute())
         self._data_key: DataKey | None = None
         self._x_unit: str | None = None
@@ -634,54 +643,54 @@ class BaseROIRequestPlotter(Plotter, ABC, Generic[ROIType, ParamsType, Converter
 
     def _create_edit_handler(self) -> Callable[[dict], None]:
         """
-        Create a per-session edit handler with closure-captured ROI state.
+        Create an edit handler over the plotter's shared live ROI state.
 
-        The handler parses edit stream data, compares with current state,
-        applies skip logic, and publishes changes. Each session gets its
-        own handler with independent ROI state.
+        The handler parses edit stream data, compares with the shared state,
+        applies skip logic, and publishes changes. All sessions' handlers read
+        and update the same ``_current_rois`` under ``_roi_lock``.
+
+        Also emits the initial ROI set once per plotter lifetime (on the first
+        presenter creation after ``compute()`` has set ``_data_key``), never
+        again on subsequent session/presenter creation.
 
         Returns
         -------
         :
             Callback function for handling edit events.
         """
-        current_rois: dict[int, ROIType] = dict(self._initial_rois)
 
         def handle_edit(stream_data: dict) -> None:
-            nonlocal current_rois
-
             new_rois = self._converter.parse_stream_data(
                 stream_data,
                 x_unit=self._x_unit,
                 y_unit=self._y_unit,
                 index_offset=self._index_offset,
             )
+            with self._roi_lock:
+                # Skip if unchanged
+                if new_rois == self._current_rois:
+                    return
+                # Apply subclass-specific skip logic
+                if self._should_skip_edit(new_rois):
+                    return
+                self._current_rois = new_rois
+                self._publish_rois(new_rois)
 
-            # Skip if unchanged
-            if new_rois == current_rois:
-                return
-
-            # Apply subclass-specific skip logic
-            if self._should_skip_edit(new_rois):
-                return
-
-            current_rois = new_rois
-            self._publish_rois(new_rois)
-
-        # Publish initial state
-        self._publish_rois(current_rois)
+        with self._roi_lock:
+            if not self._published_initial and self._publish_rois(self._current_rois):
+                self._published_initial = True
 
         return handle_edit
 
-    def _publish_rois(self, rois: dict[int, ROIType]) -> None:
-        """Publish ROIs to Kafka."""
+    def _publish_rois(self, rois: dict[int, ROIType]) -> bool:
+        """Publish ROIs to Kafka. Returns True if a message was published."""
         if not self._roi_publisher or not self._data_key:
-            return
+            return False
 
         geometry = self._roi_mapper.geometry_for_type(self._geometry_type())
         if geometry is None:
             logger.warning("%s geometry not configured", self._geometry_type())
-            return
+            return False
 
         self._roi_publisher.publish(
             workflow_id=self._data_key.workflow_id,
@@ -695,6 +704,7 @@ class BaseROIRequestPlotter(Plotter, ABC, Generic[ROIType, ParamsType, Converter
             self._geometry_type(),
             self._data_key.source_name,
         )
+        return True
 
 
 class RectanglesRequestPlotter(
@@ -750,9 +760,9 @@ class RectanglesRequestPlotter(
         presenter = RectanglesRequestPresenter(
             plotter=self,
             initial_hv_data=self._converter.to_hv_data(
-                self._initial_rois, index_to_color=None
+                self._current_rois, index_to_color=None
             ),
-            initial_stream_data=self._converter.to_stream_data(self._initial_rois),
+            initial_stream_data=self._converter.to_stream_data(self._current_rois),
             style=self._get_style(),
             max_roi_count=self._get_max_roi_count(),
             on_edit=self._create_edit_handler(),
@@ -923,9 +933,9 @@ class PolygonsRequestPlotter(
         presenter = PolygonsRequestPresenter(
             plotter=self,
             initial_hv_data=self._converter.to_hv_data(
-                self._initial_rois, index_to_color=None
+                self._current_rois, index_to_color=None
             ),
-            initial_stream_data=self._converter.to_stream_data(self._initial_rois),
+            initial_stream_data=self._converter.to_stream_data(self._current_rois),
             style=self._get_style(),
             max_roi_count=self._get_max_roi_count(),
             on_edit=self._create_edit_handler(),

--- a/tests/dashboard/roi_request_plots_test.py
+++ b/tests/dashboard/roi_request_plots_test.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for interactive ROI request plotters."""
+
+import holoviews as hv
+import pytest
+
+from ess.livedata.config.models import RectangleROI
+from ess.livedata.config.workflow_spec import DataKey, WorkflowId
+from ess.livedata.dashboard.data_roles import PRIMARY
+from ess.livedata.dashboard.roi_publisher import FakeROIPublisher
+from ess.livedata.dashboard.roi_request_plots import (
+    RectanglesRequestParams,
+    RectanglesRequestPlotter,
+)
+
+hv.extension('bokeh')
+
+
+@pytest.fixture
+def data_key() -> DataKey:
+    return DataKey(
+        workflow_id=WorkflowId(instrument='test', name='wf', version=1),
+        source_name='test_source',
+        output_name='roi_rectangle',
+    )
+
+
+@pytest.fixture
+def computed_plotter(data_key: DataKey) -> RectanglesRequestPlotter:
+    """A plotter with an empty initial set, publisher, and DataKey set."""
+    plotter = RectanglesRequestPlotter.from_params(RectanglesRequestParams())
+    plotter.set_roi_publisher(FakeROIPublisher())
+    # compute() sets the DataKey required for publishing.
+    plotter.compute({PRIMARY: {data_key: RectangleROI.to_concatenated_data_array({})}})
+    return plotter
+
+
+def _drawn_box() -> dict[str, list[float]]:
+    """BoxEdit stream data for a single drawn rectangle."""
+    return {'x0': [1.0], 'x1': [5.0], 'y0': [2.0], 'y1': [6.0]}
+
+
+def test_first_presenter_publishes_initial_set_once(
+    computed_plotter: RectanglesRequestPlotter,
+) -> None:
+    publisher = computed_plotter._roi_publisher
+    assert isinstance(publisher, FakeROIPublisher)
+
+    computed_plotter.create_presenter()
+
+    assert len(publisher.published) == 1
+    assert publisher.published[0][2] == {}
+
+
+def test_second_presenter_does_not_republish_initial_set(
+    computed_plotter: RectanglesRequestPlotter,
+) -> None:
+    """A second session must not republish the (stale) initial set."""
+    publisher = computed_plotter._roi_publisher
+    assert isinstance(publisher, FakeROIPublisher)
+
+    computed_plotter.create_presenter()
+    computed_plotter.create_presenter()
+
+    # Exactly one publish across both presenter creations: the initial empty set.
+    assert len(publisher.published) == 1
+    assert publisher.published[0][2] == {}
+
+
+def test_edit_persists_and_second_presenter_is_seeded_from_it(
+    computed_plotter: RectanglesRequestPlotter,
+) -> None:
+    """After an edit, a new session sees the edited ROIs, not the config set."""
+    publisher = computed_plotter._roi_publisher
+    assert isinstance(publisher, FakeROIPublisher)
+
+    presenter1 = computed_plotter.create_presenter()
+    presenter1._handle_edit(_drawn_box())
+
+    roi = computed_plotter._current_rois[0]
+    assert (roi.x.min, roi.x.max, roi.y.min, roi.y.max) == (1.0, 5.0, 2.0, 6.0)
+
+    presenter2 = computed_plotter.create_presenter()
+
+    # Second presenter creation does not publish: no republish of stale/initial set.
+    # Publishes so far: initial empty set, then the drawn ROI from the edit.
+    assert len(publisher.published) == 2
+    assert publisher.published[0][2] == {}
+    assert publisher.published[1][2] == computed_plotter._current_rois
+
+    # The new session's edit stream is seeded from the current (edited) ROIs.
+    assert presenter2._edit_stream.data == {
+        'x0': [1.0],
+        'y0': [2.0],
+        'x1': [5.0],
+        'y1': [6.0],
+    }


### PR DESCRIPTION
Fixes #1070: each browser session's edit handler kept a closure copy of the ROI set seeded from the config-time initial ROIs and unconditionally published it at presenter creation. Publishing replaces the backend's requested set, so any new session or tab reload wiped everyone's user-drawn ROIs.

ROI state now lives at plotter scope, shared by all sessions' edit handlers under a lock (edit events fire on each session's own document thread; the presenter-seeding read is lock-free since the handler rebinds a fresh dict atomically). The initial set is published once per plotter lifetime, on the first presenter creation after `compute()` has set the data key — that ordering is guaranteed because `create_presenter` only runs once `has_displayable_plot()` is true, which requires the same `compute()` call that sets the key. The once-flag is only set when a message actually went out, so an unwired publisher retries on the next presenter creation. New presenters seed their drawn shapes from the live state, so a session opened after edits shows the current ROIs.

Known residual (pre-existing, filed separately): a dashboard restart rebuilds plotters and republishes the config-time set, clobbering backend-side edits, because edits are never persisted back to the plot config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)