### PR TITLE
Split session teardown into two tiers for reaper safety

### DIFF
--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -161,6 +161,7 @@ class DashboardBase(ServiceBase, ABC):
             session_registry=self._services.session_registry,
             notification_queue=self._services.notification_queue,
             username=pn.state.user,
+            document=pn.state.curdoc,
         )
 
     def _start_periodic_callback(

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -181,10 +181,10 @@ class ReductionApp(DashboardBase):
             session_updater=session_updater,
         )
 
-        # Release this session's interest tokens when the browser session ends,
-        # so hidden layers stop computing promptly rather than waiting for the
-        # SessionLayer weakref finalizer to run at some later GC.
-        pn.state.on_session_destroyed(lambda _ctx: plot_grid_tabs.shutdown())
+        # PlotGridTabs registers its own two-tier teardown on the session
+        # updater (see PlotGridTabs.__init__), so it runs on both the clean
+        # disconnect and the stale-session reaper paths, releasing this
+        # session's interest tokens when the browser session ends.
 
         # Register refresh with visibility gate: skip updates when the
         # Workflows tab (index 0) is not the active tab.

--- a/src/ess/livedata/dashboard/session_registry.py
+++ b/src/ess/livedata/dashboard/session_registry.py
@@ -169,11 +169,14 @@ class SessionRegistry:
                         now - info.last_heartbeat,
                     )
 
-        # Clean up updaters outside lock to avoid potential deadlocks
+        # Clean up updaters outside lock to avoid potential deadlocks. This runs
+        # on the background update thread, off the sessions' IOLoops, so
+        # document-mutating teardown must be marshalled onto each session's
+        # IOLoop rather than run here (see SessionUpdater.cleanup).
         for session_id, updater in stale_sessions:
             if updater is not None:
                 try:
