### PR TITLE
Run Kafka integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,8 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          sed -n '/=== FAILURES ===/,$p' integration-output.txt | tail -n 160 > summary.txt
+          sed -n '/=== FAILURES ===/,/Captured stdout/p' integration-output.txt | head -n 140 > summary.txt
+          sed -n '/short test summary info/,$p' integration-output.txt >> summary.txt
           if [ ! -s summary.txt ]; then
             tail -n 60 integration-output.txt > summary.txt
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,21 +99,25 @@ jobs:
         if: failure()
         shell: bash
         run: |
+          set +e
           sed -e 's/\x1b\[[0-9;]*m//g' integration-output.txt \
             | grep -v 'Consumed 0 messages' > clean.txt
-          sed -n '/=== FAILURES ===/,$p' clean.txt | head -n 150 > summary.txt
+          awk '/=== FAILURES ===/{found=1} found && n<150 {print; n++}' clean.txt > summary.txt
+          grep 'DIAG' clean.txt >> summary.txt
           sed -n '/short test summary info/,$p' clean.txt >> summary.txt
           if [ ! -s summary.txt ]; then
-            tail -n 60 integration-output.txt > summary.txt
+            tail -n 100 clean.txt > summary.txt
           fi
           split -l 20 summary.txt chunk_
           n=0
           for f in chunk_*; do
+            [ -e "$f" ] || continue
             n=$((n + 1))
-            [ "$n" -gt 8 ] && break
+            if [ "$n" -gt 8 ]; then break; fi
             msg=$(sed -e 's/%/%25/g' "$f" | awk '{printf "%s%%0A", $0}')
             echo "::error title=integration-tests part ${n}::${msg}"
           done
+          true
 
   instrument-check:
     # Verify that an instrument deployment can construct its backend services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          sed -n '/short test summary info/,$p' integration-output.txt > summary.txt
+          sed -n '/=== FAILURES ===/,$p' integration-output.txt | tail -n 160 > summary.txt
           if [ ! -s summary.txt ]; then
             tail -n 60 integration-output.txt > summary.txt
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,30 @@ jobs:
           python-version: '${{ needs.formatting.outputs.min_python }}'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
-      - run: tox -e integration
+      - name: Run integration tests
+        shell: bash
+        run: |
+          tox -e integration 2>&1 | tee integration-output.txt
+          exit "${PIPESTATUS[0]}"
+      - name: Surface failure output as annotations
+        # Log download can be firewalled; annotations are readable via the
+        # checks API. Emit the pytest failure summary in newline-escaped
+        # chunks (annotation count and size are limited).
+        if: failure()
+        shell: bash
+        run: |
+          sed -n '/short test summary info/,$p' integration-output.txt > summary.txt
+          if [ ! -s summary.txt ]; then
+            tail -n 60 integration-output.txt > summary.txt
+          fi
+          split -l 20 summary.txt chunk_
+          n=0
+          for f in chunk_*; do
+            n=$((n + 1))
+            [ "$n" -gt 8 ] && break
+            msg=$(sed -e 's/%/%25/g' "$f" | awk '{printf "%s%%0A", $0}')
+            echo "::error title=integration-tests part ${n}::${msg}"
+          done
 
   instrument-check:
     # Verify that an instrument deployment can construct its backend services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,10 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          sed -n '/=== FAILURES ===/,/Captured stdout/p' integration-output.txt | head -n 140 > summary.txt
-          sed -n '/short test summary info/,$p' integration-output.txt >> summary.txt
+          sed -e 's/\x1b\[[0-9;]*m//g' integration-output.txt \
+            | grep -v 'Consumed 0 messages' > clean.txt
+          sed -n '/=== FAILURES ===/,$p' clean.txt | head -n 150 > summary.txt
+          sed -n '/short test summary info/,$p' clean.txt >> summary.txt
           if [ ! -s summary.txt ]; then
             tail -n 60 integration-output.txt > summary.txt
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,47 @@ jobs:
       tox-env: ${{ matrix.python.tox-env }}
     secrets: inherit
 
