### PR TITLE
Suppress plot-grid persistence during startup replay and shutdown

### DIFF
--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 import copy
 import threading
 import traceback
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NewType, Protocol
 from uuid import UUID, uuid4
@@ -388,6 +389,11 @@ class PlotOrchestrator:
         self._instrument = instrument
         self._instrument_config = instrument_config
         self._config_store = config_store
+        # Suppresses per-mutation persistence during composite lifecycle
+        # operations (startup replay, shutdown). See ``_suppress_persist``.
+        # Read/written only on the IOLoop thread, the sole topology writer,
+        # so it needs no lock.
+        self._persist_suppressed = False
         self._plot_data_service = plot_data_service
         self._frame_clock = frame_clock or FrameClock()
         self._logger = structlog.get_logger()
@@ -1664,25 +1670,56 @@ class PlotOrchestrator:
             raw_grids = data.get('grids', [])
             specs = self._parse_grid_specs(raw_grids)
 
-            # Apply each spec through the normal API
-            for spec in specs:
-                grid_id = self.add_grid(spec.title, spec.nrows, spec.ncols)
-                for cell in spec.cells:
-                    cell_id = self.add_cell(
-                        grid_id, cell.geometry, user_title=cell.user_title
-                    )
-                    for layer in cell.layers:
-                        self.add_layer(cell_id, layer.config)
-                if not spec.enabled:
-                    self.set_grid_enabled(grid_id, enabled=False)
+            # Apply each spec through the normal API. Persistence is suppressed:
+            # the mutators would otherwise write partial state after every step,
+            # so an exception partway through replay would truncate the store to
+            # whatever was applied before the crash, losing the remaining tabs
+            # even on a clean restart.
+            with self._suppress_persist():
+                for spec in specs:
+                    grid_id = self.add_grid(spec.title, spec.nrows, spec.ncols)
+                    for cell in spec.cells:
+                        cell_id = self.add_cell(
+                            grid_id, cell.geometry, user_title=cell.user_title
+                        )
+                        for layer in cell.layers:
+                            self.add_layer(cell_id, layer.config)
+                    if not spec.enabled:
+                        self.set_grid_enabled(grid_id, enabled=False)
 
             self._logger.info('Loaded %d plot grids from store', len(specs))
         except Exception:
             self._logger.exception('Failed to load plot grids from store')
 
+    @contextmanager
+    def _suppress_persist(self) -> Iterator[None]:
+        """
+        Suppress per-mutation persistence within the block.
+
+        Composite lifecycle operations (startup replay, shutdown) drive the
+        normal single-step mutators, each of which persists the *whole*
+        in-memory state. Persisting those intermediate states is what lets a
+        partially-applied replay truncate the saved layout, or a shutdown
+        overwrite it with ``{'grids': []}``. Inside this block every
+        ``_persist_to_store`` call is a no-op, so the store is never written
+        while the in-memory model is mid-transition.
+
+        Persistence is suppressed, not deferred: nothing is written on exit.
+        The model was just built from the store (replay) or is being torn down
+        (shutdown), so the last committed layout is exactly what should
+        survive. If the block raises, the store is likewise left untouched,
+        preserving the full saved layout for the next attempt.
+        """
+        was_suppressed = self._persist_suppressed
+        self._persist_suppressed = True
+        try:
+            yield
+        finally:
+            self._persist_suppressed = was_suppressed
+
     def _persist_to_store(self) -> None:
         """Persist plot grid configurations to config store."""
-        if self._config_store is None:
+        if self._config_store is None or self._persist_suppressed:
             return
 
         try:
