### PR TITLE
Fix _job_states leak on workflow recommit (#1080)

### DIFF
--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -505,6 +505,14 @@ class JobOrchestrator:
             message_id, workflow_id, "start", expected_count=len(state.staged_jobs)
         )
 
+        # Drop the superseded generation's tracked states. The old jobs have
+        # been stopped above; their final heartbeats are no longer in the
+        # current set, so on_job_status_updated would ignore them and never
+        # clean these up (the same cleanup _deactivate_workflow performs).
+        if state.current is not None:
+            for job_id in state.current.job_ids():
+                self._job_states.pop(job_id, None)
+
         state.commit(job_set)
 
         # Flip the generation, clear the workflow's buffers, and notify

--- a/tests/dashboard/restart_cleanup_test.py
+++ b/tests/dashboard/restart_cleanup_test.py
@@ -252,6 +252,29 @@ class TestRestartCleanup:
             == job_ids_3[0].job_number
         )
 
+    def test_recommit_does_not_leak_superseded_job_states(self, workflow_spec):
+        """A recommit drops the superseded generation's tracked job states.
+
+        Regression for #1080: job_number is fresh per commit, so recommit
+        keys are new; the old jobs' final heartbeats fall outside the current
+        set and can no longer self-clean. Without explicit cleanup, tracked
+        states grow by one per source on every restart-commit, unbounded.
+        """
+        _, job_orchestrator, _, _ = _make_system(workflow_spec)
+        workflow_id = workflow_spec.get_id()
+
+        job_ids_1 = job_orchestrator.commit_workflow(workflow_id)
+        for job_id in job_ids_1:
+            job_orchestrator.on_job_status_updated(
+                JobStatus(job_id=job_id, workflow_id=workflow_id, state=JobState.active)
+            )
+        assert set(job_orchestrator._job_states) == set(job_ids_1)
+
+        job_ids_2 = job_orchestrator.commit_workflow(workflow_id)
+
+        assert set(job_orchestrator._job_states).isdisjoint(job_ids_1)
+        assert set(job_ids_1).isdisjoint(job_ids_2)
+
     def test_other_workflow_data_survives_recommit(
         self, workflow_spec, workflow_spec_2
     ):


### PR DESCRIPTION
`commit_workflow` replaces the active job set but left the superseded generation's entries in `_job_states`. Because `job_number` is fresh per commit, the old jobs' final heartbeats fall outside the current set, so `on_job_status_updated` ignores them and they never self-clean. Tracked states therefore grew by one entry per source on every restart-commit — a routine operation (parameter changes, restarts) — unbounded over the lifetime of the dashboard process.

The fix pops the old job set's IDs on recommit, mirroring the cleanup `_deactivate_workflow` already performs on explicit stop. This area was heavily refactored since the issue was filed (stable-key generation model), so line numbers in #1080 are stale, but the leak was still live — confirmed with a regression test against real components that fails on `main` and passes with this change.

Closes #1080.