-                    updater.cleanup()
+                    updater.cleanup(defer_document_teardown=True)
                 except Exception:
                     logger.exception(
                         "Error cleaning up updater for stale session %s", session_id

--- a/src/ess/livedata/dashboard/session_updater.py
+++ b/src/ess/livedata/dashboard/session_updater.py
@@ -10,8 +10,9 @@ shared services in the correct session context.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager, nullcontext
+from typing import TYPE_CHECKING
 
 import panel as pn
 import structlog
@@ -20,6 +21,9 @@ from .notification_queue import NotificationEvent, NotificationQueue
 from .notifications import show_notification
 from .session_registry import SessionId, SessionRegistry
 from .widgets.heartbeat_widget import HeartbeatWidget
+
+if TYPE_CHECKING:
+    from bokeh.document import Document
 
 logger = structlog.get_logger(__name__)
 
@@ -49,6 +53,11 @@ class SessionUpdater:
         Registry for session heartbeats and tracking.
     notification_queue:
         Shared queue for notifications.
+    document:
+        The session's Bokeh document, used to marshal document-mutating
+        teardown onto the session's IOLoop when :meth:`cleanup` runs off it
+        (the stale-session reaper). ``None`` in non-session contexts (tests),
+        where teardown runs inline.
     """
 
     def __init__(
@@ -58,15 +67,20 @@ class SessionUpdater:
         session_registry: SessionRegistry,
         notification_queue: NotificationQueue,
         username: str | None = None,
+        document: Document | None = None,
     ) -> None:
         self._session_id = session_id
         self._session_registry = session_registry
         self._notification_queue = notification_queue
+        self._document = document
 
         # Callbacks for custom updates (e.g., SessionPlotManager.update_pipes)
         self._custom_handlers: list[Callable[[], None]] = []
-        # Handlers run once when the session is torn down (see cleanup).
+        # Tier-2 teardown: sever shared state. Safe on any thread; run inline.
         self._cleanup_handlers: list[Callable[[], None]] = []
+        # Tier-1 teardown: mutate Bokeh document state. Must run on the
+        # session's IOLoop (marshalled via the document on the reaper path).
+        self._document_teardown_handlers: list[Callable[[], None]] = []
         self._periodic_callback: pn.io.PeriodicCallback | None = None
 
         # Browser heartbeat mechanism using ReactiveHTML.
@@ -118,14 +132,17 @@ class SessionUpdater:
 
     def register_cleanup_handler(self, handler: Callable[[], None]) -> None:
         """
-        Register a handler to run once when the session is torn down.
+        Register a tier-2 teardown handler that severs shared state.
 
-        Use this for releasing per-session resources (e.g. a Kafka producer).
-        Handlers run from :meth:`cleanup`, which fires both on clean browser
-        disconnect (``on_session_destroyed``) and via the heartbeat-based stale
-        session reaper, so resources are released even when Panel's
-        ``on_session_destroyed`` does not fire. Handlers may be invoked from a
-        background thread and must be safe to call there.
+        Use this for releasing per-session resources held in shared state (e.g.
+        a Kafka producer, orchestrator viewer/interest tokens, lifecycle
+        subscriptions). Handlers run inline from :meth:`cleanup`, which fires
+        both on clean browser disconnect (``on_session_destroyed``) and via the
+        heartbeat-based stale-session reaper, so resources are released even
+        when Panel's ``on_session_destroyed`` does not fire. The reaper runs on
+        a background thread, so handlers must be safe to call there and must not
+        mutate Bokeh document state (use :meth:`register_document_teardown_handler`
+        for that).
 
         Parameters
         ----------
@@ -133,6 +150,24 @@ class SessionUpdater:
             Callback to invoke on session teardown.
         """
         self._cleanup_handlers.append(handler)
+
+    def register_document_teardown_handler(self, handler: Callable[[], None]) -> None:
+        """
+        Register a tier-1 teardown handler that mutates Bokeh document state.
+
+        Use this for disposing session-bound widgets (e.g. breaking Bokeh-tool
+        reference cycles). Bokeh document state may only be mutated on the
+        session's IOLoop, so on the stale-session reaper path these handlers are
+        scheduled onto that IOLoop via the session document rather than run on
+        the calling thread. They may therefore never run if the session's
+        document is already gone; tier-2 handlers must not depend on them.
+
+        Parameters
+        ----------
+        handler:
+            Callback to invoke on session teardown, on the session's IOLoop.
+        """
+        self._document_teardown_handlers.append(handler)
 
     def periodic_update(self) -> None:
         """
@@ -192,25 +227,71 @@ class SessionUpdater:
         for event in notifications:
             show_notification(event)
 
-    def cleanup(self) -> None:
-        """Clean up session resources."""
+    def cleanup(self, *, defer_document_teardown: bool = False) -> None:
+        """
+        Tear down the session in two tiers.
+
+        Tier 2 (shared-state severing) runs inline and is safe on any thread:
+        the notification-queue slot is released and cleanup handlers
+        (:meth:`register_cleanup_handler`) run. This is the leak fix and does
+        not depend on tier 1.
+
+        Tier 1 (Bokeh document mutation) stops the periodic callback and runs
+        the document-teardown handlers (:meth:`register_document_teardown_handler`).
+        Document state may only be mutated on the owning session's IOLoop, so on
+        the stale-session reaper path (``defer_document_teardown=True``) it is
+        scheduled via the captured document's ``add_next_tick_callback`` instead
+        of running on the calling thread. Scheduling into an already-destroyed
+        document is tolerated: tier 2 has already severed everything.
+
+        Parameters
+        ----------
+        defer_document_teardown:
+            Schedule tier 1 onto the session's IOLoop instead of running it
+            inline. Set by the background stale-session reaper, which is not on
+            the session's IOLoop; the clean ``on_session_destroyed`` path runs
+            on the IOLoop and leaves this ``False``.
+        """
+        # Tier 2: sever shared state. Safe on any thread.
+        self._notification_queue.unregister_session(self._session_id)
+        self._run_handlers(self._cleanup_handlers)
+        self._cleanup_handlers.clear()
+
+        # Tier 1: Bokeh document mutation. Must run on the session's IOLoop.
+        if defer_document_teardown and self._document is not None:
+            try:
+                self._document.add_next_tick_callback(self._document_teardown)
+            except Exception:
+                logger.debug(
+                    "Skipping deferred document teardown for session %s: "
+                    "document already gone",
+                    self._session_id,
+                )
+        else:
+            self._document_teardown()
+
+        logger.debug("SessionUpdater cleaned up for session %s", self._session_id)
+
+    def _document_teardown(self) -> None:
+        """Stop the periodic callback and dispose document-bound widgets.
+
+        Mutates Bokeh document state, so it must run on the session's IOLoop.
+        """
         if self._periodic_callback is not None:
             self._periodic_callback.stop()
+        self._run_handlers(self._document_teardown_handlers)
+        self._document_teardown_handlers.clear()
+        self._custom_handlers.clear()
 
-        self._notification_queue.unregister_session(self._session_id)
-
-        for handler in self._cleanup_handlers:
+    def _run_handlers(self, handlers: Iterable[Callable[[], None]]) -> None:
+        """Run teardown handlers, logging and swallowing any exception."""
+        for handler in handlers:
             try:
                 handler()
             except Exception:
                 logger.exception(
-                    "Error in cleanup handler for session %s", self._session_id
+                    "Error in teardown handler for session %s", self._session_id
                 )
-        self._cleanup_handlers.clear()
-
-        self._custom_handlers.clear()
-
-        logger.debug("SessionUpdater cleaned up for session %s", self._session_id)
 
     def _check_browser_heartbeat(self) -> None:
         """

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -248,6 +248,15 @@ class PlotGridTabs:
         # Register handler for periodic polling
         session_updater.register_custom_handler(self._poll_for_plot_updates)
 
+        # Two-tier teardown, run on both the clean disconnect
+        # (``on_session_destroyed``) and the stale-session reaper paths. Tier 2
+        # (``sever``) releases shared orchestrator state and must run even when
+        # the reaper's IOLoop tick never fires; tier 1 (``dispose_widgets``)
+        # mutates Bokeh document state and is marshalled onto the session's
+        # IOLoop. See issue #955 and ADR 0007.
+        session_updater.register_cleanup_handler(self.sever)
+        session_updater.register_document_teardown_handler(self.dispose_widgets)
+
     def _add_grid_tab(self, grid_id: GridId, grid_config: PlotGridConfig) -> None:
         """Add a new grid tab after the Manage tab."""
 
@@ -786,18 +795,34 @@ class PlotGridTabs:
             self._last_flushed_generation = generation
         self._last_active_grid_id = active_grid_id
 
-    def shutdown(self) -> None:
-        """Unsubscribe from lifecycle events and clean up session state."""
+    def sever(self) -> None:
+        """Release shared orchestrator state held by this session (tier 2).
+
+        Unsubscribes from lifecycle events and releases the session's
+        viewer/interest tokens so hidden layers stop computing. Touches only
+        shared orchestrator state, not the Bokeh document, so it is safe to call
+        from the background stale-session reaper thread and must run there
+        regardless of whether tier-1 teardown (:meth:`dispose_widgets`) ever
+        runs. Idempotent.
+        """
         if self._subscription_id is not None:
             self._orchestrator.unsubscribe_from_lifecycle(self._subscription_id)
             self._subscription_id = None
-        for layer_id, session_layer in self._session_layers.items():
+        for layer_id, session_layer in list(self._session_layers.items()):
             self._orchestrator.activate_layer(layer_id, session_layer, False)
         self._session_layers.clear()
+        self._grid_manager.shutdown()
+
+    def dispose_widgets(self) -> None:
+        """Dispose session-bound widgets (tier 1).
+
+        Disposes cell widgets, breaking Bokeh-tool reference cycles. Mutates
+        Bokeh document state, so it must run on the session's IOLoop.
+        Idempotent.
+        """
         for cell_widget in self._cells.values():
             cell_widget.dispose()
         self._cells.clear()
-        self._grid_manager.shutdown()
 
     @property
     def panel(self) -> pn.Column:

--- a/tests/dashboard/session_registry_test.py
+++ b/tests/dashboard/session_registry_test.py
@@ -12,10 +12,12 @@ class FakeSessionUpdater:
 
     def __init__(self, *, raise_on_cleanup: bool = False):
         self.cleanup_called = False
+        self.deferred_document_teardown: bool | None = None
         self._raise_on_cleanup = raise_on_cleanup
 
-    def cleanup(self) -> None:
+    def cleanup(self, *, defer_document_teardown: bool = False) -> None:
         self.cleanup_called = True
+        self.deferred_document_teardown = defer_document_teardown
         if self._raise_on_cleanup:
             raise ValueError("Cleanup error")
 
@@ -124,6 +126,9 @@ class TestSessionRegistry:
         registry.cleanup_stale_sessions()
 
         assert updater.cleanup_called
+        # #955: reaper runs off the session's IOLoop, so document-mutating
+        # teardown must be deferred onto the IOLoop.
+        assert updater.deferred_document_teardown is True
 
     def test_unregister_calls_updater_cleanup(self):
         registry = SessionRegistry()
@@ -134,6 +139,8 @@ class TestSessionRegistry:
         registry.unregister(session_id)
 
         assert updater.cleanup_called
+        # Clean disconnect runs on the session's IOLoop, so teardown runs inline.
+        assert updater.deferred_document_teardown is False
 
     def test_cleanup_error_does_not_stop_other_cleanups(self):
         registry = SessionRegistry(stale_timeout_seconds=0.01)

--- a/tests/dashboard/session_updater_test.py
+++ b/tests/dashboard/session_updater_test.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Tests for SessionUpdater."""
 
+from collections.abc import Callable
+
 from ess.livedata.dashboard.notification_queue import (
     NotificationEvent,
     NotificationQueue,
@@ -11,18 +13,55 @@ from ess.livedata.dashboard.session_registry import SessionId, SessionRegistry
 from ess.livedata.dashboard.session_updater import SessionUpdater
 
 
+class FakeDocument:
+    """Stand-in for a Bokeh document that records scheduled next-tick callbacks.
+
+    The reaper path marshals document-mutating teardown onto the session's
+    IOLoop via ``add_next_tick_callback``. This fake captures those callbacks so
+    a test can assert they were scheduled (not run on the calling thread) and
+    fire them explicitly.
+    """
+
+    def __init__(self, *, raise_on_schedule: bool = False) -> None:
+        self.next_tick_callbacks: list[Callable[[], None]] = []
+        self._raise_on_schedule = raise_on_schedule
+
+    def add_next_tick_callback(self, callback: Callable[[], None]) -> None:
+        if self._raise_on_schedule:
+            raise RuntimeError("document already destroyed")
+        self.next_tick_callbacks.append(callback)
+
+    def run_next_tick_callbacks(self) -> None:
+        callbacks = self.next_tick_callbacks[:]
+        self.next_tick_callbacks.clear()
+        for callback in callbacks:
+            callback()
+
+
+class FakeCallback:
+    """Records whether ``stop`` was called (stands in for a PeriodicCallback)."""
+
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
 def _make_updater(
     session_id: SessionId,
     registry: SessionRegistry,
     *,
     notification_queue: NotificationQueue | None = None,
     username: str | None = None,
+    document: FakeDocument | None = None,
 ) -> SessionUpdater:
     return SessionUpdater(
         session_id=session_id,
         session_registry=registry,
         notification_queue=notification_queue or NotificationQueue(),
         username=username,
+        document=document,
     )
 
 
@@ -168,19 +207,109 @@ class TestSessionUpdater:
 
         updater = _make_updater(session_id, registry)
 
-        class FakeCallback:
-            def __init__(self):
-                self.stopped = False
-
-            def stop(self):
-                self.stopped = True
-
         callback = FakeCallback()
         updater.set_periodic_callback(callback)
 
         updater.cleanup()
 
         assert callback.stopped
+
+    def test_reaper_does_not_stop_periodic_callback_on_calling_thread(self):
+        # #955: the stale-session reaper runs off the session's IOLoop.
+        # PeriodicCallback.stop() mutates the Bokeh document, so it must be
+        # scheduled onto the IOLoop, not called on the reaper thread.
+        registry = SessionRegistry()
+        document = FakeDocument()
+        updater = _make_updater(SessionId('session-1'), registry, document=document)
+
+        callback = FakeCallback()
+        updater.set_periodic_callback(callback)
+
+        updater.cleanup(defer_document_teardown=True)
+
+        # Not stopped on the calling thread; instead scheduled onto the IOLoop.
+        assert not callback.stopped
+        assert len(document.next_tick_callbacks) == 1
+
+        # The scheduled tick, running on the IOLoop, performs the stop.
+        document.run_next_tick_callbacks()
+        assert callback.stopped
+
+    def test_reaper_severs_tier2_even_when_document_tick_never_runs(self):
+        # #955 leak fix: tier-2 severing (cleanup handlers, notification-queue
+        # release) must happen on the reaper thread regardless of whether the
+        # tier-1 document tick ever runs.
+        registry = SessionRegistry()
+        queue = NotificationQueue()
+        document = FakeDocument()
+        session_id = SessionId('session-1')
+        updater = _make_updater(
+            session_id, registry, notification_queue=queue, document=document
+        )
+
+        tier2: list[int] = []
+        tier1: list[int] = []
+        updater.register_cleanup_handler(lambda: tier2.append(1))
+        updater.register_document_teardown_handler(lambda: tier1.append(1))
+
+        updater.cleanup(defer_document_teardown=True)
+
+        # Deliberately do NOT run the scheduled tick.
+        assert tier2 == [1]
+        assert tier1 == []
+
+        # Notification-queue slot released inline (tier 2).
+        queue.push(NotificationEvent(message='after cleanup'))
+        assert queue.get_new_events(session_id) == []
+
+    def test_document_teardown_handler_runs_when_tick_fires(self):
+        registry = SessionRegistry()
+        document = FakeDocument()
+        updater = _make_updater(SessionId('session-1'), registry, document=document)
+
+        tier1: list[int] = []
+        updater.register_document_teardown_handler(lambda: tier1.append(1))
+
+        updater.cleanup(defer_document_teardown=True)
+        assert tier1 == []
+
+        document.run_next_tick_callbacks()
+        assert tier1 == [1]
+
+    def test_reaper_tolerates_destroyed_document(self):
+        # Scheduling into an already-destroyed document raises; tier 2 has
+        # already severed everything, so tier 1 is moot and must not propagate.
+        registry = SessionRegistry()
+        document = FakeDocument(raise_on_schedule=True)
+        updater = _make_updater(SessionId('session-1'), registry, document=document)
+
+        callback = FakeCallback()
+        updater.set_periodic_callback(callback)
+        tier2: list[int] = []
+        updater.register_cleanup_handler(lambda: tier2.append(1))
+
+        updater.cleanup(defer_document_teardown=True)  # must not raise
+
+        assert tier2 == [1]
+        assert not callback.stopped
+
+    def test_clean_path_runs_document_teardown_inline(self):
+        # The clean on_session_destroyed path runs on the IOLoop, so tier-1
+        # teardown runs inline even with a document present.
+        registry = SessionRegistry()
+        document = FakeDocument()
+        updater = _make_updater(SessionId('session-1'), registry, document=document)
+
+        callback = FakeCallback()
+        updater.set_periodic_callback(callback)
+        tier1: list[int] = []
+        updater.register_document_teardown_handler(lambda: tier1.append(1))
+
+        updater.cleanup()  # defer_document_teardown=False
+
+        assert callback.stopped
+        assert tier1 == [1]
+        assert document.next_tick_callbacks == []
 
     def test_username_forwarded_to_registry(self):
         session_id = SessionId('session-1')

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -285,12 +285,9 @@ class TestManageTab:
 class TestShutdown:
     """Tests for widget shutdown and cleanup."""
 
-    def test_shutdown_unsubscribes_from_lifecycle(
-        self, plot_orchestrator, plot_grid_tabs
-    ):
-        """Test that shutdown unsubscribes from orchestrator lifecycle."""
-        # Shutdown the widget
-        plot_grid_tabs.shutdown()
+    def test_sever_unsubscribes_from_lifecycle(self, plot_orchestrator, plot_grid_tabs):
+        """Test that tier-2 sever unsubscribes from orchestrator lifecycle."""
+        plot_grid_tabs.sever()
 
         # Adding a grid should not affect the widget anymore
         initial_count = len(plot_grid_tabs.tabs)
@@ -299,10 +296,99 @@ class TestShutdown:
         # Tab count should not change
         assert len(plot_grid_tabs.tabs) == initial_count
 
-    def test_shutdown_can_be_called_multiple_times(self, plot_grid_tabs):
-        """Test that shutdown is idempotent."""
-        plot_grid_tabs.shutdown()
-        plot_grid_tabs.shutdown()  # Should not raise
+    def test_sever_is_idempotent(self, plot_grid_tabs):
+        """Test that tier-2 sever can be called multiple times."""
+        plot_grid_tabs.sever()
+        plot_grid_tabs.sever()  # Should not raise
+
+    def test_dispose_widgets_is_idempotent(self, plot_grid_tabs):
+        """Test that tier-1 dispose_widgets can be called multiple times."""
+        plot_grid_tabs.dispose_widgets()
+        plot_grid_tabs.dispose_widgets()  # Should not raise
+
+
+class _FakeDocument:
+    """Captures next-tick callbacks scheduled by the reaper path."""
+
+    def __init__(self):
+        self.next_tick_callbacks = []
+
+    def add_next_tick_callback(self, callback):
+        self.next_tick_callbacks.append(callback)
+
+
+class _FakeCallback:
+    def __init__(self):
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+
+class TestReaperTeardown:
+    """#955: stale-session reaper severs shared state without touching the
+    Bokeh document on the reaper thread."""
+
+    def _make_widget(
+        self,
+        plot_orchestrator,
+        workflow_registry,
+        plotting_controller,
+        workflow_status_widget,
+        plot_data_service,
+        registry,
+        document,
+    ):
+        updater = SessionUpdater(
+            session_id=SessionId('stale-session'),
+            session_registry=registry,
+            notification_queue=NotificationQueue(),
+            document=document,
+        )
+        callback = _FakeCallback()
+        updater.set_periodic_callback(callback)
+        widget = PlotGridTabs(
+            plot_orchestrator=plot_orchestrator,
+            workflow_registry=workflow_registry,
+            plotting_controller=plotting_controller,
+            workflow_status_widget=workflow_status_widget,
+            plot_data_service=plot_data_service,
+            session_updater=updater,
+        )
+        return widget, callback
+
+    def test_reaper_severs_lifecycle_without_touching_document(
+        self,
+        plot_orchestrator,
+        workflow_registry,
+        plotting_controller,
+        workflow_status_widget,
+        plot_data_service,
+    ):
+        registry = SessionRegistry(stale_timeout_seconds=-1.0)
+        document = _FakeDocument()
+        widget, callback = self._make_widget(
+            plot_orchestrator,
+            workflow_registry,
+            plotting_controller,
+            workflow_status_widget,
+            plot_data_service,
+            registry,
+            document,
+        )
+
+        cleaned = registry.cleanup_stale_sessions()
+
+        assert SessionId('stale-session') in cleaned
+        # Tier 2 ran inline on the reaper thread: lifecycle severed, so a new
+        # grid does not add a tab to this session's widget.
+        initial_count = len(widget.tabs)
+        plot_orchestrator.add_grid(title='After Reaper', nrows=2, ncols=2)
+        assert len(widget.tabs) == initial_count
+        # Tier 1 was NOT run on the reaper thread: the periodic callback is not
+        # stopped here, it is scheduled onto the session's IOLoop instead.
+        assert not callback.stopped
+        assert len(document.next_tick_callbacks) == 1
 
 
 class TestOverlayFiltering:


### PR DESCRIPTION
## What

Splits session teardown into two tiers so the stale-session reaper never mutates Bokeh document state from the background thread, and so shared-state severing runs even when a session's IOLoop tick never fires.

- **Tier 2 — shared-state severing** (`SessionUpdater.cleanup` inline, `register_cleanup_handler`): releases the notification-queue slot, lifecycle subscriptions, and the session's viewer/interest tokens. Thread-safe, unconditional, independent of tier 1.
- **Tier 1 — document mutation** (`register_document_teardown_handler` + `PeriodicCallback.stop()`): on the reaper path scheduled onto the session's IOLoop via the captured `Document.add_next_tick_callback` (scheduling into a destroyed document is tolerated); the clean `on_session_destroyed` path runs it inline.

`PlotGridTabs.shutdown()` is split along the same line into `sever()`/`dispose_widgets()`, self-registered on the `SessionUpdater`.

## Why

The reaper called `updater.cleanup()` → `PeriodicCallback.stop()` on the background update thread — a document mutation off the IOLoop, racing the session's model graph. This is the prime suspect for the Bifrost PROD single-core CPU spin after abnormal websocket closes (leaked `periodic_update` callbacks recomputing plots for dead sessions) and matches the "Dropping a patch ... previously known reference" production warnings. The reaper fires precisely when the session is abnormal, so an IOLoop tick may never run — hence severing must not depend on it.

Grid-widget teardown was additionally wired only to `on_session_destroyed`, so abnormal disconnects leaked viewer/interest tokens and lifecycle subscriptions (old audit finding: hidden layers keep computing). Routing both tiers through the `SessionUpdater` closes that leak on both paths.

## Test plan

- Regression tests fail when the fix is reverted: reaper must not stop the periodic callback on the calling thread; tier-2 severing happens even if the document tick never runs; destroyed-document scheduling is tolerated; clean path still tears down inline.
- End-to-end reaper test with real `PlotGridTabs` + orchestrator + `SessionRegistry`.
- [ ] Field check on a real backend: abnormal disconnect (kill browser) leaves no lingering CPU load and no "Dropping a patch" warnings.

Fixes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)
