### PR TITLE
Integration tests for job adoption, clear-at-commit, ROI spectra, and ACK expiry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           set +e
           sed -e 's/\x1b\[[0-9;]*m//g' integration-output.txt \
             | grep -v 'Consumed 0 messages' > clean.txt
-          awk '/=== FAILURES ===/{found=1} found && n<150 {print; n++}' clean.txt > summary.txt
+          awk '/=== (FAILURES|ERRORS) ===/{found=1} found && n<150 {print; n++}' clean.txt > summary.txt
           grep 'DIAG' clean.txt >> summary.txt
           sed -n '/short test summary info/,$p' clean.txt >> summary.txt
           if [ ! -s summary.txt ]; then

--- a/src/ess/livedata/dashboard/dashboard_services.py
+++ b/src/ess/livedata/dashboard/dashboard_services.py
@@ -212,11 +212,11 @@ class DashboardServices:
         # Create ROI publisher for publishing ROI updates to Kafka. Its
         # job-number resolver is injected in _setup_workflow_management once
         # the JobOrchestrator exists.
-        self._roi_publisher = ROIPublisher(sink=transport_resources.roi_sink)
+        self.roi_publisher = ROIPublisher(sink=transport_resources.roi_sink)
 
         self.plotting_controller = PlottingController(
             stream_manager=self.stream_manager,
-            roi_publisher=self._roi_publisher,
+            roi_publisher=self.roi_publisher,
         )
 
         # MessagePump will be wired to job_orchestrator after workflow setup
@@ -262,7 +262,7 @@ class DashboardServices:
             instrument_config=self.instrument_config,
             notification_queue=self.notification_queue,
         )
