### PR TITLE
Fix saturated 1-10 colorbar for uniform positive log-scale image data

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -633,11 +633,12 @@ class Plotter:
         error in _draw_colorbar. Scipp's nanmin/nanmax return +inf/-inf rather
         than NaN for all-NaN input, so the all-NaN case surfaces as vmax < vmin.
 
-        A second degenerate case is uniform data (``vmax == vmin``): HoloViews
-        renders a fully saturated plot with a zero-width color range. Bounds
-        bracketing the constant value give a readable colorbar instead. Log-scale
-        masking has already replaced non-positive values with NaN, so a non-NaN
-        constant is guaranteed positive.
+        Uniform data (``vmax == vmin``) is a second degenerate case. HoloViews
+        does handle it, but via an *additive* fallback (value +/- 1) that yields
+        a non-positive lower bound for small constants (e.g. 0.5 -> -0.5), which
+        is invalid on a log scale. A multiplicative bracket around the constant
+        stays positive. Log-scale masking has already replaced non-positive
+        values with NaN, so a non-NaN constant is guaranteed positive.
 
         Parameters
         ----------

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -625,13 +625,19 @@ class Plotter:
     @staticmethod
     def _get_log_scale_clim(data: sc.DataArray) -> tuple[float, float] | None:
         """
-        Return fallback clim for log scale if data is all NaN.
+        Return fallback clim for log scale when HoloViews cannot pick bounds.
 
         HoloViews' LogColorMapper fails when color_mapper.low is None (which
         happens when all data is NaN). This provides explicit bounds to avoid
         the "TypeError: '>' not supported between instances of 'NoneType' and 'int'"
-        error in _draw_colorbar. Limits are not returned if data is not 'None' as in
-        this case we let Holoviews handle the bounds.
+        error in _draw_colorbar. Scipp's nanmin/nanmax return +inf/-inf rather
+        than NaN for all-NaN input, so the all-NaN case surfaces as vmax < vmin.
+
+        A second degenerate case is uniform data (``vmax == vmin``): HoloViews
+        renders a fully saturated plot with a zero-width color range. Bounds
+        bracketing the constant value give a readable colorbar instead. Log-scale
+        masking has already replaced non-positive values with NaN, so a non-NaN
+        constant is guaranteed positive.
 
         Parameters
         ----------
@@ -641,14 +647,17 @@ class Plotter:
         Returns
         -------
         :
-            Tuple of (low, high) bounds, or None if data has valid positive values.
+            Tuple of (low, high) bounds, or None if HoloViews can pick sensible
+            bounds itself (data has a range of valid positive values).
         """
         vmin = float(data.data.nanmin().value)
         vmax = float(data.data.nanmax().value)
-        # If all NaN, nanmin/nanmax return nan
-        if np.isnan(vmin) or np.isnan(vmax) or vmax <= vmin:
-            # Return placeholder bounds for empty/invalid data
+        if vmax < vmin:
+            # All NaN: LogColorMapper cannot handle None bounds.
             return (1.0, 10.0)
