### PR TITLE
Express frame-aspect sizing via opts, attach hook JS once

### DIFF
--- a/src/ess/livedata/dashboard/frame_aspect.py
+++ b/src/ess/livedata/dashboard/frame_aspect.py
@@ -1,19 +1,30 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-"""HoloViews hook that enforces frame aspect ratios on Bokeh plots.
+"""HoloViews sizing opts that enforce frame aspect ratios on Bokeh plots.
 
 HoloViews' aspect options (``aspect="square"``, ``data_aspect``, etc.) do not
 produce correctly shaped data areas (frames) when plots use ``responsive=True``
 inside Panel containers.  This is an upstream bug spanning Bokeh, HoloViews,
 and Panel.
 
-The workaround uses HoloViews *hooks* that:
+The workaround, assembled by :func:`make_frame_aspect_opts`, has two
+cooperating parts:
 
-1. Switch the Bokeh figure to ``stretch_width`` or ``stretch_height``
-   (chosen by the user via :class:`StretchMode`) so it fills the container
-   along one axis.
-2. Attach a ``CustomJS`` callback that adjusts the *other* dimension so the
-   frame has the correct shape.
+1. Sizing opts: ``responsive=True`` plus a fixed cross dimension (an initial
+   ``height`` for :attr:`StretchMode.width`, ``width`` for
+   :attr:`StretchMode.height`).  HoloViews derives ``stretch_width`` (resp.
+   ``stretch_height``) from this combination, so the figure fills the
+   container along one axis.  Expressing the sizing mode through opts rather
+   than writing it to the figure is essential: HoloViews recomputes plot
+   properties from the opts whenever they change (``ElementPlot's
+   _update_plot``), which would overwrite figure-level writes.
+2. A hook attaching a ``CustomJS`` callback that adjusts the cross dimension
+   in the browser so the frame has the correct shape.  HoloViews runs hooks
+   from ``update_frame`` (i.e. on every data update), not only from
+   ``initialize_plot``, so the hook tags the figure and only acts once per
+   figure: repeated attaching would leak a callback set per update, and
+   re-seeding the cross dimension would collapse the figure to the seed size
+   for one layout frame per update.
 
 Two hook variants exist:
 
@@ -32,6 +43,14 @@ from collections.abc import Callable
 from typing import Any
 
 from .plot_params import PlotAspect, PlotAspectType, StretchMode
+
+# Initial size of the JS-adjusted cross dimension.  Serves double duty: its
+# presence makes HoloViews compute a stretched sizing mode (see module
+# docstring), and it sizes the figure until the CustomJS first fires.
+_INITIAL_CROSS_SIZE_PX = 400
+
+# Marks figures whose CustomJS callback is already attached.
+_HOOK_APPLIED_TAG = 'ess-livedata-frame-aspect'
 
 # ---------------------------------------------------------------------------
 # Fixed frame ratio JS (square, aspect=N) — no range reading needed