-        self._roi_publisher.set_job_number_resolver(
+        self.roi_publisher.set_job_number_resolver(
             self.job_orchestrator.get_active_job_number
         )
 

--- a/tests/integration/backend.py
+++ b/tests/integration/backend.py
@@ -164,6 +164,16 @@ class DashboardBackend:
         return self._services.job_orchestrator
 
     @property
+    def roi_publisher(self):
+        self._check_available()
+        return self._services.roi_publisher
+
+    @property
+    def notification_queue(self):
+        self._check_available()
+        return self._services.notification_queue
+
+    @property
     def config_manager(self):
         """
         Get the config store manager.

--- a/tests/integration/clear_at_commit_test.py
+++ b/tests/integration/clear_at_commit_test.py
@@ -62,14 +62,21 @@ def test_recommit_clears_accumulated_data(integration_env: IntegrationEnv) -> No
     )
     assert new_job_ids[0].job_number != job_ids[0].job_number
 
-    # The commit cleared the workflow's DataService keys and old-generation
-    # data fails the ingest filter, so the next observed cumulative output is
-    # the new generation's fresh accumulation.
-    wait_for_backend_condition(
-        backend, lambda: cumulative_total() is not None, timeout=30.0
-    )
-    post_commit_total = cumulative_total()
-    assert post_commit_total is not None
+    # The commit cleared the workflow's buffers and old-generation data fails
+    # the ingest filter, so the next readable cumulative output is the new
+    # generation's fresh accumulation. Capture it inside the condition: the
+    # total keeps growing, so a later re-read could mask the drop.
+    observed: list[float] = []
+
+    def fresh_total_observed() -> bool:
+        total = cumulative_total()
+        if total is None:
+            return False
+        observed.append(total)
+        return True
+
+    wait_for_backend_condition(backend, fresh_total_observed, timeout=30.0)
+    post_commit_total = observed[0]
     assert post_commit_total < pre_commit_total, (
         f"Cumulative total {post_commit_total} did not drop below the "
         f"pre-commit value {pre_commit_total}"

--- a/tests/integration/clear_at_commit_test.py
+++ b/tests/integration/clear_at_commit_test.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration test for clear-at-commit: a recommit starts accumulation afresh."""
+
+import pytest
+
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
+from tests.integration.conftest import IntegrationEnv
+from tests.integration.helpers import (
+    get_output_data,
+    wait_for_backend_condition,
+    wait_for_job_data,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.services('monitor')
+def test_recommit_clears_accumulated_data(integration_env: IntegrationEnv) -> None:
+    """
+    Recommitting a running workflow resets its cumulative output.
+
+    The commit flips the generation and clears the workflow's buffers, so the
+    cumulative total observed after the recommit must drop below the value
+    accumulated before it, instead of continuing to grow.
+    """
+    backend = integration_env.backend
+    workflow_id = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
+    source_name = 'monitor1'
+
+    job_ids = backend.workflow_controller.start_workflow(
+        workflow_id=workflow_id,
+        source_names=[source_name],
+        config=MonitorDataParams(),
+    )
+    wait_for_job_data(backend, workflow_id, job_ids, timeout=30.0)
+
+    def cumulative_total() -> float | None:
+        data = get_output_data(backend, workflow_id, source_name, 'cumulative')
+        if data is None:
+            return None
+        return float(data.sum().value)
+
+    first = cumulative_total()
+    assert first is not None
+
+    # The cumulative output accumulates: wait until strictly above the first
+    # observation, so the pre-commit total spans several update intervals.
+    wait_for_backend_condition(
+        backend,
+        lambda: (total := cumulative_total()) is not None and total > first,
+        timeout=30.0,
+    )
+    pre_commit_total = cumulative_total()
+    assert pre_commit_total is not None
+
+    # Recommit with identical parameters, as the UI does on Start.
+    new_job_ids = backend.workflow_controller.start_workflow(
+        workflow_id=workflow_id,
+        source_names=[source_name],
+        config=MonitorDataParams(),
+    )
+    assert new_job_ids[0].job_number != job_ids[0].job_number
+
+    # The commit cleared the workflow's DataService keys and old-generation
+    # data fails the ingest filter, so the next observed cumulative output is
+    # the new generation's fresh accumulation.
+    wait_for_backend_condition(
+        backend, lambda: cumulative_total() is not None, timeout=30.0
+    )
+    post_commit_total = cumulative_total()
+    assert post_commit_total is not None
+    assert post_commit_total < pre_commit_total, (
+        f"Cumulative total {post_commit_total} did not drop below the "
+        f"pre-commit value {pre_commit_total}"
+    )

--- a/tests/integration/command_expiry_test.py
+++ b/tests/integration/command_expiry_test.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration test for pending-command expiry when no backend responds."""
+
+import time
+
+import pytest
+
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.dashboard.job_orchestrator import PENDING_COMMAND_TIMEOUT_SECONDS
+from ess.livedata.dashboard.notification_queue import NotificationType
+from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
+from tests.integration.backend import DashboardBackend
+from tests.integration.helpers import wait_for_backend_condition
+
+
+@pytest.mark.integration
+def test_unacknowledged_start_command_expires(
+    dashboard_backend: DashboardBackend,
+) -> None:
+    """
+    A start command nobody consumes expires with an error notification.
+
+    No services run in this test, so the start command written to the
+    commands topic is never acknowledged. After
+    PENDING_COMMAND_TIMEOUT_SECONDS the pending command must expire and
+    surface as an error notification (the toast the UI would show); the
+    workflow state itself is left untouched (no status, job stays pending).
+    """
+    backend = dashboard_backend
+    workflow_id = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
+
+    sent_at = time.monotonic()
+    job_ids = backend.workflow_controller.start_workflow(
+        workflow_id=workflow_id,
+        source_names=['monitor1'],
+        config=MonitorDataParams(),
+    )
+
+    def expiry_notified() -> bool:
+        return any(
+            event.notification_type == NotificationType.ERROR
+            and 'no response from backend' in event.message
+            for event in backend.notification_queue.get_all_events()
+        )
+
+    # The expiry cannot fire before the timeout, so this wait is dominated by
+    # PENDING_COMMAND_TIMEOUT_SECONDS (30 s); the margin covers slow CI.
+    wait_for_backend_condition(
+        backend,
+        expiry_notified,
+        timeout=PENDING_COMMAND_TIMEOUT_SECONDS + 30.0,
+        poll_interval=1.0,
+    )
+    elapsed = time.monotonic() - sent_at
+    assert elapsed > PENDING_COMMAND_TIMEOUT_SECONDS - 1.0, (
+        f"Expiry fired after {elapsed:.1f}s, before the "
+        f"{PENDING_COMMAND_TIMEOUT_SECONDS:.0f}s timeout"
+    )
+
+    # No service consumed the command: the job never reported any status.
+    job_statuses = backend.job_service.job_statuses
+    assert all(job_id not in job_statuses for job_id in job_ids)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -104,20 +104,27 @@ def wait_for_condition(
         time.sleep(poll_interval)
 
 
-def _get_data_keys_for_source(
+def _get_job_data(
     data_service: Any, workflow_id: WorkflowId, source_name: str
-) -> list[DataKey]:
-    """Get all DataKeys in DataService for one workflow source.
+) -> dict[DataKey, Any]:
+    """Get all readable data in DataService for one workflow source.
 
     The data plane is keyed by the stable ``DataKey`` (workflow, source,
     output); the per-commit job_number is provenance, not identity, so jobs
     are matched via their source_name.
+
+    A generation flip (recommit) clears buffers in place: the key stays
+    iterable but reading it raises KeyError until new-generation data
+    arrives. Such cleared keys are treated as absent.
     """
-    return [
-        key
-        for key in data_service
-        if key.workflow_id == workflow_id and key.source_name == source_name
-    ]
+    result: dict[DataKey, Any] = {}
+    for key in data_service:
+        if key.workflow_id == workflow_id and key.source_name == source_name:
+            try:
+                result[key] = data_service[key]
+            except KeyError:
+                continue
+    return result
 
 
 def get_output_data(
@@ -127,11 +134,11 @@ def get_output_data(
     output_name: str,
 ) -> Any | None:
     """Return the latest data for one output of a workflow source, or None."""
-    for key in _get_data_keys_for_source(
+    for key, value in _get_job_data(
         backend.data_service, workflow_id, source_name
-    ):
+    ).items():
         if key.output_name == output_name:
-            return backend.data_service[key]
+            return value
     return None
 
 
@@ -217,14 +224,19 @@ def wait_for_job_data(
         If job data does not arrive for all jobs within the timeout period
     """
 
+    result: dict[JobId, dict[DataKey, Any]] = {}
+
     def check_for_job_data():
         backend.update()
-        return all(
-            _get_data_keys_for_source(
+        result.clear()
+        for job_id in job_ids:
+            job_data = _get_job_data(
                 backend.data_service, workflow_id, job_id.source_name
             )
-            for job_id in job_ids
-        )
+            if not job_data:
+                return False
+            result[job_id] = job_data
+        return True
 
     try:
         wait_for_condition(
@@ -234,12 +246,6 @@ def wait_for_job_data(
         dump_diagnostics(backend)
         raise
 
-    result = {}
-    for job_id in job_ids:
-        keys = _get_data_keys_for_source(
-            backend.data_service, workflow_id, job_id.source_name
-        )
-        result[job_id] = {key: backend.data_service[key] for key in keys}
     return result
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -37,10 +37,12 @@ def dump_diagnostics(backend: Any, instrument: str = 'dummy') -> None:
     try:
         for suffix in (
             'beam_monitor',
+            'detector',
             'livedata_commands',
             'livedata_responses',
             'livedata_heartbeat',
             'livedata_data',
+            'livedata_roi',
         ):
             topic = f'{instrument}_{suffix}'
             try:
@@ -50,6 +52,25 @@ def dump_diagnostics(backend: Any, instrument: str = 'dummy') -> None:
                 logger.warning("DIAG topic %s: low=%s high=%s", topic, low, high)
             except Exception as e:
                 logger.warning("DIAG topic %s: watermark fetch failed: %s", topic, e)
+    finally:
+        consumer.close()
+
+
+def topic_high_watermark(topic: str) -> int:
+    """Return the high watermark offset of a topic's single partition.
+
+    Reads broker metadata without consuming, so it can prove that no new
+    message was written to a topic (e.g. no spurious command was sent).
+    """
+    from confluent_kafka import Consumer, TopicPartition
+
+    config = load_config(namespace=config_names.kafka, env='dev')
+    consumer = Consumer({**config, 'group.id': f'watermark-{uuid.uuid4()}'})
+    try:
+        _low, high = consumer.get_watermark_offsets(
+            TopicPartition(topic, 0), timeout=10.0
+        )
+        return high
     finally:
         consumer.close()
 
@@ -97,6 +118,63 @@ def _get_data_keys_for_source(
         for key in data_service
         if key.workflow_id == workflow_id and key.source_name == source_name
     ]
+
+
+def get_output_data(
+    backend: Any,
+    workflow_id: WorkflowId,
+    source_name: str,
+    output_name: str,
+) -> Any | None:
+    """Return the latest data for one output of a workflow source, or None."""
+    for key in _get_data_keys_for_source(
+        backend.data_service, workflow_id, source_name
+    ):
+        if key.output_name == output_name:
+            return backend.data_service[key]
+    return None
+
+
+def wait_for_backend_condition(
+    backend: Any,
+    condition: Callable[[], bool],
+    timeout: float = 10.0,
+    poll_interval: float = 0.5,
+    instrument: str = 'dummy',
+) -> None:
+    """Pump the backend until ``condition()`` holds.
+
+    Calls ``backend.update()`` before each check and dumps DIAG diagnostics
+    on timeout, like the job-specific helpers.
+
+    Parameters
+    ----------
+    backend:
+        The DashboardBackend instance (must have .update())
+    condition:
+        Callable returning True when the awaited state is reached
+    timeout:
+        Maximum time to wait in seconds
+    poll_interval:
+        Time between checks in seconds
+    instrument:
+        Instrument name, used for topic names in timeout diagnostics
+
+    Raises
+    ------
+    WaitTimeout:
+        If the condition is not met within the timeout period
+    """
+
+    def check() -> bool:
+        backend.update()
+        return condition()
+
+    try:
+        wait_for_condition(check, timeout=timeout, poll_interval=poll_interval)
+    except WaitTimeout:
+        dump_diagnostics(backend, instrument=instrument)
+        raise
 
 
 # Job-specific helpers

--- a/tests/integration/job_adoption_test.py
+++ b/tests/integration/job_adoption_test.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration test for job adoption from heartbeat observation (ADR 0008)."""
+
+import pytest
+
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.core.job import JobState
+from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
+from tests.integration.backend import DashboardBackend
+from tests.integration.conftest import IntegrationEnv
+from tests.integration.helpers import (
+    topic_high_watermark,
+    wait_for_backend_condition,
+    wait_for_job_data,
+)
+
+COMMANDS_TOPIC = 'dummy_livedata_commands'
+
+
+@pytest.mark.integration
+@pytest.mark.services('monitor')
+def test_new_dashboard_adopts_running_job_without_restart(
+    integration_env: IntegrationEnv,
+) -> None:
+    """
+    A fresh dashboard adopts a running job from heartbeats (ADR 0008).
+
+    Stopping the dashboard leaves the backend service running the job and
+    publishing heartbeats. A new dashboard instance must adopt the observed
+    job as the workflow's current generation: same job_number, ACTIVE status,
+    and data flowing again -- all without sending any command (no spurious
+    restart).
+    """
+    backend_a = integration_env.backend
+    workflow_id = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
+
+    job_ids = backend_a.workflow_controller.start_workflow(
+        workflow_id=workflow_id,
+        source_names=['monitor1'],
+        config=MonitorDataParams(),
+    )
+    job_id = job_ids[0]
+
+    def job_active_on(backend: DashboardBackend) -> bool:
+        status = backend.job_service.job_statuses.get(job_id)
+        return status is not None and status.state == JobState.active
+
+    wait_for_backend_condition(
+        backend_a, lambda: job_active_on(backend_a), timeout=30.0
+    )
+    wait_for_job_data(backend_a, workflow_id, job_ids, timeout=30.0)
+
+    # Stop the dashboard. The service keeps running the job and heartbeating;
+    # no stop command is sent on dashboard shutdown.
+    backend_a.stop()
+    commands_watermark = topic_high_watermark(COMMANDS_TOPIC)
+
+    # Backends are single-use, so a dashboard restart is a fresh instance.
+    # Its config store is empty (in-memory), so adoption can only come from
+    # heartbeat observation, not from a persisted record.
+    with DashboardBackend(instrument='dummy', dev=True) as backend_b:
+        wait_for_backend_condition(
+            backend_b,
+            lambda: (
+                backend_b.job_orchestrator.get_active_job_number(workflow_id)
+                == job_id.job_number
+            ),
+            timeout=30.0,
+        )
+        wait_for_backend_condition(
+            backend_b, lambda: job_active_on(backend_b), timeout=30.0
+        )
+
+        # Data is admitted again under the adopted generation.
+        wait_for_job_data(backend_b, workflow_id, job_ids, timeout=30.0)
+
+        # No spurious restart: the adopted job_number is unchanged and no
+        # command (start or stop) was written to the commands topic.
+        assert (
+            backend_b.job_orchestrator.get_active_job_number(workflow_id)
+            == job_id.job_number
+        )
+        assert topic_high_watermark(COMMANDS_TOPIC) == commands_watermark

--- a/tests/integration/roi_spectra_test.py
+++ b/tests/integration/roi_spectra_test.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration test for ROI spectra: published ROIs drive backend spectra."""
+
+import pytest
+
+from ess.livedata.config.models import Interval, RectangleROI
+from ess.livedata.config.roi_names import get_roi_mapper
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.workflows.detector_view_specs import DetectorViewParams
+from tests.integration.conftest import IntegrationEnv
+from tests.integration.helpers import (
+    get_output_data,
+    wait_for_backend_condition,
+    wait_for_job_data,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.services('detector')
+def test_roi_spectra_follow_published_rois(integration_env: IntegrationEnv) -> None:
+    """
+    ROI spectra results arrive for published ROIs and follow ROI changes.
+
+    Publishes rectangle ROIs the way the dashboard does (ROIPublisher to the
+    LIVEDATA_ROI topic, addressed to the workflow's current job) and asserts
+    the detector view's roi_spectra output tracks the published set.
+    """
+    backend = integration_env.backend
+    workflow_id = WorkflowId(instrument='dummy', name='panel_0_xy', version=1)
+    source_name = 'panel_0'
+
+    job_ids = backend.workflow_controller.start_workflow(
+        workflow_id=workflow_id,
+        source_names=[source_name],
+        config=DetectorViewParams(),
+    )
+    wait_for_job_data(backend, workflow_id, job_ids, timeout=60.0)
+
+    geometry = get_roi_mapper().geometry_for_type('rectangle')
+    assert geometry is not None
+
+    def roi_spectra_count() -> int | None:
+        data = get_output_data(
+            backend, workflow_id, source_name, 'roi_spectra_cumulative'
+        )
+        if data is None:
+            return None
+        return data.sizes['roi']
+
+    # Publish one ROI (pixel indices on the 128x128 panel_0 logical view).
+    roi_a = RectangleROI(x=Interval(min=10, max=60), y=Interval(min=10, max=60))
+    backend.roi_publisher.publish(
+        workflow_id=workflow_id,
+        source_name=source_name,
+        rois={0: roi_a},
+        geometry=geometry,
+    )
+    wait_for_backend_condition(backend, lambda: roi_spectra_count() == 1, timeout=30.0)
+    spectra = get_output_data(
+        backend, workflow_id, source_name, 'roi_spectra_cumulative'
+    )
+    assert list(spectra.coords['roi'].values) == [0]
+
+    # Change the ROI selection: the spectra must follow.
+    roi_b = RectangleROI(x=Interval(min=70, max=120), y=Interval(min=70, max=120))
+    backend.roi_publisher.publish(
+        workflow_id=workflow_id,
+        source_name=source_name,
+        rois={0: roi_a, 1: roi_b},
+        geometry=geometry,
+    )
+    wait_for_backend_condition(backend, lambda: roi_spectra_count() == 2, timeout=30.0)
+    spectra = get_output_data(
+        backend, workflow_id, source_name, 'roi_spectra_cumulative'
+    )
+    assert list(spectra.coords['roi'].values) == [0, 1]


### PR DESCRIPTION
Automates four items of the field-verification checklist in #1097 as real-Kafka integration tests, running the actual service stack (fake sources + monitor_data/detector_data) against the dashboard backend:

- **Job adoption (ADR 0008)**: stop the dashboard while a job runs, create a fresh backend, assert the job is adopted from heartbeat observation (same job_number, ACTIVE, data flows) with no command written (commands-topic watermark unchanged).
- **Clear-at-commit**: let a monitor workflow's cumulative output grow, recommit, assert the first post-commit total drops below the pre-commit value.
- **ROI spectra**: publish rectangle ROIs through the dashboard's ROIPublisher path and assert the detector view's roi_spectra output tracks the published set (first detector-pipeline coverage in the integration suite).
- **Command-ACK expiry**: with no services running, a start command expires after `PENDING_COMMAND_TIMEOUT_SECONDS` and surfaces as the error notification the UI would toast; the job never reports a status.

`DashboardServices.roi_publisher` is made public so tests exercise the same publish path the UI uses; the test backend additionally exposes `roi_publisher` and `notification_queue`. The DIAG timeout diagnostics gain the detector and ROI topics, plus a generic pump-and-wait helper and a topic-watermark probe. CI failure annotations now also capture the pytest ERRORS section (fixture failures were previously unreadable).

One subtlety the clear-at-commit test surfaced: `DataService.clear_keys` empties buffers in place, so after a generation flip a key stays iterable while `__getitem__` raises KeyError until new-generation data arrives. The wait helpers now treat such cleared keys as absent; whether `DataService` should keep violating the Mapping contract there may deserve its own discussion.

Part of #1097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
