### PR TITLE
Move grid lifecycle from cross-session push to version polling

### DIFF
--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -476,7 +476,7 @@ class PlotOrchestrator:
         grid = PlotGridConfig(title=title, nrows=nrows, ncols=ncols)
         with self._topology_lock:
             self._grids[grid_id] = grid
-            self._bump_topology_version()
+        self._bump_topology_version()
         self._persist_to_store()
         self._logger.info(
             'Added plot grid %s (%s) with size %dx%d', grid_id, title, nrows, ncols
@@ -502,7 +502,7 @@ class PlotOrchestrator:
 
             with self._topology_lock:
                 del self._grids[grid_id]
-                self._bump_topology_version()
+            self._bump_topology_version()
             self._persist_to_store()
             self._logger.info('Removed plot grid %s (%s)', grid_id, title)
 
@@ -551,7 +551,7 @@ class PlotOrchestrator:
         keys.insert(new_index, keys.pop(current_index))
         with self._topology_lock:
             self._grids = {k: self._grids[k] for k in keys}
-            self._bump_topology_version()
+        self._bump_topology_version()
         self._persist_to_store()
         self._logger.info('Moved grid %s by %d positions', grid_id, delta)
 
@@ -632,7 +632,7 @@ class PlotOrchestrator:
             items = list(self._grids.items())
             items.insert(position, (new_grid_id, new_grid))
             self._grids = dict(items)
-            self._bump_topology_version()
+        self._bump_topology_version()
 
         self._persist_to_store()
         self._logger.info(
@@ -668,14 +668,21 @@ class PlotOrchestrator:
         -------
         :
             ID of the added cell.
+
+        Raises
+        ------
+        KeyError
+            If the grid does not exist (e.g. removed by another session).
         """
+        if grid_id not in self._grids:
+            raise KeyError(f'Grid {grid_id} no longer exists')
         cell_id = CellId(uuid4())
         cell = PlotCell(geometry=geometry, layers=[], user_title=user_title)
         grid = self._grids[grid_id]
         with self._topology_lock:
             grid.cells[cell_id] = cell
             self._cell_to_grid[cell_id] = grid_id
-            self._bump_topology_version()
+        self._bump_topology_version()
         return cell_id
 
     def remove_cell(self, cell_id: CellId) -> None:
@@ -687,6 +694,8 @@ class PlotOrchestrator:
         cell_id
             ID of the cell to remove.
         """
+        if cell_id not in self._cell_to_grid:
+            return
         grid_id = self._cell_to_grid[cell_id]
         grid = self._grids[grid_id]
         cell = grid.cells[cell_id]
@@ -708,6 +717,8 @@ class PlotOrchestrator:
             New user-defined title, or ``None``/empty to clear it and fall back
             to the derived title.
         """
+        if cell_id not in self._cell_to_grid:
+            return
         grid_id = self._cell_to_grid[cell_id]
         cell = self._grids[grid_id].cells[cell_id]
         cell.user_title = title or None
@@ -773,10 +784,14 @@ class PlotOrchestrator:
 
         Raises
         ------
+        KeyError
+            If the cell does not exist (e.g. removed by another session).
         ValueError
             If the resulting cell would combine a non-overlayable layer (a table
             or a layout-mode plot) with any other layer.
         """
+        if cell_id not in self._cell_to_grid:
+            raise KeyError(f'Cell {cell_id} no longer exists')
         grid_id = self._cell_to_grid[cell_id]
         cell = self._grids[grid_id].cells[cell_id]
 
@@ -805,6 +820,8 @@ class PlotOrchestrator:
         layer_id
             ID of the layer to remove.
         """
+        if layer_id not in self._layer_to_cell:
+            return
         cell_id = self._layer_to_cell[layer_id]
         grid_id = self._cell_to_grid[cell_id]
         cell = self._grids[grid_id].cells[cell_id]
@@ -840,7 +857,14 @@ class PlotOrchestrator:
             ID of the layer to update.
         new_config
             New plot configuration.
+
+        Raises
+        ------
+        KeyError
+            If the layer does not exist (e.g. removed by another session).
         """
+        if layer_id not in self._layer_to_cell:
+            raise KeyError(f'Layer {layer_id} no longer exists')
         cell_id = self._layer_to_cell[layer_id]
         grid_id = self._cell_to_grid[cell_id]
         cell = self._grids[grid_id].cells[cell_id]

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import copy
 import threading
 import traceback
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NewType, Protocol
 from uuid import UUID, uuid4
@@ -44,7 +44,6 @@ from .plotting_controller import PlottingController
 if TYPE_CHECKING:
     from ess.livedata.config import Instrument
 
-SubscriptionId = NewType('SubscriptionId', UUID)
 GridId = NewType('GridId', UUID)
 CellId = NewType('CellId', UUID)
 
@@ -183,51 +182,6 @@ class PlotGridConfig:
     enabled: bool = True
 
 
-GridCreatedCallback = Callable[[GridId, PlotGridConfig], None]
-GridRemovedCallback = Callable[[GridId], None]
-GridUpdatedCallback = Callable[[GridId, PlotGridConfig], None]
-CellRemovedCallback = Callable[[GridId, CellGeometry], None]
-
-
-class CellUpdatedCallback(Protocol):
-    """Callback for cell configuration changes.
-
-    Called when a cell's configuration changes (layer added/removed/updated).
-    Subscribers should query PlotDataService for layer state (error, stopped, data).
-    """
-
-    def __call__(
-        self,
-        *,
-        grid_id: GridId,
-        cell_id: CellId,
-        cell: PlotCell,
-    ) -> None:
-        """
-        Handle cell configuration update.
-
-        Parameters
-        ----------
-        grid_id
-            ID of the grid containing the cell.
-        cell_id
-            ID of the cell being updated.
-        cell
-            Plot cell configuration with all layers.
-        """
-
-
-@dataclass
-class LifecycleSubscription:
-    """Subscription to plot grid lifecycle events."""
-
-    on_grid_created: GridCreatedCallback | None = None
-    on_grid_removed: GridRemovedCallback | None = None
-    on_grid_updated: GridUpdatedCallback | None = None
-    on_cell_updated: CellUpdatedCallback | None = None
-    on_cell_removed: CellRemovedCallback | None = None
-
-
 def _stream_role_for_mode(mode: TimeWindowMode) -> StreamRole:
     """Map a window mode to the stream role its data is subscribed from."""
     return 'since_start' if mode is TimeWindowMode.since_start else 'per_update'
@@ -343,7 +297,34 @@ class _LayerJobTracker:
 
 
 class PlotOrchestrator:
-    """Manages plot grid configurations and plot lifecycle."""
+    """Manages plot grid configurations and plot lifecycle.
+
+    Threading
+    ---------
+    The topology mappings (``_grids``, ``_cell_to_grid``, ``_layer_to_cell``)
+    are shared across all browser sessions. They are mutated only on the single
+    Tornado/Bokeh IOLoop thread (all UI callbacks and per-session polls run
+    there): the IOLoop thread is the sole topology *writer*. The only other
+    thread touching topology is the ``orchestrator-update`` thread, which
+    *reads* it during ingestion (``_grid_of_layer``, ``_pull_and_build``,
+    ``get_layer_config`` via ``_reset_layer_presentation``).
+
+    ``_topology_lock`` (an ``RLock``) makes those cross-thread reads see a
+    consistent multi-dict snapshot. Writers hold it only around the dict
+    mutations themselves -- never across file I/O (``_persist_to_store``),
+    pipeline setup, ``plotter.compute``, or ``DataService`` unregistration --
+    so ingestion latency never couples to those. Deletes are leaf-first
+    (``_layer_to_cell`` before ``_cell_to_grid`` before ``_grids``) and inserts
+    root-first, so a reader that races a mutation fails at the first hop with a
+    ``KeyError`` that all read paths tolerate. Lock order is
+    ``_topology_lock`` before ``_dirty_lock``, never the reverse.
+
+    Widgets do not receive pushed lifecycle notifications. Each mutator bumps
+    ``_topology_version``; each session's poll compares it against its last
+    seen value and reconciles on its own IOLoop tick and document lock (ADR
+    0007). ``topology_version()`` needs no lock: the bump and every poll read
+    happen on the same IOLoop thread, and an int read is atomic regardless.
+    """
 
     def __init__(
         self,
@@ -399,7 +380,12 @@ class PlotOrchestrator:
         self._cell_to_grid: dict[CellId, GridId] = {}
         self._layer_jobs: dict[LayerId, _LayerJobTracker] = {}
         self._layer_to_cell: dict[LayerId, CellId] = {}
-        self._lifecycle_subscribers: dict[SubscriptionId, LifecycleSubscription] = {}
+        # Bumped by every topology mutator on the IOLoop thread; polled by each
+        # session's widgets to detect grid/cell changes (see class docstring).
+        self._topology_version: int = 0
+        # Guards cross-thread multi-dict reads of the topology mappings; see the
+        # class "Threading" docstring for the discipline and lock order.
+        self._topology_lock = threading.RLock()
         self._data_subscriptions: dict[LayerId, Any] = {}  # DataSubscriber
         self._layer_resolvers: dict[LayerId, Any] = {}  # LayerId -> TitleResolver
         # Layers whose DataService keys changed since the last flush, bucketed
@@ -423,6 +409,20 @@ class PlotOrchestrator:
         if grid_id is None:
             return 0
         return self._frame_clock.generation(grid_id)
+
+    def topology_version(self) -> int:
+        """Monotonic counter bumped on every grid/cell/layer topology change.
+
+        Sessions poll this to detect creation, removal, reorder, rename,
+        enable/disable, and cell/layer composition changes, then reconcile
+        their widgets. It does *not* advance for pure data flow (frame
+        flushes). See the class "Threading" docstring.
+        """
+        return self._topology_version
+
+    def _bump_topology_version(self) -> None:
+        """Advance the topology version. IOLoop-thread only."""
+        self._topology_version += 1
 
     @property
     def instrument(self) -> str:
@@ -474,12 +474,13 @@ class PlotOrchestrator:
         """
         grid_id = GridId(uuid4())
         grid = PlotGridConfig(title=title, nrows=nrows, ncols=ncols)
-        self._grids[grid_id] = grid
+        with self._topology_lock:
+            self._grids[grid_id] = grid
+            self._bump_topology_version()
         self._persist_to_store()
         self._logger.info(
             'Added plot grid %s (%s) with size %dx%d', grid_id, title, nrows, ncols
         )
-        self._notify_grid_created(grid_id)
         return grid_id
 
     def remove_grid(self, grid_id: GridId) -> None:
@@ -499,10 +500,11 @@ class PlotOrchestrator:
             for cell_id, cell in list(grid.cells.items()):
                 self._remove_cell_and_cleanup(grid_id, cell_id, cell)
 
-            del self._grids[grid_id]
+            with self._topology_lock:
+                del self._grids[grid_id]
+                self._bump_topology_version()
             self._persist_to_store()
             self._logger.info('Removed plot grid %s (%s)', grid_id, title)
-            self._notify_grid_removed(grid_id)
 
     def rename_grid(self, grid_id: GridId, new_title: str) -> None:
         """
@@ -515,11 +517,13 @@ class PlotOrchestrator:
         new_title
             New display title for the grid.
         """
+        if grid_id not in self._grids:
+            return
         grid = self._grids[grid_id]
         grid.title = new_title
         self._persist_to_store()
         self._logger.info('Renamed grid %s to %s', grid_id, new_title)
-        self._notify_grid_updated(grid_id)
+        self._bump_topology_version()
 
     def move_grid(self, grid_id: GridId, delta: int) -> None:
         """
@@ -535,6 +539,8 @@ class PlotOrchestrator:
         delta
             Number of positions to move (negative=up, positive=down).
         """
+        if grid_id not in self._grids:
+            return
         keys = list(self._grids.keys())
         current_index = keys.index(grid_id)
         new_index = current_index + delta
@@ -543,10 +549,11 @@ class PlotOrchestrator:
 
         # Rebuild dict in new order
         keys.insert(new_index, keys.pop(current_index))
-        self._grids = {k: self._grids[k] for k in keys}
+        with self._topology_lock:
+            self._grids = {k: self._grids[k] for k in keys}
+            self._bump_topology_version()
         self._persist_to_store()
         self._logger.info('Moved grid %s by %d positions', grid_id, delta)
-        self._notify_grid_updated(grid_id)
 
     def set_grid_enabled(self, grid_id: GridId, *, enabled: bool) -> None:
         """
@@ -562,11 +569,13 @@ class PlotOrchestrator:
         enabled
             Whether the grid should be visible.
         """
+        if grid_id not in self._grids:
+            return
         grid = self._grids[grid_id]
         grid.enabled = enabled
         self._persist_to_store()
         self._logger.info('Set grid %s enabled=%s', grid_id, enabled)
-        self._notify_grid_updated(grid_id)
+        self._bump_topology_version()
 
     def replace_grid(
         self, grid_id: GridId, title: str, nrows: int, ncols: int
@@ -574,10 +583,10 @@ class PlotOrchestrator:
         """
         Replace a grid with a new empty grid at the same position.
 
-        Tears down all cells/layers of the old grid, fires ``on_grid_removed``,
-        then creates a new grid at the same position with the given dimensions
-        and fires ``on_grid_created``. The new grid inherits the old grid's
-        ``enabled`` state.
+        Tears down all cells/layers of the old grid, then creates a new grid at
+        the same position with the given dimensions. The new grid inherits the
+        old grid's ``enabled`` state. Bumps the topology version once; sessions
+        reconcile the position change on their next poll.
 
         Parameters
         ----------
@@ -611,19 +620,19 @@ class PlotOrchestrator:
         for cell_id, cell in list(old_grid.cells.items()):
             self._remove_cell_and_cleanup(grid_id, cell_id, cell)
 
-        del self._grids[grid_id]
-        self._notify_grid_removed(grid_id)
-
         # Create new grid and insert at the same position
         new_grid_id = GridId(uuid4())
         new_grid = PlotGridConfig(
             title=title, nrows=nrows, ncols=ncols, enabled=enabled
         )
 
-        # Rebuild dict with new grid at the original position
-        items = list(self._grids.items())
-        items.insert(position, (new_grid_id, new_grid))
-        self._grids = dict(items)
+        with self._topology_lock:
+            del self._grids[grid_id]
+            # Rebuild dict with new grid at the original position
+            items = list(self._grids.items())
+            items.insert(position, (new_grid_id, new_grid))
+            self._grids = dict(items)
+            self._bump_topology_version()
 
         self._persist_to_store()
         self._logger.info(
@@ -633,7 +642,6 @@ class PlotOrchestrator:
             title,
             position,
         )
-        self._notify_grid_created(new_grid_id)
         return new_grid_id
 
     def add_cell(
@@ -664,8 +672,10 @@ class PlotOrchestrator:
         cell_id = CellId(uuid4())
         cell = PlotCell(geometry=geometry, layers=[], user_title=user_title)
         grid = self._grids[grid_id]
-        grid.cells[cell_id] = cell
-        self._cell_to_grid[cell_id] = grid_id
+        with self._topology_lock:
+            grid.cells[cell_id] = cell
+            self._cell_to_grid[cell_id] = grid_id
+            self._bump_topology_version()
         return cell_id
 
     def remove_cell(self, cell_id: CellId) -> None:
@@ -684,7 +694,7 @@ class PlotOrchestrator:
         self._remove_cell_and_cleanup(grid_id, cell_id, cell)
 
         self._persist_to_store()
-        self._notify_cell_removed(grid_id, cell_id, cell)
+        self._bump_topology_version()
 
     def set_cell_title(self, cell_id: CellId, title: str | None) -> None:
         """
@@ -703,7 +713,7 @@ class PlotOrchestrator:
         cell.user_title = title or None
         self._persist_to_store()
         self._logger.info('Set cell %s title to %r', cell_id, cell.user_title)
-        self._notify_cell_updated(grid_id, cell_id, cell)
+        self._bump_topology_version()
 
     def get_layer_config(self, layer_id: LayerId) -> PlotConfig:
         """
@@ -719,12 +729,13 @@ class PlotOrchestrator:
         :
             The layer's plot configuration.
         """
-        cell_id = self._layer_to_cell[layer_id]
-        grid_id = self._cell_to_grid[cell_id]
-        cell = self._grids[grid_id].cells[cell_id]
-        for layer in cell.layers:
-            if layer.layer_id == layer_id:
-                return layer.config
+        with self._topology_lock:
+            cell_id = self._layer_to_cell[layer_id]
+            grid_id = self._cell_to_grid[cell_id]
+            cell = self._grids[grid_id].cells[cell_id]
+            for layer in cell.layers:
+                if layer.layer_id == layer_id:
+                    return layer.config
         raise KeyError(f'Layer {layer_id} not found in cell {cell_id}')
 
     def get_cell(self, cell_id: CellId) -> PlotCell:
@@ -775,10 +786,10 @@ class PlotOrchestrator:
 
         layer_id = LayerId(uuid4())
         layer = Layer(layer_id=layer_id, config=config)
-        cell.layers.append(layer)
-
-        self._layer_to_cell[layer_id] = cell_id
-        self._setup_layer(grid_id, cell_id, layer)
+        with self._topology_lock:
+            cell.layers.append(layer)
+            self._layer_to_cell[layer_id] = cell_id
+        self._setup_layer(layer)
         self._refresh_resolvers_for_cell(cell_id)
 
         return layer_id
@@ -799,7 +810,8 @@ class PlotOrchestrator:
         cell = self._grids[grid_id].cells[cell_id]
 
         # Find and remove the layer
-        cell.layers = [layer for layer in cell.layers if layer.layer_id != layer_id]
+        with self._topology_lock:
+            cell.layers = [layer for layer in cell.layers if layer.layer_id != layer_id]
 
         # Unsubscribe and clean up layer state
         self._cleanup_layer(layer_id)
@@ -811,9 +823,7 @@ class PlotOrchestrator:
 
         self._refresh_resolvers_for_cell(cell_id)
         self._persist_to_store()
-
-        # Notify with updated cell config
-        self._notify_cell_updated(grid_id, cell_id, cell)
+        self._bump_topology_version()
 
     def update_layer_config(self, layer_id: LayerId, new_config: PlotConfig) -> None:
         """
@@ -860,13 +870,12 @@ class PlotOrchestrator:
 
         # Create new layer with new identity
         new_layer = Layer(layer_id=new_layer_id, config=new_config)
-        cell.layers[layer_index] = new_layer
-
-        # Set up mapping for new layer
-        self._layer_to_cell[new_layer_id] = cell_id
+        with self._topology_lock:
+            cell.layers[layer_index] = new_layer
+            self._layer_to_cell[new_layer_id] = cell_id
 
         # Subscribe new layer to workflow
-        self._setup_layer(grid_id, cell_id, new_layer)
+        self._setup_layer(new_layer)
         self._refresh_resolvers_for_cell(cell_id)
 
     def _remove_cell_and_cleanup(
@@ -890,8 +899,9 @@ class PlotOrchestrator:
 
         # Remove cell from grid and mapping
         grid = self._grids[grid_id]
-        del grid.cells[cell_id]
-        del self._cell_to_grid[cell_id]
+        with self._topology_lock:
+            del grid.cells[cell_id]
+            del self._cell_to_grid[cell_id]
 
     def _cleanup_layer(
         self, layer_id: LayerId, *, remove_from_cell_mapping: bool = True
@@ -921,7 +931,8 @@ class PlotOrchestrator:
         self._plot_data_service.remove(layer_id)
         self._layer_resolvers.pop(layer_id, None)
         if remove_from_cell_mapping:
-            self._layer_to_cell.pop(layer_id, None)
+            with self._topology_lock:
+                self._layer_to_cell.pop(layer_id, None)
 
     def _check_overlayable_composition(self, configs: list[PlotConfig]) -> None:
         """Reject a multi-layer cell that contains a non-overlayable layer.
@@ -1044,7 +1055,8 @@ class PlotOrchestrator:
             self._dirty_layers.setdefault(grid_id, set()).add(layer_id)
 
     def _grid_of_layer(self, layer_id: LayerId) -> GridId:
-        return self._cell_to_grid[self._layer_to_cell[layer_id]]
+        with self._topology_lock:
+            return self._cell_to_grid[self._layer_to_cell[layer_id]]
 
     def flush_frames(self) -> None:
         """Rebuild each grid's dirty viewed layers, committing per grid.
@@ -1107,9 +1119,10 @@ class PlotOrchestrator:
         transitions the layer to ERROR and thus still warrants a frame
         commit), False if the layer is gone or its data is not ready.
         """
-        if layer_id not in self._layer_to_cell:
-            return False
-        subscriber = self._data_subscriptions.get(layer_id)
+        with self._topology_lock:
+            if layer_id not in self._layer_to_cell:
+                return False
+            subscriber = self._data_subscriptions.get(layer_id)
         if subscriber is None:
             return False
         state = self._plot_data_service.get(layer_id)
@@ -1175,7 +1188,7 @@ class PlotOrchestrator:
         state = self._plot_data_service.get(layer_id)
         return None if state is None else state.version
 
-    def _setup_layer(self, grid_id: GridId, cell_id: CellId, layer: Layer) -> None:
+    def _setup_layer(self, layer: Layer) -> None:
         """
         Create a layer's plotter and data pipeline.
 
@@ -1194,10 +1207,6 @@ class PlotOrchestrator:
 
         Parameters
         ----------
-        grid_id
-            ID of the grid containing the cell.
-        cell_id
-            ID of the cell containing the layer.
         layer
             The layer to set up.
         """
@@ -1214,8 +1223,7 @@ class PlotOrchestrator:
                 # Empty input: a static overlay computes from its params alone.
                 self._compute_layer(layer_id, plotter, state.version, {})
                 self._frame_clock.commit(self._grid_of_layer(layer_id))
-            cell = self._grids[grid_id].cells[cell_id]
-            self._notify_cell_updated(grid_id, cell_id, cell)
+            self._bump_topology_version()
             self._persist_to_store()
             return
 
@@ -1255,9 +1263,9 @@ class PlotOrchestrator:
                 if any(n is None for n in self._layer_jobs[layer_id].job_numbers):
                     self._plot_data_service.job_stopped(layer_id)
 
-        # Always notify current config - sessions will poll PlotDataService for state
-        cell = self._grids[grid_id].cells[cell_id]
-        self._notify_cell_updated(grid_id, cell_id, cell)
+        # Sessions poll PlotDataService for state; the version bump makes them
+        # reconcile the new cell/layer composition.
+        self._bump_topology_version()
         self._persist_to_store()
 
     def _current_job_numbers(
@@ -1692,142 +1700,6 @@ class PlotOrchestrator:
             Safe to modify without affecting internal state.
         """
         return copy.deepcopy(self._grids)
-
-    def subscribe_to_lifecycle(
-        self,
-        *,
-        on_grid_created: GridCreatedCallback | None = None,
-        on_grid_removed: GridRemovedCallback | None = None,
-        on_grid_updated: GridUpdatedCallback | None = None,
-        on_cell_updated: CellUpdatedCallback | None = None,
-        on_cell_removed: CellRemovedCallback | None = None,
-    ) -> SubscriptionId:
-        """
-        Subscribe to plot grid lifecycle events.
-
-        Subscribers will be notified when grids or cells are created, updated,
-        or removed. At least one callback must be provided.
-
-        Callbacks are fired in the order grids are created. Late subscribers
-        (subscribing after grids already exist) should call `get_all_grids()`
-        to get existing grids in their creation order before relying on callbacks
-        for new grids.
-
-        Parameters
-        ----------
-        on_grid_created
-            Called when a new grid is created with (grid_id, grid_config).
-        on_grid_removed
-            Called when a grid is removed.
-        on_grid_updated
-            Called when a grid is renamed, reordered, or enabled/disabled.
-        on_cell_updated
-            Called when a cell is added or updated.
-        on_cell_removed
-            Called when a cell is removed.
-
-        Returns
-        -------
-        :
-            Subscription ID that can be used to unsubscribe.
-        """
-        subscription_id = SubscriptionId(uuid4())
-        self._lifecycle_subscribers[subscription_id] = LifecycleSubscription(
-            on_grid_created=on_grid_created,
-            on_grid_removed=on_grid_removed,
-            on_grid_updated=on_grid_updated,
-            on_cell_updated=on_cell_updated,
-            on_cell_removed=on_cell_removed,
-        )
-        return subscription_id
-
-    def unsubscribe_from_lifecycle(self, subscription_id: SubscriptionId) -> None:
-        """
-        Unsubscribe from plot grid lifecycle events.
-
-        Parameters
-        ----------
-        subscription_id
-            The subscription ID returned from subscribe_to_lifecycle.
-        """
-        if subscription_id in self._lifecycle_subscribers:
-            del self._lifecycle_subscribers[subscription_id]
-
-    def _notify_grid_created(self, grid_id: GridId) -> None:
-        """Notify subscribers that a grid was created."""
-        grid = self._grids[grid_id]
-        for subscription in self._lifecycle_subscribers.values():
-            if subscription.on_grid_created:
-                try:
-                    subscription.on_grid_created(grid_id, grid)
-                except Exception:
-                    self._logger.exception(
-                        'Error in grid created callback for grid %s', grid_id
-                    )
-
-    def _notify_grid_removed(self, grid_id: GridId) -> None:
-        """Notify subscribers that a grid was removed."""
-        for subscription in self._lifecycle_subscribers.values():
-            if subscription.on_grid_removed:
-                try:
-                    subscription.on_grid_removed(grid_id)
-                except Exception:
-                    self._logger.exception(
-                        'Error in grid removed callback for grid %s', grid_id
-                    )
-
-    def _notify_grid_updated(self, grid_id: GridId) -> None:
-        """Notify subscribers that a grid was renamed, reordered, or toggled."""
-        grid = self._grids[grid_id]
-        for subscription in self._lifecycle_subscribers.values():
-            if subscription.on_grid_updated:
-                try:
-                    subscription.on_grid_updated(grid_id, grid)
-                except Exception:
-                    self._logger.exception(
-                        'Error in grid updated callback for grid %s', grid_id
-                    )
-
-    def _notify_cell_updated(
-        self,
-        grid_id: GridId,
-        cell_id: CellId,
-        cell: PlotCell,
-    ) -> None:
-        """Notify subscribers that a cell config was added or updated."""
-        for subscription in self._lifecycle_subscribers.values():
-            if subscription.on_cell_updated:
-                try:
-                    subscription.on_cell_updated(
-                        grid_id=grid_id,
-                        cell_id=cell_id,
-                        cell=cell,
-                    )
-                except Exception:
-                    self._logger.exception(
-                        'Error in cell updated callback for grid %s cell %s at (%d,%d)',
-                        grid_id,
-                        cell_id,
-                        cell.geometry.row,
-                        cell.geometry.col,
-                    )
-
-    def _notify_cell_removed(
-        self, grid_id: GridId, cell_id: CellId, cell: PlotCell
-    ) -> None:
-        """Notify subscribers that a cell was removed."""
-        for subscription in self._lifecycle_subscribers.values():
-            if subscription.on_cell_removed:
-                try:
-                    subscription.on_cell_removed(grid_id, cell.geometry)
-                except Exception:
-                    self._logger.exception(
-                        'Error in cell removed callback for grid %s cell %s at (%d,%d)',
-                        grid_id,
-                        cell_id,
-                        cell.geometry.row,
-                        cell.geometry.col,
-                    )
 
     def shutdown(self) -> None:
         """

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -30,6 +30,7 @@ from ..format_utils import extract_error_summary
 from ..hover_suspend import make_hover_suspend_hook
 from ..plot_data_service import LayerState, LayerStateMachine, PlotDataService
 from ..plot_orchestrator import (
+    CellGeometry,
     CellId,
     LayerId,
     PlotCell,
@@ -239,6 +240,11 @@ class CellWidget:
     def view(self) -> pn.Column:
         """The Panel widget for this cell."""
         return self._view
+
+    @property
+    def geometry(self) -> CellGeometry:
+        """Grid geometry (position and span) of this cell."""
+        return self._cell.geometry
 
     @property
     def has_plot(self) -> bool:

--- a/src/ess/livedata/dashboard/widgets/plot_grid_manager.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_manager.py
@@ -23,7 +23,6 @@ from ..plot_orchestrator import (
     PlotCell,
     PlotGridConfig,
     PlotOrchestrator,
-    SubscriptionId,
 )
 from .buttons import ButtonStyles, create_download_button, create_tool_button
 from .plot_widgets import get_workflow_display_info
@@ -254,8 +253,9 @@ class PlotGridManager:
     Widget for managing plot grid configurations.
 
     Provides a form to add new grids and a list of existing grids with
-    remove buttons. Automatically updates when grids are added or removed
-    through the orchestrator.
+    remove buttons. The grid list is refreshed by the owning ``PlotGridTabs``
+    via :meth:`on_topology_changed` when the orchestrator's topology version
+    changes; the manager has no periodic callback of its own.
 
     Parameters
     ----------
@@ -265,15 +265,22 @@ class PlotGridManager:
     workflow_registry
         Registry of available workflows and their specifications. Used to
         look up workflow titles for display in the grid preview.
+    on_local_grid_created
+        Optional callback invoked with the new grid's id on the three local
+        creation paths (add, save changes, save as copy). Lets the owning
+        session focus the new grid's tab without a shared focus signal.
     """
 
     def __init__(
         self,
         orchestrator: PlotOrchestrator,
         workflow_registry: Mapping[WorkflowId, WorkflowSpec],
+        *,
+        on_local_grid_created: Callable[[GridId], None] | None = None,
     ) -> None:
         self._orchestrator = orchestrator
         self._workflow_registry = workflow_registry
+        self._on_local_grid_created = on_local_grid_created
         templates = orchestrator.get_available_templates()
         self._templates = {t.name: t for t in templates}
         self._selected_template: GridSpec | None = None
@@ -368,15 +375,6 @@ class PlotGridManager:
         # tab addition better when all tabs have the same sizing mode.
         self._grid_list = pn.Column(
             sizing_mode='stretch_both', margin=(0, _HORIZONTAL_MARGIN)
-        )
-
-        # Subscribe to orchestrator updates
-        self._subscription_id: SubscriptionId | None = (
-            self._orchestrator.subscribe_to_lifecycle(
-                on_grid_created=self._on_grid_created,
-                on_grid_removed=self._on_grid_removed,
-                on_grid_updated=self._on_grid_updated,
-            )
         )
 
         # Source indicator shows what the preview is displaying
@@ -720,6 +718,8 @@ class PlotGridManager:
             for layer in cell.layers:
                 self._orchestrator.add_layer(cell_id, layer.config)
 
+        self._notify_local_grid_created(grid_id)
+
         # Reset to Template mode with no template selected
         with pn.io.hold():
             self._mode_selector.value = _MODE_TEMPLATE
@@ -735,18 +735,20 @@ class PlotGridManager:
             self._reset_to_defaults()
             self._update_preview()
 
-    def _on_grid_created(self, grid_id: GridId, grid_config: PlotGridConfig) -> None:
-        """Handle grid creation from orchestrator."""
-        self._update_grid_list()
+    def on_topology_changed(self) -> None:
+        """Refresh the grid list after a topology change.
 
-    def _on_grid_removed(self, grid_id: GridId) -> None:
-        """Handle grid removal from orchestrator."""
-        if self._editing_grid_id == grid_id:
+        Called by the owning ``PlotGridTabs`` on its poll when the
+        orchestrator's topology version changed. If the grid being edited was
+        removed by another session, exit edit mode first (its form state is
+        stale). Form/edit state is otherwise preserved: only the grid rows are
+        rebuilt.
+        """
+        if (
+            self._editing_grid_id is not None
+            and self._orchestrator.peek_grid(self._editing_grid_id) is None
+        ):
             self._exit_edit_mode()
-        self._update_grid_list()
-
-    def _on_grid_updated(self, grid_id: GridId, grid_config: PlotGridConfig) -> None:
-        """Handle grid update (rename, reorder, enable/disable) from orchestrator."""
         self._update_grid_list()
 
     def _update_grid_list(self) -> None:
@@ -958,6 +960,8 @@ class PlotGridManager:
             for layer in cell.layers:
                 self._orchestrator.add_layer(cell_id, layer.config)
 
+        self._notify_local_grid_created(new_grid_id)
+
     def _on_save_as_copy(self, event) -> None:
         """Handle Save as Copy button click in edit mode."""
         cells_to_add = self._editing_cells or ()
@@ -975,11 +979,12 @@ class PlotGridManager:
             for layer in cell.layers:
                 self._orchestrator.add_layer(cell_id, layer.config)
 
-    def shutdown(self) -> None:
-        """Unsubscribe from lifecycle events."""
-        if self._subscription_id is not None:
-            self._orchestrator.unsubscribe_from_lifecycle(self._subscription_id)
-            self._subscription_id = None
+        self._notify_local_grid_created(grid_id)
+
+    def _notify_local_grid_created(self, grid_id: GridId) -> None:
+        """Report a locally-initiated grid creation to the owning tabs widget."""
+        if self._on_local_grid_created is not None:
+            self._on_local_grid_created(grid_id)
 
     @property
     def panel(self) -> pn.Column:

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -4,7 +4,8 @@
 PlotGridTabs - Tabbed interface for managing multiple plot grids.
 
 Provides a Panel Tabs widget that displays multiple PlotGrid instances,
-synchronized with PlotOrchestrator via lifecycle subscriptions.
+kept in sync with PlotOrchestrator by polling its topology version on each
+session's own periodic tick (see ``PlotOrchestrator`` "Threading").
 """
 
 from __future__ import annotations
@@ -29,7 +30,6 @@ from ..plot_orchestrator import (
     PlotConfig,
     PlotGridConfig,
     PlotOrchestrator,
-    SubscriptionId,
 )
 from ..plots import TimeBounds
 from ..session_layer import SessionLayer
@@ -81,8 +81,9 @@ class PlotGridTabs:
 
     Displays static tabs for Workflows and Manage Plots,
     followed by one tab per plot grid.
-    Synchronizes with PlotOrchestrator via lifecycle subscriptions to support
-    multiple linked instances.
+    Each instance polls the orchestrator's topology version on its own periodic
+    tick and reconciles tabs and cells independently, so cross-session changes
+    are picked up under this session's document lock rather than pushed.
 
     Parameters
     ----------
@@ -132,6 +133,18 @@ class PlotGridTabs:
         # updated in place by the poll loop (freshness pill, layer time labels).
         # Rebuilt on cell/layer changes; disposed when the cell goes away.
         self._cells: dict[CellId, CellWidget] = {}
+
+        # Topology-version polling state. ``_last_topology_version`` gates the
+        # tab reconcile; ``_cell_signatures`` detects per-cell composition
+        # changes (layer add/remove/reconfigure, title) each tick;
+        # ``_cell_grid`` records which grid each built cell lives in, so a cell
+        # that vanished from topology can still be removed from its grid widget.
+        self._last_topology_version: int | None = None
+        self._cell_signatures: dict[CellId, tuple] = {}
+        self._cell_grid: dict[CellId, GridId] = {}
+        # Set by the local grid-creation callback; the creating session's next
+        # poll focuses this grid's tab. Never shared across sessions.
+        self._pending_focus_grid_id: GridId | None = None
 
         # Gate state for coalescing plot-data flushes (see _poll_for_plot_updates).
         # The data push runs only when a new data-burst frame is ready or the
@@ -212,17 +225,6 @@ class PlotGridTabs:
             sizing_mode='stretch_both',
         )
 
-        # Subscribe to lifecycle events
-        self._subscription_id: SubscriptionId | None = (
-            self._orchestrator.subscribe_to_lifecycle(
-                on_grid_created=self._on_grid_created,
-                on_grid_removed=self._on_grid_removed,
-                on_grid_updated=self._on_grid_updated,
-                on_cell_updated=self._on_cell_updated,
-                on_cell_removed=self._on_cell_removed,
-            )
-        )
-
         # Add Workflows tab (always first)
         self._tabs.append(('Workflows', workflow_status_widget.panel()))
 
@@ -230,20 +232,24 @@ class PlotGridTabs:
         if system_status_widget is not None:
             self._tabs.append(('System Status', system_status_widget.panel()))
 
-        # Add Manage tab
+        # Add Manage tab. The manager reports locally-initiated grid creations
+        # so this session (only) focuses the new tab on its next poll; other
+        # sessions merely gain the tab.
         self._grid_manager = PlotGridManager(
             orchestrator=plot_orchestrator,
             workflow_registry=workflow_registry,
+            on_local_grid_created=self._on_local_grid_created,
         )
         self._tabs.append(('Manage Plots', self._grid_manager.panel))
 
         # Store static tabs count for use as offset in grid tab index calculations
         self._static_tabs_count = len(self._tabs)
 
-        # Initialize from existing grids (skip disabled ones)
-        for grid_id, grid_config in self._orchestrator.get_all_grids().items():
-            if grid_config.enabled:
-                self._add_grid_tab(grid_id, grid_config)
+        # Build grid tabs from current topology and record the version so the
+        # first poll does not rebuild everything again (cells are populated on
+        # the first poll). Mirrors WorkflowStatusWidget's init-to-current pattern.
+        self._reconcile_topology()
+        self._last_topology_version = self._orchestrator.topology_version()
 
         # Register handler for periodic polling
         session_updater.register_custom_handler(self._poll_for_plot_updates)
@@ -277,17 +283,9 @@ class PlotGridTabs:
         # Append grid directly to tabs (Manage tab is always first at index 0)
         # NOTE: Do NOT wrap each grid with modal_container here. The modal
         # container is shared across all tabs and lives at the top level
-        # (wrapping the entire Tabs widget).
+        # (wrapping the entire Tabs widget). Cells are populated by the poll's
+        # cell reconcile, not here.
         self._tabs.append((grid_config.title, plot_grid.panel))
-
-        # Populate with existing cells (important for late subscribers / new sessions)
-        for cell_id, cell in grid_config.cells.items():
-            # Notify about cell config - widget will query PlotDataService for state
-            self._on_cell_updated(
-                grid_id=grid_id,
-                cell_id=cell_id,
-                cell=cell,
-            )
 
     def _tabbed_grid_ids(self) -> list[GridId]:
         """GridIds that currently have a tab, in tab order.
@@ -310,16 +308,6 @@ class PlotGridTabs:
                 tabbed.append(grid_id)
         return tabbed
 
-    def _remove_grid_tab(self, grid_id: GridId) -> None:
-        """Remove a grid tab."""
-        if grid_id not in self._grid_widgets:
-            return
-
-        tabbed = self._tabbed_grid_ids()
-        if grid_id in tabbed:
-            self._tabs.pop(self._static_tabs_count + tabbed.index(grid_id))
-        del self._grid_widgets[grid_id]
-
     def _get_active_grid_id(self) -> GridId | None:
         """Return the GridId of the currently visible grid tab, or None.
 
@@ -340,28 +328,58 @@ class PlotGridTabs:
             return tabbed[grid_idx]
         return None
 
-    def _on_grid_created(self, grid_id: GridId, grid_config: PlotGridConfig) -> None:
-        """Handle grid creation from orchestrator.
+    def _on_local_grid_created(self, grid_id: GridId) -> None:
+        """Record a grid this session just created so its tab is focused.
 
-        Uses full reconciliation to insert the tab at the correct position
-        (e.g., when ``replace_grid`` inserts a new grid at a middle position).
+        Called by ``PlotGridManager`` on the three local creation paths. The
+        creating session's next poll activates the new grid's tab; other
+        sessions gain the tab without a focus change. This is the only mechanism
+        that moves ``tabs.active`` on grid creation -- there is no shared focus
+        signal.
         """
+        self._pending_focus_grid_id = grid_id
+
+    def _reconcile_topology(self) -> None:
+        """Rebuild grid tabs to match orchestrator topology, preserving focus.
+
+        Runs on this session's thread (constructor or poll). Captures the
+        active tab by identity first (bypassing ``_get_active_grid_id``'s modal
+        guard, which would misreport "no active grid" while a modal is open),
+        rebuilds all grid tabs, then restores the active tab by identity. A
+        pending local-creation focus overrides the restore. Cells are
+        reconciled separately by the poll loop.
+        """
+        # Capture the active tab by identity before the rebuild reorders tabs.
+        active_before = self._tabs.active
+        static_active = active_before < self._static_tabs_count
+        active_grid_id: GridId | None = None
+        if not static_active:
+            tabbed = self._tabbed_grid_ids()
+            idx = active_before - self._static_tabs_count
+            if 0 <= idx < len(tabbed):
+                active_grid_id = tabbed[idx]
+
         self._reconcile_grid_tabs()
 
-        tabbed = self._tabbed_grid_ids()
-        if grid_id in tabbed:
-            self._tabs.active = self._static_tabs_count + tabbed.index(grid_id)
+        # Restore the active tab by identity.
+        if static_active:
+            self._tabs.active = active_before
+        elif active_grid_id is not None:
+            tabbed = self._tabbed_grid_ids()
+            if active_grid_id in tabbed:
+                self._tabs.active = self._static_tabs_count + tabbed.index(
+                    active_grid_id
+                )
+            # else: the active grid was removed; leave Bokeh's clamped value.
 
-    def _on_grid_removed(self, grid_id: GridId) -> None:
-        """Handle grid removal from orchestrator."""
-        self._remove_grid_tab(grid_id)
-
-    def _on_grid_updated(self, grid_id: GridId, grid_config: PlotGridConfig) -> None:
-        """Handle grid rename, reorder, or enable/disable from orchestrator.
-
-        Reconciles the current tab state against the orchestrator's grid list.
-        """
-        self._reconcile_grid_tabs()
+        # A locally-created grid overrides the restore and focuses its tab.
+        if self._pending_focus_grid_id is not None:
+            tabbed = self._tabbed_grid_ids()
+            if self._pending_focus_grid_id in tabbed:
+                self._tabs.active = self._static_tabs_count + tabbed.index(
+                    self._pending_focus_grid_id
+                )
+                self._pending_focus_grid_id = None
 
     def _reconcile_grid_tabs(self) -> None:
         """Rebuild grid tabs to match orchestrator state (order, titles, enabled)."""
@@ -532,93 +550,21 @@ class PlotGridTabs:
         self._modal_container.append(modal.modal)
         modal.show()
 
-    def _on_cell_updated(
-        self,
-        *,
-        grid_id: GridId,
-        cell_id: CellId,
-        cell: PlotCell,
-    ) -> None:
+    @staticmethod
+    def _cell_signature(cell: PlotCell) -> tuple:
+        """Composition fingerprint of a cell: geometry, title, and layer ids.
+
+        Changes when a layer is added, removed, or reconfigured
+        (``update_layer_config`` mints a fresh ``LayerId``) or the user title
+        changes -- exactly the transitions that require rebuilding the cell
+        widget. Plotter swaps within a layer keep the same ``LayerId`` and are
+        picked up by the per-layer ``state.version`` path instead.
         """
-        Handle cell update from orchestrator.
-
-        Creates a cell widget with per-layer toolbars and either a placeholder
-        or the composed plot, then inserts it into the grid.
-
-        This is called when cell configuration changes (layer added/removed/updated).
-        Layer runtime state (error, stopped, data) is queried from PlotDataService.
-
-        Parameters
-        ----------
-        grid_id
-            ID of the grid containing the cell.
-        cell_id
-            ID of the cell being updated.
-        cell
-            Plot cell configuration with all layers.
-        """
-        plot_grid = self._grid_widgets.get(grid_id)
-        if plot_grid is None:
-            return
-
-        # Build the cell widget. Composing its plot creates fresh session
-        # components: when config changes, update_layer_config() creates a new
-        # layer_id; the old one is orphaned and cleaned up by update_pipes(),
-        # and new layer_ids have no cache, so components are created naturally.
-        #
-        # Note: SessionLayer.create() already records state.version in
-        # last_seen_version, so _poll_for_plot_updates won't trigger
-        # redundant rebuilds.
-        cell_widget = self._build_cell(cell_id, cell)
-        view = cell_widget.view
-
-        # Defer insertion for plots to allow Panel to update layout sizing.
-        # A layer's plot is created synchronously at add-layer time, so the
-        # HoloViews pane can initialize with collapsed/default size before the
-        # grid container is properly sized, resulting in "glitched" rendering.
-        # Deferring to the next event loop iteration allows Panel to process
-        # layout updates first.
-        if cell_widget.has_plot:
-            pn.state.execute(
-                lambda g=cell.geometry: plot_grid.insert_widget_at(g, view)
-            )
-        else:
-            # Status widgets can be inserted immediately
-            plot_grid.insert_widget_at(cell.geometry, view)
-
-    def _on_cell_removed(self, grid_id: GridId, geometry: CellGeometry) -> None:
-        """
-        Handle cell removal from orchestrator.
-
-        Removes the widget from the grid at the specified position.
-
-        Parameters
-        ----------
-        grid_id
-            ID of the grid containing the cell.
-        geometry
-            Cell geometry of the removed cell.
-        """
-        plot_grid = self._grid_widgets.get(grid_id)
-        if plot_grid is None:
-            return
-
-        # Remove widget at explicit position
-        plot_grid.remove_widget_at(geometry)
-
-        # Drop the cell widget for the removed cell, disposing its autoscale
-        # controller. The geometry → cell_id mapping isn't tracked here, so we
-        # sweep widgets whose CellId no longer matches any active cell.
-        active_cell_ids: set[CellId] = set()
-        for grid_config in (
-            self._orchestrator.peek_grid(gid) for gid in self._grid_widgets
-        ):
-            if grid_config is None:
-                continue
-            active_cell_ids.update(grid_config.cells.keys())
-        for cid in list(self._cells):
-            if cid not in active_cell_ids:
-                self._cells.pop(cid).dispose()
+        return (
+            cell.geometry,
+            cell.user_title,
+            tuple(layer.layer_id for layer in cell.layers),
+        )
 
     def _build_cell(self, cell_id: CellId, cell: PlotCell) -> CellWidget:
         """Build (or rebuild) the session widget for a cell.
@@ -639,23 +585,31 @@ class PlotGridTabs:
 
     def _poll_for_plot_updates(self) -> None:
         """
-        Poll PlotDataService for updates and set up new layers.
+        Reconcile topology and push plot-data updates for this session.
 
-        Called from SessionUpdater's periodic callback. Single pass over all
-        orchestrator layers to:
-        - Push data updates to existing session pipes (active tab only)
-        - Detect version changes requiring cell rebuilds
-        - Create/update session layers as needed
+        Called from SessionUpdater's periodic callback (inside hold+freeze).
+        First, on a topology-version change, rebuilds grid tabs and refreshes
+        the manager. Then a single pass over all orchestrator cells:
+        - Detects cell composition changes via signatures (layer add/remove/
+          reconfigure, title) and per-layer ``state.version`` changes (plotter
+          swaps), rebuilding affected cells.
+        - Sweeps cells that vanished from topology, removing and disposing them.
+        - Creates/updates session layers and pushes data to the active tab.
 
         Only layers on the currently visible grid tab call ``update_pipe()``,
         since ``dynamic=True`` on Tabs means hidden tabs have no materialized
         Bokeh models. Skipped layers keep their dirty flag set; on tab switch
-        the next poll cycle sends the latest cached state.
-
-        Version-based change detection replaces callback-based updates for state
-        changes (waiting/ready/stopped/error). Polling at ~100ms intervals is
-        acceptable for config UI updates.
+        the next poll cycle sends the latest cached state. Polling at ~100ms
+        intervals is acceptable for config UI updates.
         """
+        # Reconcile grid tabs only when the shared topology changed. Runs on
+        # this session's thread and document lock, not pushed cross-session.
+        version = self._orchestrator.topology_version()
+        if version != self._last_topology_version:
+            self._last_topology_version = version
+            self._reconcile_topology()
+            self._grid_manager.on_topology_changed()
+
         cells_to_rebuild: dict[CellId, tuple[PlotCell, PlotGrid]] = {}
         versions_to_apply: dict[LayerId, int] = {}
         seen_layer_ids: set[LayerId] = set()
@@ -686,6 +640,23 @@ class PlotGridTabs:
             is_active = grid_id == active_grid_id
 
             for cell_id, cell in grid_config.cells.items():
+                # A cell always has >=1 layer while it exists in topology (the
+                # last layer's removal removes the cell); skip the transient
+                # empty state defensively.
+                if not cell.layers:
+                    continue
+
+                # Detect composition changes (layer add/remove/reconfigure,
+                # title). Plotter swaps keep the layer ids and are handled by
+                # the per-layer version path below.
+                signature = self._cell_signature(cell)
+                if cell_id not in self._cells or signature != self._cell_signatures.get(
+                    cell_id
+                ):
+                    cells_to_rebuild[cell_id] = (cell, plot_grid)
+                    self._cell_signatures[cell_id] = signature
+                    self._cell_grid[cell_id] = grid_id
+
                 for layer in cell.layers:
                     layer_id = layer.layer_id
                     seen_layer_ids.add(layer_id)
@@ -747,15 +718,38 @@ class PlotGridTabs:
                 )
                 del self._session_layers[layer_id]
 
+        # Sweep cells that vanished from topology (cell or grid removed). A cell
+        # on a merely disabled grid still exists in topology and is kept so its
+        # widget (and state) survives a re-enable, even though the poll loop
+        # above skips disabled grids. Remove the widget from its grid (if the
+        # grid still exists) and dispose it.
+        for cell_id in list(self._cells):
+            grid_id = self._cell_grid.get(cell_id)
+            grid_config = (
+                self._orchestrator.peek_grid(grid_id) if grid_id is not None else None
+            )
+            if grid_config is not None and cell_id in grid_config.cells:
+                continue
+            cell_widget = self._cells.pop(cell_id)
+            self._cell_grid.pop(cell_id, None)
+            self._cell_signatures.pop(cell_id, None)
+            plot_grid = self._grid_widgets.get(grid_id) if grid_id is not None else None
+            if plot_grid is not None:
+                plot_grid.remove_widget_at(cell_widget.geometry)
+            cell_widget.dispose()
+
         # Rebuild affected cells.
         # Defer insertion to allow Bokeh to process any pending model updates
         # from pipe.send() calls above. Without deferral, widget removal can
         # race with DynamicMap updates, causing KeyError when Panel tries to
-        # access removed models.
+        # access removed models. The guard skips the insert if the cell was
+        # removed before the deferred callback runs.
         for cell_id, (cell, plot_grid) in cells_to_rebuild.items():
             view = self._build_cell(cell_id, cell).view
             pn.state.execute(
-                lambda g=cell.geometry, w=view, pg=plot_grid: pg.insert_widget_at(g, w)
+                lambda g=cell.geometry, w=view, pg=plot_grid, cid=cell_id: (
+                    pg.insert_widget_at(g, w) if cid in self._cells else None
+                )
             )
             # Bump versions only after successful rebuild — if the rebuild
             # raised, the version stays stale so the next poll retries.
@@ -798,20 +792,19 @@ class PlotGridTabs:
     def sever(self) -> None:
         """Release shared orchestrator state held by this session (tier 2).
 
-        Unsubscribes from lifecycle events and releases the session's
-        viewer/interest tokens so hidden layers stop computing. Touches only
-        shared orchestrator state, not the Bokeh document, so it is safe to call
-        from the background stale-session reaper thread and must run there
-        regardless of whether tier-1 teardown (:meth:`dispose_widgets`) ever
-        runs. Idempotent.
+        Releases the session's viewer/interest tokens so hidden layers stop
+        computing. Touches only shared orchestrator state, not the Bokeh
+        document, so it is safe to call from the background stale-session reaper
+        thread and must run there regardless of whether tier-1 teardown
+        (:meth:`dispose_widgets`) ever runs. Idempotent.
+
+        There is no lifecycle subscription to unsubscribe: topology changes are
+        observed by polling, which stops when the session's periodic callback
+        stops.
         """
-        if self._subscription_id is not None:
-            self._orchestrator.unsubscribe_from_lifecycle(self._subscription_id)
-            self._subscription_id = None
         for layer_id, session_layer in list(self._session_layers.items()):
             self._orchestrator.activate_layer(layer_id, session_layer, False)
         self._session_layers.clear()
-        self._grid_manager.shutdown()
 
     def dispose_widgets(self) -> None:
         """Dispose session-bound widgets (tier 1).

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -142,6 +142,11 @@ class PlotGridTabs:
         self._last_topology_version: int | None = None
         self._cell_signatures: dict[CellId, tuple] = {}
         self._cell_grid: dict[CellId, GridId] = {}
+        # Tab-level fingerprint of the topology (grid ids, titles, enabled, in
+        # order). Cell/layer changes bump the topology version too, but must
+        # not tear down and re-append the Tabs entries (Bokeh model churn and
+        # flicker on the active tab); the rebuild runs only when this changes.
+        self._tab_composition: tuple[tuple[GridId, str, bool], ...] | None = None
         # Set by the local grid-creation callback; the creating session's next
         # poll focuses this grid's tab. Never shared across sessions.
         self._pending_focus_grid_id: GridId | None = None
@@ -342,49 +347,62 @@ class PlotGridTabs:
     def _reconcile_topology(self) -> None:
         """Rebuild grid tabs to match orchestrator topology, preserving focus.
 
-        Runs on this session's thread (constructor or poll). Captures the
-        active tab by identity first (bypassing ``_get_active_grid_id``'s modal
-        guard, which would misreport "no active grid" while a modal is open),
-        rebuilds all grid tabs, then restores the active tab by identity. A
-        pending local-creation focus overrides the restore. Cells are
-        reconciled separately by the poll loop.
+        Runs on this session's thread (constructor or poll). The tab rebuild
+        runs only when the tab-level composition (grid ids, titles, enabled,
+        order) changed -- cell/layer edits bump the topology version too but
+        must not churn the Tabs models. For a rebuild: captures the active tab
+        by identity first (bypassing ``_get_active_grid_id``'s modal guard,
+        which would misreport "no active grid" while a modal is open), rebuilds
+        all grid tabs, then restores the active tab by identity. A pending
+        local-creation focus overrides the restore. Cells are reconciled
+        separately by the poll loop.
         """
-        # Capture the active tab by identity before the rebuild reorders tabs.
-        active_before = self._tabs.active
-        static_active = active_before < self._static_tabs_count
-        active_grid_id: GridId | None = None
-        if not static_active:
-            tabbed = self._tabbed_grid_ids()
-            idx = active_before - self._static_tabs_count
-            if 0 <= idx < len(tabbed):
-                active_grid_id = tabbed[idx]
+        all_grids = self._orchestrator.get_all_grids()
+        composition = tuple(
+            (grid_id, config.title, config.enabled)
+            for grid_id, config in all_grids.items()
+        )
+        if composition != self._tab_composition:
+            self._tab_composition = composition
 
-        self._reconcile_grid_tabs()
+            # Capture the active tab by identity before the rebuild reorders
+            # tabs.
+            active_before = self._tabs.active
+            static_active = active_before < self._static_tabs_count
+            active_grid_id: GridId | None = None
+            if not static_active:
+                tabbed = self._tabbed_grid_ids()
+                idx = active_before - self._static_tabs_count
+                if 0 <= idx < len(tabbed):
+                    active_grid_id = tabbed[idx]
 
-        # Restore the active tab by identity.
-        if static_active:
-            self._tabs.active = active_before
-        elif active_grid_id is not None:
-            tabbed = self._tabbed_grid_ids()
-            if active_grid_id in tabbed:
-                self._tabs.active = self._static_tabs_count + tabbed.index(
-                    active_grid_id
-                )
-            # else: the active grid was removed; leave Bokeh's clamped value.
+            self._reconcile_grid_tabs(all_grids)
+
+            # Restore the active tab by identity.
+            if static_active:
+                self._tabs.active = active_before
+            elif active_grid_id is not None:
+                tabbed = self._tabbed_grid_ids()
+                if active_grid_id in tabbed:
+                    self._tabs.active = self._static_tabs_count + tabbed.index(
+                        active_grid_id
+                    )
+                # else: the active grid was removed; leave Bokeh's clamped
+                # value.
 
         # A locally-created grid overrides the restore and focuses its tab.
+        # Cleared unconditionally: if the grid vanished again before this poll,
+        # the focus intent is dead.
         if self._pending_focus_grid_id is not None:
             tabbed = self._tabbed_grid_ids()
             if self._pending_focus_grid_id in tabbed:
                 self._tabs.active = self._static_tabs_count + tabbed.index(
                     self._pending_focus_grid_id
                 )
-                self._pending_focus_grid_id = None
+            self._pending_focus_grid_id = None
 
-    def _reconcile_grid_tabs(self) -> None:
+    def _reconcile_grid_tabs(self, all_grids: dict[GridId, PlotGridConfig]) -> None:
         """Rebuild grid tabs to match orchestrator state (order, titles, enabled)."""
-        all_grids = self._orchestrator.get_all_grids()
-
         # Rebuild _grid_widgets in orchestrator order, preserving existing widgets
         old_widgets = self._grid_widgets
         self._grid_widgets = {}
@@ -428,8 +446,13 @@ class PlotGridTabs:
 
         def on_success(plot_config: PlotConfig) -> None:
             """Handle successful plot configuration."""
-            cell_id = self._orchestrator.add_cell(grid_id, geometry)
-            self._orchestrator.add_layer(cell_id, plot_config)
+            try:
+                cell_id = self._orchestrator.add_cell(grid_id, geometry)
+                self._orchestrator.add_layer(cell_id, plot_config)
+            except KeyError:
+                # The grid vanished while the modal was open (removed or
+                # replaced by another session).
+                show_error('Cannot add plot: the grid was removed.')
 
         self._show_config_modal(on_success=on_success)
 
@@ -450,10 +473,20 @@ class PlotGridTabs:
             """Handle successful layer reconfiguration."""
             try:
                 self._orchestrator.update_layer_config(layer_id, plot_config)
+            except KeyError:
+                # The layer vanished while the modal was open (removed by
+                # another session).
+                show_error('Cannot apply changes: the plot was removed.')
             except ValueError as e:
                 show_error(str(e))
 
-        current_config = self._orchestrator.get_layer_config(layer_id)
+        try:
+            current_config = self._orchestrator.get_layer_config(layer_id)
+        except KeyError:
+            # Gear click raced a removal in another session within the poll
+            # window; the widget disappears on the next poll.
+            show_error('The plot was removed.')
+            return
         self._show_config_modal(on_success=on_success, initial_config=current_config)
 
     def _on_add_layer(self, cell_id: CellId) -> None:
@@ -473,6 +506,10 @@ class PlotGridTabs:
             """Handle successful layer configuration."""
             try:
                 self._orchestrator.add_layer(cell_id, plot_config)
+            except KeyError:
+                # The cell vanished while the modal was open (removed by
+                # another session).
+                show_error('Cannot add layer: the cell was removed.')
             except ValueError as e:
                 show_error(str(e))
 
@@ -610,7 +647,7 @@ class PlotGridTabs:
             self._reconcile_topology()
             self._grid_manager.on_topology_changed()
 
-        cells_to_rebuild: dict[CellId, tuple[PlotCell, PlotGrid]] = {}
+        cells_to_rebuild: dict[CellId, tuple[PlotCell, PlotGrid, GridId]] = {}
         versions_to_apply: dict[LayerId, int] = {}
         seen_layer_ids: set[LayerId] = set()
         # Per-cell, per-layer time bounds for active-grid cells, driving the
@@ -653,9 +690,7 @@ class PlotGridTabs:
                 if cell_id not in self._cells or signature != self._cell_signatures.get(
                     cell_id
                 ):
-                    cells_to_rebuild[cell_id] = (cell, plot_grid)
-                    self._cell_signatures[cell_id] = signature
-                    self._cell_grid[cell_id] = grid_id
+                    cells_to_rebuild[cell_id] = (cell, plot_grid, grid_id)
 
                 for layer in cell.layers:
                     layer_id = layer.layer_id
@@ -687,11 +722,11 @@ class PlotGridTabs:
                         )
                         self._session_layers[layer_id] = session_layer
                         # New layer → rebuild cell
-                        cells_to_rebuild[cell_id] = (cell, plot_grid)
+                        cells_to_rebuild[cell_id] = (cell, plot_grid, grid_id)
                     else:
                         # Check for version changes (plotter changes increment version)
                         if state.version != session_layer.last_seen_version:
-                            cells_to_rebuild[cell_id] = (cell, plot_grid)
+                            cells_to_rebuild[cell_id] = (cell, plot_grid, grid_id)
                             versions_to_apply[layer_id] = state.version
 
                     # Drive the layer compute gate: on 0→1 the orchestrator
@@ -744,15 +779,18 @@ class PlotGridTabs:
         # race with DynamicMap updates, causing KeyError when Panel tries to
         # access removed models. The guard skips the insert if the cell was
         # removed before the deferred callback runs.
-        for cell_id, (cell, plot_grid) in cells_to_rebuild.items():
+        for cell_id, (cell, plot_grid, grid_id) in cells_to_rebuild.items():
             view = self._build_cell(cell_id, cell).view
             pn.state.execute(
                 lambda g=cell.geometry, w=view, pg=plot_grid, cid=cell_id: (
                     pg.insert_widget_at(g, w) if cid in self._cells else None
                 )
             )
-            # Bump versions only after successful rebuild — if the rebuild
-            # raised, the version stays stale so the next poll retries.
+            # Record signature/grid and bump versions only after a successful
+            # rebuild — if _build_cell raised, the stale records make the next
+            # poll retry.
+            self._cell_signatures[cell_id] = self._cell_signature(cell)
+            self._cell_grid[cell_id] = grid_id
             for layer in cell.layers:
                 if layer.layer_id in versions_to_apply:
                     sl = self._session_layers.get(layer.layer_id)

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -12,7 +12,6 @@ from ess.livedata.dashboard.plot_orchestrator import (
     DataSourceConfig,
     GridId,
     PlotConfig,
-    PlotGridConfig,
     PlotOrchestrator,
 )
 from ess.livedata.dashboard.plots import PresenterBase
@@ -88,69 +87,6 @@ class FakePresenter(PresenterBase):
         import holoviews as hv
 
         return hv.DynamicMap(self._plotter, streams=[pipe], cache_size=1)
-
-
-class CallbackCapture:
-    """Captures callback invocations for testing."""
-
-    def __init__(self, side_effect: BaseException | None = None):
-        """Initialize callback capture.
-
-        Parameters
-        ----------
-        side_effect:
-            Optional exception to raise when called.
-        """
-        self._calls: list[tuple] = []
-        self._side_effect = side_effect
-
-    def __call__(self, *args, **kwargs) -> None:
-        """Record call and optionally raise exception."""
-        self._calls.append((args, kwargs))
-        if self._side_effect is not None:
-            raise self._side_effect
-
-    @property
-    def call_count(self) -> int:
-        """Return the number of calls."""
-        return len(self._calls)
-
-    @property
-    def call_args(self) -> tuple:
-        """Return the arguments of the last call.
-
-        Returns a tuple of (args, kwargs) tuples for Mock-like compatibility.
-        """
-        if not self._calls:
-            raise AssertionError("No calls recorded")
-        args, kwargs = self._calls[-1]
-        # Return in Mock-compatible format: call_args[0] gets positional args
-        return (args, kwargs)
-
-    def assert_called_once(self) -> None:
-        """Assert that callback was called exactly once."""
-        assert self.call_count == 1, f"Expected 1 call, got {self.call_count}"
-
-    def assert_called_once_with(self, *args, **kwargs) -> None:
-        """Assert that callback was called once with specific arguments."""
-        self.assert_called_once()
-        last_args, last_kwargs = self._calls[-1]
-        assert last_args == args, f"Expected args {args}, got {last_args}"
-        assert last_kwargs == kwargs, f"Expected kwargs {kwargs}, got {last_kwargs}"
-
-    def assert_called_with(self, *args, **kwargs) -> None:
-        """Assert that callback was called with specific arguments."""
-        if not any(
-            call_args == args and call_kwargs == kwargs
-            for call_args, call_kwargs in self._calls
-        ):
-            raise AssertionError(
-                f"Not called with args {args}, kwargs {kwargs}. Calls: {self._calls}"
-            )
-
-    def assert_not_called(self) -> None:
-        """Assert that callback was not called."""
-        assert self.call_count == 0, f"Expected 0 calls, got {self.call_count}"
 
 
 class FakePipe:
@@ -875,248 +811,178 @@ class TestWorkflowIntegrationAndPlotCreationTiming:
         assert plotter.compute_calls
 
 
-class TestLifecycleEventNotifications:
-    """Tests for lifecycle event notifications."""
+class TestTopologyVersion:
+    """The topology version bumps on every grid/cell/layer change, and only on
+    those -- sessions poll it to reconcile their widgets (replaces the former
+    push-based lifecycle notifications)."""
 
-    def test_on_grid_created_called_with_correct_grid_id_and_config(
-        self, plot_orchestrator
-    ):
-        """on_grid_created called with correct grid_id and config."""
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_created=callback)
+    def test_add_grid_bumps_version(self, plot_orchestrator):
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=4)
+        assert plot_orchestrator.topology_version() > before
 
-        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=4)
-
-        callback.assert_called_once()
-        call_args = callback.call_args[0]
-        assert call_args[0] == grid_id
-        assert isinstance(call_args[1], PlotGridConfig)
-        assert call_args[1].title == 'Test Grid'
-        assert call_args[1].nrows == 3
-        assert call_args[1].ncols == 4
-
-    def test_on_grid_removed_called_when_grid_removed(self, plot_orchestrator):
-        """on_grid_removed called when grid removed."""
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_removed=callback)
-
+    def test_remove_grid_bumps_version(self, plot_orchestrator):
         grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
+        before = plot_orchestrator.topology_version()
         plot_orchestrator.remove_grid(grid_id)
+        assert plot_orchestrator.topology_version() > before
 
-        callback.assert_called_once_with(grid_id)
+    def test_rename_grid_bumps_version(self, plot_orchestrator):
+        grid_id = plot_orchestrator.add_grid(title='Old', nrows=3, ncols=3)
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.rename_grid(grid_id, 'New')
+        assert plot_orchestrator.topology_version() > before
 
-    def test_on_cell_updated_called_when_cell_added_no_plot_yet(
-        self, plot_orchestrator, plot_cell
-    ):
-        """on_cell_updated called when cell added (no plot yet)."""
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_cell_updated=callback)
+    def test_move_grid_bumps_version(self, plot_orchestrator):
+        id_a = plot_orchestrator.add_grid(title='A', nrows=2, ncols=2)
+        plot_orchestrator.add_grid(title='B', nrows=2, ncols=2)
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.move_grid(id_a, 1)
+        assert plot_orchestrator.topology_version() > before
 
+    def test_set_grid_enabled_bumps_version(self, plot_orchestrator):
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.set_grid_enabled(grid_id, enabled=False)
+        assert plot_orchestrator.topology_version() > before
+
+    def test_replace_grid_bumps_version(self, plot_orchestrator):
+        grid_id = plot_orchestrator.add_grid(title='X', nrows=2, ncols=2)
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.replace_grid(grid_id, 'Y', nrows=3, ncols=3)
+        assert plot_orchestrator.topology_version() > before
+
+    def test_add_cell_and_layer_bump_version(self, plot_orchestrator, plot_cell):
+        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
+        before = plot_orchestrator.topology_version()
+        add_cell_with_layer(plot_orchestrator, grid_id, plot_cell[0], plot_cell[1])
+        assert plot_orchestrator.topology_version() > before
+
+    def test_remove_cell_bumps_version(self, plot_orchestrator, plot_cell):
         grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
         cell_id = add_cell_with_layer(
             plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
         )
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.remove_cell(cell_id)
+        assert plot_orchestrator.topology_version() > before
 
-        callback.assert_called_once()
-        call_kwargs = callback.call_args[1]
-        assert call_kwargs['grid_id'] == grid_id
-        assert call_kwargs['cell_id'] == cell_id
-        # Verify cell has correct geometry and layer config
-        cell = call_kwargs['cell']
-        assert cell.geometry == plot_cell[0]
-        assert len(cell.layers) == 1
-        assert cell.layers[0].config == plot_cell[1]
-        # Callback now has simplified signature (just config, no state)
-        assert set(call_kwargs.keys()) == {'grid_id', 'cell_id', 'cell'}
+    def test_remove_layer_bumps_version(self, plot_orchestrator, workflow_id):
+        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
+        cell_id = plot_orchestrator.add_cell(grid_id, DEFAULT_GEOMETRY)
+        plot_orchestrator.add_layer(cell_id, make_plot_config(workflow_id))
+        layer_id = plot_orchestrator.add_layer(cell_id, make_plot_config(workflow_id))
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.remove_layer(layer_id)
+        assert plot_orchestrator.topology_version() > before
 
-    def test_on_cell_updated_called_when_cell_added_not_on_data_arrival(
+    def test_update_layer_config_bumps_version(
+        self, plot_orchestrator, plot_cell, workflow_id
+    ):
+        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
+        )
+        layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.update_layer_config(
+            layer_id,
+            make_plot_config(
+                workflow_id,
+                source_names=['new_source'],
+                output_name='new_output',
+                plot_name='new_plot',
+                params=FakePlotParams(),
+            ),
+        )
+        assert plot_orchestrator.topology_version() > before
+
+    def test_set_cell_title_bumps_version(
+        self, plot_orchestrator, plot_cell, workflow_id
+    ):
+        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
+        cell_id = add_cell_with_layer(
+            plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
+        )
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.set_cell_title(cell_id, 'Renamed')
+        assert plot_orchestrator.topology_version() > before
+
+    def test_flush_frames_does_not_bump_version(
         self,
         plot_orchestrator,
         plot_cell,
         workflow_id,
         workflow_spec,
         job_orchestrator,
-        fake_plotting_controller,
         fake_data_service,
     ):
-        """on_cell_updated called only when cell added, not on data arrival."""
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_cell_updated=callback)
-
-        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
-        cell_id = add_cell_with_layer(
-            plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
-        )
-
-        # Should have been called once when cell was added
-        assert callback.call_count == 1
-        call_kwargs = callback.call_args[1]
-        assert call_kwargs['grid_id'] == grid_id
-        assert call_kwargs['cell_id'] == cell_id
-
-        # Commit workflow
-        commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
-
-        # Simulate data arrival for ALL sources
+        """Pure data flow (commit + data arrival + flush) must not bump the
+        topology version: it is not a topology change."""
         import scipp as sc
 
         from ess.livedata.config.workflow_spec import DataKey
 
-        for source_name in plot_cell[1].source_names:
-            result_key = DataKey(
-                workflow_id=workflow_id,
-                source_name=source_name,
-                output_name=plot_cell[1].view_name,
-            )
-            fake_data_service[result_key] = sc.scalar(1.0)
-
-        # Still only called once (no notification on workflow commit or data arrival)
-        # Sessions poll PlotDataService directly instead
-        assert callback.call_count == 1
-
-    def test_on_cell_updated_called_when_plot_fails_with_error_message(
-        self,
-        plot_orchestrator,
-        plot_cell,
-        workflow_id,
-        workflow_spec,
-        job_orchestrator,
-        fake_plotting_controller,
-        fake_data_service,
-        plot_data_service,
-    ):
-        """on_cell_updated called when plot creation fails (with error message)."""
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_cell_updated=callback)
-
         grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
         add_cell_with_layer(plot_orchestrator, grid_id, plot_cell[0], plot_cell[1])
 
-        # Should have been called once when cell was added
-        assert callback.call_count == 1
-        call_kwargs = callback.call_args[1]
-        cell = call_kwargs['cell']
-        layer_id = cell.layers[0].layer_id
-
-        # Configure controller to raise on the plotter re-creation that a
-        # commit's presentation reset triggers
-        fake_plotting_controller.configure_to_raise(ValueError('Test error'))
-
         commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
+        after_setup = plot_orchestrator.topology_version()
+
+        for source_name in plot_cell[1].source_names:
+            fake_data_service[
+                DataKey(
+                    workflow_id=workflow_id,
+                    source_name=source_name,
+                    output_name=plot_cell[1].view_name,
+                )
+            ] = sc.scalar(1.0)
         plot_orchestrator.sync_job_states()
+        plot_orchestrator.flush_frames()
 
-        # Only 1 call - initial cell creation
-        # Error state changes are now detected via polling, not callbacks
-        assert callback.call_count == 1
+        assert plot_orchestrator.topology_version() == after_setup
 
-        # Error is stored in PlotDataService for polling-based detection
-        state = plot_data_service.get(layer_id)
-        assert state is not None
-        assert state.error_message is not None
-        assert 'Test error' in state.error_message
 
-    def test_on_cell_updated_called_when_layer_config_updated_no_plot_yet(
-        self, plot_orchestrator, plot_cell, workflow_id
-    ):
-        """on_cell_updated called when layer config updated (no plot yet)."""
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_cell_updated=callback)
+class TestTopologyReadPathsTolerateConcurrentRemoval:
+    """The update-thread read paths must not raise when the IOLoop thread
+    removed the layer they hold a handle to (Hazard 1). Deletes are leaf-first
+    and the reads tolerate the resulting KeyError; this exercises that
+    deterministically without threads."""
 
-        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
+    def _setup_layer(self, plot_orchestrator, workflow_id):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         cell_id = add_cell_with_layer(
-            plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
+            plot_orchestrator, grid_id, DEFAULT_GEOMETRY, make_plot_config(workflow_id)
         )
+        return plot_orchestrator.get_cell(cell_id).layers[0].layer_id
 
-        # Get layer_id for the cell
-        grid = plot_orchestrator.get_grid(grid_id)
-        layer_id = grid.cells[cell_id].layers[0].layer_id
-
-        # Update config
-        new_config = make_plot_config(
-            workflow_id,
-            source_names=['new_source'],
-            output_name='new_output',
-            plot_name='new_plot',
-            params=FakePlotParams(),
-        )
-        plot_orchestrator.update_layer_config(layer_id, new_config)
-
-        # Should have been called twice (add + update)
-        assert callback.call_count == 2
-        # Callback now has simplified signature (just config, no state)
-        call_kwargs = callback.call_args[1]
-        assert set(call_kwargs.keys()) == {'grid_id', 'cell_id', 'cell'}
-
-    def test_on_cell_removed_called_when_cell_removed(
-        self, plot_orchestrator, plot_cell
+    def test_mark_layer_dirty_after_removal_does_not_raise(
+        self, plot_orchestrator, workflow_id
     ):
-        """on_cell_removed called when cell removed."""
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_cell_removed=callback)
+        layer_id = self._setup_layer(plot_orchestrator, workflow_id)
+        plot_orchestrator.remove_layer(layer_id)
+        # No cell mapping remains; the mark is silently dropped.
+        plot_orchestrator._mark_layer_dirty(layer_id)
 
-        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
-        cell_id = add_cell_with_layer(
-            plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
-        )
-        plot_orchestrator.remove_cell(cell_id)
-
-        callback.assert_called_once()
-        call_args = callback.call_args[0]
-        assert call_args[0] == grid_id
-        # Verify the removed cell's geometry matches
-        assert call_args[1] == plot_cell[0]
-
-    def test_multiple_subscribers_all_receive_notifications(self, plot_orchestrator):
-        """Multiple subscribers all receive notifications."""
-        callback_1 = CallbackCapture()
-        callback_2 = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_created=callback_1)
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_created=callback_2)
-
-        plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
-
-        callback_1.assert_called_once()
-        callback_2.assert_called_once()
-
-    def test_unsubscribe_prevents_further_notifications(self, plot_orchestrator):
-        """Unsubscribe prevents further notifications."""
-        callback = CallbackCapture()
-        subscription_id = plot_orchestrator.subscribe_to_lifecycle(
-            on_grid_created=callback
-        )
-
-        plot_orchestrator.add_grid(title='Grid 1', nrows=3, ncols=3)
-        assert callback.call_count == 1
-
-        # Unsubscribe
-        plot_orchestrator.unsubscribe_from_lifecycle(subscription_id)
-
-        plot_orchestrator.add_grid(title='Grid 2', nrows=3, ncols=3)
-        # Should still be 1 (not called for Grid 2)
-        assert callback.call_count == 1
-
-    def test_late_subscriber_does_not_receive_events_for_existing_grids(
-        self, plot_orchestrator
+    def test_pull_and_build_after_removal_returns_false(
+        self, plot_orchestrator, workflow_id
     ):
-        """Late subscriber doesn't receive events for existing grids."""
-        # Add grid before subscribing
-        plot_orchestrator.add_grid(title='Existing Grid', nrows=3, ncols=3)
+        layer_id = self._setup_layer(plot_orchestrator, workflow_id)
+        plot_orchestrator.remove_layer(layer_id)
+        assert plot_orchestrator._pull_and_build(layer_id) is False
 
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_created=callback)
-
-        # Should not have been called for existing grid
-        callback.assert_not_called()
-
-        # Should be called for new grids
-        plot_orchestrator.add_grid(title='New Grid', nrows=3, ncols=3)
-        callback.assert_called_once()
+    def test_reset_layer_presentation_after_removal_does_not_raise(
+        self, plot_orchestrator, workflow_id
+    ):
+        layer_id = self._setup_layer(plot_orchestrator, workflow_id)
+        plot_orchestrator.remove_layer(layer_id)
+        plot_orchestrator._reset_layer_presentation(layer_id)
 
 
 class TestErrorHandling:
     """Tests for error handling."""
 
-    def test_plotting_controller_raises_exception_calls_on_cell_updated_with_error(
+    def test_plotting_controller_raises_exception_stores_error_in_plot_data_service(
         self,
         plot_orchestrator,
         plot_cell,
@@ -1128,35 +994,24 @@ class TestErrorHandling:
         plot_data_service,
     ):
         """PlottingController exception stores error in PlotDataService."""
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_cell_updated=callback)
-
         grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
         cell_id = add_cell_with_layer(
             plot_orchestrator, grid_id, plot_cell[0], plot_cell[1]
         )
+        layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
 
-        # Should have been called once when cell was added
-        assert callback.call_count == 1
-        cell = plot_orchestrator.get_cell(cell_id)
-        layer_id = cell.layers[0].layer_id
+        # Configure controller to raise on the plotter re-creation that a
+        # commit's presentation reset triggers.
+        fake_plotting_controller.configure_to_raise(ValueError('Test error'))
 
-        fake_plotting_controller.configure_to_raise(
-            RuntimeError('Plot creation failed')
-        )
-        # Commit + poll: the presentation reset re-creates the plotter, failing
         commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
         plot_orchestrator.sync_job_states()
-
-        # Only 1 call - initial cell creation
-        # Error state changes are now detected via polling, not callbacks
-        assert callback.call_count == 1
 
         # Error is stored in PlotDataService for polling-based detection
         state = plot_data_service.get(layer_id)
         assert state is not None
         assert state.error_message is not None
-        assert 'Plot creation failed' in state.error_message
+        assert 'Test error' in state.error_message
 
     def test_plotting_controller_raises_exception_orchestrator_remains_usable(
         self,
@@ -1181,35 +1036,6 @@ class TestErrorHandling:
         # Orchestrator should still be usable
         fake_plotting_controller.reset()
         plot_orchestrator.remove_cell(cell_id)
-        assert plot_orchestrator.get_grid(grid_id) is not None
-
-    def test_lifecycle_callback_raises_exception_other_callbacks_still_invoked(
-        self, plot_orchestrator
-    ):
-        """Lifecycle callback raises exception but other callbacks still invoked."""
-        failing_callback = CallbackCapture(side_effect=RuntimeError('Callback failed'))
-        working_callback = CallbackCapture()
-
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_created=failing_callback)
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_created=working_callback)
-
-        plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
-
-        # Both should have been called
-        failing_callback.assert_called_once()
-        working_callback.assert_called_once()
-
-    def test_lifecycle_callback_raises_exception_orchestrator_remains_usable(
-        self, plot_orchestrator
-    ):
-        """Lifecycle callback raises exception but orchestrator remains usable."""
-        failing_callback = CallbackCapture(side_effect=RuntimeError('Callback failed'))
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_created=failing_callback)
-
-        plot_orchestrator.add_grid(title='Grid 1', nrows=3, ncols=3)
-
-        # Should still be able to add more grids
-        grid_id = plot_orchestrator.add_grid(title='Grid 2', nrows=3, ncols=3)
         assert plot_orchestrator.get_grid(grid_id) is not None
 
 
@@ -2242,17 +2068,6 @@ class TestRenameGrid:
         grids = plot_orchestrator.get_all_grids()
         assert grids[grid_id].title == 'New Title'
 
-    def test_rename_grid_notifies_subscribers(self, plot_orchestrator):
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_updated=callback)
-
-        grid_id = plot_orchestrator.add_grid(title='Old', nrows=3, ncols=3)
-        plot_orchestrator.rename_grid(grid_id, 'New')
-
-        callback.assert_called_once()
-        assert callback.call_args[0][0] == grid_id
-        assert callback.call_args[0][1].title == 'New'
-
     def test_rename_grid_persists(self, plot_orchestrator):
         """Rename triggers persistence (no error from _persist_to_store)."""
         grid_id = plot_orchestrator.add_grid(title='Before', nrows=2, ncols=2)
