### PR TITLE
Adopt running jobs from heartbeat observation (ADR 0008)

### DIFF
--- a/docs/developer/adr/0008-job-adoption-from-heartbeat-observation.md
+++ b/docs/developer/adr/0008-job-adoption-from-heartbeat-observation.md
@@ -1,0 +1,119 @@
+# ADR 0008: Job adoption from heartbeat observation replaces persisted job identity
+
+- Status: proposed
+- Deciders: Simon
+- Date: 2026-07-21
+
+## Context
+
+Since the stable-data-key rework (#1042), the dashboard's data plane is keyed
+by stable `DataKey`s and the per-commit `job_number` acts only as a generation
+filter and provenance stamp. What remains job-scoped is the dashboard's
+knowledge of *which backend job is the current generation*: established
+locally at commit time in `ActiveJobRegistry`, persisted as `current_job` in
+the config store, and re-established after a dashboard restart by
+`ActiveJobRegistry.restore()` reading that store. The last remaining step of
+#1042 replaces this persistence-as-authority with *adoption*: deriving the
+current generation from live signals. This ADR decides how.
+
+Persistence-based re-recognition is trust in a local record, not observation.
+Its failure modes are the ones seen in pre-production (#714): jobs running on
+the backend with no dashboard-side owner after a restart with a lost or stale
+store, and — analysed on #1046 during the pending-command-expiry work
+(#1067) — a stop command swallowed by the producer, which leaves an orphan
+that no UI affordance can reach: local state says "stopped", so the stop
+button is gone and a recommit skips the stop-old-jobs branch.
+
+That analysis also settled what adoption must enable: **desired/observed
+reconciliation**. UI state derives from desired state (user intent, held
+locally) compared against observed state (what the backend reports); commands
+are actuators, re-issued while the two differ. Command acknowledgements stay
+what #1067 made them — fast user feedback (toasts), never a state driver —
+because a lost ACK is indistinguishable from a lost command. Reconciliation
+needs observed run-state; it does not need config content.
+
+`JobStatus` heartbeats already carry `job_id` (source name + `job_number`),
+`workflow_id`, run state, and start time. That is sufficient to observe *which
+job runs as which generation*. What heartbeats do not carry is the job's
+configuration — needed only for provenance (`resolve_config`) and for
+labelling the running job in the UI.
+
+Deployment reality, load-bearing for this decision: exactly one dashboard
+instance writes commands, and no external actor (e.g. NICOS) starts jobs.
+Every running job was started by this dashboard or a previous incarnation of
+it, from a config this dashboard staged and persisted.
+
+## Decision
+
+The dashboard adopts running jobs from heartbeat observation; the persisted
+job record is demoted from identity-authority to provenance cache. No wire
+protocol change.
+
+- **Identity by observation.** At startup and continuously thereafter, a
+  non-stale `JobStatus` for a known workflow establishes that workflow's
+  observed generation. `ActiveJobRegistry`'s current generation is initialized
+  from observation; `ActiveJobRegistry.restore()` and the use of `current_job`
+  as the source of truth for "what is running" are deleted. If several
+  job_numbers heartbeat for one workflow (a stop-lagged predecessor alongside
+  its replacement), the record resolves which is current; absent a record,
+  the latest start time wins and the others surface as orphans.
+- **Config by record, demoted.** The generation→config record (what
+  `current_job` persistence carries today) continues to be written at commit,
+  but is consulted only to label an observed job: provenance
+  (`resolve_config`), UI display of the running parameters. It never decides
+  whether a job runs.
+- **Record misses degrade, they do not lie.** An observed job whose
+  `job_number` is not in the record (crash between send and persist, store
+  loss) is surfaced as running-with-unknown-config: visible, stoppable,
+  counted in reconciliation, without params provenance. The next commit
+  supersedes it.
+- **Reconciliation drives run-state UI.** Desired "stopped" with observed
+  running heartbeats re-issues the stop (bounded, logged); desired "running"
+  with no observed heartbeats within the status-staleness window surfaces
+  through the existing PENDING-plus-expiry path. Lost sends, lost ACKs, and
+  orphans collapse into one recovery mechanism.
+
+## Alternatives considered
+
+- **Keep persisted `current_job` as authority** (status quo): the record
+  cannot see reality — every #714 scenario is a record/reality divergence,
+  and the swallowed-stop analysis showed the divergence can be unreachable
+  from the UI. Rejected; this is what adoption replaces.
+- **Commands-topic replay**: reconstruct identity by re-reading the command
+  stream at startup. Rejected: replay reconstructs *intent*, not *reality* —
+  a swallowed send never reached the topic, and a job whose worker died still
+  replays as "started". Correctness would hinge on topic retention
+  configuration, it adds a second consumer with a startup phase, and it only
+  helps at startup, while heartbeats are continuous.
+- **Config-fingerprint echo in `JobStatus`**: the dashboard mints a
+  fingerprint of the committed config, sends it in `WorkflowConfig`, and the
+  backend echoes it opaquely in every heartbeat; the dashboard recovers a
+  running job's config by content instead of by record. Rejected for now:
+  with a single dashboard instance the record covers every case except the
+  crash-window/store-loss misses, which degrade gracefully above — a backend
+  protocol change buying only that corner. Content is also not identity:
+  byte-identical recommits share a fingerprint, so `job_number` remains the
+  generation key regardless. Revisit if a second command writer (another
+  dashboard instance, externally started jobs) becomes real — that breaks
+  this ADR's "record ≈ my own history" premise and makes self-describing
+  heartbeats worth the protocol change.
+- **Full-config echo in `JobStatus`**: superset of the fingerprint; same
+  rejection plus params payload in every heartbeat.
+
+## Consequences
+
+- Dashboard-only change; the backend and wire formats are untouched.
+- `ActiveJobRegistry.restore()` is deleted; the `is_known_job` ingest window
+  is fed by adoption instead of restoration; the generation→config record
+  keeps being written but nothing reads it to decide run-state. This is the
+  final step of #1042; its completion closes that issue.
+- #714 closes when adoption plus reconciliation land: orphans become visible
+  and stoppable, and the lost-stop scenario recovers via re-issued stops
+  instead of requiring a backend restart.
+- The single-writer deployment assumption is recorded here and must hold: a
+  second dashboard instance or external job starts invalidate the premise,
+  and the fingerprint-echo alternative is the designated escape hatch.
+- Adoption latency is bounded by heartbeat cadence plus the status-staleness
+  window: after a restart the dashboard may briefly show a running workflow
+  as pending until its first heartbeat arrives. This replaces trusting a
+  possibly-wrong record instantly with being provably right shortly.

--- a/docs/developer/adr/0008-job-adoption-from-heartbeat-observation.md
+++ b/docs/developer/adr/0008-job-adoption-from-heartbeat-observation.md
@@ -1,6 +1,6 @@
 # ADR 0008: Job adoption from heartbeat observation replaces persisted job identity
 
-- Status: proposed
+- Status: accepted
 - Deciders: Simon
 - Date: 2026-07-21
 

--- a/src/ess/livedata/dashboard/active_job_registry.py
+++ b/src/ess/livedata/dashboard/active_job_registry.py
@@ -31,11 +31,14 @@ class Generation:
     """One commit of a workflow: its wire-level job_number and its config.
 
     The config is retained so data stamped with this generation can be
-    resolved back to the parameters it was computed with (provenance).
+    resolved back to the parameters it was computed with (provenance). It is
+    ``None`` for a generation adopted from heartbeat observation without a
+    persisted record: the job runs and its data is admitted, but its
+    parameters are unknown.
     """
 
     job_number: JobNumber
-    config: Mapping[str, Any]
+    config: Mapping[str, Any] | None
 
 
 @dataclass
@@ -66,9 +69,10 @@ class ActiveJobRegistry:
     The dashboard's data plane is keyed by stable ``DataKey``s, so buffered
     data is not evicted when a job stops — a stopped workflow's last data
     stays displayed under its keys. The one eviction point is
-    :py:meth:`begin_generation` (called only from ``commit_workflow``): the
-    workflow's buffers are cleared so the new generation starts blank and a
-    windowed extractor can never aggregate across a parameter change.
+    :py:meth:`begin_generation` (called from ``commit_workflow`` and from
+    heartbeat adoption): the workflow's buffers are cleared so the new
+    generation starts blank and a windowed extractor can never aggregate
+    across a parameter change.
     """
 
     def __init__(self, *, data_service: DataService, job_service: JobService) -> None:
@@ -99,26 +103,35 @@ class ActiveJobRegistry:
                 and record.current.job_number == job_number
             )
 
-    def is_known_job(self, job_number: JobNumber) -> bool:
-        """Check whether a job_number is any workflow's current or last generation.
+    def is_known_generation(
+        self, workflow_id: WorkflowId, job_number: JobNumber
+    ) -> bool:
+        """Check whether a job_number is the workflow's current or last generation.
 
-        Used to filter ``JobStatus`` heartbeats, which keep job-number
-        semantics: a just-stopped or just-replaced job may still report its
-        final states.
+        Membership in the two-entry window, independent of whether the
+        generation's config is known: a just-stopped or just-replaced job is
+        known here even though it no longer admits data, so heartbeat adoption
+        does not mistake it for a new job.
         """
         with self._lock:
+            record = self._generations.get(workflow_id)
+            if record is None:
+                return False
             return any(
                 gen is not None and gen.job_number == job_number
-                for record in self._generations.values()
                 for gen in (record.current, record.last)
             )
 
     def begin_generation(
-        self, workflow_id: WorkflowId, job_number: JobNumber, config: Mapping[str, Any]
+        self,
+        workflow_id: WorkflowId,
+        job_number: JobNumber,
+        config: Mapping[str, Any] | None,
     ) -> None:
         """Flip a workflow to a new generation and clear its buffered data.
 
-        This is the commit flip: the previous current generation rotates into
+        Called at commit and on heartbeat adoption (``config`` is None when
+        adopting a job without a record): the previous current generation rotates into
         ``last`` (its retained config still resolvable for provenance), the
         generation that drops off the two-entry window has its job-status
         entries pruned, and the workflow's DataService buffers are cleared —
@@ -163,16 +176,6 @@ class ActiveJobRegistry:
             record.current = None
             if dropped is not None:
                 self._job_service.remove_jobs_by_number(dropped.job_number)
-
-    def restore(self, workflow_id: WorkflowId, *, current: Generation) -> None:
-        """Restore the persisted current generation without acquiring the lock.
-
-        Used during initialization when no other threads are running. Only
-        ``current`` survives a dashboard restart: a stopped backend job no
-        longer heartbeats, so there is nothing a restored ``last`` generation
-        would admit.
-        """
-        self._generations[workflow_id] = _GenerationRecord(current=current)
 
     def resolve_config(
         self, workflow_id: WorkflowId, job_number: JobNumber

--- a/src/ess/livedata/dashboard/dashboard_services.py
+++ b/src/ess/livedata/dashboard/dashboard_services.py
@@ -152,6 +152,10 @@ class DashboardServices:
                 # a silently dropped send surfaces as an error toast rather than a
                 # workflow stuck waiting for the backend. Cheap scan of a tiny dict.
                 self.job_orchestrator.expire_pending_commands()
+                # Compare desired run-state against observed heartbeats and
+                # re-issue stops while they contradict (ADR 0008). Also prunes
+                # observed statuses whose heartbeat aged out.
+                self.job_orchestrator.reconcile_observed_jobs()
                 self.session_registry.cleanup_stale_sessions()
                 # Run-state poll before the flush: a commit observed here
                 # resets the affected layers' presentation, so the same pass's
@@ -253,11 +257,11 @@ class DashboardServices:
             command_service=self.command_service,
             workflow_registry=self.processor_factory,
             active_job_registry=active_job_registry,
+            job_service=self.job_service,
             config_store=self.workflow_config_store,
             instrument_config=self.instrument_config,
             notification_queue=self.notification_queue,
         )
-        self.job_service.on_status_updated = self.job_orchestrator.on_job_status_updated
         self._roi_publisher.set_job_number_resolver(
             self.job_orchestrator.get_active_job_number
         )

--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -117,6 +117,11 @@ class WorkflowState:
     ``current`` is the desired run-state: the JobSet the user committed (or
     that was adopted from observation). Whether the backend actually runs it
     is observed via heartbeats; the two are compared by reconciliation.
+
+    All run-state changes go through the transition methods below, which keep
+    ``current``, ``stopped_reason``, the adoption fields, and ``version``
+    consistent. Side effects (commands, generation flips, persistence) are the
+    orchestrator's responsibility and must not migrate here.
     """
 
     current: JobSet | None = None
@@ -128,6 +133,49 @@ class WorkflowState:
     # observed start_time may replace the adopted job. Cleared on commit/stop.
     adopted_without_record: bool = False
     adopted_start_time: Timestamp | None = None
+
+    def commit(self, job_set: JobSet) -> None:
+        """Set a committed JobSet as the desired run-state."""
+        self.current = job_set
+        self.stopped_reason = None
+        self.adopted_without_record = False
+        self.adopted_start_time = None
+        self.version += 1
+
+    def deactivate(self, reason: StoppedReason) -> None:
+        """Clear the desired run-state, recording why it stopped."""
+        self.current = None
+        self.stopped_reason = reason
+        self.adopted_without_record = False
+        self.adopted_start_time = None
+        self.version += 1
+
+    def adopt(
+        self,
+        job_number: JobNumber,
+        start_time: Timestamp | None,
+        source_name: SourceName,
+    ) -> None:
+        """Take an observed record-less job as the desired run-state."""
+        self.current = JobSet(
+            job_number=job_number,
+            jobs={source_name: JobConfig(params={}, aux_source_names={})},
+        )
+        self.adopted_without_record = True
+        self.adopted_start_time = start_time
+        self.stopped_reason = None
+        self.version += 1
+
+    def extend_adopted(self, source_name: SourceName) -> None:
+        """Add a newly observed source to the adopted JobSet."""
+        if self.current is None:
+            msg = "Cannot extend adopted job set: no current job set"
+            raise RuntimeError(msg)
+        if not self.adopted_without_record:
+            msg = "Cannot extend adopted job set: not in adopted_without_record state"
+            raise RuntimeError(msg)
+        self.current.jobs[source_name] = JobConfig(params={}, aux_source_names={})
+        self.version += 1
 
 
 class JobOrchestrator:
@@ -413,7 +461,7 @@ class JobOrchestrator:
         # commit supersedes them all.
         old_job_ids = dict.fromkeys(
             (state.current.job_ids() if state.current is not None else [])
-            + self._observed_running_job_ids(workflow_id)
+            + self._job_service.fresh_running_job_ids(workflow_id)
         )
         if old_job_ids:
             logger.info(
@@ -457,11 +505,7 @@ class JobOrchestrator:
             message_id, workflow_id, "start", expected_count=len(state.staged_jobs)
         )
 
-        # Set as current JobSet
-        state.current = job_set
-        state.stopped_reason = None
-        state.adopted_without_record = False
-        state.adopted_start_time = None
+        state.commit(job_set)
 
         # Flip the generation, clear the workflow's buffers, and notify
         # subscribers atomically under the ingestion guard, *before* sending
@@ -493,9 +537,6 @@ class JobOrchestrator:
 
         # Persist full state (staged configs + active jobs) to store
         self._persist_state_to_store(workflow_id)
-
-        # Notify widget lifecycle subscribers that workflow was committed
-        self._notify_workflow_committed(workflow_id)
 
         # Return JobIds for all created jobs
         return job_set.job_ids()
@@ -802,7 +843,7 @@ class JobOrchestrator:
         desired = state.current
         observed_extra = [
             job_id
-            for job_id in self._observed_running_job_ids(workflow_id)
+            for job_id in self._job_service.fresh_running_job_ids(workflow_id)
             if desired is None or job_id.job_number != desired.job_number
         ]
         if desired is None and not observed_extra:
@@ -855,13 +896,9 @@ class JobOrchestrator:
             for job_id in state.current.job_ids():
                 self._job_states.pop(job_id, None)
             self._active_job_registry.deactivate(workflow_id)
-            state.current = None
-        state.stopped_reason = reason
-        state.adopted_without_record = False
-        state.adopted_start_time = None
+        state.deactivate(reason)
 
         self._persist_state_to_store(workflow_id)
-        self._notify_workflow_stopped(workflow_id)
 
     def on_job_status_updated(self, job_status: JobStatus) -> None:
         """React to a job status update from ``JobService``.
@@ -931,10 +968,7 @@ class JobOrchestrator:
             elif state.adopted_without_record and source_name not in state.current.jobs:
                 # Another source of the adopted job surfaces: extend the
                 # JobSet so stop/status cover it. Params stay unknown.
-                state.current.jobs[source_name] = JobConfig(
-                    params={}, aux_source_names={}
-                )
-                state.version += 1
+                state.extend_adopted(source_name)
             return
         if self._active_job_registry.is_known_generation(workflow_id, job_number):
             # A just-replaced or just-stopped generation reporting late
@@ -949,33 +983,16 @@ class JobOrchestrator:
             # Among record-less jobs the latest start time wins; this one
             # loses and reconciliation stops it.
             return
-        state.current = JobSet(
-            job_number=job_number,
-            jobs={source_name: JobConfig(params={}, aux_source_names={})},
-        )
-        state.adopted_without_record = True
-        state.adopted_start_time = job_status.start_time
-        state.stopped_reason = None
+        state.adopt(job_number, job_status.start_time, source_name)
         with self._active_job_registry.ingestion_guard():
             self._active_job_registry.begin_generation(
                 workflow_id, job_number, config=None
             )
-        state.version += 1
         logger.warning(
             'Adopted running job with unknown config: workflow %s, job_number %s',
             workflow_id,
             job_number,
         )
-
-    def _observed_running_job_ids(self, workflow_id: WorkflowId) -> list[JobId]:
-        """Job ids of the workflow with a fresh, non-stopped observed status."""
-        return [
-            job_id
-            for job_id, status in self._job_service.job_statuses.items()
-            if status.workflow_id == workflow_id
-            and status.state != JobState.stopped
-            and not self._job_service.is_status_stale(job_id)
-        ]
 
     def is_known_workflow(self, workflow_id: WorkflowId) -> bool:
         """Whether this workflow is managed here (heartbeat admit filter)."""
@@ -1152,14 +1169,6 @@ class JobOrchestrator:
         if self._transaction_workflow is not None:
             return
 
-        self._workflows[workflow_id].version += 1
-
-    def _notify_workflow_committed(self, workflow_id: WorkflowId) -> None:
-        """Increment workflow state version when a workflow is committed."""
-        self._workflows[workflow_id].version += 1
-
-    def _notify_workflow_stopped(self, workflow_id: WorkflowId) -> None:
-        """Increment workflow state version when a workflow is stopped."""
         self._workflows[workflow_id].version += 1
 
     def _notify_command_success(

--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -1004,9 +1004,24 @@ class JobOrchestrator:
         Desired "stopped" (or superseded) with fresh non-stopped heartbeats
         re-issues the stop, rate-bounded per job_number and logged: lost
         sends, lost ACKs, and orphans all collapse into this one recovery
-        path (ADR 0008). Desired "running" with no heartbeats needs no action
-        here — it surfaces through the PENDING display and pending-command
-        expiry.
+        path (ADR 0008).
+
+        Deliberately asymmetric: starts are never re-issued. A stop re-issue
+        acts on positive evidence (heartbeats prove the job exists and the
+        stop has not taken effect) and a redundant stop is free. A start
+        re-issue would act on absence of evidence — "desired running, no
+        heartbeats" conflates a lost send (re-issue correct), a slow or down
+        backend (the original command sits durably in the commands topic;
+        re-issue duplicates), delayed heartbeats from a healthy job (re-issue
+        destructive: ``JobManager.schedule_job`` overwrites the running job,
+        wiping its accumulated data), and a crashed job (re-issue is silent
+        auto-restart — supervision policy, and a crash loop if the params
+        crash the job deterministically). That divergence instead surfaces
+        through the PENDING display and pending-command expiry; recommit is
+        the explicit, safe re-issue. If lost starts turn out to be common in
+        the field, the fix is an idempotent backend start (no-op when the
+        job_id is already active), after which reconciliation could converge
+        in both directions.
         """
         self._job_service.prune_stale()
         now = self._clock()

--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -32,11 +32,13 @@ from ess.livedata.config.workflow_spec import (
 )
 from ess.livedata.core.job import JobState, JobStatus
 from ess.livedata.core.job_manager import JobAction, JobCommand
+from ess.livedata.core.timestamp import Timestamp
 
-from .active_job_registry import ActiveJobRegistry, Generation
+from .active_job_registry import ActiveJobRegistry
 from .command_service import CommandService
 from .config_store import ConfigStore
 from .configuration_adapter import ConfigurationState
+from .job_service import JobService
 from .notification_queue import NotificationEvent, NotificationQueue, NotificationType
 from .pending_command_tracker import PendingCommandTracker
 from .workflow_configuration_adapter import WorkflowConfigurationAdapter
@@ -54,6 +56,13 @@ SourceName = str
 # heartbeat-staleness constants in job_service.py, which answer a different
 # question about backend liveness.
 PENDING_COMMAND_TIMEOUT_SECONDS = 30.0
+
+# While a job's observed heartbeats contradict the desired state (stopped or
+# superseded), reconciliation re-issues the stop command, rate-bounded per
+# job_number so the backend gets time to act on the previous stop — including
+# the normal case where the just-sent stop of a commit or stop_workflow has
+# simply not been processed yet.
+STOP_REISSUE_INTERVAL_SECONDS = 30.0
 
 
 class JobConfig(BaseModel):
@@ -87,11 +96,11 @@ class JobSet(BaseModel):
         ]
 
 
-def _generation_of(job_set: JobSet | None) -> Generation | None:
-    """Registry-facing view of a JobSet: its job_number and config."""
-    if job_set is None:
-        return None
-    return Generation(job_number=job_set.job_number, config=job_set.jobs)
+def _starts_later(candidate: Timestamp | None, incumbent: Timestamp | None) -> bool:
+    """Whether a candidate start time beats the incumbent (None is earliest)."""
+    if candidate is None:
+        return False
+    return incumbent is None or candidate > incumbent
 
 
 class StoppedReason(StrEnum):
@@ -103,12 +112,22 @@ class StoppedReason(StrEnum):
 
 @dataclass
 class WorkflowState:
-    """State for an active workflow, including transitions."""
+    """State for an active workflow, including transitions.
+
+    ``current`` is the desired run-state: the JobSet the user committed (or
+    that was adopted from observation). Whether the backend actually runs it
+    is observed via heartbeats; the two are compared by reconciliation.
+    """
 
     current: JobSet | None = None
     staged_jobs: dict[SourceName, JobConfig] = field(default_factory=dict)
     version: int = 0
     stopped_reason: StoppedReason | None = None
+    # Set when ``current`` was adopted from heartbeat observation without a
+    # persisted record: params are unknown (degraded provenance), and a later
+    # observed start_time may replace the adopted job. Cleared on commit/stop.
+    adopted_without_record: bool = False
+    adopted_start_time: Timestamp | None = None
 
 
 class JobOrchestrator:
@@ -120,6 +139,7 @@ class JobOrchestrator:
         command_service: CommandService,
         workflow_registry: Mapping[WorkflowId, WorkflowSpec],
         active_job_registry: ActiveJobRegistry,
+        job_service: JobService,
         config_store: ConfigStore | None = None,
         instrument_config: Instrument | None = None,
         notification_queue: NotificationQueue | None = None,
@@ -137,6 +157,10 @@ class JobOrchestrator:
         active_job_registry
             Thread-safe registry for tracking active job numbers and
             cleaning up data on deactivation.
+        job_service
+            Holder of observed job statuses (heartbeats). The orchestrator
+            subscribes to its updates for adoption and reads it during
+            reconciliation.
         config_store
             Optional store for persisting workflow configurations across sessions.
             Orchestrator loads configs on init and persists on commit.
@@ -153,9 +177,11 @@ class JobOrchestrator:
         self._command_service = command_service
         self._workflow_registry = workflow_registry
         self._active_job_registry = active_job_registry
+        self._job_service = job_service
         self._config_store = config_store
         self._instrument_config = instrument_config
         self._notification_queue = notification_queue
+        self._clock = clock
 
         # Command acknowledgement tracking
         self._pending_commands = PendingCommandTracker(clock=clock)
@@ -163,6 +189,9 @@ class JobOrchestrator:
         # Workflow state tracking
         self._workflows: dict[WorkflowId, WorkflowState] = {}
         self._job_states: dict[JobId, JobState] = {}
+        # When the last stop was issued per job_number, bounding re-issues
+        # during reconciliation.
+        self._stop_issued_at: dict[JobNumber, float] = {}
 
         # Transaction state for batching staging operations
         self._transaction_workflow: WorkflowId | None = None
@@ -176,6 +205,8 @@ class JobOrchestrator:
 
         # Load persisted configs
         self._load_configs_from_store()
+
+        job_service.on_status_updated = self.on_job_status_updated
 
     def _load_configs_from_store(self) -> None:
         """Initialize all workflows with either loaded configs or defaults from spec."""
@@ -237,7 +268,12 @@ class JobOrchestrator:
                     len(spec.source_names),
                 )
 
-            # Restore active job state if present
+            # The persisted current_job is the generation→config record: it
+            # restores the desired run-state (the workflow shows as pending
+            # until its job is observed) and labels the observed job with the
+            # committed params. It does not touch ActiveJobRegistry — only a
+            # heartbeat observation establishes the generation that admits
+            # data (ADR 0008).
             if config_data:
                 if current_data := config_data.get('current_job'):
                     try:
@@ -248,11 +284,6 @@ class JobOrchestrator:
                             workflow_id,
                             e,
                         )
