### PR TITLE
Run the Playwright browser suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,57 @@ jobs:
           done
           true
 
+  browser:
+    # Playwright UI tests: a real chromium driving the dashboard served by the
+    # in-process fake backend (no Kafka), covering multi-session sync and grid
+    # management flows. Runs in parallel with the unit-test job.
+    name: Browser UI tests (Playwright)
+    needs: formatting
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '${{ needs.formatting.outputs.min_python }}'
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -r requirements/ci.txt
+      - name: Install chromium system libraries
+        # The chromium binary itself is installed by the tox env (matching its
+        # playwright version); only the apt-level libraries need sudo here.
+        run: |
+          python -m pip install playwright
+          playwright install-deps chromium
+      - name: Run browser tests
+        shell: bash
+        run: |
+          tox -e browser 2>&1 | tee browser-output.txt
+          exit "${PIPESTATUS[0]}"
+      - name: Surface failure output as annotations
+        # Log download can be firewalled; annotations are readable via the
+        # checks API. Emit the pytest failure summary in newline-escaped
+        # chunks (annotation count and size are limited).
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          sed -e 's/\x1b\[[0-9;]*m//g' browser-output.txt > clean.txt
+          awk '/=== (FAILURES|ERRORS) ===/{found=1} found && n<150 {print; n++}' clean.txt > summary.txt
+          sed -n '/short test summary info/,$p' clean.txt >> summary.txt
+          if [ ! -s summary.txt ]; then
+            tail -n 100 clean.txt > summary.txt
+          fi
+          split -l 20 summary.txt chunk_
+          n=0
+          for f in chunk_*; do
+            [ -e "$f" ] || continue
+            n=$((n + 1))
+            if [ "$n" -gt 8 ]; then break; fi
+            msg=$(sed -e 's/%/%25/g' "$f" | awk '{printf "%s%%0A", $0}')
+            echo "::error title=browser-tests part ${n}::${msg}"
+          done
+          true
+
   instrument-check:
     # Verify that an instrument deployment can construct its backend services
     # using only the dependencies declared in its extras. Catches imports that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@ python -m venv .venv && source .venv/bin/activate && pip install -e ".[test]"
   malformed/insane wire payloads consumed by the adapter- and service-level
   robustness tests (add new corruption modes there). Known holes are strict
   `xfail`s referencing their issue; fixing the issue flips them loudly.
-- `pytest -m browser` runs local Playwright UI tests (fake backend, e.g. the
-  multi-session smoke test); excluded from the default run and CI.
+- `pytest -m browser` runs Playwright UI tests (fake backend, e.g. the
+  multi-session smoke test); excluded from the default run, CI runs them
+  via `tox -e browser`.
 
 ```sh
 python -m pytest                      # fast tests only (~25s)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ markers = [
   "instrument: Specify instrument name for parameterized tests",
   "services: Specify which services to use in integration_env fixture (monitor, detector, or reduction)",
   "slow: Slow tests (>2s) excluded by default, run in CI via tox",
-  "browser: Browser-driven (Playwright) UI tests; run locally, excluded from CI",
+  "browser: Browser-driven (Playwright) UI tests; excluded from the default run, run in CI via tox -e browser",
 ]
 filterwarnings = [
   "error",

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -13,9 +13,9 @@ through the stable ``lt-*`` automation hooks:
   updating.
 
 Each test launches its own dashboard on a dedicated port for isolation, since
-grid topology changes are process-global. Runs locally via ``pytest -m
-browser`` (excluded from the default run and CI; skips cleanly where
-Playwright is absent).
+grid topology changes are process-global. Runs via ``pytest -m browser``
+(excluded from the default run; CI runs them via ``tox -e browser``; skips
+cleanly where Playwright is absent).
 """
 
 from __future__ import annotations

--- a/tests/dashboard/multisession_smoke_test.py
+++ b/tests/dashboard/multisession_smoke_test.py
@@ -18,8 +18,8 @@ session must disturb neither. It is deliberately behavioral -- it observes
 rendered ColumnDataSource contents, not internals -- so it stays valid across
 delivery-mechanism refactors (#1045, #1046).
 
-Runs locally via ``pytest -m browser`` (excluded from the default run and CI;
-skips cleanly where Playwright is absent).
+Runs via ``pytest -m browser`` (excluded from the default run; CI runs them
+via ``tox -e browser``; skips cleanly where Playwright is absent).
 """
 
 from __future__ import annotations

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,18 @@ setenv =
   JUPYTER_PLATFORM_DIRS = 1
 commands = pytest -m integration {posargs} tests/integration/
 
+[testenv:browser]
+description = Run browser-driven (Playwright) UI tests against the fake backend
+deps =
+  -r requirements/test.txt
+  playwright
+setenv =
+  JUPYTER_PLATFORM_DIRS = 1
+# System libraries for chromium are not installed here; on CI a workflow step
+# runs `playwright install-deps chromium` (needs sudo) before invoking tox.
+commands_pre = playwright install chromium
+commands = pytest -m browser {posargs} tests/dashboard/
+
 [testenv:nightly]
 deps = -r requirements/nightly.txt
 setenv =


### PR DESCRIPTION
The Playwright browser tests (`pytest -m browser`: multi-session smoke test and dashboard UI flows, fake backend, no Kafka) ran nowhere in CI and could silently rot. This adds a `browser` tox env (installs playwright and its matching chromium) and a CI job modeled on the integration job: chromium system libraries are installed via `playwright install-deps` outside tox, and failures are surfaced as check-run annotations. Docs claiming the suite is excluded from CI are updated; it remains excluded from the default pytest run and the other tox envs.

Part of the #1097 follow-up work.

Note: browser tests are the most flakiness-prone job in this workflow (real chromium, timing-sensitive UI assertions on 4-core runners). Watch it across a few PRs before considering it as a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