@@ -2299,16 +2114,12 @@ class TestMoveGrid:
         keys = list(plot_orchestrator.get_all_grids().keys())
         assert keys == [id_a, id_b]
 
-    def test_move_grid_notifies_subscribers(self, plot_orchestrator):
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_updated=callback)
-
-        id_a = plot_orchestrator.add_grid(title='A', nrows=2, ncols=2)
-        plot_orchestrator.add_grid(title='B', nrows=2, ncols=2)
-
-        plot_orchestrator.move_grid(id_a, 1)
-
-        callback.assert_called_once()
+    def test_move_grid_missing_id_is_noop(self, plot_orchestrator):
+        """A move for a grid another session removed is a silent no-op."""
+        plot_orchestrator.add_grid(title='A', nrows=2, ncols=2)
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.move_grid(GridId(uuid.uuid4()), 1)
+        assert plot_orchestrator.topology_version() == before
 
 
 class TestSetGridEnabled:
@@ -2328,16 +2139,6 @@ class TestSetGridEnabled:
 
         grids = plot_orchestrator.get_all_grids()
         assert grids[grid_id].enabled is True
-
-    def test_set_grid_enabled_notifies_subscribers(self, plot_orchestrator):
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_grid_updated=callback)
-
-        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
-        plot_orchestrator.set_grid_enabled(grid_id, enabled=False)
-
-        callback.assert_called_once()
-        assert callback.call_args[0][1].enabled is False
 
     def test_disabled_grid_serialized(self, plot_orchestrator):
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
@@ -2385,21 +2186,6 @@ class TestCellTitle:
         cell_id = plot_orchestrator.add_cell(grid_id, DEFAULT_GEOMETRY, user_title='X')
         plot_orchestrator.set_cell_title(cell_id, '')
         assert plot_orchestrator.get_cell(cell_id).user_title is None