-
-                if state.current is not None:
-                    self._active_job_registry.restore(
-                        workflow_id, current=_generation_of(state.current)
-                    )
 
             self._workflows[workflow_id] = state
 
@@ -377,21 +408,29 @@ class JobOrchestrator:
         # Prepare all commands (stop old jobs + start new workflow) in single batch
         commands = []
 
-        # Stop old jobs if any
-        if state.current is not None:
+        # Stop the desired predecessor and any observed job of this workflow
+        # still heartbeating (e.g. an orphan whose stop was lost): the new
+        # commit supersedes them all.
+        old_job_ids = dict.fromkeys(
+            (state.current.job_ids() if state.current is not None else [])
+            + self._observed_running_job_ids(workflow_id)
+        )
+        if old_job_ids:
             logger.info(
-                'Workflow %s already has active jobs, stopping: %s',
+                'Workflow %s has %d old job(s), stopping before start',
                 workflow_id,
-                state.current.job_number,
+                len(old_job_ids),
             )
             # Fire-and-forget: each stop gets an auto-generated message_id the
             # dashboard does not register, so the owning worker's ack is dropped.
             # Reusing the start's message_id would inflate its tracked ack count.
             commands.extend(
                 JobCommand(job_id=job_id, action=JobAction.stop)
-                for job_id in state.current.job_ids()
+                for job_id in old_job_ids
             )