+        if vmax == vmin:
+            # Uniform positive data: bracket the constant value.
+            return (vmin * 0.9, vmax * 1.1)
         return None
 
     def compute(

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -2986,6 +2986,14 @@ class TestGetLogScaleClim:
         assert low == pytest.approx(constant * 0.9)
         assert high == pytest.approx(constant * 1.1)
 
+    def test_uniform_small_constant_keeps_positive_bounds(self) -> None:
+        # HoloViews' own additive value+/-1 fallback would give a non-positive
+        # lower bound here (0.5 -> -0.5), invalid on a log scale.
+        data = self._image([[0.5, 0.5], [0.5, 0.5]])
+        low, high = plots.Plotter._get_log_scale_clim(data)
+        assert low > 0.0
+        assert low < 0.5 < high
+
     def test_uniform_data_with_nan_brackets_the_constant(self) -> None:
         constant = 1e6
         data = self._image([[constant, np.nan], [np.nan, constant]])

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -2960,3 +2960,39 @@ class TestTimeseriesDownsamplingAndThrottle:
         plotter.compute({'primary': {data_key: data}})
         # No throttle path: recomputes unconditionally, fresh cached state object.
         assert plotter.get_cached_state() is not first_state
+
+
+class TestGetLogScaleClim:
+    @staticmethod
+    def _image(values: list[list[float]]) -> sc.DataArray:
+        arr = np.array(values, dtype='float64')
+        return sc.DataArray(
+            sc.array(dims=['y', 'x'], values=arr, unit='counts'),
+            coords={
+                'y': sc.arange('y', arr.shape[0], unit='m'),
+                'x': sc.arange('x', arr.shape[1], unit='m'),
+            },
+        )
+
+    def test_all_nan_returns_placeholder(self) -> None:
+        data = self._image([[np.nan, np.nan], [np.nan, np.nan]])
+        assert plots.Plotter._get_log_scale_clim(data) == (1.0, 10.0)
+
+    def test_uniform_positive_data_brackets_the_constant(self) -> None:
+        constant = 1e6
+        data = self._image([[constant, constant], [constant, constant]])
+        low, high = plots.Plotter._get_log_scale_clim(data)
+        assert low < constant < high
+        assert low == pytest.approx(constant * 0.9)
+        assert high == pytest.approx(constant * 1.1)
+
+    def test_uniform_data_with_nan_brackets_the_constant(self) -> None:
+        constant = 1e6
+        data = self._image([[constant, np.nan], [np.nan, constant]])
+        low, high = plots.Plotter._get_log_scale_clim(data)
+        assert low == pytest.approx(constant * 0.9)
+        assert high == pytest.approx(constant * 1.1)
+
+    def test_varying_data_defers_to_holoviews(self) -> None:
+        data = self._image([[1.0, 2.0], [3.0, 4.0]])
+        assert plots.Plotter._get_log_scale_clim(data) is None


### PR DESCRIPTION
## Summary

`Plotter._get_log_scale_clim` supplies fallback color limits for log-scale images that HoloViews' `LogColorMapper` cannot bound itself. Its guard collapsed two unrelated cases: genuinely unplottable all-NaN data, and uniform positive data (`vmax == vmin`). Both returned the placeholder `(1.0, 10.0)`, so a constant-valued detector image (e.g. all `1e6` counts) rendered fully saturated with a colorbar reading `1-10` — well outside the actual data range.

## Why

The original guard `vmax <= vmin` was meant to catch all-NaN data. Two things were off. First, scipp's `nanmin`/`nanmax` return `+inf`/`-inf` (not NaN) for all-NaN input, so the all-NaN case actually surfaces as `vmax < vmin`; the `==` branch was only ever hit by uniform data, which is plottable. Second, the saturation was *our* forced placeholder, not HoloViews: left to itself HoloViews handles uniform data fine.

We still special-case uniform data, but for a subtler reason: HoloViews' own fallback for a zero-width range is *additive* (`value ± 1`), which produces a non-positive lower bound for small constants (e.g. `0.5 → -0.5`, `1.0 → 0.0`) — invalid on a log scale. A *multiplicative* bracket (`vmin * 0.9`, `vmax * 1.1`) stays positive and gives a readable colorbar. Log-scale masking has already replaced non-positive values with NaN, so a non-NaN constant is guaranteed positive (a constant negative or zero image becomes all-NaN and correctly falls through to the placeholder).

Fixes #1078.

## Test plan

- [x] New unit tests for `_get_log_scale_clim`: all-NaN placeholder; uniform data (with and without NaN) brackets the constant; small uniform constant keeps positive bounds; varying data defers to HoloViews.
- [x] `pytest tests/dashboard/plots_test.py -k "GetLogScaleClim or ImagePlotter"` passes.