+  integration:
+    # Real-Kafka integration tests: fake data sources feeding the real
+    # service stack (monitor_data/detector_data/data_reduction) plus the
+    # dashboard backend, against a single-node KRaft broker. Runs in
+    # parallel with the unit-test job.
+    name: Integration tests (Kafka)
+    needs: formatting
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    services:
+      kafka:
+        image: apache/kafka:3.9.1
+        ports:
+          - 9092:9092
+        env:
+          KAFKA_NODE_ID: 1
+          KAFKA_PROCESS_ROLES: broker,controller
+          KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+          KAFKA_MESSAGE_MAX_BYTES: 104857600
+          KAFKA_REPLICA_FETCH_MAX_BYTES: 104857600
+        options: >-
+          --health-cmd "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"
+          --health-interval 5s
+          --health-timeout 10s
+          --health-retries 12
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '${{ needs.formatting.outputs.min_python }}'
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -r requirements/ci.txt
+      - run: tox -e integration
+
   instrument-check:
     # Verify that an instrument deployment can construct its backend services
     # using only the dependencies declared in its extras. Catches imports that

--- a/src/ess/livedata/kafka/consumer.py
+++ b/src/ess/livedata/kafka/consumer.py
@@ -34,6 +34,13 @@ def assign_all_partitions(consumer: kafka.Consumer, topics: list[str]) -> None:
     ``Consumer.assign`` replaces the entire assignment, so all partitions of all
     topics must be passed in a single call; assigning per topic in a loop would
     leave only the last topic assigned.