-            logger.debug('Will stop %d old jobs in batch', len(state.current.jobs))
+            now = self._clock()
+            for job_id in old_job_ids:
+                self._stop_issued_at[job_id.job_number] = now
 
         # Send workflow configs to all staged sources
         # Note: Currently all jobs use same params, but aux_source_names may
@@ -421,6 +460,8 @@ class JobOrchestrator:
         # Set as current JobSet
         state.current = job_set
         state.stopped_reason = None
+        state.adopted_without_record = False
+        state.adopted_start_time = None
 
         # Flip the generation, clear the workflow's buffers, and notify
         # subscribers atomically under the ingestion guard, *before* sending
@@ -489,8 +530,10 @@ class JobOrchestrator:
                 }
             }
 
-        # Add active job state
-        if state.current is not None:
+        # The generation→config record. Not written for a job adopted without
+        # a record — its params are unknown and the record must not lie; after
+        # a restart such a job is simply re-adopted from observation.
+        if state.current is not None and not state.adopted_without_record:
             config_dict['current_job'] = state.current.model_dump(mode='json')
 
         # Persist if we have something to save
@@ -740,7 +783,10 @@ class JobOrchestrator:
         Stop all jobs for a workflow.
 
         Sends stop commands to the backend and clears the local active job state.
-        The workflow configuration remains staged for future restarts.
+        Covers both the desired JobSet and any observed job of the workflow
+        still heartbeating outside it. The workflow configuration remains
+        staged for future restarts. If a stop is lost, reconciliation
+        re-issues it while heartbeats keep arriving.
 
         Parameters
         ----------
