### PR TITLE
Automate Kafka-free items of the #1097 verification checklist

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -59,7 +59,11 @@ no text, `title`, or `aria-label` — leaving nothing semantic for browser autom
 `lt-wf-*` and `lt-grid-*` slug different things on purpose: a workflow has a stable
 *name* identity to slug (`workflow_status_widget.py`'s `_tool_css_class`), but a grid has
 none, so `lt-grid-*` slugs the grid *title* instead (`plot_grid_manager.py`) — the same
-title that also drives the grid's download filename.
+title that also drives the grid's download filename. Plot cells have neither a name nor
+a stable title, so their titlebar pencil carries the grid position as
+`lt-cell-r{row}c{col}` (`cell.py`) — unique per grid, and only the active tab's grid is
+rendered. Do not rely on DOM order for cells: a rebuilt cell (e.g. after a rename) moves
+to the end of the document.
 
 These classes have no associated style rules — adding/removing them is visually inert.
 Treat them as a stable contract: do not drop them in refactors (a test in

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -402,6 +402,7 @@ class CellWidget:
             self._toolbars_shown = visible
             layers_column.visible = visible
 
+        geometry = cell.geometry
         return create_cell_titlebar(
             title=title,
             has_user_title=has_user_title,
@@ -411,6 +412,10 @@ class CellWidget:
             toolbars_visible=self._toolbars_shown,
             on_toggle_toolbars_callback=on_toggle_toolbars,
             freshness_pane=self._freshness_pane,
+            # Per-cell automation hook: a rebuilt cell's DOM position is not
+            # stable, so the grid position addresses it (unique per grid, and
+            # only the active tab's grid is rendered).
+            css_classes=[f'lt-cell-r{geometry.row}c{geometry.col}'],
         )
 
     def _build_layer_toolbars(

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -375,6 +375,7 @@ def create_cell_titlebar(
     toolbars_visible: bool,
     on_toggle_toolbars_callback: Callable[[bool], None],
     freshness_pane: pn.pane.HTML | None = None,
+    css_classes: list[str] | None = None,
 ) -> pn.Row:
     """
     Create the cell-level titlebar shown above the per-layer info rows.
@@ -407,6 +408,10 @@ def create_cell_titlebar(
     freshness_pane:
         Optional pane showing the data freshness/lag indicator, placed between
         the title and the action buttons. Updated in place by the caller.
+    css_classes:
+        Extra context classes for the edit (pencil) button so repeated cell
+        instances are uniquely addressable in automation (e.g.
+        ``lt-cell-r0c0``); a rebuilt cell's DOM position is not stable.
 
     Returns
     -------
@@ -430,6 +435,7 @@ def create_cell_titlebar(
         button_color=Colors.TEXT_MUTED,
         hover_color=HoverColors.MUTED,
         on_click_callback=on_edit_title_callback,
+        css_classes=css_classes,
     )
     toggle_button = _create_toolbar_visibility_button(
         visible=toolbars_visible,

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -2,16 +2,15 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Browser-driven regression tests for dashboard UI flows.
 
-Automates checklist items from #1097 that need no Kafka backend, driving the
-fake-backend dashboard (seeded from the committed dummy fixture) through the
-stable ``lt-*`` automation hooks:
+Automates the recurring manual verification items that need no Kafka backend,
+driving the fake-backend dashboard (seeded from the committed dummy fixture)
+through the stable ``lt-*`` automation hooks:
 
 - session reload restores tabs and live updates;
-- a grid created in one session appears in others without stealing focus
-  (#1040);
-- a cell title survives a no-op Save of the cell-properties modal (#1083);
+- a grid created in one session appears in others without stealing focus;
+- a cell title survives a no-op Save of the cell-properties modal;
 - disabling or removing a grid keeps the remaining tabs resolving and
-  updating (#1088).
+  updating.
 
 Each test launches its own dashboard on a dedicated port for isolation, since
 grid topology changes are process-global. Runs locally via ``pytest -m
@@ -87,8 +86,8 @@ def test_grid_created_in_one_session_appears_in_other_without_stealing_focus():
             lambda: "Created Elsewhere" in observer.tab_names(),
             label="new grid tab in the other session",
         )
-        # ...but its active tab must not change (#1040). The creating session
-        # focuses the new tab, which is local intent, not shared state.
+        # ...but its active tab must not change: tab focus is local intent,
+        # not shared state, so only the creating session focuses the new tab.
         assert _active_tab(observer) == observer_tab
         wait_until(
             creator,
@@ -116,7 +115,8 @@ def test_cell_title_survives_noop_save_of_cell_properties_modal():
             label="renamed cell titlebar",
         )
 
-        # Reopen and Save without typing: the title must survive (#1083).
+        # Reopen and Save without typing: an untouched Save must not clear
+        # the user title (the field pre-fill must round-trip through Save).
         dash.open_modal(pencil)
         assert page.locator(_CELL_TITLE_INPUT).input_value() == "My Cell"
         page.get_by_role("button", name="Save", exact=True).click()
@@ -134,7 +134,9 @@ def test_remaining_tabs_keep_updating_after_disabling_and_removing_grids():
     with fake_dashboard("dummy", 5036) as url, Dashboard.connect(url) as dash:
         # Arrange three grids ordered [Bravo, Charlie, Detectors]: two empty
         # grids ahead of the fixture's populated one, so disabling the first
-        # and removing the middle both shift the Detectors tab index (#1088).
+        # and removing the middle both shift the Detectors tab position --
+        # the regression class where tab indices fall out of alignment with
+        # the grid list once a preceding grid is hidden or gone.
         dash.goto_tab("Manage Plots")
         _add_grid(dash, "Bravo")
         dash.goto_tab("Manage Plots")

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Browser-driven regression tests for dashboard UI flows.
+
+Automates checklist items from #1097 that need no Kafka backend, driving the
+fake-backend dashboard (seeded from the committed dummy fixture) through the
+stable ``lt-*`` automation hooks:
+
+- session reload restores tabs and live updates;
+- a grid created in one session appears in others without stealing focus
+  (#1040);
+- a cell title survives a no-op Save of the cell-properties modal (#1083);
+- disabling or removing a grid keeps the remaining tabs resolving and
+  updating (#1088).
+
+Each test launches its own dashboard on a dedicated port for isolation, since
+grid topology changes are process-global. Runs locally via ``pytest -m
+browser`` (excluded from the default run and CI; skips cleanly where
+Playwright is absent).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+from tests.helpers.browser import (
+    Dashboard,
+    assert_updating,
+    fake_dashboard,
+    fingerprint,
+    wait_until,
+)
+
+_CELL_TITLE_INPUT = 'input[placeholder="Leave empty to use the derived title"]'
+_GRID_TITLE_INPUT = 'input[placeholder="Enter grid title"]'
+
+
+def _active_tab(dash: Dashboard) -> str:
+    return dash.page.locator(".bk-tab.bk-active").first.inner_text().strip()
+
+
+def _add_grid(dash: Dashboard, title: str) -> None:
+    """Add an empty grid via the Manage Plots form (must be the active tab).
+
+    Panel's TextInput syncs ``value`` on Enter/blur, so press Enter before
+    clicking the button. Adding focuses the new grid's tab in this session.
+    """
+    dash.page.locator(_GRID_TITLE_INPUT).fill(title)
+    dash.page.keyboard.press("Enter")
+    dash.page.get_by_role("button", name="Add Grid", exact=True).click()
+    wait_until(
+        dash, lambda: title in dash.tab_names(), label=f"tab {title!r} to appear"
+    )
+
+
+@pytest.mark.browser
+def test_session_reload_restores_tabs_and_live_updates():
+    with fake_dashboard("dummy", 5033) as url, Dashboard.connect(url) as dash:
+        dash.goto_tab("Detectors")
+        assert_updating(dash, "session before reload")
+
+        dash.page.reload(wait_until="networkidle")
+        dash.page.wait_for_timeout(5000)
+
+        assert "Detectors" in dash.tab_names()
+        dash.goto_tab("Detectors")
+        fp = fingerprint(dash)
+        assert fp["sources"] > 0, "no data sources rendered after reload"
+        assert_updating(dash, "session after reload")
+
+
+@pytest.mark.browser
+def test_grid_created_in_one_session_appears_in_other_without_stealing_focus():
+    with (
+        fake_dashboard("dummy", 5034) as url,
+        Dashboard.connect_many(2, url) as (creator, observer),
+    ):
+        observer_tab = _active_tab(observer)
+        creator.goto_tab("Manage Plots")
+
+        _add_grid(creator, "Created Elsewhere")
+
+        # The other session gains the tab via its topology poll...
+        wait_until(
+            observer,
+            lambda: "Created Elsewhere" in observer.tab_names(),
+            label="new grid tab in the other session",
+        )
+        # ...but its active tab must not change (#1040). The creating session
+        # focuses the new tab, which is local intent, not shared state.
+        assert _active_tab(observer) == observer_tab
+        wait_until(
+            creator,
+            lambda: _active_tab(creator) == "Created Elsewhere",
+            label="creating session to focus its new tab",
+        )
+
+
+@pytest.mark.browser
+def test_cell_title_survives_noop_save_of_cell_properties_modal():
+    # The per-cell hook (not DOM order) addresses the cell: a rebuilt cell --
+    # e.g. after the rename below -- moves to the end of the document.
+    pencil = ".lt-cell-r0c0.lt-tool-pencil"
+    with fake_dashboard("dummy", 5035) as url, Dashboard.connect(url) as dash:
+        page = dash.page
+        dash.goto_tab("Detectors")
+
+        # Give the first cell a user-defined title.
+        dash.open_modal(pencil)
+        page.locator(_CELL_TITLE_INPUT).fill("My Cell")
+        page.get_by_role("button", name="Save", exact=True).click()
+        wait_until(
+            dash,
+            page.get_by_text("My Cell", exact=True).first.is_visible,
+            label="renamed cell titlebar",
+        )
+
+        # Reopen and Save without typing: the title must survive (#1083).
+        dash.open_modal(pencil)
+        assert page.locator(_CELL_TITLE_INPUT).input_value() == "My Cell"
+        page.get_by_role("button", name="Save", exact=True).click()
+        page.locator("[role=dialog]").first.wait_for(state="hidden", timeout=10000)
+
+        # The titlebar keeps the title, and the persisted state still carries
+        # it: reopening the modal pre-fills the unchanged user title.
+        assert page.get_by_text("My Cell", exact=True).first.is_visible()
+        dash.open_modal(pencil)
+        assert page.locator(_CELL_TITLE_INPUT).input_value() == "My Cell"
+
+
+@pytest.mark.browser
+def test_remaining_tabs_keep_updating_after_disabling_and_removing_grids():
+    with fake_dashboard("dummy", 5036) as url, Dashboard.connect(url) as dash:
+        # Arrange three grids ordered [Bravo, Charlie, Detectors]: two empty
+        # grids ahead of the fixture's populated one, so disabling the first
+        # and removing the middle both shift the Detectors tab index (#1088).
+        dash.goto_tab("Manage Plots")
+        _add_grid(dash, "Bravo")
+        dash.goto_tab("Manage Plots")
+        _add_grid(dash, "Charlie")
+        dash.goto_tab("Manage Plots")
+        for expected in (
+            ["Bravo", "Detectors", "Charlie"],
+            ["Bravo", "Charlie", "Detectors"],
+        ):
+            dash.click(".lt-grid-detectors.lt-tool-chevron-down")
+            wait_until(
+                dash,
+                lambda expected=expected: dash.tab_names()[-3:] == expected,
+                label=f"grid tab order {expected}",
+            )
+
+        # Disable the first grid: its tab vanishes, the rest keep working.
+        dash.click(".lt-grid-bravo.lt-tool-eye")
+        wait_until(
+            dash,
+            lambda: "Bravo" not in dash.tab_names(),
+            label="disabled grid tab to vanish",
+        )
+        assert "Charlie" in dash.tab_names()
+        dash.goto_tab("Detectors")
+        assert_updating(dash, "Detectors tab after disabling first grid")
+
+        # Remove the middle grid of [Bravo (disabled), Charlie, Detectors].
+        dash.goto_tab("Manage Plots")
+        dash.click(".lt-grid-charlie.lt-tool-x")
+        wait_until(
+            dash,
+            lambda: "Charlie" not in dash.tab_names(),
+            label="removed grid tab to vanish",
+        )
+        dash.goto_tab("Detectors")
+        assert_updating(dash, "Detectors tab after removing middle grid")

--- a/tests/dashboard/multisession_smoke_test.py
+++ b/tests/dashboard/multisession_smoke_test.py
@@ -24,63 +24,21 @@ skips cleanly where Playwright is absent).
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
-
 pytest.importorskip("playwright.sync_api")
-from drive_dashboard import Dashboard, _fake_dashboard  # noqa: E402
-
-# How long to watch for a data update before declaring a session stalled. The
-# fake backend emits at 1 Hz, so this is a generous margin.
-_UPDATE_WINDOW_MS = 6000
-
-# Fingerprint of all rendered ColumnDataSource data in the page: source and
-# column-length counts plus a value checksum (sampling nested/typed arrays, so
-# image payloads contribute). Any data update changes it.
-_DATA_FINGERPRINT_JS = """() => {
-  let sources = 0, length = 0, checksum = 0;
-  const sample = (column) => {
-    for (let i = 0; i < Math.min(column.length, 64); i++) {
-      const v = column[i];
-      if (typeof v === 'number' && Number.isFinite(v)) checksum += v;
-      else if (v && typeof v.length === 'number') sample(v);
-    }
-  };
-  for (const doc of (window.Bokeh && Bokeh.documents) || []) {
-    for (const m of Array.from(doc._all_models.values())) {
-      if (m.type === 'ColumnDataSource') {
-        sources++;
-        for (const column of Object.values(m.data)) {
-          length += column.length;
-          sample(column);
-        }
-      }
-    }
-  }
-  return {sources, length, checksum};
-}"""
-
-
-def _fingerprint(dash: Dashboard) -> dict:
-    return dash.page.evaluate(_DATA_FINGERPRINT_JS)
-
-
-def _assert_updating(dash: Dashboard, label: str) -> None:
-    before = _fingerprint(dash)
-    dash.page.wait_for_timeout(_UPDATE_WINDOW_MS)
-    after = _fingerprint(dash)
-    assert after != before, f"{label} stopped receiving data updates: {before}"
+from tests.helpers.browser import (
+    Dashboard,
+    assert_updating,
+    fake_dashboard,
+    fingerprint,
+)
 
 
 @pytest.mark.browser
 def test_two_sessions_see_plots_and_keep_receiving_updates():
     with (
-        _fake_dashboard("dummy", 5032) as url,
+        fake_dashboard("dummy", 5032) as url,
         Dashboard.connect_many(2, url) as (
             first,
             second,
@@ -96,17 +54,17 @@ def test_two_sessions_see_plots_and_keep_receiving_updates():
         # Both sessions render populated plots, including the session that
         # joined after the workflows were already running.
         for label, dash in [("first session", first), ("second session", second)]:
-            fp = _fingerprint(dash)
+            fp = fingerprint(dash)
             assert fp["sources"] > 0, f"{label} rendered no data sources"
             assert fp["length"] > 0, f"{label} rendered only empty data sources"
 
         # Both sessions keep receiving live updates.
-        _assert_updating(first, "first session")
-        _assert_updating(second, "second session")
+        assert_updating(first, "first session")
+        assert_updating(second, "second session")
 
         # Tab switching in one session must not stall delivery to either: the
         # switching session must resume on return, the other must be unaffected.
         second.goto_tab("Workflows")
         second.goto_tab("Detectors")
-        _assert_updating(second, "second session after tab switch")
-        _assert_updating(first, "first session while other session switched tabs")
+        assert_updating(second, "second session after tab switch")
+        assert_updating(first, "first session while other session switched tabs")

--- a/tests/dashboard/temporal_buffers_test.py
+++ b/tests/dashboard/temporal_buffers_test.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
+from itertools import pairwise
+
 import pytest
 import scipp as sc
 
@@ -433,6 +435,40 @@ class TestTemporalBuffer:
         buffer.add(make_single_slice_datetime([11.0, 11.0], 11))
         result = buffer.get()
         assert result.coords['time'].values[-1] == sc.datetime(11, unit='s').value
+
+    def test_datetime64_buffer_keeps_accepting_after_repeated_wraparound(self):
+        """Sustained adds past capacity must keep working with datetime64 times.
+
+        Regression test for https://github.com/scipp/esslivedata/issues/1087:
+        a datetime64 time coord must survive many wraparound cycles, not just
+        the first trim. After running several multiples of capacity, the
+        newest data is retained, the oldest dropped, and the time coord stays
+        monotonic datetime64.
+        """
+        timespan = 3.0
+        buffer = TemporalBuffer()
+        buffer.set_required_timespan(timespan)
+        buffer.set_max_memory(100)  # Tiny ring so wraparound happens fast
+
+        buffer.add(make_single_slice_datetime([0.0, 0.0], 0))
+        capacity = buffer._data_buffer.max_capacity
+        n_total = 3 * capacity
+        for t in range(1, n_total):
+            buffer.add(make_single_slice_datetime([float(t)] * 2, t))
+
+        result = buffer.get()
+        times = result.coords['time']
+        assert times.dtype == sc.DType.datetime64
+        # Newest data retained, with values still aligned to their times.
+        assert times.values[-1] == sc.datetime(n_total - 1, unit='s').value
+        assert result['time', -1].values[0] == float(n_total - 1)
+        # Oldest data dropped: nothing older than the required timespan.
+        assert (
+            times.values[0] >= sc.datetime(n_total - 1 - int(timespan), unit='s').value
+        )
+        # Time coord is strictly monotonic (no stale or reordered samples).
+        int_times = times.values.astype('datetime64[s]').astype('int64')
+        assert all(b > a for a, b in pairwise(int_times))
 
     def test_timespan_zero_trims_all_old_data_on_overflow(self):
         """Test that timespan=0.0 trims all data to make room for new data."""

--- a/tests/dashboard/temporal_buffers_test.py
+++ b/tests/dashboard/temporal_buffers_test.py
@@ -439,9 +439,9 @@ class TestTemporalBuffer:
     def test_datetime64_buffer_keeps_accepting_after_repeated_wraparound(self):
         """Sustained adds past capacity must keep working with datetime64 times.
 
-        Regression test for https://github.com/scipp/esslivedata/issues/1087:
-        a datetime64 time coord must survive many wraparound cycles, not just
-        the first trim. After running several multiples of capacity, the
+        The datetime64 trim path runs on every overflow, not just the first,
+        so a single-trim test cannot catch corruption that accumulates over
+        wraparound cycles. After running several multiples of capacity, the
         newest data is retained, the oldest dropped, and the time coord stays
         monotonic datetime64.
         """

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -27,6 +27,7 @@ from ess.livedata.dashboard.widgets.plot_widgets import (
     _create_configure_button_or_menu,
     _create_toolbar_visibility_button,
     _format_window_info,
+    create_cell_titlebar,
     derive_cell_title,
     get_plot_cell_display_info,
 )
@@ -54,6 +55,31 @@ class TestPerPanelToolHooks:
         )
         assert 'lt-tool' in menu.css_classes
         assert 'lt-tool-settings' in menu.css_classes
+
+    def test_titlebar_pencil_carries_per_cell_context_hook(self) -> None:
+        """The edit pencil must carry the caller's per-cell context class.
+
+        A rebuilt cell's DOM position is not stable, so automation addresses
+        the pencil via the cell-position context (e.g. lt-cell-r0c0) instead
+        of DOM order.
+        """
+        titlebar = create_cell_titlebar(
+            title='T',
+            has_user_title=False,
+            on_edit_title_callback=lambda: None,
+            configure_layers=[(LayerId('a'), 'A')],
+            on_configure_layer=lambda _: None,
+            toolbars_visible=True,
+            on_toggle_toolbars_callback=lambda _: None,
+            css_classes=['lt-cell-r0c0'],
+        )
+        pencils = [
+            obj
+            for obj in titlebar.objects
+            if 'lt-tool-pencil' in (getattr(obj, 'css_classes', None) or [])
+        ]
+        assert len(pencils) == 1
+        assert 'lt-cell-r0c0' in pencils[0].css_classes
 
 
 class _FakeParams(TimeWindowMixin):

--- a/tests/helpers/browser.py
+++ b/tests/helpers/browser.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Shared helpers for browser-driven (Playwright) dashboard tests.
+
+Importing this module requires Playwright; test modules must call
+``pytest.importorskip("playwright.sync_api")`` before importing it.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from drive_dashboard import Dashboard, _fake_dashboard  # noqa: E402
+
+fake_dashboard = _fake_dashboard
+
+# How long to watch for a data update before declaring a session stalled. The
+# fake backend emits at 1 Hz, so this is a generous margin.
+UPDATE_WINDOW_MS = 6000
+
+# Cross-session state propagates via per-session version polling (~1 s tick);
+# generous margin for a change made in one session to appear in another.
+PROPAGATION_TIMEOUT_MS = 20_000
+
+# Fingerprint of all rendered ColumnDataSource data in the page: source and
+# column-length counts plus a value checksum (sampling nested/typed arrays, so
+# image payloads contribute). Any data update changes it.
+DATA_FINGERPRINT_JS = """() => {
+  let sources = 0, length = 0, checksum = 0;
+  const sample = (column) => {
+    for (let i = 0; i < Math.min(column.length, 64); i++) {
+      const v = column[i];
+      if (typeof v === 'number' && Number.isFinite(v)) checksum += v;
+      else if (v && typeof v.length === 'number') sample(v);
+    }
+  };
+  for (const doc of (window.Bokeh && Bokeh.documents) || []) {
+    for (const m of Array.from(doc._all_models.values())) {
+      if (m.type === 'ColumnDataSource') {
+        sources++;
+        for (const column of Object.values(m.data)) {
+          length += column.length;
+          sample(column);
+        }
+      }
+    }
+  }
+  return {sources, length, checksum};
+}"""
+
+
+def fingerprint(dash: Dashboard) -> dict:
+    return dash.page.evaluate(DATA_FINGERPRINT_JS)
+
+
+def assert_updating(dash: Dashboard, label: str) -> None:
+    """Assert the session's rendered data changes within the update window."""
+    before = fingerprint(dash)
+    dash.page.wait_for_timeout(UPDATE_WINDOW_MS)
+    after = fingerprint(dash)
+    assert after != before, f"{label} stopped receiving data updates: {before}"
+
+
+def wait_until(
+    dash: Dashboard,
+    condition: Callable[[], bool],
+    *,
+    label: str,
+    timeout_ms: int = PROPAGATION_TIMEOUT_MS,
+    interval_ms: int = 250,
+) -> None:
+    """Poll ``condition`` until true, failing after ``timeout_ms``."""
+    waited = 0
+    while not condition():
+        if waited >= timeout_ms:
+            raise AssertionError(f"Timed out after {timeout_ms} ms waiting for {label}")
+        dash.page.wait_for_timeout(interval_ms)
+        waited += interval_ms


### PR DESCRIPTION
Automates the checklist items of #1097 that need no Kafka backend, so the recurring manual verification round shrinks to the backend-dependent items.

**Unit test**: `TemporalBuffer` with a datetime64 time coord keeps accepting and correctly trimming data through repeated wraparound past capacity (#1087) — newest retained, oldest dropped, time coord stays monotonic datetime64. The existing datetime64 regression test only covered the first trim.

**Browser tests** (Playwright against the fake backend, each on an isolated server):
- session reload restores tabs and live plot updates;
- a grid created in one session appears in other sessions without changing their active tab (#1040);
- a cell title survives a no-op Save of the cell-properties modal (#1083);
- disabling the first grid and removing a middle grid keep the remaining tabs resolving and updating (#1088).

The shared ColumnDataSource-fingerprint and condition-wait helpers move from the multisession smoke test into `tests/helpers/browser.py`. The cell titlebar pencil gains a per-cell `lt-cell-r{row}c{col}` automation hook (with a unit guard test): a rebuilt cell moves to the end of the DOM, so DOM order cannot address a specific cell.

Browser tests are excluded from CI and the default run; run them locally with:

```sh
python -m pytest -m browser tests/dashboard/
```

Verified locally: three consecutive full browser-suite runs green, fast unit suite green.

Part of #1097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