+
+    Offsets are pinned to the current high watermark rather than left to
+    ``auto.offset.reset``: with manual assignment, "latest" is resolved lazily
+    when fetching starts, so a message produced between ``assign()`` and the
+    first fetch would be skipped silently (e.g. a command sent right after a
+    service reports ready). Pinning makes the contract deterministic: every
+    message produced after assignment is consumed.
     """
     assignment: list[kafka.TopicPartition] = []
     for topic in topics:
@@ -48,12 +55,29 @@ def assign_all_partitions(consumer: kafka.Consumer, topics: list[str]) -> None:
             logger.error("topic_has_no_partitions", topic=topic)
             raise ValueError(f"Topic '{topic}' exists but has no partitions")
         partition_ids = list(partitions.keys())
-        assignment.extend(kafka.TopicPartition(topic, p) for p in partition_ids)
+        offsets: dict[int, int] = {}
+        for partition in partition_ids:
+            try:
+                _low, high = consumer.get_watermark_offsets(
+                    kafka.TopicPartition(topic, partition), timeout=5.0
+                )
+            except KafkaException as e:
+                logger.exception(
+                    "watermark_fetch_failed", topic=topic, partition=partition
+                )
+                raise ValueError(
+                    f"Failed to fetch watermark for '{topic}' partition"
+                    f" {partition}: {e}"
+                ) from e
+            offsets[partition] = high
+        assignment.extend(
+            kafka.TopicPartition(topic, p, offsets[p]) for p in partition_ids
+        )
         logger.info(
             "partitions_resolved",
             topic=topic,
             partition_count=len(partition_ids),
-            partitions=partition_ids,
+            offsets=offsets,
         )
     consumer.assign(assignment)
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -50,7 +50,7 @@ def test_my_workflow(integration_env):
 
     # Use helper to wait for data for the specific jobs we created
     # Returns dict[JobId, dict[ResultKey, data]]
-    job_data = wait_for_job_data(backend, job_ids, timeout=10.0)
+    job_data = wait_for_job_data(backend, workflow_id, job_ids, timeout=10.0)
 
     # Make assertions about the jobs we created
     assert job_ids[0] in job_data

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -255,7 +255,7 @@ def monitor_services(request) -> Generator[ServiceGroup, None, None]:
                     'dev': True,
                     'readiness_messages': [
                         'Service started',
-                        'Kafka consumer ready and polling',
+                        'kafka_consumer_ready',
                     ],
                 },
             ),
@@ -286,7 +286,7 @@ def detector_services(request) -> Generator[ServiceGroup, None, None]:
                     'dev': True,
                     'readiness_messages': [
                         'Service started',
-                        'Kafka consumer ready and polling',
+                        'kafka_consumer_ready',
                     ],
                 },
             ),
@@ -317,7 +317,7 @@ def reduction_services(request) -> Generator[ServiceGroup, None, None]:
                     'dev': True,
                     'readiness_messages': [
                         'Service started',
-                        'Kafka consumer ready and polling',
+                        'kafka_consumer_ready',
                     ],
                 },
             ),
@@ -327,7 +327,7 @@ def reduction_services(request) -> Generator[ServiceGroup, None, None]:
                     'dev': True,
                     'readiness_messages': [
                         'Service started',
-                        'Kafka consumer ready and polling',
+                        'kafka_consumer_ready',
                     ],
                 },
             ),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,11 +7,51 @@ from collections.abc import Generator
 from dataclasses import dataclass
 
 import pytest
+from confluent_kafka import KafkaError, KafkaException
+from confluent_kafka.admin import AdminClient, NewTopic
 
+from ess.livedata.config import config_names
+from ess.livedata.config.config_loader import load_config
+from ess.livedata.config.streams import get_stream_mapping
 from tests.integration.backend import DashboardBackend
 from tests.integration.service_process import ServiceGroup, ServiceProcess
 
 logger = logging.getLogger(__name__)
+
+
+def _ensure_topics_exist(instrument: str) -> None:
+    """Create the topics consumers validate at startup.
+
+    Consumers fail fast on missing topics (``validate_topics_exist``), and
+    broker-side auto-creation only triggers on produce, so a pristine broker
+    (CI, fresh local setup) needs the topics created up front. Idempotent.
+    """
+    mapping = get_stream_mapping(instrument=instrument, dev=True)
+    topics = (
+        mapping.detector_topics
+        | mapping.area_detector_topics
+        | mapping.monitor_topics
+        | mapping.log_topics
+        | {
+            mapping.topics.livedata_commands,
+            mapping.topics.livedata_data,
+            mapping.topics.livedata_responses,
+            mapping.topics.livedata_roi,
+            mapping.topics.livedata_status,
+            mapping.topics.filewriter,
+        }
+    )
+    admin = AdminClient(load_config(namespace=config_names.kafka, env='dev'))
+    futures = admin.create_topics(
+        [NewTopic(topic, num_partitions=1) for topic in sorted(topics)]
+    )
+    for topic, future in futures.items():
+        try:
+            future.result()
+        except KafkaException as e:
+            if e.args[0].code() != KafkaError.TOPIC_ALREADY_EXISTS:
+                raise
+            logger.debug("Topic already exists: %s", topic)
 
 
 @dataclass
@@ -63,6 +103,7 @@ def _create_service_group(
         ServiceGroup instance
     """
     instrument, log_level = _get_instrument_and_log_level(request)
+    _ensure_topics_exist(instrument)
 
     services_dict = {}
     for name, (module_path, extra_kwargs) in services_config.items():
@@ -106,6 +147,8 @@ def dashboard_backend(request) -> Generator[DashboardBackend, None, None]:
         DashboardBackend instance
     """
     instrument, log_level_name = _get_instrument_and_log_level(request)
+
+    _ensure_topics_exist(instrument)
 
     logger.info("Creating dashboard backend for instrument: %s", instrument)
     with DashboardBackend(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,17 +2,56 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Helper utilities for integration tests."""
 
+import logging
 import time
+import uuid
 from collections.abc import Callable
 from typing import Any
 
+from ess.livedata.config import config_names
+from ess.livedata.config.config_loader import load_config
 from ess.livedata.config.workflow_spec import JobId, ResultKey