@@ -752,8 +798,38 @@ class JobOrchestrator:
         :
             True if jobs were stopped, False if no active jobs.
         """
-        if not self._send_job_commands(workflow_id, JobAction.stop):
+        state = self._workflows[workflow_id]
+        desired = state.current
+        observed_extra = [
+            job_id
+            for job_id in self._observed_running_job_ids(workflow_id)
+            if desired is None or job_id.job_number != desired.job_number
+        ]
+        if desired is None and not observed_extra:
+            logger.debug('No active jobs for workflow %s to stop', workflow_id)
             return False
+
+        if desired is not None:
+            self._send_job_commands(workflow_id, JobAction.stop)
+            self._stop_issued_at[desired.job_number] = self._clock()
+        if observed_extra:
+            # Fire-and-forget, like reconciliation's re-issued stops: these
+            # jobs are outside the desired set, so there is no per-source ack
+            # count to track for user feedback.
+            logger.info(
+                'Stopping %d observed job(s) of workflow %s outside the desired set',
+                len(observed_extra),
+                workflow_id,
+            )
+            self._command_service.send_batch(
+                [
+                    JobCommand(job_id=job_id, action=JobAction.stop)
+                    for job_id in observed_extra
+                ]
+            )
+            now = self._clock()
+            for job_id in observed_extra:
+                self._stop_issued_at[job_id.job_number] = now
 
         # Remove from active set immediately, before the backend has processed
         # the stop command. This means any final results the backend publishes
@@ -781,6 +857,8 @@ class JobOrchestrator:
             self._active_job_registry.deactivate(workflow_id)
             state.current = None
         state.stopped_reason = reason
+        state.adopted_without_record = False
+        state.adopted_start_time = None
 
         self._persist_state_to_store(workflow_id)
         self._notify_workflow_stopped(workflow_id)
@@ -788,14 +866,21 @@ class JobOrchestrator:
     def on_job_status_updated(self, job_status: JobStatus) -> None:
         """React to a job status update from ``JobService``.
 
-        When a backend worker shuts down, it sends a final heartbeat marking
-        all jobs as stopped. This tracks the latest state per job and checks
-        whether all jobs in the workflow have reported stopped, deactivating
-        the workflow if so.
+        Two responsibilities:
+
+        - Adoption (ADR 0008): a non-stopped status for a known workflow is
+          the observation that a job runs as that workflow's generation.
+        - Backend shutdown: a worker's final heartbeat marks its jobs
+          stopped; once all jobs of the desired set reported stopped, the
+          workflow is deactivated.
         """
         workflow_id = job_status.workflow_id
         state = self._workflows.get(workflow_id)
-        if state is None or state.current is None:
+        if state is None:
+            return
+        if job_status.state != JobState.stopped:
+            self._adopt_observed_job(workflow_id, state, job_status)
+        if state.current is None:
             return
         job_ids = list(state.current.job_ids())
         if job_status.job_id not in job_ids:
@@ -811,6 +896,142 @@ class JobOrchestrator:
                 workflow_id,
             )
             self._deactivate_workflow(workflow_id, StoppedReason.backend_shutdown)
+
+    def _adopt_observed_job(
+        self, workflow_id: WorkflowId, state: WorkflowState, job_status: JobStatus
+    ) -> None:
+        """Derive the workflow's current generation from an observed running job.
+
+        Cases (ADR 0008):
+
+        - The observed job matches the desired JobSet but the registry has no
+          generation for it (dashboard restart): re-attach, labelled by the
+          persisted record.
+        - The observed job is entirely unknown (record miss: crash between
+          send and persist, store loss): adopt as running-with-unknown-config;
+          among several record-less jobs the latest start time wins.
+        - The observed job is a current/last generation or is superseded by a
+          committed JobSet: nothing to adopt — reconciliation re-issues its
+          stop if it keeps running.
+        """
+        job_number = job_status.job_id.job_number
+        source_name = job_status.job_id.source_name
+        if state.current is not None and state.current.job_number == job_number:
+            if not self._active_job_registry.is_current(workflow_id, job_number):
+                with self._active_job_registry.ingestion_guard():
+                    self._active_job_registry.begin_generation(
+                        workflow_id, job_number, config=state.current.jobs
+                    )
+                logger.info(
+                    'Adopted running job from heartbeat observation: '
+                    'workflow %s, job_number %s',
+                    workflow_id,
+                    job_number,
+                )
+            elif state.adopted_without_record and source_name not in state.current.jobs:
+                # Another source of the adopted job surfaces: extend the
+                # JobSet so stop/status cover it. Params stay unknown.
+                state.current.jobs[source_name] = JobConfig(
+                    params={}, aux_source_names={}
+                )
+                state.version += 1
+            return
+        if self._active_job_registry.is_known_generation(workflow_id, job_number):
+            # A just-replaced or just-stopped generation reporting late
+            # states; if it keeps running, reconciliation stops it.
+            return
+        if state.current is not None and not state.adopted_without_record:
+            # Superseded by a committed JobSet; reconciliation stops it.
+            return
+        if state.current is not None and not _starts_later(
+            job_status.start_time, state.adopted_start_time
+        ):
+            # Among record-less jobs the latest start time wins; this one
+            # loses and reconciliation stops it.
+            return
+        state.current = JobSet(
+            job_number=job_number,
+            jobs={source_name: JobConfig(params={}, aux_source_names={})},
+        )
+        state.adopted_without_record = True
+        state.adopted_start_time = job_status.start_time
+        state.stopped_reason = None
+        with self._active_job_registry.ingestion_guard():
+            self._active_job_registry.begin_generation(
+                workflow_id, job_number, config=None
+            )
+        state.version += 1
+        logger.warning(
+            'Adopted running job with unknown config: workflow %s, job_number %s',
+            workflow_id,
+            job_number,
+        )
+
+    def _observed_running_job_ids(self, workflow_id: WorkflowId) -> list[JobId]:
+        """Job ids of the workflow with a fresh, non-stopped observed status."""
+        return [
+            job_id
+            for job_id, status in self._job_service.job_statuses.items()
+            if status.workflow_id == workflow_id
+            and status.state != JobState.stopped
+            and not self._job_service.is_status_stale(job_id)
+        ]
+
+    def is_known_workflow(self, workflow_id: WorkflowId) -> bool:
+        """Whether this workflow is managed here (heartbeat admit filter)."""
+        return workflow_id in self._workflows
+
+    def reconcile_observed_jobs(self) -> None:
+        """Re-issue stops while observed run-state contradicts desired state.
+
+        Desired "stopped" (or superseded) with fresh non-stopped heartbeats
+        re-issues the stop, rate-bounded per job_number and logged: lost
+        sends, lost ACKs, and orphans all collapse into this one recovery
+        path (ADR 0008). Desired "running" with no heartbeats needs no action
+        here — it surfaces through the PENDING display and pending-command
+        expiry.
+        """
+        self._job_service.prune_stale()
+        now = self._clock()
+        to_stop: list[JobId] = []
+        fresh_numbers: set[JobNumber] = set()
+        for job_id, status in self._job_service.job_statuses.items():
+            if status.state == JobState.stopped:
+                continue
+            if self._job_service.is_status_stale(job_id):
+                continue
+            fresh_numbers.add(job_id.job_number)
+            state = self._workflows.get(status.workflow_id)
+            if state is None:
+                continue
+            if (
+                state.current is not None
+                and state.current.job_number == job_id.job_number
+            ):
+                continue
+            issued = self._stop_issued_at.get(job_id.job_number)
+            if issued is not None and now - issued < STOP_REISSUE_INTERVAL_SECONDS:
+                continue
+            to_stop.append(job_id)
+        # Drop ledger entries no longer backed by fresh observations so the
+        # dict does not grow with every job_number ever stopped.
+        self._stop_issued_at = {
+            number: t
+            for number, t in self._stop_issued_at.items()
+            if number in fresh_numbers or now - t < STOP_REISSUE_INTERVAL_SECONDS
+        }
+        if not to_stop:
+            return
+        for job_id in to_stop:
+            self._stop_issued_at[job_id.job_number] = now
+        logger.warning(
+            'Re-issuing stop for %d job(s) observed running against desired state: %s',
+            len(to_stop),
+            [str(job_id) for job_id in to_stop],
+        )
+        self._command_service.send_batch(
+            [JobCommand(job_id=job_id, action=JobAction.stop) for job_id in to_stop]
+        )
 
     def reset_workflow(self, workflow_id: WorkflowId) -> bool:
         """