-
-    def test_set_cell_title_notifies_cell_updated(self, plot_orchestrator, workflow_id):
-        callback = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(on_cell_updated=callback)
-        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
-        cell_id = add_cell_with_layer(
-            plot_orchestrator,
-            grid_id,
-            DEFAULT_GEOMETRY,
-            make_plot_config(workflow_id),
-        )
-        before = callback.call_count
-        plot_orchestrator.set_cell_title(cell_id, 'Renamed')
-        assert callback.call_count == before + 1
-        assert callback.call_args[1]['cell'].user_title == 'Renamed'
 
     def test_user_title_serialized_when_set(self, plot_orchestrator, workflow_id):
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
@@ -2519,23 +2305,12 @@ class TestReplaceGrid:
         assert plot_orchestrator.get_grid(new_id).title == 'B2'
         assert plot_orchestrator.get_grid(new_id).nrows == 4
 
-    def test_replace_fires_removed_then_created(self, plot_orchestrator):
-        removed = CallbackCapture()
-        created = CallbackCapture()
-        plot_orchestrator.subscribe_to_lifecycle(
-            on_grid_removed=removed, on_grid_created=created
-        )
-
+    def test_replace_returns_new_grid_id(self, plot_orchestrator):
         grid_id = plot_orchestrator.add_grid(title='X', nrows=2, ncols=2)