+
+logger = logging.getLogger(__name__)
 
 
 class WaitTimeout(Exception):
     """Raised when waiting for a condition times out."""
 
     pass
+
+
+def dump_diagnostics(backend: Any, instrument: str = 'dummy') -> None:
+    """Print pipeline state for debugging a wait timeout.
+
+    Watermark offsets show per-topic message counts without consuming,
+    distinguishing "backend never published" from "dashboard never consumed".
+    Lines are prefixed DIAG so CI failure annotations can grep them.
+    """
+    from confluent_kafka import Consumer, TopicPartition
+
+    logger.warning("DIAG data_service keys: %s", list(backend.data_service))
+    logger.warning("DIAG job_statuses: %s", backend.job_service.job_statuses)
+    config = load_config(namespace=config_names.kafka, env='dev')
+    consumer = Consumer({**config, 'group.id': f'diag-{uuid.uuid4()}'})
+    try:
+        for suffix in (
+            'beam_monitor',
+            'livedata_commands',
+            'livedata_responses',
+            'livedata_heartbeat',
+            'livedata_data',
+        ):
+            topic = f'{instrument}_{suffix}'
+            try:
+                low, high = consumer.get_watermark_offsets(
+                    TopicPartition(topic, 0), timeout=5.0
+                )
+                logger.warning("DIAG topic %s: low=%s high=%s", topic, low, high)
+            except Exception as e:
+                logger.warning("DIAG topic %s: watermark fetch failed: %s", topic, e)
+    finally:
+        consumer.close()
 
 
 def wait_for_condition(
@@ -94,7 +133,13 @@ def wait_for_job_data(
                 return False
         return True
 
-    wait_for_condition(check_for_job_data, timeout=timeout, poll_interval=poll_interval)
+    try:
+        wait_for_condition(
+            check_for_job_data, timeout=timeout, poll_interval=poll_interval
+        )
+    except WaitTimeout:
+        dump_diagnostics(backend)
+        raise
 
     result = {}
     for job_id in job_ids:
@@ -141,8 +186,12 @@ def wait_for_job_statuses(
         backend.update()
         return all(job_id in backend.job_service.job_statuses for job_id in job_ids)
 
-    wait_for_condition(
-        check_for_status_updates, timeout=timeout, poll_interval=poll_interval
-    )
+    try:
+        wait_for_condition(
+            check_for_status_updates, timeout=timeout, poll_interval=poll_interval
+        )
+    except WaitTimeout:
+        dump_diagnostics(backend)
+        raise
 
     return {job_id: backend.job_service.job_statuses[job_id] for job_id in job_ids}

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from ess.livedata.config import config_names
 from ess.livedata.config.config_loader import load_config
-from ess.livedata.config.workflow_spec import JobId, ResultKey
+from ess.livedata.config.workflow_spec import DataKey, JobId, WorkflowId
 
 logger = logging.getLogger(__name__)
 
@@ -83,9 +83,20 @@ def wait_for_condition(
         time.sleep(poll_interval)
 
 
-def _get_result_keys_for_job_id(data_service: Any, job_id: JobId) -> list[ResultKey]:
-    """Get all ResultKeys in DataService that match the given JobId."""
-    return [key for key in data_service if key.job_id == job_id]
+def _get_data_keys_for_source(
+    data_service: Any, workflow_id: WorkflowId, source_name: str
+) -> list[DataKey]:
+    """Get all DataKeys in DataService for one workflow source.
+
+    The data plane is keyed by the stable ``DataKey`` (workflow, source,
+    output); the per-commit job_number is provenance, not identity, so jobs
+    are matched via their source_name.
+    """
+    return [
+        key
+        for key in data_service
+        if key.workflow_id == workflow_id and key.source_name == source_name
+    ]
 
 
 # Job-specific helpers
@@ -93,12 +104,13 @@ def _get_result_keys_for_job_id(data_service: Any, job_id: JobId) -> list[Result
 
 def wait_for_job_data(
     backend: Any,
+    workflow_id: WorkflowId,
     job_ids: list[JobId],
     timeout: float = 10.0,
     poll_interval: float = 0.5,
-) -> dict[JobId, dict[ResultKey, Any]]:
+) -> dict[JobId, dict[DataKey, Any]]:
     """
-    Wait for job data to arrive for specific jobs.
+    Wait for data to arrive for every source of the given jobs.
 
     This helper processes messages via backend.update() and waits until all
     specified jobs have received data, then returns the data.
@@ -107,6 +119,8 @@ def wait_for_job_data(
     ----------
     backend:
         The DashboardBackend instance (must have .update() and .data_service)
+    workflow_id:
+        Workflow the jobs belong to
     job_ids:
         List of JobIds to wait for
     timeout:
@@ -117,7 +131,7 @@ def wait_for_job_data(
     Returns
     -------
     :
-        Dictionary mapping JobId to {ResultKey: data} for each job
+        Dictionary mapping JobId to {DataKey: data} for each job
 
     Raises
     ------
@@ -127,11 +141,12 @@ def wait_for_job_data(
 
     def check_for_job_data():
         backend.update()
-        for job_id in job_ids:
-            keys = _get_result_keys_for_job_id(backend.data_service, job_id)
-            if not keys:
-                return False
-        return True
+        return all(
+            _get_data_keys_for_source(
+                backend.data_service, workflow_id, job_id.source_name
+            )
+            for job_id in job_ids
+        )
 
     try:
         wait_for_condition(
@@ -143,7 +158,9 @@ def wait_for_job_data(
 
     result = {}
     for job_id in job_ids:
-        keys = _get_result_keys_for_job_id(backend.data_service, job_id)
+        keys = _get_data_keys_for_source(
+            backend.data_service, workflow_id, job_id.source_name
+        )
         result[job_id] = {key: backend.data_service[key] for key in keys}
     return result
 

--- a/tests/integration/helpers_test.py
+++ b/tests/integration/helpers_test.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 import scipp as sc
 
-from ess.livedata.config.workflow_spec import JobId, JobNumber, ResultKey, WorkflowId
+from ess.livedata.config.workflow_spec import DataKey, JobId, JobNumber, WorkflowId
 from ess.livedata.core.job_manager import JobState, JobStatus
 from ess.livedata.dashboard.data_service import DataService
 from ess.livedata.dashboard.job_service import JobService
@@ -60,7 +60,7 @@ class IntegrationTestBackend:
     """Backend stub for testing wait helpers with real services."""
 
     def __init__(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         self.job_service = job_service
         self.data_service = data_service
@@ -79,7 +79,7 @@ class IntegrationTestBackend:
 
 
 @pytest.fixture
-def data_service() -> DataService[ResultKey, Any]:
+def data_service() -> DataService[DataKey, Any]:
     """Create a DataService for testing."""
     return DataService()
 
@@ -119,36 +119,38 @@ class TestWaitForJobData:
     """Tests for wait_for_job_data helper."""
 
     def test_succeeds_when_data_arrives_for_single_job(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         """wait_for_job_data should return when data arrives for single job."""
         backend = IntegrationTestBackend(job_service, data_service)
         workflow_a = make_workflow_id('workflow_a')
         job_1 = make_job_number(1)
         job_id = make_job_id(job_1, 'source1')
-        result_key = ResultKey(
+        data_key = DataKey(
             workflow_id=workflow_a,
-            job_id=job_id,
+            source_name=job_id.source_name,
             output_name='output1',
         )
 
         # Simulate data arriving after a few updates
         def simulate_data_arrival():
             if backend.update_count == 2:
-                data_service[result_key] = make_test_result('data')
+                data_service[data_key] = make_test_result('data')
 
         backend.on_update_callbacks.append(simulate_data_arrival)
 
-        result = wait_for_job_data(backend, [job_id], timeout=2.0, poll_interval=0.05)
+        result = wait_for_job_data(
+            backend, workflow_a, [job_id], timeout=2.0, poll_interval=0.05
+        )
 
         assert backend.update_count >= 2
-        # Should return dict mapping JobId to {ResultKey: data}
+        # Should return dict mapping JobId to {DataKey: data}
         assert job_id in result
-        assert result_key in result[job_id]
-        assert result[job_id][result_key].value == 'data'
+        assert data_key in result[job_id]
+        assert result[job_id][data_key].value == 'data'
 
     def test_succeeds_when_data_arrives_for_all_jobs(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         """wait_for_job_data should return when data arrives for all specified jobs."""
         backend = IntegrationTestBackend(job_service, data_service)
@@ -164,21 +166,21 @@ class TestWaitForJobData:
             if backend.update_count == 2:
                 for job_id in job_ids:
                     data_service[
-                        ResultKey(
+                        DataKey(
                             workflow_id=workflow_a,
-                            job_id=job_id,
+                            source_name=job_id.source_name,
                             output_name='output1',
                         )
                     ] = make_test_result('data')
 
         backend.on_update_callbacks.append(simulate_data_arrival)
 
-        wait_for_job_data(backend, job_ids, timeout=2.0, poll_interval=0.05)
+        wait_for_job_data(backend, workflow_a, job_ids, timeout=2.0, poll_interval=0.05)
 
         assert backend.update_count >= 2
 
     def test_must_not_succeed_if_only_some_jobs_have_data(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         """CRITICAL: must NOT succeed if only some jobs have data (require all)."""
         backend = IntegrationTestBackend(job_service, data_service)
@@ -191,18 +193,20 @@ class TestWaitForJobData:
 
         # Add data for only the first job
         data_service[
-            ResultKey(
+            DataKey(
                 workflow_id=workflow_a,
-                job_id=job_ids[0],
+                source_name=job_ids[0].source_name,
                 output_name='output1',
             )
         ] = make_test_result('data')
 
         with pytest.raises(WaitTimeout):
-            wait_for_job_data(backend, job_ids, timeout=0.3, poll_interval=0.05)
+            wait_for_job_data(
+                backend, workflow_a, job_ids, timeout=0.3, poll_interval=0.05
+            )
 
     def test_must_not_succeed_for_wrong_job(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         """CRITICAL: must NOT succeed when data arrives for different job."""
         backend = IntegrationTestBackend(job_service, data_service)
@@ -211,18 +215,41 @@ class TestWaitForJobData:
         job_id_expected = make_job_id(job_1, 'source1')
         job_id_other = make_job_id(job_1, 'other_source')
 
-        # Add data for different job
+        # Add data for different source
         data_service[
-            ResultKey(
+            DataKey(
                 workflow_id=workflow_a,
-                job_id=job_id_other,
+                source_name=job_id_other.source_name,
                 output_name='output1',
             )
         ] = make_test_result('data')
 
         with pytest.raises(WaitTimeout):
             wait_for_job_data(
-                backend, [job_id_expected], timeout=0.3, poll_interval=0.05
+                backend, workflow_a, [job_id_expected], timeout=0.3, poll_interval=0.05
+            )
+
+    def test_must_not_succeed_for_wrong_workflow(
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
+    ):
+        """Data for the same source under another workflow must not match."""
+        backend = IntegrationTestBackend(job_service, data_service)
+        job_id = make_job_id(make_job_number(1), 'source1')
+        data_service[
+            DataKey(
+                workflow_id=make_workflow_id('workflow_b'),
+                source_name='source1',
+                output_name='output1',
+            )
+        ] = make_test_result('data')
+
+        with pytest.raises(WaitTimeout):
+            wait_for_job_data(
+                backend,
+                make_workflow_id('workflow_a'),
+                [job_id],
+                timeout=0.3,
+                poll_interval=0.05,
             )
 
 
@@ -230,7 +257,7 @@ class TestWaitForJobStatuses:
     """Tests for wait_for_job_statuses helper."""
 
     def test_succeeds_when_status_arrives_for_single_job(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         """wait_for_job_statuses should return when status arrives for single job."""
         backend = IntegrationTestBackend(job_service, data_service)
@@ -261,7 +288,7 @@ class TestWaitForJobStatuses:
         assert result[job_id].state == JobState.active
 
     def test_succeeds_when_status_arrives_for_all_jobs(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         """wait_for_job_statuses should return when status arrives for all jobs."""
         backend = IntegrationTestBackend(job_service, data_service)
@@ -291,7 +318,7 @@ class TestWaitForJobStatuses:
         assert backend.update_count >= 2
 
     def test_must_not_succeed_if_only_some_jobs_have_status(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         """CRITICAL: must NOT succeed if only some jobs have status (require all)."""
         backend = IntegrationTestBackend(job_service, data_service)
@@ -315,7 +342,7 @@ class TestWaitForJobStatuses:
             wait_for_job_statuses(backend, job_ids, timeout=0.3, poll_interval=0.05)
 
     def test_must_not_succeed_for_wrong_job(
-        self, job_service: JobService, data_service: DataService[ResultKey, Any]
+        self, job_service: JobService, data_service: DataService[DataKey, Any]
     ):
         """CRITICAL: must NOT succeed when status arrives for different job."""
         backend = IntegrationTestBackend(job_service, data_service)

--- a/tests/integration/service_process.py
+++ b/tests/integration/service_process.py
@@ -36,7 +36,7 @@ class ServiceProcess:
         Log messages to wait for during startup. Services are considered ready
         when ALL messages have appeared in the output. Defaults to waiting for
         "Service started". For services with Kafka consumers, consider also
-        waiting for "Kafka consumer ready and polling" to ensure functional
+        waiting for "kafka_consumer_ready" to ensure functional
         readiness.
     **kwargs:
         Service-specific arguments passed as command-line flags

--- a/tests/integration/workflow_lifecycle_test.py
+++ b/tests/integration/workflow_lifecycle_test.py
@@ -48,7 +48,7 @@ def test_workflow_can_start_and_receive_data(integration_env: IntegrationEnv) ->
     assert job_id.source_name == 'monitor1'
 
     # Wait for job data to arrive for the specific jobs we created
-    all_job_data = wait_for_job_data(backend, job_ids, timeout=30.0)
+    all_job_data = wait_for_job_data(backend, workflow_id, job_ids, timeout=30.0)
 
     # Verify that we received data with expected outputs
     job_data = all_job_data[job_id]

--- a/tests/integration/workflow_lifecycle_test.py
+++ b/tests/integration/workflow_lifecycle_test.py
@@ -48,7 +48,7 @@ def test_workflow_can_start_and_receive_data(integration_env: IntegrationEnv) ->
     assert job_id.source_name == 'monitor1'
 
     # Wait for job data to arrive for the specific jobs we created
-    all_job_data = wait_for_job_data(backend, job_ids, timeout=10.0)
+    all_job_data = wait_for_job_data(backend, job_ids, timeout=30.0)
 
     # Verify that we received data with expected outputs
     job_data = all_job_data[job_id]
@@ -86,7 +86,7 @@ def test_workflow_status_updates(integration_env: IntegrationEnv) -> None:
     job_id = job_ids[0]
 
     # Wait for job status updates for the specific jobs we created
-    all_statuses = wait_for_job_statuses(backend, job_ids, timeout=10.0)
+    all_statuses = wait_for_job_statuses(backend, job_ids, timeout=30.0)
 
     # Verify we received status updates for the specific job
     assert job_id in all_statuses, (

--- a/tests/kafka/consumer_test.py
+++ b/tests/kafka/consumer_test.py
@@ -30,13 +30,24 @@ class _ClusterMetadata:
 class _FakeConsumer:
     """Records ``assign`` calls; serves per-topic partition metadata."""
 
-    def __init__(self, topic_partitions: dict[str, list[int]]) -> None:
+    def __init__(
+        self,
+        topic_partitions: dict[str, list[int]],
+        high_watermarks: dict[tuple[str, int], int] | None = None,
+    ) -> None:
         self._topic_partitions = topic_partitions
+        self._high_watermarks = high_watermarks or {}
         self.assignments: list[list] = []
 
     def list_topics(self, topic: str, timeout: float | None = None) -> _ClusterMetadata:
         ids = self._topic_partitions.get(topic, [])
         return _ClusterMetadata({topic: _TopicMetadata(ids)})
+
+    def get_watermark_offsets(
+        self, partition, timeout: float | None = None
+    ) -> tuple[int, int]:
+        high = self._high_watermarks.get((partition.topic, partition.partition), 0)
+        return 0, high
 
     def assign(self, partitions: list) -> None:
         self.assignments.append(partitions)
@@ -51,6 +62,21 @@ def test_assigns_all_partitions_of_all_topics_in_one_call() -> None:
     assert len(consumer.assignments) == 1
     assigned = {(tp.topic, tp.partition) for tp in consumer.assignments[0]}
     assert assigned == {('a', 0), ('a', 1), ('b', 0)}
+
+
+def test_assignment_pins_offsets_to_high_watermark() -> None:
+    # Relying on auto.offset.reset would resolve "latest" only at first
+    # fetch, silently skipping messages produced between assign() and that
+    # fetch. The assignment must carry the high watermark explicitly.
+    consumer = _FakeConsumer(
+        {'a': [0, 1], 'b': [0]},
+        high_watermarks={('a', 0): 42, ('a', 1): 7, ('b', 0): 0},
+    )
+
+    assign_all_partitions(consumer, ['a', 'b'])
+
+    offsets = {(tp.topic, tp.partition): tp.offset for tp in consumer.assignments[0]}
+    assert offsets == {('a', 0): 42, ('a', 1): 7, ('b', 0): 0}
 
 
 def test_raises_when_topic_has_no_partitions() -> None:


### PR DESCRIPTION
The `tests/integration/` harness (fake data sources feeding the real `monitor_data`/`detector_data`/`data_reduction` services plus the dashboard backend over real Kafka) existed but no workflow ever ran it. This adds a CI job with a single-node KRaft service container running `tox -e integration`, in parallel with the unit-test job. Failure output is emitted as check-run annotations because raw log download is firewalled in some dev environments.

Getting the suite green on a pristine broker surfaced real rot, fixed here:

- **Lost-command bug in the Kafka consumer (src)**: manual partition assignment relied on `auto.offset.reset=latest`, which is resolved lazily at first fetch — a message produced between `assign()` and that fetch is skipped silently. On a cold broker this reliably swallowed the workflow start command (no ACK, no job, no data, while heartbeats flowed). Plausible source of lost commands in production; the assignment is now pinned to the broker high watermark, making "everything produced after assignment is consumed" deterministic.
- **Topics were never created by the harness**: consumers fail fast on missing topics and auto-creation only triggers on produce, so the suite only ever passed against brokers holding topics from earlier runs. Fixtures now pre-create the instrument's topics from its `StreamMapping`.
- **Readiness gate matched a log message that no longer exists** ("Kafka consumer ready and polling" vs the actual `kafka_consumer_ready`), silently burning the 10 s timeout on every service start and leaving tests to race service startup.
- **Wait helpers spoke the pre-restructure data plane**: they matched `ResultKey.job_id` on `DataService` keys, which are `DataKey` (workflow, source, output) since the delivery restructure. Jobs are now matched by workflow + source, with a guard test that another workflow's data does not satisfy the wait.
- On timeout the helpers now log DataService keys, job statuses, and per-topic watermark offsets — the diagnostics that pinpointed the lost command.

Part of #1097; enables automating its backend-dependent checklist items (job adoption, clear-at-commit, ROI spectra, ACK expiry) as integration tests in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)