--- a/src/ess/livedata/dashboard/job_service.py
+++ b/src/ess/livedata/dashboard/job_service.py
@@ -8,8 +8,8 @@ from uuid import UUID
 
 import structlog
 
-from ess.livedata.config.workflow_spec import JobId
-from ess.livedata.core.job import JobStatus
+from ess.livedata.config.workflow_spec import JobId, WorkflowId
+from ess.livedata.core.job import JobState, JobStatus
 
 logger = structlog.get_logger(__name__)
 
@@ -53,6 +53,20 @@ class JobService:
         self._job_status_timestamps[job_status.job_id] = time.time_ns()
         if self._on_status_updated is not None:
             self._on_status_updated(job_status)
+
+    def fresh_running_job_ids(self, workflow_id: WorkflowId) -> list[JobId]:
+        """Job ids of the workflow with a fresh, non-stopped observed status.
+
+        Iterates a snapshot: callers run on the UI or update thread while
+        ``status_updated`` inserts from the ingestion thread.
+        """
+        return [
+            job_id
+            for job_id, status in self.job_statuses.items()
+            if status.workflow_id == workflow_id
+            and status.state != JobState.stopped
+            and not self.is_status_stale(job_id)
+        ]
 
     def is_status_stale(self, job_id: JobId) -> bool:
         """Check if a job's status is stale (no recent heartbeat).

--- a/src/ess/livedata/dashboard/job_service.py
+++ b/src/ess/livedata/dashboard/job_service.py
@@ -76,6 +76,21 @@ class JobService:
 
         return age_ns > self._heartbeat_timeout_ns
 
+    def prune_stale(self) -> None:
+        """Drop statuses whose heartbeat aged past the staleness window.
+
+        A job that stopped heartbeating (worker gone, job long stopped) is no
+        longer observed; keeping its last status would otherwise accumulate
+        entries forever now that heartbeats are admitted per workflow rather
+        than per known job_number. A revived job re-adds itself with its next
+        heartbeat.
+        """
+        stale = [jid for jid in self._job_statuses if self.is_status_stale(jid)]
+        for jid in stale:
+            logger.debug("Pruning stale job status %s", jid)
+            self._job_statuses.pop(jid, None)
+            self._job_status_timestamps.pop(jid, None)
+
     def remove_jobs_by_number(self, job_number: UUID) -> None:
         """Remove all jobs matching a given job number.
 

--- a/src/ess/livedata/dashboard/orchestrator.py
+++ b/src/ess/livedata/dashboard/orchestrator.py
@@ -109,7 +109,10 @@ class Orchestrator:
         Data messages are admitted only if their wire job_number is the
         workflow's current generation (:class:`ActiveJobRegistry`); stale or
         unknown generations are counted and dropped. Job status messages are
-        admitted for current and last generations.
+        admitted for any known workflow: they are the observation feed for
+        job adoption and desired/observed reconciliation (ADR 0008), so
+        unknown job_numbers must reach the orchestrator instead of being
+        filtered here.
 
         Parameters
         ----------
@@ -122,7 +125,7 @@ class Orchestrator:
             if isinstance(value, ServiceStatus):
                 self._service_registry.status_updated(value)
             elif isinstance(value, JobStatus):
-                if self._active_job_registry.is_known_job(value.job_id.job_number):
+                if self._job_orchestrator.is_known_workflow(value.workflow_id):
                     self._job_service.status_updated(value)
             else:
                 self._logger.warning("Unknown status type: %s", type(value))

--- a/tests/dashboard/active_job_registry_test.py
+++ b/tests/dashboard/active_job_registry_test.py
@@ -6,7 +6,7 @@ import scipp as sc
 
 from ess.livedata.config.workflow_spec import DataKey, JobId, WorkflowId
 from ess.livedata.core.job import JobState, JobStatus
-from ess.livedata.dashboard.active_job_registry import ActiveJobRegistry, Generation
+from ess.livedata.dashboard.active_job_registry import ActiveJobRegistry
 from ess.livedata.dashboard.data_service import DataService, DataServiceSubscriber
 from ess.livedata.dashboard.extractors import LatestValueExtractor
 from ess.livedata.dashboard.job_service import JobService
@@ -157,16 +157,23 @@ class TestDeactivate:
         registry.deactivate(_workflow_id)  # no exception
 
 
-class TestIsKnownJob:
+class TestIsKnownGeneration:
     def test_current_and_last_are_known(self):
         registry, _ds, _js = _make_registry()
         old, new = uuid.uuid4(), uuid.uuid4()
         registry.begin_generation(_workflow_id, old, config={})
         registry.begin_generation(_workflow_id, new, config={})
 
-        assert registry.is_known_job(new)
-        assert registry.is_known_job(old)
-        assert not registry.is_known_job(uuid.uuid4())
+        assert registry.is_known_generation(_workflow_id, new)
+        assert registry.is_known_generation(_workflow_id, old)
+        assert not registry.is_known_generation(_workflow_id, uuid.uuid4())
+
+    def test_window_is_per_workflow(self):
+        registry, _ds, _js = _make_registry()
+        job_number = uuid.uuid4()
+        registry.begin_generation(_workflow_id, job_number, config={})
+
+        assert not registry.is_known_generation(_other_workflow_id, job_number)
 
     def test_generation_leaving_the_window_is_forgotten(self):
         registry, _ds, _js = _make_registry()
@@ -175,7 +182,15 @@ class TestIsKnownJob:
         for _ in range(2):
             registry.begin_generation(_workflow_id, uuid.uuid4(), config={})
 
-        assert not registry.is_known_job(first)
+        assert not registry.is_known_generation(_workflow_id, first)
+
+    def test_unknown_config_generation_is_known(self):
+        registry, _ds, _js = _make_registry()
+        job_number = uuid.uuid4()
+        registry.begin_generation(_workflow_id, job_number, config=None)
+
+        assert registry.is_known_generation(_workflow_id, job_number)
+        assert registry.resolve_config(_workflow_id, job_number) is None
 
 
 class TestResolveConfig:
@@ -191,20 +206,8 @@ class TestResolveConfig:
         assert registry.resolve_config(_other_workflow_id, new) is None
 
 
-class TestRestore:
-    def test_restored_current_admits_data(self):
-        registry, _ds, _js = _make_registry()
-        job_number = uuid.uuid4()
-
-        registry.restore(
-            _workflow_id,
-            current=Generation(job_number=job_number, config={"a": 1}),
-        )
-
-        assert registry.is_current(_workflow_id, job_number)
-        assert registry.resolve_config(_workflow_id, job_number) == {"a": 1}
-
-    def test_unrestored_workflow_admits_nothing(self):
+class TestUnobservedWorkflow:
+    def test_admits_nothing(self):
         registry, _ds, _js = _make_registry()
 
         assert not registry.is_current(_workflow_id, uuid.uuid4())

--- a/tests/dashboard/conftest.py
+++ b/tests/dashboard/conftest.py
@@ -119,14 +119,13 @@ def job_orchestrator(
     command_service, workflow_registry, active_job_registry, job_service
 ):
     """Create a JobOrchestrator with fakes for testing."""
