### PR TITLE
Hide cleared keys from the DataService Mapping view

### DIFF
--- a/src/ess/livedata/dashboard/data_service.py
+++ b/src/ess/livedata/dashboard/data_service.py
@@ -417,14 +417,25 @@ class DataService(MutableMapping[K, V]):
             self._notify()
 
     def __iter__(self) -> Iterator[K]:
-        """Iterate over keys."""
+        """Iterate over keys that hold data.
+
+        Buffers survive :py:meth:`clear_keys` (only their data is dropped),
+        but a key whose read would raise must not be yielded — Mapping
+        consumers pair iteration with ``__getitem__`` (``items()``,
+        ``dict(service)``). Emptiness is probed cheaply, without assembling
+        the buffered data.
+        """
         with self._lock:
-            return iter(list(self._buffer_manager))
+            return iter(
+                [k for k in self._buffer_manager if self._buffer_manager.has_data(k)]
+            )
 
     def __len__(self) -> int:
-        """Return the number of keys."""
+        """Return the number of keys that hold data."""
         with self._lock:
-            return len(self._buffer_manager)
+            return sum(
+                1 for k in self._buffer_manager if self._buffer_manager.has_data(k)
+            )
 
     def _notify(self) -> None:
         # Some updates may have been added while notifying. Drain pending under

--- a/src/ess/livedata/dashboard/temporal_buffer_manager.py
+++ b/src/ess/livedata/dashboard/temporal_buffer_manager.py
@@ -79,6 +79,14 @@ class TemporalBufferManager(Mapping[K, BufferProtocol[sc.DataArray]], Generic[K]
             return None
         return self._states[key].buffer.get()
 
+    def has_data(self, key: K) -> bool:
+        """Return whether a buffer exists for the key and holds data.
+
+        Cheap emptiness probe, unlike :py:meth:`get_buffered_data` which
+        assembles the buffered data.
+        """
+        return key in self._states and not self._states[key].buffer.is_empty()
+
     def create_buffer(self, key: K, extractors: Sequence[UpdateExtractor]) -> None:
         """
         Create a buffer with appropriate type based on extractors.

--- a/src/ess/livedata/dashboard/temporal_buffers.py
+++ b/src/ess/livedata/dashboard/temporal_buffers.py
@@ -52,6 +52,10 @@ class BufferProtocol(ABC, Generic[T]):
         """Clear all data from the buffer."""
 
     @abstractmethod
+    def is_empty(self) -> bool:
+        """Return whether the buffer holds no data. Cheap, unlike ``get``."""
+
+    @abstractmethod
     def set_required_timespan(self, seconds: float) -> None:
         """
         Set the required timespan for the buffer.
@@ -109,6 +113,10 @@ class SingleValueBuffer(BufferProtocol[T]):
     def clear(self) -> None:
         """Clear the stored value."""
         self._data = None
+
+    def is_empty(self) -> bool:
+        """Return whether no value is stored."""
+        return self._data is None
 
     def set_required_timespan(self, seconds: float) -> None:
         """Set required timespan (unused for SingleValueBuffer)."""
@@ -385,6 +393,10 @@ class TemporalBuffer(BufferProtocol[sc.DataArray]):
         self._data_buffer = None
         self._coord_buffers = {}
         self._reference = None
+
+    def is_empty(self) -> bool:
+        """Return whether no data has been buffered."""
+        return self._data_buffer is None
 
     def set_required_timespan(self, seconds: float) -> None:
         """Set the required timespan for the buffer."""

--- a/tests/dashboard/data_service_test.py
+++ b/tests/dashboard/data_service_test.py
@@ -1629,6 +1629,27 @@ class TestClearKeysAndStamps:
         assert service["other"].value == 3
         assert get_pipe().notifications[-1] == {"key1", "key2"}
 
+    def test_cleared_keys_are_absent_from_the_mapping_view(self):
+        """Every iterated key must be readable: dict(service) after a clear.
+
+        Buffers survive clear_keys (extractors, retention), but a key whose
+        read raises must not be yielded by iteration or counted by len.
+        """
+        service = DataService[str, int]()
+        service["key1"] = make_test_data(1)
+        service["key2"] = make_test_data(2)
+
+        service.clear_keys(["key1"])
+
+        assert set(service) == {"key2"}
+        assert len(service) == 1
+        assert "key1" not in service
+        assert {k: v.value for k, v in dict(service).items()} == {"key2": 2}
+
+        service["key1"] = make_test_data(3)
+        assert set(service) == {"key1", "key2"}
+        assert len(service) == 2
+
     def test_clear_keys_preserves_subscriber_registration(self):
         """Data arriving after a clear reaches the still-registered subscriber."""
         service = DataService[str, int]()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -107,24 +107,17 @@ def wait_for_condition(
 def _get_job_data(
     data_service: Any, workflow_id: WorkflowId, source_name: str
 ) -> dict[DataKey, Any]:
-    """Get all readable data in DataService for one workflow source.
+    """Get all data in DataService for one workflow source.
 
     The data plane is keyed by the stable ``DataKey`` (workflow, source,
     output); the per-commit job_number is provenance, not identity, so jobs
     are matched via their source_name.
-
-    A generation flip (recommit) clears buffers in place: the key stays
-    iterable but reading it raises KeyError until new-generation data
-    arrives. Such cleared keys are treated as absent.
     """
-    result: dict[DataKey, Any] = {}
-    for key in data_service:
-        if key.workflow_id == workflow_id and key.source_name == source_name:
-            try:
-                result[key] = data_service[key]
-            except KeyError:
-                continue
-    return result
+    return {
+        key: data_service[key]
+        for key in data_service
+        if key.workflow_id == workflow_id and key.source_name == source_name
+    }
 
 
 def get_output_data(


### PR DESCRIPTION
`clear_keys` (the clear-at-commit generation flip) empties buffers in place so extractor registrations and retention requirements survive — intended. Unintended: the cleared key stayed visible to `__iter__`/`__len__` while `__getitem__` raised `KeyError`, violating the Mapping contract. Any consumer pairing iteration with reads (`items()`, `dict(service)`, the integration wait helpers in #1114) crashed if a recommit landed in between. `__contains__` was already data-based via the Mapping mixin, so membership and iteration also disagreed.

Iteration and `len` now skip empty buffers, probed via a new cheap `is_empty` on the buffer protocol rather than assembling buffered data. "Exists but empty" is only reachable through `clear_keys` (buffer creation and first write share one lock hold), so the observable change is confined to the formerly broken window. The #1114 helper workaround for cleared-but-present keys is reverted.

Found by the clear-at-commit integration test while automating the #1097 checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)