### PR TITLE
Count variances in TemporalBuffer memory-limit sizing

### DIFF
--- a/src/ess/livedata/dashboard/temporal_buffers.py
+++ b/src/ess/livedata/dashboard/temporal_buffers.py
@@ -13,6 +13,14 @@ import scipp as sc
 T = TypeVar('T')
 
 
+def _variable_nbytes(var: sc.Variable) -> int:
+    """Return the byte size of a variable's values, plus variances if present."""
+    nbytes = var.values.nbytes
+    if var.variances is not None:
+        nbytes += var.variances.nbytes
+    return nbytes
+
+
 class BufferProtocol(ABC, Generic[T]):
     """Common interface for all buffer types."""
 
@@ -399,9 +407,9 @@ class TemporalBuffer(BufferProtocol[sc.DataArray]):
 
         # Calculate max_capacity from memory limit, accounting for the data buffer
         # plus every accumulated coord buffer.
-        bytes_per_element = data.data.values.nbytes
+        bytes_per_element = _variable_nbytes(data.data)
         for name in accumulated:
-            bytes_per_element += data.coords[name].values.nbytes
+            bytes_per_element += _variable_nbytes(data.coords[name])
         if 'time' in data.dims:
             bytes_per_element /= data.sizes['time']
 

--- a/src/ess/livedata/dashboard/temporal_buffers.py
+++ b/src/ess/livedata/dashboard/temporal_buffers.py
@@ -14,11 +14,12 @@ T = TypeVar('T')
 
 
 def _variable_nbytes(var: sc.Variable) -> int:
-    """Return the byte size of a variable's values, plus variances if present."""
-    nbytes = var.values.nbytes
-    if var.variances is not None:
-        nbytes += var.variances.nbytes
-    return nbytes
+    """Return the byte size of a variable's values, plus variances if present.
+
+    Variances always match the values array's shape and dtype, so their size
+    is derived rather than read via a second scipp property access.
+    """
+    return var.values.nbytes * (2 if var.variances is not None else 1)
 
 
 class BufferProtocol(ABC, Generic[T]):

--- a/tests/dashboard/temporal_buffers_test.py
+++ b/tests/dashboard/temporal_buffers_test.py
@@ -288,6 +288,44 @@ class TestTemporalBuffer:
         with pytest.raises(ValueError, match="exceeds buffer capacity even after"):
             buffer.add(large_data)
 
+    def test_max_capacity_accounts_for_variances(self):
+        """Test that variances are counted towards the per-element memory budget.
+
+        Uses a large x dimension so the (variance-free) scalar 'time' coord's
+        contribution to the per-element byte count is negligible, making the
+        variances-vs-no-variances capacities differ by close to a factor of 2.
+        """
+        x_size = 1000
+        max_memory = 1_000_000
+
+        buffer_without_variances = TemporalBuffer()
+        buffer_without_variances.set_max_memory(max_memory)
+        buffer_without_variances.add(make_single_slice([1.0] * x_size, 0.0))
+        capacity_without_variances = buffer_without_variances._data_buffer.max_capacity
+
+        buffer_with_variances = TemporalBuffer()
+        buffer_with_variances.set_max_memory(max_memory)
+        data = sc.DataArray(
+            sc.array(
+                dims=['x'],
+                values=[1.0] * x_size,
+                variances=[0.1] * x_size,
+                unit='counts',
+            ),
+            coords={
+                'x': sc.arange('x', x_size, unit='m'),
+                'time': sc.scalar(0.0, unit='s'),
+            },
+        )
+        buffer_with_variances.add(data)
+        capacity_with_variances = buffer_with_variances._data_buffer.max_capacity
+
+        # Values and variances are both 8-byte floats, so counting variances
+        # roughly halves the number of elements that fit in the same budget.
+        assert capacity_with_variances == pytest.approx(
+            capacity_without_variances / 2, rel=0.01
+        )
+
     def test_ring_buffer_behavior_when_full_with_infinite_timespan(self):
         """Test that buffer drops oldest data when full and timespan is infinite."""
         buffer = TemporalBuffer()


### PR DESCRIPTION
## Summary
`TemporalBuffer._initialize_buffers` sized the per-element memory budget from `.values.nbytes` alone, ignoring `.variances`. Data carrying variances (common for reduced/accumulated detector or monitor data) could therefore use up to ~2x the configured `max_memory` budget, undermining the dashboard's per-key memory bounding strategy on memory-constrained deployments.

- Adds a `_variable_nbytes` helper that includes `.variances.nbytes` when present.
- Applies it to both the data buffer and each accumulated coord buffer.
- Adds a regression test asserting that variances roughly halve the resulting `max_capacity` for a fixed memory budget.

Fixes #1081

## Test plan
- [x] `python -m pytest tests/dashboard/temporal_buffers_test.py` passes, new test fails without the fix
- [x] Full `python -m pytest` suite passes