-    orchestrator = JobOrchestrator(
+    return JobOrchestrator(
         command_service=command_service,
         workflow_registry=workflow_registry,
         active_job_registry=active_job_registry,
+        job_service=job_service,
         config_store=None,
     )
-    job_service.on_status_updated = orchestrator.on_job_status_updated
-    return orchestrator
 
 
 @pytest.fixture

--- a/tests/dashboard/derived_devices_test.py
+++ b/tests/dashboard/derived_devices_test.py
@@ -209,12 +209,14 @@ class TestWithRealOrchestrator:
 
     @pytest.fixture
     def orchestrator(self, registry) -> JobOrchestrator:
+        js = JobService()
         return JobOrchestrator(
             command_service=CommandService(sink=FakeMessageSink()),
             workflow_registry=registry,
             active_job_registry=ActiveJobRegistry(
-                data_service=DataService(), job_service=JobService()
+                data_service=DataService(), job_service=js
             ),
+            job_service=js,
             config_store=None,
         )
 

--- a/tests/dashboard/job_adoption_test.py
+++ b/tests/dashboard/job_adoption_test.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for job adoption from heartbeat observation and desired/observed
+reconciliation (ADR 0008).
+
+The persisted current_job record restores desired state and labels observed
+jobs, but only a heartbeat observation establishes the generation that admits
+data. Reconciliation re-issues stops while observed heartbeats contradict the
+desired state.
+"""
+
+import uuid
+
+import pytest
+
+from ess.livedata.config.workflow_spec import JobId
+from ess.livedata.core.job import JobState, JobStatus
+from ess.livedata.core.job_manager import JobCommand
+from ess.livedata.core.timestamp import Timestamp
+from ess.livedata.dashboard.active_job_registry import ActiveJobRegistry
+from ess.livedata.dashboard.command_service import CommandService
+from ess.livedata.dashboard.data_service import DataService
+from ess.livedata.dashboard.job_orchestrator import (
+    STOP_REISSUE_INTERVAL_SECONDS,
+    JobOrchestrator,
+)
+from ess.livedata.dashboard.job_service import JobService
+from ess.livedata.fakes import FakeMessageSink
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@pytest.fixture
+def clock():
+    return FakeClock()
+
+
+@pytest.fixture
+def store() -> dict:
+    """Config store shared between orchestrator incarnations (dashboard
+    restarts)."""
+    return {}
+
+
+@pytest.fixture
+def make_system(workflow_registry, store, clock):
+    """Build a fresh orchestrator incarnation sharing the persisted store."""
+
+    def _make(*, heartbeat_timeout_ns: int | None = None):
+        data_service = DataService()
+        kwargs = (
+            {}
+            if heartbeat_timeout_ns is None
+            else {'heartbeat_timeout_ns': heartbeat_timeout_ns}
+        )
+        job_service = JobService(**kwargs)
+        registry = ActiveJobRegistry(data_service=data_service, job_service=job_service)
+        sink = FakeMessageSink()
+        orchestrator = JobOrchestrator(
+            command_service=CommandService(sink=sink),
+            workflow_registry=workflow_registry,
+            active_job_registry=registry,
+            job_service=job_service,
+            config_store=store,
+            clock=clock,
+        )
+        return orchestrator, registry, job_service, sink
+
+    return _make
+
+
+def _heartbeat(
+    job_service: JobService,
+    job_id: JobId,
+    workflow_id,
+    state: JobState = JobState.active,
+    start_time_ns: int = 1_000_000_000,
+) -> None:
+    job_service.status_updated(
+        JobStatus(
+            job_id=job_id,
+            workflow_id=workflow_id,
+            state=state,
+            start_time=Timestamp.from_ns(start_time_ns),
+        )
+    )
+
+
+def _sent_stop_job_ids(sink: FakeMessageSink) -> list[JobId]:
+    return [
+        msg.value.job_id
+        for msg in sink.messages
+        if isinstance(msg.value, JobCommand) and msg.value.action.value == 'stop'
+    ]
+
+
+class TestAdoptionAfterRestart:
+    def test_record_restores_desired_state_but_admits_no_data(
+        self, make_system, workflow_id
+    ):
+        """After a restart the record says what should be running, but only
+        an observation establishes the generation that admits data."""
+        orchestrator1, _, _, _ = make_system()
+        job_ids = orchestrator1.commit_workflow(workflow_id)
+        job_number = job_ids[0].job_number
+
+        orchestrator2, registry2, _, _ = make_system()
+
+        assert orchestrator2.get_active_job_number(workflow_id) == job_number
+        assert not registry2.is_current(workflow_id, job_number)
+
+    def test_heartbeat_adopts_recorded_job(self, make_system, workflow_id):
+        orchestrator1, _, _, _ = make_system()
+        job_ids = orchestrator1.commit_workflow(workflow_id)
+        job_number = job_ids[0].job_number
+        committed_config = orchestrator1.get_active_config(workflow_id)
+
+        _, registry2, job_service2, _ = make_system()
+        _heartbeat(job_service2, job_ids[0], workflow_id)
+
+        assert registry2.is_current(workflow_id, job_number)
+        resolved = registry2.resolve_config(workflow_id, job_number)
+        assert resolved is not None
+        assert resolved.keys() == committed_config.keys()
+
+    def test_stopped_heartbeat_does_not_adopt(self, make_system, workflow_id):
+        orchestrator1, _, _, _ = make_system()
+        job_ids = orchestrator1.commit_workflow(workflow_id)
+
+        _, registry2, job_service2, _ = make_system()
+        _heartbeat(job_service2, job_ids[0], workflow_id, state=JobState.stopped)
+
+        assert not registry2.is_current(workflow_id, job_ids[0].job_number)
+
+    def test_all_stopped_heartbeats_after_restart_deactivate(
+        self, make_system, workflow_id
+    ):
+        """A backend that stopped the jobs while the dashboard was down
+        reports stopped states; the workflow transitions to stopped instead
+        of waiting forever."""
+        orchestrator1, _, _, _ = make_system()
+        job_ids = orchestrator1.commit_workflow(workflow_id)
+
+        orchestrator2, _, job_service2, _ = make_system()
+        for job_id in job_ids:
+            _heartbeat(job_service2, job_id, workflow_id, state=JobState.stopped)
+
+        assert orchestrator2.get_active_job_number(workflow_id) is None
+
+    def test_predecessor_heartbeat_does_not_displace_record(
+        self, make_system, workflow_id
+    ):
+        """When several job_numbers heartbeat for one workflow, the record
+        resolves which is current (ADR 0008)."""
+        orchestrator1, _, _, _ = make_system()
+        job_ids = orchestrator1.commit_workflow(workflow_id)
+        recorded_number = job_ids[0].job_number
+
+        orchestrator2, registry2, job_service2, _ = make_system()
+        predecessor = JobId(source_name='source1', job_number=uuid.uuid4())
+        _heartbeat(job_service2, predecessor, workflow_id)
+
+        assert orchestrator2.get_active_job_number(workflow_id) == recorded_number
+        assert not registry2.is_current(workflow_id, predecessor.job_number)
+
+
+class TestOrphanAdoption:
+    def test_orphan_adopted_with_unknown_config(self, make_system, workflow_id):
+        """A record miss degrades, it does not lie: the job is visible and
+        admits data, without params provenance."""
+        orchestrator, registry, job_service, _ = make_system()
+        orphan = JobId(source_name='source1', job_number=uuid.uuid4())
+
+        _heartbeat(job_service, orphan, workflow_id)
+
+        assert orchestrator.get_active_job_number(workflow_id) == orphan.job_number
+        assert registry.is_current(workflow_id, orphan.job_number)
+        assert registry.resolve_config(workflow_id, orphan.job_number) is None
+        active = orchestrator.get_active_config(workflow_id)
+        assert active['source1'].params == {}
+
+    def test_second_source_extends_adopted_job(self, make_system, workflow_id):
+        orchestrator, _, job_service, _ = make_system()
+        job_number = uuid.uuid4()
+
+        for source in ('source1', 'source2'):
+            _heartbeat(
+                job_service,
+                JobId(source_name=source, job_number=job_number),
+                workflow_id,
+            )
+
+        assert set(orchestrator.get_active_config(workflow_id)) == {
+            'source1',
+            'source2',
+        }
+
+    def test_latest_start_time_wins_among_recordless_jobs(
+        self, make_system, workflow_id
+    ):
+        orchestrator, _, job_service, _ = make_system()
+        older = JobId(source_name='source1', job_number=uuid.uuid4())
+        newer = JobId(source_name='source1', job_number=uuid.uuid4())
+
+        _heartbeat(job_service, older, workflow_id, start_time_ns=1_000)
+        _heartbeat(job_service, newer, workflow_id, start_time_ns=2_000)
+        _heartbeat(job_service, older, workflow_id, start_time_ns=1_000)
+
+        assert orchestrator.get_active_job_number(workflow_id) == newer.job_number
+
+    def test_earlier_start_does_not_displace_later(self, make_system, workflow_id):
+        orchestrator, _, job_service, _ = make_system()
+        newer = JobId(source_name='source1', job_number=uuid.uuid4())
+        older = JobId(source_name='source1', job_number=uuid.uuid4())
+
+        _heartbeat(job_service, newer, workflow_id, start_time_ns=2_000)
+        _heartbeat(job_service, older, workflow_id, start_time_ns=1_000)
+
+        assert orchestrator.get_active_job_number(workflow_id) == newer.job_number
+
+    def test_adopted_job_is_stoppable(self, make_system, workflow_id):
+        orchestrator, _, job_service, sink = make_system()
+        orphan = JobId(source_name='source1', job_number=uuid.uuid4())
+        _heartbeat(job_service, orphan, workflow_id)
+
+        assert orchestrator.stop_workflow(workflow_id) is True
+        assert orphan in _sent_stop_job_ids(sink)
+        assert orchestrator.get_active_job_number(workflow_id) is None
+
+    def test_adopted_job_is_not_persisted_as_record(
+        self, make_system, store, workflow_id
+    ):
+        """The record must not lie: an adopted job's params are unknown, so
+        no current_job record is written for it."""
+        _, _, job_service, _ = make_system()
+        orphan = JobId(source_name='source1', job_number=uuid.uuid4())
+
+        _heartbeat(job_service, orphan, workflow_id)
+
+        stored = store.get(str(workflow_id))
+        assert stored is None or 'current_job' not in stored
+
+    def test_user_stopped_job_is_not_readopted(self, make_system, workflow_id):
+        """A stop-lagged job's continued heartbeats must not resurrect it;
+        reconciliation re-issues the stop instead."""
+        orchestrator, _, job_service, _ = make_system()
+        job_ids = orchestrator.commit_workflow(workflow_id)
+        _heartbeat(job_service, job_ids[0], workflow_id)
+        orchestrator.stop_workflow(workflow_id)
+
+        _heartbeat(job_service, job_ids[0], workflow_id)
+
+        assert orchestrator.get_active_job_number(workflow_id) is None
+
+    def test_bumps_version_on_adoption(self, make_system, workflow_id):
+        orchestrator, _, job_service, _ = make_system()
+        version_before = orchestrator.get_workflow_state_version(workflow_id)
+
+        _heartbeat(
+            job_service,
+            JobId(source_name='source1', job_number=uuid.uuid4()),
+            workflow_id,
+        )
+
+        assert orchestrator.get_workflow_state_version(workflow_id) > version_before
+
+
+class TestReconciliation:
+    def test_reissues_stop_after_interval_while_heartbeats_continue(
+        self, make_system, clock, workflow_id
+    ):
+        """A swallowed stop recovers: while the job keeps heartbeating
+        against desired stopped, the stop is re-issued, rate-bounded."""
+        orchestrator, _, job_service, sink = make_system()
+        job_ids = orchestrator.commit_workflow(workflow_id)
+        _heartbeat(job_service, job_ids[0], workflow_id)
+        orchestrator.stop_workflow(workflow_id)
+        stops_after_user_stop = len(_sent_stop_job_ids(sink))
+
+        _heartbeat(job_service, job_ids[0], workflow_id)
+        orchestrator.reconcile_observed_jobs()
+        assert len(_sent_stop_job_ids(sink)) == stops_after_user_stop
+
+        clock.advance(STOP_REISSUE_INTERVAL_SECONDS + 1)
+        _heartbeat(job_service, job_ids[0], workflow_id)
+        orchestrator.reconcile_observed_jobs()
+        assert len(_sent_stop_job_ids(sink)) == stops_after_user_stop + 1
+
+        orchestrator.reconcile_observed_jobs()
+        assert len(_sent_stop_job_ids(sink)) == stops_after_user_stop + 1
+
+    def test_no_reissue_for_desired_running_job(self, make_system, clock, workflow_id):
+        orchestrator, _, job_service, sink = make_system()
+        job_ids = orchestrator.commit_workflow(workflow_id)
+        _heartbeat(job_service, job_ids[0], workflow_id)
+
+        clock.advance(STOP_REISSUE_INTERVAL_SECONDS + 1)
+        orchestrator.reconcile_observed_jobs()
+
+        assert _sent_stop_job_ids(sink) == []
+
+    def test_stops_superseded_unknown_job(self, make_system, workflow_id):
+        """An observed job that is neither the desired generation nor a
+        known predecessor is stopped promptly."""
+        orchestrator, _, job_service, sink = make_system()
+        orchestrator.commit_workflow(workflow_id)
+        unknown = JobId(source_name='source1', job_number=uuid.uuid4())
+        _heartbeat(job_service, unknown, workflow_id)
+
+        orchestrator.reconcile_observed_jobs()
+
+        assert unknown in _sent_stop_job_ids(sink)
+
+    def test_ignores_stale_heartbeats(self, make_system, workflow_id):
+        orchestrator, _, job_service, sink = make_system(heartbeat_timeout_ns=-1)
+        job_ids = orchestrator.commit_workflow(workflow_id)
+        _heartbeat(job_service, job_ids[0], workflow_id)
+        orchestrator.stop_workflow(workflow_id)
+        stops_after_user_stop = len(_sent_stop_job_ids(sink))
+
+        _heartbeat(job_service, job_ids[0], workflow_id)
+        orchestrator.reconcile_observed_jobs()
+
+        assert len(_sent_stop_job_ids(sink)) == stops_after_user_stop
+
+    def test_prunes_stale_statuses(self, make_system, workflow_id):
+        orchestrator, _, job_service, _ = make_system(heartbeat_timeout_ns=-1)
+        _heartbeat(
+            job_service,
+            JobId(source_name='source1', job_number=uuid.uuid4()),
+            workflow_id,
+            state=JobState.stopped,
+        )
+
+        orchestrator.reconcile_observed_jobs()
+
+        assert job_service.job_statuses == {}
+
+
+class TestCommitSupersedesObserved:
+    def test_recommit_stops_job_whose_stop_was_lost(self, make_system, workflow_id):
+        """After a user stop whose send was swallowed, the job keeps
+        heartbeating with no local owner; the next commit supersedes it by
+        stopping it alongside starting the new generation."""
+        orchestrator, _, job_service, sink = make_system()
+        job_ids = orchestrator.commit_workflow(workflow_id)
+        _heartbeat(job_service, job_ids[0], workflow_id)
+        orchestrator.stop_workflow(workflow_id)
+        sink.messages.clear()
+
+        _heartbeat(job_service, job_ids[0], workflow_id)
+        orchestrator.commit_workflow(workflow_id)
+
+        assert job_ids[0] in _sent_stop_job_ids(sink)

--- a/tests/dashboard/job_orchestrator_test.py
+++ b/tests/dashboard/job_orchestrator_test.py
@@ -222,6 +222,7 @@ def make_orchestrator(
         ),
         workflow_registry=registry,
         active_job_registry=ActiveJobRegistry(data_service=ds, job_service=js),
+        job_service=js,
         config_store=config_store,
         notification_queue=notification_queue,
         clock=clock,

--- a/tests/dashboard/orchestrator_test.py
+++ b/tests/dashboard/orchestrator_test.py
@@ -33,10 +33,15 @@ def make_service_registry() -> ServiceRegistry:
 
 
 class FakeJobOrchestrator:
-    """Fake job orchestrator that records processed acknowledgements."""
+    """Fake job orchestrator that records processed acknowledgements.
 
-    def __init__(self):
+    Admits heartbeats for all workflows unless ``known_workflows`` restricts
+    the set.
+    """
+
+    def __init__(self, known_workflows: set[WorkflowId] | None = None):
         self.acknowledgements: list[tuple[str, str, str | None]] = []
+        self._known_workflows = known_workflows
 
     def process_acknowledgement(
         self, message_id: str, response: str, error_message: str | None = None
@@ -44,14 +49,14 @@ class FakeJobOrchestrator:
         """Record the processed acknowledgement."""
         self.acknowledgements.append((message_id, response, error_message))
 
+    def is_known_workflow(self, workflow_id: WorkflowId) -> bool:
+        return self._known_workflows is None or workflow_id in self._known_workflows
+
 
 class PermissiveJobRegistry:
     """Accepts every generation; used where filtering is orthogonal to the test."""
 
     def is_current(self, workflow_id: WorkflowId, job_number: uuid.UUID) -> bool:
-        return True
-
-    def is_known_job(self, job_number: uuid.UUID) -> bool:
         return True
 
     def record_stale(self, workflow_id: WorkflowId, job_number: uuid.UUID) -> None:
@@ -651,7 +656,9 @@ class TestOrchestratorGenerationFiltering:
 
         assert result_key.data_key not in data_service
 
-    def test_accepts_job_status_for_current_and_last_generation(self) -> None:
+    def test_accepts_job_status_for_any_generation_of_known_workflow(self) -> None:
+        """Heartbeats are the observation feed for adoption (ADR 0008): they
+        are admitted per known workflow, regardless of job_number."""
         from ess.livedata.core.job import JobState, JobStatus
 
         old_number = make_job_number()
@@ -661,7 +668,7 @@ class TestOrchestratorGenerationFiltering:
         )
         registry.begin_generation(self._workflow_id, new_number, config={})
 
-        for job_number in (old_number, new_number):
+        for job_number in (old_number, new_number, make_job_number()):
             status = JobStatus(
                 job_id=JobId(source_name="det1", job_number=job_number),
                 workflow_id=self._workflow_id,
@@ -669,13 +676,18 @@ class TestOrchestratorGenerationFiltering:
             )
             orchestrator.forward(STATUS_STREAM_ID, status)
 
-        assert len(job_service.job_statuses) == 2
+        assert len(job_service.job_statuses) == 3
 
-    def test_discards_job_status_for_unknown_job(self) -> None:
+    def test_discards_job_status_for_unknown_workflow(self) -> None:
         from ess.livedata.core.job import JobState, JobStatus
 
-        orchestrator, _, job_service, _ = self._make_orchestrator(
-            {self._workflow_id: make_job_number()}
+        source = FakeMessageSource()
+        job_service = JobService()
+        orchestrator = _make_orchestrator(
+            message_source=source,
+            data_service=DataService(),
+            job_service=job_service,
+            job_orchestrator=FakeJobOrchestrator(known_workflows=set()),
         )
 
         status = JobStatus(

--- a/tests/dashboard/restart_cleanup_test.py
+++ b/tests/dashboard/restart_cleanup_test.py
@@ -93,6 +93,7 @@ def _make_system(*workflow_specs):
         command_service=CommandService(sink=fake_sink),
         workflow_registry=registry,
         active_job_registry=active_job_registry,
+        job_service=job_service,
     )
 
     orchestrator = Orchestrator(
@@ -226,9 +227,11 @@ class TestRestartCleanup:
 
         assert len(job_service.job_statuses) == 1
 
-    def test_status_for_generation_beyond_window_is_rejected(self, workflow_spec):
+    def test_status_beyond_window_is_observed_but_not_adopted(self, workflow_spec):
         """Two recommits push the first generation out of the (current, last)
-        window; its heartbeats are no longer recognized."""
+        window. Its heartbeats are still observed (ADR 0008) — the job is an
+        orphan for reconciliation to stop — but they do not displace the
+        committed current generation."""
         orchestrator, job_orchestrator, _, job_service = _make_system(workflow_spec)
         workflow_id = workflow_spec.get_id()
 
@@ -236,14 +239,18 @@ class TestRestartCleanup:
         oldest_job_id = job_ids[0]
 
         job_orchestrator.commit_workflow(workflow_id)
-        job_orchestrator.commit_workflow(workflow_id)
+        job_ids_3 = job_orchestrator.commit_workflow(workflow_id)
 
         status = JobStatus(
             job_id=oldest_job_id, workflow_id=workflow_id, state=JobState.active
         )
         orchestrator.forward(STATUS_STREAM_ID, status)
 
-        assert len(job_service.job_statuses) == 0
+        assert len(job_service.job_statuses) == 1
+        assert (
+            job_orchestrator.get_active_job_number(workflow_id)
+            == job_ids_3[0].job_number
+        )
 
     def test_other_workflow_data_survives_recommit(
         self, workflow_spec, workflow_spec_2

--- a/tests/dashboard/widgets/derived_devices_overview_test.py
+++ b/tests/dashboard/widgets/derived_devices_overview_test.py
@@ -91,9 +91,9 @@ def orchestrator(registry) -> JobOrchestrator:
         active_job_registry=ActiveJobRegistry(
             data_service=DataService(), job_service=js
         ),
+        job_service=js,
         config_store=None,
     )
-    js.on_status_updated = orch.on_job_status_updated
     return orch
 
 

--- a/tests/dashboard/widgets/workflow_status_device_test.py
+++ b/tests/dashboard/widgets/workflow_status_device_test.py
@@ -120,9 +120,9 @@ def orchestrator(registry, job_service) -> JobOrchestrator:
         active_job_registry=ActiveJobRegistry(
             data_service=DataService(), job_service=job_service
         ),
+        job_service=job_service,
         config_store=None,
     )