-        # Reset counters after add_grid fires on_grid_created
-        created._calls.clear()
-
         new_id = plot_orchestrator.replace_grid(grid_id, 'Y', nrows=3, ncols=3)
-
-        removed.assert_called_once()
-        assert removed.call_args[0][0] == grid_id
-        created.assert_called_once()
-        assert created.call_args[0][0] == new_id
+        assert new_id != grid_id
+        assert plot_orchestrator.get_grid(grid_id) is None
+        assert plot_orchestrator.get_grid(new_id).title == 'Y'
 
     def test_replace_cleans_up_old_cells(self, plot_orchestrator, plot_cell):
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=3, ncols=3)

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -6,9 +6,14 @@ import uuid
 import pydantic
 import pytest
 
-from ess.livedata.dashboard.plot_data_service import LayerState, PlotDataService
+from ess.livedata.dashboard.plot_data_service import (
+    LayerId,
+    LayerState,
+    PlotDataService,
+)
 from ess.livedata.dashboard.plot_orchestrator import (
     CellGeometry,
+    CellId,
     DataSourceConfig,
     GridId,
     PlotConfig,
@@ -977,6 +982,48 @@ class TestTopologyReadPathsTolerateConcurrentRemoval:
         layer_id = self._setup_layer(plot_orchestrator, workflow_id)
         plot_orchestrator.remove_layer(layer_id)
         plot_orchestrator._reset_layer_presentation(layer_id)
+
+
+class TestMissingIdsAcrossSessions:
+    """Ids can vanish between a session's poll and its click (another session
+    removed them). Mutators of a gone target are silent no-ops, matching the
+    grid-level mutators; creators/updaters, whose user input would otherwise be
+    dropped silently, raise KeyError for the widget layer to surface."""
+
+    def test_remove_cell_missing_id_is_noop(self, plot_orchestrator):
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.remove_cell(CellId(uuid.uuid4()))
+        assert plot_orchestrator.topology_version() == before
+
+    def test_set_cell_title_missing_id_is_noop(self, plot_orchestrator):
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.set_cell_title(CellId(uuid.uuid4()), 'Title')
+        assert plot_orchestrator.topology_version() == before
+
+    def test_remove_layer_missing_id_is_noop(self, plot_orchestrator):
+        before = plot_orchestrator.topology_version()
+        plot_orchestrator.remove_layer(LayerId(uuid.uuid4()))
+        assert plot_orchestrator.topology_version() == before
+
+    def test_update_layer_config_missing_layer_raises_key_error(
+        self, plot_orchestrator, workflow_id
+    ):
+        with pytest.raises(KeyError, match='no longer exists'):
+            plot_orchestrator.update_layer_config(
+                LayerId(uuid.uuid4()), make_plot_config(workflow_id)
+            )
+
+    def test_add_layer_missing_cell_raises_key_error(
+        self, plot_orchestrator, workflow_id
+    ):
+        with pytest.raises(KeyError, match='no longer exists'):
+            plot_orchestrator.add_layer(
+                CellId(uuid.uuid4()), make_plot_config(workflow_id)
+            )
+
+    def test_add_cell_missing_grid_raises_key_error(self, plot_orchestrator):
+        with pytest.raises(KeyError, match='no longer exists'):
+            plot_orchestrator.add_cell(GridId(uuid.uuid4()), DEFAULT_GEOMETRY)
 
 
 class TestErrorHandling:

--- a/tests/dashboard/widgets/plot_grid_manager_test.py
+++ b/tests/dashboard/widgets/plot_grid_manager_test.py
@@ -86,52 +86,32 @@ class TestPlotGridManagerInitialization:
 class TestMultipleManagers:
     """Tests for multiple manager instances (multi-user scenario)."""
 
-    def test_multiple_managers_stay_synchronized(
+    def test_managers_refresh_grid_list_on_topology_change(
         self, plot_orchestrator, workflow_registry
     ):
-        """Test that multiple managers sharing same orchestrator stay in sync."""
-        # Create managers which register as callbacks with orchestrator
-        _manager1 = PlotGridManager(
+        """Each manager rebuilds its grid list when its owner reports a topology
+        change (the owning PlotGridTabs polls and calls on_topology_changed)."""
+        manager1 = PlotGridManager(
             orchestrator=plot_orchestrator, workflow_registry=workflow_registry
         )
-        _manager2 = PlotGridManager(
+        manager2 = PlotGridManager(
             orchestrator=plot_orchestrator, workflow_registry=workflow_registry
         )
 
-        # Add grid via orchestrator
-        grid_id = plot_orchestrator.add_grid(title='Shared Grid', nrows=3, ncols=3)
+        plot_orchestrator.add_grid(title='Shared Grid', nrows=3, ncols=3)
+        manager1.on_topology_changed()
+        manager2.on_topology_changed()
 
-        # Both managers should react - verify via orchestrator
-        assert len(plot_orchestrator.get_all_grids()) == 1
-        assert grid_id in plot_orchestrator.get_all_grids()
+        # Both managers show one grid row.
+        assert len(manager1._grid_list.objects) == 1
+        assert len(manager2._grid_list.objects) == 1
 
-        # Remove grid via orchestrator
-        plot_orchestrator.remove_grid(grid_id)
+        plot_orchestrator.remove_grid(next(iter(plot_orchestrator.get_all_grids())))
+        manager1.on_topology_changed()
+        manager2.on_topology_changed()
 
-        # Both managers should reflect removal - verify via orchestrator
-        assert len(plot_orchestrator.get_all_grids()) == 0
-
-
-class TestShutdown:
-    """Tests for manager shutdown and cleanup."""
-
-    def test_shutdown_unsubscribes_from_lifecycle(
-        self, plot_orchestrator, grid_manager
-    ):
-        """Test that shutdown unsubscribes from orchestrator lifecycle."""
-        # Shutdown the manager
-        grid_manager.shutdown()
-
-        # Adding a grid should not cause errors even though manager is shut down
-        plot_orchestrator.add_grid(title='After Shutdown', nrows=3, ncols=3)
-
-        # Verify grid was added to orchestrator (manager is just unsubscribed)
-        assert len(plot_orchestrator.get_all_grids()) == 1
-
-    def test_shutdown_can_be_called_multiple_times(self, grid_manager):
-        """Test that shutdown is idempotent."""
-        grid_manager.shutdown()
-        grid_manager.shutdown()  # Should not raise
+        assert len(manager1._grid_list.objects) == 0
+        assert len(manager2._grid_list.objects) == 0
 
 
 class TestSanitizeFilename:
@@ -436,23 +416,18 @@ cells:
         assert grid_manager._nrows_input.value == 3
         assert grid_manager._ncols_input.value == 3
 
-    def test_upload_triggers_lifecycle_on_add(
+    def test_upload_then_add_reports_local_grid_creation(
         self, plot_orchestrator, workflow_registry
     ):
-        """Test that Add Grid after upload triggers lifecycle callback."""
+        """Add Grid after upload creates the grid and reports it as a local
+        creation (so the owning session can focus the new tab)."""
         from ess.livedata.dashboard.widgets.plot_grid_manager import _MODE_UPLOAD
 
-        created_grids = []
-
-        # Subscribe to lifecycle events
-        plot_orchestrator.subscribe_to_lifecycle(
-            on_grid_created=lambda grid_id, config: created_grids.append(
-                (grid_id, config)
-            ),
-        )
-
+        created_local: list = []
         manager = PlotGridManager(
-            orchestrator=plot_orchestrator, workflow_registry=workflow_registry
+            orchestrator=plot_orchestrator,
+            workflow_registry=workflow_registry,
+            on_local_grid_created=created_local.append,
         )
 
         # Switch to Upload mode
@@ -465,15 +440,17 @@ cells:
 
         manager._on_file_uploaded(FakeEvent())
 
-        # No callback yet - grid not created
-        assert len(created_grids) == 0
+        # No grid yet.
+        assert len(created_local) == 0
+        assert len(plot_orchestrator.get_all_grids()) == 0
 
-        # Now click Add Grid
+        # Now click Add Grid.
         manager._on_add_grid(None)
 
-        # Lifecycle callback should have been called
-        assert len(created_grids) == 1
-        assert created_grids[0][1].title == 'Sync Test'
+        assert len(created_local) == 1
+        grids = plot_orchestrator.get_all_grids()
+        assert created_local[0] in grids
+        assert grids[created_local[0]].title == 'Sync Test'
 
     def test_upload_none_value_is_ignored(self, grid_manager, plot_orchestrator):
         """Test that None value (cleared file input) is ignored."""
@@ -990,7 +967,10 @@ class TestEditMode:
         grid_manager._enter_edit_mode(grid_id)
         assert grid_manager._editing_grid_id is not None
 
+        # Another session removes the edited grid; the owning tabs widget polls
+        # and notifies the manager, which exits edit mode.
         plot_orchestrator.remove_grid(grid_id)
+        grid_manager.on_topology_changed()
 
         assert grid_manager._editing_grid_id is None
         assert grid_manager._editing_cells is None

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -202,9 +202,9 @@ class TestPollHandlesLayoutPlotters:
         """First poll with a Layout plotter creates a session layer with components."""
         plotter = FakePlotter(cached_state=_make_layout())
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
-        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         layer_id = _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
 
+        # First poll adds the grid tab and builds the cell/session layer.
         plot_grid_tabs._poll_for_plot_updates()
 
         session_layer = plot_grid_tabs._session_layers.get(layer_id)
@@ -220,7 +220,6 @@ class TestPollHandlesLayoutPlotters:
         """
         plotter = FakePlotter(cached_state=_make_layout())
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
-        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         layer_id = _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
 
         plot_grid_tabs._poll_for_plot_updates()
@@ -276,9 +275,12 @@ class TestFreshnessIndicator:
         )
         plotter = FakePlotter(cached_state=_make_layout(), time_bounds=bounds)
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
-        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
 
+        # First poll adds the tab and builds the cell; activate then poll again
+        # so the freshness pane fills for the now-active grid.
+        plot_grid_tabs._poll_for_plot_updates()
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         plot_grid_tabs._poll_for_plot_updates()
 
         panes = [cw.freshness_pane for cw in plot_grid_tabs._cells.values()]
@@ -316,7 +318,6 @@ class TestFreshnessIndicator:
             max_end=Timestamp.from_ns(now_ns - int(1e9)),
         )
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
-        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
 
         cell_id = CellId(uuid4())
         l1, l2 = LayerId(uuid4()), LayerId(uuid4())
@@ -348,6 +349,10 @@ class TestFreshnessIndicator:
             )
             plot_data_service.data_arrived(lid)
 
+        # First poll adds the tab and builds the cell; activate then poll again
+        # so the per-layer time panes fill for the now-active grid.
+        plot_grid_tabs._poll_for_plot_updates()
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         plot_grid_tabs._poll_for_plot_updates()
 
         cell_widget = plot_grid_tabs._cells[cell_id]

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -107,6 +107,17 @@ def plot_grid_tabs(
     )
 
 
+def _tick(*widgets: PlotGridTabs) -> None:
+    """Drive one poll cycle for each widget.
+
+    Under polling, tab/cell reconciliation happens on the session's periodic
+    callback rather than on a push from the orchestrator, so tests must poll
+    explicitly after mutating shared state.
+    """
+    for widget in widgets:
+        widget._poll_for_plot_updates()
+
+
 class TestPlotGridTabsInitialization:
     """Tests for PlotGridTabs initialization."""
 
@@ -146,43 +157,59 @@ class TestPlotGridTabsInitialization:
         # Should have 4 tabs: Workflows + Manage + 2 grids
         assert len(widget.tabs) == 4
 
-    def test_subscribes_to_lifecycle_events(self, plot_orchestrator, plot_grid_tabs):
-        """Test that widget subscribes to orchestrator lifecycle events."""
-        # Verify subscription by adding a grid and checking it appears
+    def test_new_grid_appears_on_poll(self, plot_orchestrator, plot_grid_tabs):
+        """A grid added after construction appears as a tab on the next poll."""
         plot_orchestrator.add_grid(title='New Grid', nrows=3, ncols=3)
+        _tick(plot_grid_tabs)
 
         # Should now have 3 tabs: Workflows + Manage + New Grid
         assert len(plot_grid_tabs.tabs) == 3
 
 
 class TestGridTabManagement:
-    """Tests for adding and removing grid tabs."""
+    """Tests for adding and removing grid tabs (driven by polling)."""
 
-    def test_on_grid_created_adds_tab(self, plot_orchestrator, plot_grid_tabs):
-        """Test that creating a grid adds a new tab."""
+    def test_add_grid_adds_tab_on_poll(self, plot_orchestrator, plot_grid_tabs):
+        """Test that creating a grid adds a new tab after a poll."""
         initial_count = len(plot_grid_tabs.tabs)
 
         plot_orchestrator.add_grid(title='Test Grid', nrows=4, ncols=4)
+        _tick(plot_grid_tabs)
 
         # Should have one more tab
         assert len(plot_grid_tabs.tabs) == initial_count + 1
 
-    def test_on_grid_created_switches_to_new_tab(
+    def test_grid_created_directly_does_not_switch_tab(
         self, plot_orchestrator, plot_grid_tabs
     ):
-        """Test that creating a grid auto-switches to that tab."""
-        plot_orchestrator.add_grid(title='Auto Switch', nrows=3, ncols=3)
+        """A grid created directly on the orchestrator (no local flag) appears
+        but does not steal focus -- the "other session" view."""
+        plot_orchestrator.add_grid(title='Other Session Grid', nrows=3, ncols=3)
+        _tick(plot_grid_tabs)
 
-        # Active tab should be newly created grid
-        # (Workflows=0, Manage=1, grid=2)
+        # Tab exists but active is unchanged (still Workflows at index 0).
+        assert len(plot_grid_tabs.tabs) == 3
+        assert plot_grid_tabs.tabs.active == 0
+
+    def test_local_grid_creation_switches_to_new_tab(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """A grid created via this session's manager focuses its tab on poll."""
+        plot_grid_tabs._grid_manager._on_add_grid(None)
+        _tick(plot_grid_tabs)
+
+        # Active tab should be the newly created grid (Workflows=0, Manage=1,
+        # grid=2).
         assert plot_grid_tabs.tabs.active == 2
 
-    def test_on_grid_removed_removes_tab(self, plot_orchestrator, plot_grid_tabs):
-        """Test that removing a grid removes its tab."""
+    def test_remove_grid_removes_tab_on_poll(self, plot_orchestrator, plot_grid_tabs):
+        """Test that removing a grid removes its tab after a poll."""
         grid_id = plot_orchestrator.add_grid(title='To Remove', nrows=3, ncols=3)
+        _tick(plot_grid_tabs)
         assert len(plot_grid_tabs.tabs) == 3  # Workflows + Manage + Grid
 
         plot_orchestrator.remove_grid(grid_id)
+        _tick(plot_grid_tabs)
 
         # Should only have two static tabs left (Workflows + Manage)
         assert len(plot_grid_tabs.tabs) == 2
@@ -192,12 +219,43 @@ class TestGridTabManagement:
         plot_orchestrator.add_grid(title='Grid 1', nrows=2, ncols=2)
         grid_id_2 = plot_orchestrator.add_grid(title='Grid 2', nrows=3, ncols=3)
         plot_orchestrator.add_grid(title='Grid 3', nrows=4, ncols=4)
+        _tick(plot_grid_tabs)
 
         # Remove middle grid
         plot_orchestrator.remove_grid(grid_id_2)
+        _tick(plot_grid_tabs)
 
         # Should have Workflows + Manage + 2 remaining grids
         assert len(plot_grid_tabs.tabs) == 4
+
+    def _make_widget(
+        self,
+        plot_orchestrator,
+        workflow_registry,
+        plotting_controller,
+        job_service,
+        job_orchestrator,
+        plot_data_service,
+        session_id,
+    ):
+        registry = SessionRegistry()
+        session_updater = SessionUpdater(
+            session_id=SessionId(session_id),
+            session_registry=registry,
+            notification_queue=NotificationQueue(),
+        )
+        workflow_status_widget = WorkflowStatusListWidget(
+            orchestrator=job_orchestrator,
+            job_service=job_service,
+        )
+        return PlotGridTabs(
+            plot_orchestrator=plot_orchestrator,
+            workflow_registry=workflow_registry,
+            plotting_controller=plotting_controller,
+            workflow_status_widget=workflow_status_widget,
+            plot_data_service=plot_data_service,
+            session_updater=session_updater,
+        )
 
     def test_multiple_widget_instances_stay_synchronized(
         self,
@@ -208,50 +266,29 @@ class TestGridTabManagement:
         job_orchestrator,
         plot_data_service,
     ):
-        """Test that multiple widgets sharing same orchestrator stay in sync."""
-        # Create separate session updaters for each widget (simulating different
-        # sessions)
-        registry = SessionRegistry()
-        session_updater1 = SessionUpdater(
-            session_id=SessionId('session-1'),
-            session_registry=registry,
-            notification_queue=NotificationQueue(),
+        """Two widgets sharing an orchestrator both reconcile on their polls."""
+        widget1 = self._make_widget(
+            plot_orchestrator,
+            workflow_registry,
+            plotting_controller,
+            job_service,
+            job_orchestrator,
+            plot_data_service,
+            'session-1',
         )
-        session_updater2 = SessionUpdater(
-            session_id=SessionId('session-2'),
-            session_registry=registry,
-            notification_queue=NotificationQueue(),
-        )
-
-        # Create separate workflow status widgets for each instance
-        workflow_status_widget1 = WorkflowStatusListWidget(
-            orchestrator=job_orchestrator,
-            job_service=job_service,
-        )
-        workflow_status_widget2 = WorkflowStatusListWidget(
-            orchestrator=job_orchestrator,
-            job_service=job_service,
-        )
-
-        widget1 = PlotGridTabs(
-            plot_orchestrator=plot_orchestrator,
-            workflow_registry=workflow_registry,
-            plotting_controller=plotting_controller,
-            workflow_status_widget=workflow_status_widget1,
-            plot_data_service=plot_data_service,
-            session_updater=session_updater1,
-        )
-        widget2 = PlotGridTabs(
-            plot_orchestrator=plot_orchestrator,
-            workflow_registry=workflow_registry,
-            plotting_controller=plotting_controller,
-            workflow_status_widget=workflow_status_widget2,
-            plot_data_service=plot_data_service,
-            session_updater=session_updater2,
+        widget2 = self._make_widget(
+            plot_orchestrator,
+            workflow_registry,
+            plotting_controller,
+            job_service,
+            job_orchestrator,
+            plot_data_service,
+            'session-2',
         )
 
         # Add grid via orchestrator
         grid_id = plot_orchestrator.add_grid(title='Shared Grid', nrows=3, ncols=3)
+        _tick(widget1, widget2)
 
         # Both widgets should have the new tab
         assert len(widget1.tabs) == 3  # Workflows + Manage + Shared Grid
@@ -259,10 +296,91 @@ class TestGridTabManagement:
 
         # Remove grid
         plot_orchestrator.remove_grid(grid_id)
+        _tick(widget1, widget2)
 
         # Both widgets should reflect removal
         assert len(widget1.tabs) == 2  # Workflows + Manage
         assert len(widget2.tabs) == 2
+
+    def test_local_creation_focuses_only_creating_session(
+        self,
+        plot_orchestrator,
+        workflow_registry,
+        plotting_controller,
+        job_service,
+        job_orchestrator,
+        plot_data_service,
+    ):
+        """Headline cross-session regression: a grid created via session A's
+        local manager path focuses the tab in A only; B gains the tab but its
+        active tab is unchanged. On the pre-change push code this failed because
+        ``_on_grid_created`` set ``tabs.active`` in every session."""
+        widget_a = self._make_widget(
+            plot_orchestrator,
+            workflow_registry,
+            plotting_controller,
+            job_service,
+            job_orchestrator,
+            plot_data_service,
+            'session-a',
+        )
+        widget_b = self._make_widget(
+            plot_orchestrator,
+            workflow_registry,
+            plotting_controller,
+            job_service,
+            job_orchestrator,
+            plot_data_service,
+            'session-b',
+        )
+        assert widget_a.tabs.active == 0
+        assert widget_b.tabs.active == 0
+
+        # A creates a grid through its own manager (local path sets A's pending
+        # focus); B never learns it was local.
+        widget_a._grid_manager._on_add_grid(None)
+        _tick(widget_a, widget_b)
+
+        # Both gained the tab.
+        assert len(widget_a.tabs) == 3
+        assert len(widget_b.tabs) == 3
+        # A focused the new grid; B's active tab is unchanged.
+        assert widget_a.tabs.active == 2
+        assert widget_b.tabs.active == 0
+
+    def test_replace_grid_keeps_position_without_stealing_focus(
+        self,
+        plot_orchestrator,
+        workflow_registry,
+        plotting_controller,
+        job_service,
+        job_orchestrator,
+        plot_data_service,
+    ):
+        """replace_grid keeps the tab position; a non-creating session viewing
+        the replaced grid stays on that position and is not thrown elsewhere."""
+        widget_b = self._make_widget(
+            plot_orchestrator,
+            workflow_registry,
+            plotting_controller,
+            job_service,
+            job_orchestrator,
+            plot_data_service,
+            'session-b',
+        )
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        _tick(widget_b)
+        # B views the grid tab (index 2: Workflows, Manage, G).
+        widget_b.tabs.active = 2
+
+        # Another session replaces the grid; B carries no local focus flag.
+        plot_orchestrator.replace_grid(grid_id, 'G2', nrows=3, ncols=3)
+        _tick(widget_b)
+
+        static = widget_b._static_tabs_count
+        assert widget_b.tabs._names[static:] == ['G2']
+        # Same position; focus not stolen to a static tab.
+        assert widget_b.tabs.active == 2
 
 
 class TestManageTab:
@@ -274,27 +392,53 @@ class TestManageTab:
         """Test that adding grids doesn't remove or duplicate the Manage tab."""
         initial_count = len(plot_grid_tabs.tabs)
         plot_orchestrator.add_grid(title='Grid 1', nrows=2, ncols=2)
+        _tick(plot_grid_tabs)
         # Should have exactly one more tab
         assert len(plot_grid_tabs.tabs) == initial_count + 1
 
         plot_orchestrator.add_grid(title='Grid 2', nrows=3, ncols=3)
+        _tick(plot_grid_tabs)
         # Should have exactly one more tab again
         assert len(plot_grid_tabs.tabs) == initial_count + 2
+
+
+def _register_active_layer(plot_orchestrator, plot_data_service, plot_grid_tabs):
+    """Register a layer with an active viewer token held by the session.
+
+    Returns the layer id. Used to assert tier-2 sever releases the token.
+    """
+    from uuid import uuid4
+
+    from ess.livedata.dashboard.plot_data_service import LayerId
+    from ess.livedata.dashboard.session_layer import SessionLayer
+
+    layer_id = LayerId(uuid4())
+    plot_data_service.job_started(layer_id, object())
+    state = plot_data_service.get(layer_id)
+    session_layer = SessionLayer(layer_id=layer_id, last_seen_version=state.version)
+    plot_grid_tabs._session_layers[layer_id] = session_layer
+    plot_orchestrator.activate_layer(layer_id, session_layer, True)
+    return layer_id
 
 
 class TestShutdown:
     """Tests for widget shutdown and cleanup."""
 
-    def test_sever_unsubscribes_from_lifecycle(self, plot_orchestrator, plot_grid_tabs):
-        """Test that tier-2 sever unsubscribes from orchestrator lifecycle."""
+    def test_sever_releases_viewer_tokens(
+        self, plot_orchestrator, plot_grid_tabs, plot_data_service
+    ):
+        """Tier-2 sever releases the session's viewer/interest tokens and drops
+        its session-layer records. There is no lifecycle subscription to sever:
+        topology changes stop being observed once polling stops."""
+        layer_id = _register_active_layer(
+            plot_orchestrator, plot_data_service, plot_grid_tabs
+        )
+        assert plot_data_service.get(layer_id).has_viewers
+
         plot_grid_tabs.sever()
 
-        # Adding a grid should not affect the widget anymore
-        initial_count = len(plot_grid_tabs.tabs)
-        plot_orchestrator.add_grid(title='After Shutdown', nrows=3, ncols=3)
-
-        # Tab count should not change
-        assert len(plot_grid_tabs.tabs) == initial_count
+        assert not plot_data_service.get(layer_id).has_viewers
+        assert plot_grid_tabs._session_layers == {}
 
     def test_sever_is_idempotent(self, plot_grid_tabs):
         """Test that tier-2 sever can be called multiple times."""
@@ -357,7 +501,7 @@ class TestReaperTeardown:
         )
         return widget, callback
 
-    def test_reaper_severs_lifecycle_without_touching_document(
+    def test_reaper_severs_shared_state_without_touching_document(
         self,
         plot_orchestrator,
         workflow_registry,
@@ -376,15 +520,18 @@ class TestReaperTeardown:
             registry,
             document,
         )
+        # Hold an active viewer token so we can observe tier-2 release it.
+        layer_id = _register_active_layer(plot_orchestrator, plot_data_service, widget)
+        assert plot_data_service.get(layer_id).has_viewers
 
         cleaned = registry.cleanup_stale_sessions()
 
         assert SessionId('stale-session') in cleaned
-        # Tier 2 ran inline on the reaper thread: lifecycle severed, so a new
-        # grid does not add a tab to this session's widget.
-        initial_count = len(widget.tabs)
-        plot_orchestrator.add_grid(title='After Reaper', nrows=2, ncols=2)
-        assert len(widget.tabs) == initial_count
+        # Tier 2 ran inline on the reaper thread: the session's viewer token was
+        # released and its session-layer records cleared. There is no lifecycle
+        # subscription to sever under polling.
+        assert not plot_data_service.get(layer_id).has_viewers
+        assert widget._session_layers == {}
         # Tier 1 was NOT run on the reaper thread: the periodic callback is not
         # stopped here, it is scheduled onto the session's IOLoop instead.
         assert not callback.stopped
@@ -881,9 +1028,11 @@ class TestDisabledGridTabs:
     def test_disabling_grid_removes_tab(self, plot_orchestrator, plot_grid_tabs):
         """Disabling a grid removes its tab."""
         grid_id = plot_orchestrator.add_grid(title='Will Hide', nrows=2, ncols=2)
+        _tick(plot_grid_tabs)
         tabs_before = len(plot_grid_tabs.tabs)
 
         plot_orchestrator.set_grid_enabled(grid_id, enabled=False)
+        _tick(plot_grid_tabs)
 
         assert len(plot_grid_tabs.tabs) == tabs_before - 1
 
@@ -891,9 +1040,11 @@ class TestDisabledGridTabs:
         """Re-enabling a disabled grid adds its tab back."""
         grid_id = plot_orchestrator.add_grid(title='Toggle', nrows=2, ncols=2)
         plot_orchestrator.set_grid_enabled(grid_id, enabled=False)
+        _tick(plot_grid_tabs)
         tabs_after_disable = len(plot_grid_tabs.tabs)
 
         plot_orchestrator.set_grid_enabled(grid_id, enabled=True)
+        _tick(plot_grid_tabs)
 
         assert len(plot_grid_tabs.tabs) == tabs_after_disable + 1
 
@@ -922,8 +1073,10 @@ class TestDisabledGridTabs:
     def test_rename_updates_tab_title(self, plot_orchestrator, plot_grid_tabs):
         """Renaming a grid updates the corresponding tab title."""
         grid_id = plot_orchestrator.add_grid(title='Old Name', nrows=2, ncols=2)
+        _tick(plot_grid_tabs)
 
         plot_orchestrator.rename_grid(grid_id, 'New Name')
+        _tick(plot_grid_tabs)
 
         assert 'New Name' in plot_grid_tabs.tabs._names
         assert 'Old Name' not in plot_grid_tabs.tabs._names
@@ -934,6 +1087,7 @@ class TestDisabledGridTabs:
         id_b = plot_orchestrator.add_grid(title='Beta', nrows=2, ncols=2)
 
         plot_orchestrator.move_grid(id_b, -1)
+        _tick(plot_grid_tabs)
 
         static = plot_grid_tabs._static_tabs_count
         grid_titles = plot_grid_tabs.tabs._names[static:]
@@ -953,6 +1107,7 @@ class TestDisabledGridTabs:
         id_c = plot_orchestrator.add_grid(title='C', nrows=2, ncols=2)
 
         plot_orchestrator.set_grid_enabled(id_a, enabled=False)
+        _tick(plot_grid_tabs)
 
         static = plot_grid_tabs._static_tabs_count
         # Two visible grid tabs: B then C.
@@ -973,6 +1128,7 @@ class TestDisabledGridTabs:
         id_c = plot_orchestrator.add_grid(title='C', nrows=2, ncols=2)
 
         plot_orchestrator.set_grid_enabled(id_b, enabled=False)
+        _tick(plot_grid_tabs)
 
         static = plot_grid_tabs._static_tabs_count
         assert plot_grid_tabs.tabs._names[static:] == ['A', 'C']
@@ -997,11 +1153,143 @@ class TestDisabledGridTabs:
         id_c = plot_orchestrator.add_grid(title='C', nrows=2, ncols=2)
 
         plot_orchestrator.set_grid_enabled(id_a, enabled=False)
+        _tick(plot_grid_tabs)
 
         static = plot_grid_tabs._static_tabs_count
         assert plot_grid_tabs.tabs._names[static:] == ['B', 'C']
 
         plot_orchestrator.remove_grid(id_c)
+        _tick(plot_grid_tabs)
 
         # C's tab is gone; B remains.
         assert plot_grid_tabs.tabs._names[static:] == ['B']
+
+
+def _add_static_cell(plot_orchestrator, grid_id, geometry, *, positions='10, 20'):
+    """Add a cell with a single static (no-workflow) vlines layer.
+
+    Static overlays compute from params alone, so they let cell-reconcile tests
+    run without workflow data.
+    """
+    from ess.livedata.config.workflow_spec import WorkflowId
+    from ess.livedata.dashboard.data_roles import PRIMARY
+    from ess.livedata.dashboard.plot_orchestrator import DataSourceConfig, PlotConfig
+    from ess.livedata.dashboard.static_plots import LinesCoordinates, VLinesParams
+
+    config = PlotConfig(
+        data_sources={
+            PRIMARY: DataSourceConfig(
+                workflow_id=WorkflowId(instrument='test', name='wf', version=1),
+                source_names=[],
+                view_name='guides',
+            )
+        },
+        plot_name='vlines',
+        params=VLinesParams(geometry=LinesCoordinates(positions=positions)),
+    )
+    cell_id = plot_orchestrator.add_cell(grid_id, geometry)
+    plot_orchestrator.add_layer(cell_id, config)
+    return cell_id
+
+
+class TestCellReconcile:
+    """Poll-driven cell reconcile (replaces the former push cell callbacks)."""
+
+    _GEO = None  # set in setup
+
+    @staticmethod
+    def _geometry():
+        from ess.livedata.dashboard.plot_orchestrator import CellGeometry
+
+        return CellGeometry(row=0, col=0, row_span=1, col_span=1)
+
+    def test_new_cell_built_on_poll(self, plot_orchestrator, plot_grid_tabs):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+
+        assert cell_id not in plot_grid_tabs._cells
+        _tick(plot_grid_tabs)
+        assert cell_id in plot_grid_tabs._cells
+
+    def test_remove_last_layer_removes_and_disposes_cell(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+        assert cell_id in plot_grid_tabs._cells
+        layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+
+        # Removing the only layer removes the whole cell from topology.
+        plot_orchestrator.remove_layer(layer_id)
+        _tick(plot_grid_tabs)
+
+        assert cell_id not in plot_grid_tabs._cells
+        assert cell_id not in plot_grid_tabs._cell_grid
+        assert cell_id not in plot_grid_tabs._cell_signatures
+
+    def test_set_cell_title_rebuilds_cell(self, plot_orchestrator, plot_grid_tabs):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+        widget_before = plot_grid_tabs._cells[cell_id]
+
+        plot_orchestrator.set_cell_title(cell_id, 'Renamed')
+        _tick(plot_grid_tabs)
+
+        # Signature changed (user_title) -> the cell widget was rebuilt.
+        assert plot_grid_tabs._cells[cell_id] is not widget_before
+
+    def test_disabling_grid_does_not_dispose_cell(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """Disabling a grid must not dispose its cells: the grid still exists in
+        topology (only hidden), so the removal sweep keeps the cell widget even
+        though the poll loop skips disabled grids. Re-enabling restores it."""
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+        widget = plot_grid_tabs._cells[cell_id]
+
+        plot_orchestrator.set_grid_enabled(grid_id, enabled=False)
+        _tick(plot_grid_tabs)
+
+        # Same instance: preserved across disable, not swept/disposed.
+        assert plot_grid_tabs._cells.get(cell_id) is widget
+
+        plot_orchestrator.set_grid_enabled(grid_id, enabled=True)
+        _tick(plot_grid_tabs)
+        # Still present after re-enable (rebuilt from a fresh session layer).
+        assert cell_id in plot_grid_tabs._cells
+
+    def test_update_layer_config_rebuilds_cell(self, plot_orchestrator, plot_grid_tabs):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+        widget_before = plot_grid_tabs._cells[cell_id]
+        layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+
+        from ess.livedata.config.workflow_spec import WorkflowId
+        from ess.livedata.dashboard.data_roles import PRIMARY
+        from ess.livedata.dashboard.plot_orchestrator import (
+            DataSourceConfig,
+            PlotConfig,
+        )
+        from ess.livedata.dashboard.static_plots import LinesCoordinates, VLinesParams
+
+        new_config = PlotConfig(
+            data_sources={
+                PRIMARY: DataSourceConfig(
+                    workflow_id=WorkflowId(instrument='test', name='wf', version=1),
+                    source_names=[],
+                    view_name='guides',
+                )
+            },
+            plot_name='vlines',
+            params=VLinesParams(geometry=LinesCoordinates(positions='30, 40')),
+        )
+        plot_orchestrator.update_layer_config(layer_id, new_config)
+        _tick(plot_grid_tabs)
+
+        # Reconfigure mints a fresh LayerId -> signature changed -> rebuilt.
+        assert plot_grid_tabs._cells[cell_id] is not widget_before

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -1262,6 +1262,39 @@ class TestCellReconcile:
         # Still present after re-enable (rebuilt from a fresh session layer).
         assert cell_id in plot_grid_tabs._cells
 
+    def test_cell_edit_does_not_churn_tabs(self, plot_orchestrator, plot_grid_tabs):
+        """Cell-level changes bump the topology version but must not tear down
+        and re-append the Tabs entries -- that would discard the active tab's
+        Bokeh models (flicker) on every layer edit in every session. Grid-level
+        changes still rebuild the tabs."""
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+
+        events: list = []
+        plot_grid_tabs.tabs.param.watch(events.append, 'objects')
+
+        plot_orchestrator.set_cell_title(cell_id, 'Renamed')
+        _tick(plot_grid_tabs)
+        assert events == []
+
+        plot_orchestrator.rename_grid(grid_id, 'G2')
+        _tick(plot_grid_tabs)
+        assert events
+
+    def test_reconfigure_vanished_layer_shows_error_not_modal(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """A gear click racing a removal in another session (poll window) must
+        not raise; no modal opens (an error notification is shown instead)."""
+        from uuid import uuid4
+
+        from ess.livedata.dashboard.plot_data_service import LayerId
+
+        plot_grid_tabs._on_reconfigure_layer(LayerId(uuid4()))
+
+        assert plot_grid_tabs._current_modal is None
+
     def test_update_layer_config_rebuilds_cell(self, plot_orchestrator, plot_grid_tabs):
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())


### PR DESCRIPTION
## What

Converts the last dashboard widgets still on the cross-session push model — the grid tabs and grid manager — to the versioned-pull pattern of ADR 0007, and gives the shared topology dicts an explicit thread-safety discipline. This completes the dashboard-side restructure tracked by #1046.

- `PlotOrchestrator` mutators bump a single topology version; the subscribe/notify lifecycle machinery is deleted. Each session's `PlotGridTabs` polls the version from its own periodic tick and reconciles tabs under its own document lock, restoring the active tab by identity. Cell composition changes (layer add/remove/reconfigure, title) are detected per tick via cell signatures; vanished cells are swept and disposed. Cells of a merely disabled grid survive for re-enable.
- Tab-focus semantics change deliberately: auto-switching to a new grid happens only in the session that created it (`PlotGridManager` reports local creations to its owning `PlotGridTabs`); other sessions just gain the tab. Previously grid creation set `tabs.active` in every session.
- Thread-safety (hazard 1 of #1040): the IOLoop thread remains the sole topology writer; a narrow `RLock` makes the ingestion thread's multi-dict traversals see consistent snapshots. The lock stays off persist/compute/pipeline paths; the discipline (lock order, leaf-first deletes) is documented on the class.
- `rename_grid`/`move_grid`/`set_grid_enabled` now tolerate ids removed by another session inside the poll window instead of raising.

## Why

Lifecycle notifications fanned out to every session's widgets on the *mutating* session's thread: session A's `add_grid` rebuilt session B's Bokeh document outside B's document lock (intermittent cross-session corruption), and hijacked B's active tab. Per-layer data already moved to versioned pull; lifecycle was the remaining push surface. The topology dicts were additionally read by the ingestion thread with no consistency guarantee across the three mappings.

## Test plan

- Lifecycle-notification tests rewritten as topology-version tests; widget tests drive the poll explicitly.
- New cross-session regression tests: grid created via session A focuses the tab in A only, B's active tab unchanged (fails on the push model); direct orchestrator creation steals no focus; `replace_grid` keeps position without stealing focus; cell reconcile add/remove/retitle; ingestion read paths tolerate concurrent layer removal; disabled-grid cells are not disposed.
- Full fast suite passes; `pytest -m browser` multisession smoke test passes on this branch.
- [ ] Field verification items on #1097 (cross-session tab isolation with a real backend).

Fixes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