@@ -1749,9 +1786,13 @@ class PlotOrchestrator:
         Call this method when the orchestrator is no longer needed to prevent
         memory leaks.
         """
-        # Remove all grids (which unsubscribes all plots)
+        # Remove all grids (which unsubscribes all plots). Persistence is
+        # suppressed so tearing down the in-memory model does not overwrite the
+        # saved layout with an empty one; the last committed layout must
+        # survive to the next session.
         grid_ids = list(self._grids.keys())
-        for grid_id in grid_ids:
-            self.remove_grid(grid_id)
+        with self._suppress_persist():
+            for grid_id in grid_ids:
+                self.remove_grid(grid_id)
 
         self._logger.info('PlotOrchestrator shutdown complete')

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
+import copy
 import uuid
 
 import pydantic
@@ -2523,6 +2524,132 @@ class TestPersistenceRoundTrip:
 
         raw = config_store.get('plot_grids')
         assert 'enabled' not in raw['grids'][0]
+
+
+class TestPersistenceResilience:
+    """A failing startup replay or a shutdown must never truncate the saved layout.
+
+    Regression tests for #1073: every mutator persists the whole in-memory model
+    on each step, so composite lifecycle operations that drive those mutators
+    (startup replay, shutdown) could otherwise leak partial or empty state to the
+    store and permanently lose the user's tabs.
+    """
+
+    @pytest.fixture
+    def config_store(self):
+        from ess.livedata.dashboard.config_store import InMemoryConfigStore
+
+        return InMemoryConfigStore()
+
+    def _make_orchestrator(
+        self,
+        job_orchestrator,
+        fake_plotting_controller,
+        fake_data_service,
+        plot_data_service,
+        config_store,
+    ):
+        return PlotOrchestrator(
+            plotting_controller=fake_plotting_controller,
+            job_orchestrator=job_orchestrator,
+            data_service=fake_data_service,
+            instrument='dummy',
+            plot_data_service=plot_data_service,
+            config_store=config_store,
+        )
+
+    def test_replay_failure_preserves_full_saved_layout(
+        self,
+        job_orchestrator,
+        fake_plotting_controller,
+        fake_data_service,
+        plot_data_service,
+        config_store,
+        workflow_id,
+    ):
+        """A mid-replay exception leaves the entire saved layout intact."""
+        # Two valid grids straddling a broken one in the store.
+        orch1 = self._make_orchestrator(
+            job_orchestrator,
+            fake_plotting_controller,
+            fake_data_service,
+            plot_data_service,
+            config_store,
+        )
+        for title in ('First', 'Third'):
+            grid_id = orch1.add_grid(title=title, nrows=1, ncols=1)
+            add_cell_with_layer(
+                orch1, grid_id, DEFAULT_GEOMETRY, make_plot_config(workflow_id)
+            )
+
+        # Insert a grid whose cell stacks two non-overlayable ('table') layers
+        # between the good ones. It parses fine but add_layer rejects the second
+        # layer during replay, aborting the loop before 'Third' is reached.
+        grids = config_store['plot_grids']['grids']
+        assert [g['title'] for g in grids] == ['First', 'Third']
+        table_layer = copy.deepcopy(grids[0]['cells'][0]['layers'][0])
+        table_layer['plot_name'] = 'table'
+        broken_grid = {
+            'title': 'Broken',
+            'nrows': 1,
+            'ncols': 1,
+            'cells': [
+                {
+                    'geometry': {'row': 0, 'col': 0, 'row_span': 1, 'col_span': 1},
+                    'layers': [copy.deepcopy(table_layer), copy.deepcopy(table_layer)],
+                }
+            ],
+        }
+        grids.insert(1, broken_grid)
+        config_store['plot_grids'] = {'grids': grids}
+        saved_before = copy.deepcopy(config_store['plot_grids'])
+
+        # A fresh session replays the store; 'Broken' raises mid-replay.
+        self._make_orchestrator(
+            job_orchestrator,
+            fake_plotting_controller,
+            fake_data_service,
+            plot_data_service,
+            config_store,
+        )
+
+        # All three grid definitions survive, including 'Third' which was never
+        # reached: nothing was overwritten, so a later fix/restart recovers them.
+        assert config_store['plot_grids'] == saved_before
+        assert [g['title'] for g in config_store['plot_grids']['grids']] == [
+            'First',
+            'Broken',
+            'Third',
+        ]
+
+    def test_shutdown_preserves_saved_layout(
+        self,
+        job_orchestrator,
+        fake_plotting_controller,
+        fake_data_service,
+        plot_data_service,
+        config_store,
+        workflow_id,
+    ):
+        """Tearing down the in-memory model does not wipe the saved layout."""
+        orch = self._make_orchestrator(
+            job_orchestrator,
+            fake_plotting_controller,
+            fake_data_service,
+            plot_data_service,
+            config_store,
+        )
+        grid_id = orch.add_grid(title='Keep', nrows=1, ncols=1)
+        add_cell_with_layer(
+            orch, grid_id, DEFAULT_GEOMETRY, make_plot_config(workflow_id)
+        )
+        saved_before = copy.deepcopy(config_store['plot_grids'])
+        assert saved_before['grids']
+
+        orch.shutdown()
+
+        assert orch.get_all_grids() == {}
+        assert config_store['plot_grids'] == saved_before
 
 
 class TestDeliveryPausedForHiddenLayers:


### PR DESCRIPTION
Fixes #1073.

## Problem

Every `PlotOrchestrator` mutator persists the *whole* in-memory model to the config store on each step (`plot_grids` is a single aggregate blob, rewritten in full). There is no way to treat a multi-step operation as one commit, so any composite lifecycle operation that drives those mutators leaks intermediate state to the store:

- **Startup replay** (`_load_from_store`) reapplies grids/cells/layers through the normal API. If an `add_layer` raises partway through — e.g. a stale layer config that parses but is rejected on add — the loop aborts *after* earlier steps have already overwritten the store. The saved layout is permanently truncated to the partial state, so the user's remaining tabs are gone even on a clean restart.
- **`shutdown()`** removes each grid in turn, every removal persisting, ending at `{'grids': []}` and wiping the saved layout. (Latent today — only tests call it — but the same defect.)

## Fix

A single `_suppress_persist()` context manager makes `_persist_to_store()` a no-op within the block; startup replay and shutdown both run under it. Persistence is suppressed, not deferred — nothing is written on exit: the model was just built from the store (replay) or is being torn down (shutdown), so the last committed layout is exactly what should survive, and a raising block leaves the store untouched, preserving the full layout for the next attempt.

## Similar problems

The sibling `JobOrchestrator` follows the same load-then-persist shape but is structurally immune: it persists one store key *per workflow* rather than a single aggregate blob, so a partial load can never clobber the other entries. The cluster is confined to `PlotOrchestrator`'s two aggregate-blob operations, both fixed here.

## Tests

Two regression tests in `TestPersistenceResilience`, each verified to fail without the fix:

- a store seeded with two valid grids straddling a broken one (a cell stacking two non-overlayable layers) — after the failed replay all three grid definitions still survive in the store, including the one never reached;
- `shutdown()` leaves the saved layout intact.