-    job_service.on_status_updated = orch.on_job_status_updated
     return orch
 
 

--- a/tests/dashboard/workflow_controller_test.py
+++ b/tests/dashboard/workflow_controller_test.py
@@ -140,6 +140,7 @@ def workflow_controller(
         command_service=command_service,
         workflow_registry=workflow_registry,
         active_job_registry=ActiveJobRegistry(data_service=ds, job_service=js),
+        job_service=js,
         config_store=fake_config_store,
     )
 
@@ -293,6 +294,7 @@ class TestWorkflowController:
             command_service=command_service,
             workflow_registry=registry,
             active_job_registry=ActiveJobRegistry(data_service=ds, job_service=js),
+            job_service=js,
             config_store=config_store,
         )
 

--- a/tests/integration/job_state_persistence_test.py
+++ b/tests/integration/job_state_persistence_test.py
@@ -3,6 +3,7 @@
 """Integration tests for job state persistence in JobOrchestrator."""
 
 from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.core.job import JobState, JobStatus
 from ess.livedata.dashboard.config_store import ConfigStoreManager
 from ess.livedata.handlers.monitor_workflow_specs import MonitorDataParams
 from ess.livedata.parameter_models import Scale, TimeUnit, TOAEdges
@@ -16,8 +17,9 @@ def test_active_job_persisted_and_restored(tmp_path) -> None:
     This test verifies:
     1. Starting a workflow creates an active job with a job_number
     2. The active job state (job_number, jobs) is persisted to config store