@@ -120,12 +139,9 @@ def _make_hook(
         from bokeh.models import CustomJS
 
         fig = plot.handles['plot']
-        if fill_width:
-            fig.sizing_mode = "stretch_width"
-            fig.height = 400
-        else:
-            fig.sizing_mode = "stretch_height"
-            fig.width = 400
+        if _HOOK_APPLIED_TAG in fig.tags:
+            return
+        fig.tags.append(_HOOK_APPLIED_TAG)
 
         callback = CustomJS(
             args={"fig": fig, **js_args},
@@ -198,14 +214,14 @@ def make_data_aspect_hook(
     )
 
 
-def make_frame_aspect_hook_from_config(
-    aspect: PlotAspect,
-) -> Callable[[Any, Any], None] | None:
-    """Create a frame-aspect hook if the config requires one.
+def make_frame_aspect_opts(aspect: PlotAspect) -> dict[str, Any]:
+    """Create the HoloViews sizing opts enforcing the configured aspect.
 
-    Returns ``None`` for ``free`` (no aspect constraint).
-    Returns a fixed-ratio hook for ``square`` and ``aspect``, or a
-    data-aspect hook for ``equal`` and ``data_aspect``.
+    Returns plain ``{'responsive': True}`` for ``free`` (no aspect
+    constraint).  Otherwise adds the initial cross dimension (from which
+    HoloViews derives the stretched sizing mode) and a hook — a fixed-ratio
+    hook for ``square`` and ``aspect``, or a data-aspect hook for ``equal``
+    and ``data_aspect`` — that adjusts the cross dimension in the browser.
 
     Parameters
     ----------
@@ -215,16 +231,18 @@ def make_frame_aspect_hook_from_config(
     Returns
     -------
     :
-        A hook function, or None if no hook is needed.
+        Opts dict suitable for any Bokeh-backed HoloViews element type.
     """
     match aspect.aspect_type:
         case PlotAspectType.square:
-            return make_fixed_frame_ratio_hook(1.0, aspect.stretch_mode)
+            hook = make_fixed_frame_ratio_hook(1.0, aspect.stretch_mode)
         case PlotAspectType.aspect:
-            return make_fixed_frame_ratio_hook(aspect.ratio, aspect.stretch_mode)
+            hook = make_fixed_frame_ratio_hook(aspect.ratio, aspect.stretch_mode)
         case PlotAspectType.equal:
-            return make_data_aspect_hook(1.0, aspect.stretch_mode)
+            hook = make_data_aspect_hook(1.0, aspect.stretch_mode)
         case PlotAspectType.data_aspect:
-            return make_data_aspect_hook(aspect.ratio, aspect.stretch_mode)
+            hook = make_data_aspect_hook(aspect.ratio, aspect.stretch_mode)
         case _:
-            return None
+            return {'responsive': True}
+    cross = 'height' if aspect.stretch_mode == StretchMode.width else 'width'
+    return {'responsive': True, cross: _INITIAL_CROSS_SIZE_PX, 'hooks': [hook]}

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -20,7 +20,7 @@ from ess.livedata.config.workflow_spec import DataKey
 from ess.livedata.core.timestamp import Timestamp
 
 from .data_roles import PRIMARY
-from .frame_aspect import make_frame_aspect_hook_from_config
+from .frame_aspect import make_frame_aspect_opts
 from .plot_params import (
     CombineMode,
     LayoutParams,
@@ -491,19 +491,17 @@ class Plotter:
         self.layout_params = layout_params or LayoutParams()
         aspect_params = aspect_params or PlotAspect()
 
-        # All non-free aspect types are enforced by a JS hook
+        # All non-free aspect types are enforced by sizing opts plus a JS hook
         # (see frame_aspect.py) that adjusts the Bokeh figure dimensions.
         # HoloViews' own aspect/data_aspect opts are not set — they conflict
-        # with responsive mode in Panel containers (upstream bug). The hook is
-        # declared per leaf element type alongside ``responsive`` so it lands on
-        # every figure the plotter produces, whether the datasets are overlaid
-        # (one shared figure) or laid out (one figure per sub-plot). Each layer
-        # carries its own aspect, so an overlay of layers with differing aspects
-        # applies each hook to the shared figure (free aspect contributes none).
-        self._sizing_opts: dict[str, Any] = {'responsive': True}
-        aspect_hook = make_frame_aspect_hook_from_config(aspect_params)
-        if aspect_hook is not None:
-            self._sizing_opts['hooks'] = [aspect_hook]
+        # with responsive mode in Panel containers (upstream bug). The opts are
+        # declared per leaf element type so they land on every figure the
+        # plotter produces, whether the datasets are overlaid (one shared
+        # figure, leaf sizing opts propagate to the OverlayPlot) or laid out
+        # (one figure per sub-plot). Each layer carries its own aspect; on a
+        # shared figure the first layer's hook attaches its callback (the
+        # figure is tagged), later ones are no-ops.
+        self._sizing_opts: dict[str, Any] = make_frame_aspect_opts(aspect_params)
 
     @staticmethod
     def _make_tick_opts(tick_params: TickParams | None) -> dict[str, Any]:

--- a/tests/dashboard/frame_aspect_test.py
+++ b/tests/dashboard/frame_aspect_test.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for frame-aspect sizing opts and their CustomJS hook."""
+
+from __future__ import annotations
+
+import holoviews as hv
+import numpy as np
+import pytest
+from holoviews.streams import Pipe
+
+from ess.livedata.dashboard.frame_aspect import make_frame_aspect_opts
+from ess.livedata.dashboard.plot_params import (
+    PlotAspect,
+    PlotAspectType,
+    StretchMode,
+)
+
+hv.extension('bokeh')
+
+
+def _image(data: np.ndarray) -> hv.Image:
+    return hv.Image((np.arange(data.shape[1]), np.arange(data.shape[0]), data))
+
+
+def _n_js_callbacks(model) -> int:
+    return sum(len(cbs) for cbs in model.js_property_callbacks.values())
+
+
+@pytest.fixture
+def rendered_dmap():
+    """Render a data-aspect DynamicMap and return (figure, pipe) for updates."""
+    opts = make_frame_aspect_opts(
+        PlotAspect(
+            aspect_type=PlotAspectType.data_aspect, stretch_mode=StretchMode.width
+        )
+    )
+    pipe = Pipe(data=np.zeros((4, 8)))
+    dmap = hv.DynamicMap(lambda data: _image(data).opts(**opts), streams=[pipe])
+    plot = hv.renderer('bokeh').get_plot(dmap)
+    return plot.state, pipe
+
+
+class TestMakeFrameAspectOpts:
+    def test_free_aspect_yields_plain_responsive(self) -> None:
+        opts = make_frame_aspect_opts(PlotAspect(aspect_type=PlotAspectType.free))
+        assert opts == {'responsive': True}
+
+    @pytest.mark.parametrize(
+        'aspect_type',
+        [
+            PlotAspectType.square,
+            PlotAspectType.aspect,
+            PlotAspectType.equal,
+            PlotAspectType.data_aspect,
+        ],
+    )
+    def test_fill_width_fixes_height_so_holoviews_stretches_width(
+        self, aspect_type: PlotAspectType
+    ) -> None:
+        opts = make_frame_aspect_opts(
+            PlotAspect(aspect_type=aspect_type, stretch_mode=StretchMode.width)
+        )
+        fig = hv.render(_image(np.zeros((4, 8))).opts(**opts))
+        assert fig.sizing_mode == 'stretch_width'
+        assert fig.height == opts['height']
+        assert fig.width is None
+
+    def test_fill_height_fixes_width_so_holoviews_stretches_height(self) -> None:
+        opts = make_frame_aspect_opts(
+            PlotAspect(
+                aspect_type=PlotAspectType.square, stretch_mode=StretchMode.height
+            )
+        )
+        fig = hv.render(_image(np.zeros((4, 8))).opts(**opts))
+        assert fig.sizing_mode == 'stretch_height'
+        assert fig.width == opts['width']
+        assert fig.height is None
+
+
+class TestHookAcrossUpdates:
+    def test_callback_set_attached_exactly_once(self, rendered_dmap) -> None:
+        fig, pipe = rendered_dmap
+        # One callback on each of inner_width/inner_height and range start/end.
+        assert _n_js_callbacks(fig) == 2
+        assert _n_js_callbacks(fig.x_range) == 2
+        assert _n_js_callbacks(fig.y_range) == 2
+
+        for _ in range(3):
+            pipe.send(np.ones((4, 8)))
+
+        assert _n_js_callbacks(fig) == 2
+        assert _n_js_callbacks(fig.x_range) == 2
+        assert _n_js_callbacks(fig.y_range) == 2
+
+    def test_updates_leave_figure_geometry_untouched(self, rendered_dmap) -> None:
+        fig, pipe = rendered_dmap
+        # Simulate the browser-side CustomJS having adjusted the height.
+        fig.height = 513
+
+        for _ in range(3):
+            pipe.send(np.ones((4, 8)))
+
+        assert fig.sizing_mode == 'stretch_width'
+        assert fig.height == 513


### PR DESCRIPTION
Fixes #1092
Fixes #1093

## What and why

Plots with a non-free aspect flickered to a collapsed frame on every data update, and the frame-aspect hook leaked a CustomJS callback set per update (quadratic client-side cost over a session).

Instrumenting all server-side writes to `Figure.sizing_mode/height/width` showed the root cause is a duel between the hook and HoloViews — not Panel as #1092 hypothesized: `ElementPlot._update_plot` recomputes plot properties from the *opts* (`responsive=True` with no dimensions → `stretch_both`) and re-applies them to the figure, while the hook wrote `stretch_width`/`stretch_height` plus a 400px seed on every execution (HoloViews runs hooks from `update_frame`, not only `initialize_plot`).

The fix expresses sizing where HoloViews looks for it: `responsive=True` plus a fixed cross dimension (`height` for Fill width, `width` for Fill height), from which HoloViews derives `stretch_width`/`stretch_height` itself and re-applies it stably on every update. The cross dimension doubles as the initial seed and is applied only at initialization, so the browser-adjusted size survives updates. The hook shrinks to a one-shot CustomJS attach guarded by a figure tag, fixing the leak. Leaf sizing opts propagate to `OverlayPlot`, so multi-layer cells behave the same.

## Test plan

- New unit tests drive a real Pipe-fed DynamicMap through updates: callback count stays constant, and a browser-adjusted height survives updates (both fail on the previous implementation).
- Playwright harness (fake backend, data-aspect config): server-side writes drop to three per figure at init with zero afterwards; figure geometry bit-stable across ~18s of updates; JS callback count constant vs. growth to ~32/figure in 20s before.
- [x] Manual browser verification of data-aspect plots across job start and updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