-    3. Creating a new backend with the same config store restores the active job
-    4. Subscribers are notified of the restored active job
+    3. Creating a new backend with the same config store restores the
+       desired state (job_number, configs) — but data admission awaits a
+       heartbeat observation, which adopts the running job (ADR 0008)
     """
     workflow_id = WorkflowId(
         instrument='dummy',
@@ -77,6 +79,15 @@ def test_active_job_persisted_and_restored(tmp_path) -> None:
 
         # Verify params were also restored correctly
         assert restored_active['monitor1'].params == custom_params.model_dump()
+
+        # The record alone does not admit data; the first heartbeat for the
+        # recorded job adopts it as the current generation
+        registry = backend2.job_orchestrator.active_job_registry
+        assert not registry.is_current(workflow_id, original_job_number)
+        backend2.job_service.status_updated(
+            JobStatus(job_id=job_ids[0], workflow_id=workflow_id, state=JobState.active)
+        )
+        assert registry.is_current(workflow_id, original_job_number)
 
 
 def test_recommit_persists_only_current_job(tmp_path) -> None:


### PR DESCRIPTION
Implements ADR 0008 (included in this PR): the dashboard adopts running backend jobs from `JobStatus` heartbeat observation; the persisted `current_job` record is demoted from identity-authority to desired state plus provenance cache. No wire protocol change.

Motivation: persistence-based re-recognition trusts a local record that cannot see reality. Every #714 scenario is a record/reality divergence, and the swallowed-stop analysis on #1046 showed the divergence can become unreachable from the UI (stop button gone, recommit skips the stop-old-jobs branch). See the ADR for the full decision and rejected alternatives.

What changes:

- Heartbeats are admitted per known workflow instead of per known job_number, making them the observation feed. `ActiveJobRegistry.restore()` is deleted; only observation establishes the generation that admits data. After a restart the workflow shows PENDING until its first heartbeat re-attaches the running job, labelled by the record.
- A record-miss job (crash between send and persist, store loss) is adopted as running-with-unknown-config: visible, stoppable, admits data, no params provenance, never written back as a record. Among record-less jobs the latest start time wins.
- Desired/observed reconciliation runs each update tick: while fresh heartbeats contradict desired stopped or superseded state, the stop is re-issued (rate-bounded per job_number, logged, fire-and-forget — command ACKs stay toast-only per #1067). Commit and stop also cover observed jobs outside the desired set, so a recommit supersedes orphans.
- `JobService` prunes statuses whose heartbeat aged past the staleness window, bounding the wider admit window.

Closes #1042 (final step of the stable-data-key rework). Closes #714 via re-issued stops and adoption.

Test plan:

- Unit coverage in `job_adoption_test.py` pins the ADR cases: restart re-attach, PENDING-until-observed, record-miss adoption, latest-start-time-wins, no re-adoption of stopped/superseded jobs, bounded stop re-issue, recommit superseding a lost-stop orphan.
- Field verification against a real backend:
  - [x] Restart the dashboard while a workflow runs: shows PENDING briefly, then reattaches; plots fill without recommit.
  - [ ] Orphan recovery: stop a workflow whose backend is wedged or whose stop was lost; observe re-issued stops in the logs and eventual STOPPED state.
  - [ ] Note any remaining orphaned jobs on #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
