### PR TITLE
Integration tests: stop reconciliation and service crash (ADR 0008)

### DIFF
--- a/tests/integration/backend.py
+++ b/tests/integration/backend.py
@@ -134,6 +134,11 @@ class DashboardBackend:
         return self._services.job_service
 
     @property
+    def service_registry(self):
+        self._check_available()
+        return self._services.service_registry
+
+    @property
     def plotting_controller(self):
         self._check_available()
         return self._services.plotting_controller

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -75,6 +75,45 @@ def topic_high_watermark(topic: str) -> int:
         consumer.close()
 
 
+def wait_for_watermark_stall(
+    topic: str, *, settle: float = 4.0, timeout: float = 40.0
+) -> int:
+    """Wait until a topic's high watermark stops advancing, then return it.
+
+    The watermark counts as stalled once two samples taken ``settle`` seconds
+    apart are equal. Proves that a producer went quiet (e.g. a stopped job
+    publishes no further results), tolerating in-flight messages produced
+    just before the observation started.
+
+    Parameters
+    ----------
+    topic:
+        Topic whose single-partition high watermark to observe.
+    settle:
+        Window in seconds within which no new message may arrive; must exceed
+        the producer's publish cadence for a stall to be provable.
+    timeout:
+        Maximum total time to wait for a stall.
+
+    Raises
+    ------
+    WaitTimeout:
+        If the watermark is still advancing after the timeout.
+    """
+    deadline = time.time() + timeout
+    previous = topic_high_watermark(topic)
+    while True:
+        time.sleep(settle)
+        current = topic_high_watermark(topic)
+        if current == previous:
+            return current
+        if time.time() > deadline:
+            raise WaitTimeout(
+                f"Watermark of {topic} still advancing after {timeout} seconds"
+            )
+        previous = current
+
+
 def wait_for_condition(
     condition: Callable[[], bool], timeout: float = 5.0, poll_interval: float = 0.1
 ) -> None:

--- a/tests/integration/reconciliation_restop_test.py
+++ b/tests/integration/reconciliation_restop_test.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration tests for stop reconciliation (ADR 0008).
+
+Covers the #1097 checklist item "a job whose stop was commanded before the
+restart is re-stopped by reconciliation", split into what the architecture
+provides:
+
+- Within a dashboard's lifetime, a stop the backend has not acted on is
+  re-issued by reconciliation while the job keeps a fresh observed status
+  (``test_unacted_stop_is_reissued_by_reconciliation``).
+- Across a dashboard restart, the desired-stopped intent is not persisted:
+  the config store records only presence or absence of ``current_job``, and
+  an absent record is indistinguishable from a record miss (crash between
+  send and persist, store loss), which ADR 0008 resolves toward adoption
+  ("record misses degrade, they do not lie"). The restarted dashboard
+  therefore adopts the still-running job instead of re-stopping it; the
+  guarantee is that the job is visible and stoppable
+  (``test_restart_after_lost_stop_adopts_job_instead_of_restopping``).
+"""
+
+import signal
+
+import pytest
+
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.core.job import JobState
+from ess.livedata.dashboard.config_store import ConfigStoreManager
+from ess.livedata.dashboard.job_orchestrator import STOP_REISSUE_INTERVAL_SECONDS
+from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
+from tests.integration.backend import DashboardBackend
+from tests.integration.conftest import IntegrationEnv
+from tests.integration.helpers import (
+    topic_high_watermark,
+    wait_for_backend_condition,
+    wait_for_job_data,
+    wait_for_watermark_stall,
+)
+
+COMMANDS_TOPIC = 'dummy_livedata_commands'
+DATA_TOPIC = 'dummy_livedata_data'
+
+WORKFLOW_ID = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
+
+
+def _job_active(backend: DashboardBackend, job_id) -> bool:
+    status = backend.job_service.job_statuses.get(job_id)
+    return status is not None and status.state == JobState.active
+
+
+@pytest.mark.integration
+@pytest.mark.services('monitor')
+def test_unacted_stop_is_reissued_by_reconciliation(
+    integration_env: IntegrationEnv,
+) -> None:
+    """
+    A stop the backend has not acted on is re-issued by reconciliation.
+
+    The backend service is frozen with SIGSTOP, so a commanded stop is
+    neither consumed nor acknowledged while the job's last observed status
+    stays fresh (heartbeat staleness is 60 s). Desired state (stopped)
+    then contradicts observed state (running), and after
+    STOP_REISSUE_INTERVAL_SECONDS the background reconciliation re-issues
+    the stop — observed as one extra message on the commands topic that no
+    user action produced (ADR 0008). Once the service resumes it consumes
+    the stops and the job's result stream goes quiet.
+    """
+    backend = integration_env.backend
+    job_ids = backend.workflow_controller.start_workflow(
+        workflow_id=WORKFLOW_ID,
+        source_names=['monitor1'],
+        config=MonitorDataParams(),
+    )
+    job_id = job_ids[0]
+    wait_for_backend_condition(
+        backend, lambda: _job_active(backend, job_id), timeout=30.0
+    )
+    wait_for_job_data(backend, WORKFLOW_ID, job_ids, timeout=30.0)
+
+    service = integration_env.services['monitor_data']
+    service.process.send_signal(signal.SIGSTOP)
+    try:
+        watermark_before_stop = topic_high_watermark(COMMANDS_TOPIC)
+        assert backend.job_orchestrator.stop_workflow(WORKFLOW_ID)
+        wait_for_backend_condition(
+            backend,
+            lambda: topic_high_watermark(COMMANDS_TOPIC) == watermark_before_stop + 1,
+            timeout=10.0,
+        )
+
+        # The re-issue is rate-bounded per job_number, so it appears one
+        # reissue interval after the user's stop. The observed status must
+        # still be fresh by then: 30 s reissue bound < 60 s staleness.
+        wait_for_backend_condition(
+            backend,
+            lambda: topic_high_watermark(COMMANDS_TOPIC) >= watermark_before_stop + 2,
+            timeout=STOP_REISSUE_INTERVAL_SECONDS + 20.0,
+            poll_interval=1.0,
+        )
+        # The re-issue did not resurrect the workflow: desired state is
+        # still stopped.
+        assert backend.job_orchestrator.get_active_job_number(WORKFLOW_ID) is None
+    finally:
+        service.process.send_signal(signal.SIGCONT)
+
+    # The resumed service consumes the stop commands and removes the job; a
+    # commanded stop publishes no final status, so the observable effect is
+    # the result stream going quiet.
+    wait_for_watermark_stall(DATA_TOPIC)
+
+
+@pytest.mark.integration
+def test_restart_after_lost_stop_adopts_job_instead_of_restopping(
+    monitor_services, tmp_path
+) -> None:
+    """
+    After a restart, a job whose stop was swallowed is adopted, not re-stopped.
+
+    A stop whose send the producer swallowed (the #1046 scenario ADR 0008
+    cites) leaves the persisted state without ``current_job`` while the
+    backend keeps running the job. After a dashboard restart that state is
+    indistinguishable from a record miss, so the running job is adopted from
+    heartbeat observation as running-with-unknown-config — reconciliation
+    does not re-issue the stop (no command is written at all). The ADR's
+    degraded-mode guarantee is that the job is visible and stoppable, which
+    the final stop exercises end-to-end.
+    """
+    with DashboardBackend(
+        instrument='dummy', dev=True, config_dir=tmp_path
+    ) as backend_a:
+        job_ids = backend_a.workflow_controller.start_workflow(
+            workflow_id=WORKFLOW_ID,
+            source_names=['monitor1'],
+            config=MonitorDataParams(),
+        )
+        job_id = job_ids[0]
+        wait_for_backend_condition(
+            backend_a, lambda: _job_active(backend_a, job_id), timeout=30.0
+        )
+        wait_for_job_data(backend_a, WORKFLOW_ID, job_ids, timeout=30.0)
+    # Dashboard gone; the service keeps running the job and heartbeating.
+
+    # Reproduce the persisted state a swallowed stop leaves behind:
+    # stop_workflow writes the store entry without ``current_job``, but its
+    # stop command never reaches Kafka. Editing the store directly yields
+    # exactly that state without the durable command a real send would leave
+    # in the commands topic (which the service would consume on its own).
+    store = ConfigStoreManager(instrument='dummy', config_dir=tmp_path).get_store(
+        'workflow_configs'
+    )
+    entry = store[str(WORKFLOW_ID)]
+    assert 'current_job' in entry, "commit should have persisted the job record"
+    del entry['current_job']
+    store[str(WORKFLOW_ID)] = entry
+
+    commands_watermark = topic_high_watermark(COMMANDS_TOPIC)
+    with DashboardBackend(
+        instrument='dummy', dev=True, config_dir=tmp_path
+    ) as backend_b:
+        # Adoption from heartbeat observation: same job_number, data admitted.
+        wait_for_backend_condition(
+            backend_b,
+            lambda: (
+                backend_b.job_orchestrator.get_active_job_number(WORKFLOW_ID)
+                == job_id.job_number
+            ),
+            timeout=30.0,
+        )
+        # Adopted without a record: params provenance is degraded.
+        active = backend_b.job_orchestrator.get_active_config(WORKFLOW_ID)
+        assert active[job_id.source_name].params == {}
+        wait_for_job_data(backend_b, WORKFLOW_ID, job_ids, timeout=30.0)
+
+        # Reconciliation issued nothing: desired and observed state agree
+        # once the job is adopted, so no stop (and no start) was written.
+        assert topic_high_watermark(COMMANDS_TOPIC) == commands_watermark
+
+        # The adopted job is stoppable — the degraded-mode guarantee.
+        assert backend_b.job_orchestrator.stop_workflow(WORKFLOW_ID)
+        wait_for_watermark_stall(DATA_TOPIC)

--- a/tests/integration/service_crash_test.py
+++ b/tests/integration/service_crash_test.py
@@ -47,6 +47,15 @@ def test_dashboard_flags_crashed_service_worker_stale(
     job_id = job_ids[0]
     wait_for_job_data(backend, WORKFLOW_ID, job_ids, timeout=30.0)
 
+    # The job's ACTIVE status must have been observed before the crash:
+    # results can arrive ahead of the first status heartbeat (2 s cadence),
+    # and the post-crash assertions are about the *last observed* state.
+    def job_active() -> bool:
+        status = backend.job_service.job_statuses.get(job_id)
+        return status is not None and status.state == JobState.active
+
+    wait_for_backend_condition(backend, job_active, timeout=30.0)
+
     def running_monitor_worker_keys() -> list[str]:
         return [
             key

--- a/tests/integration/service_crash_test.py
+++ b/tests/integration/service_crash_test.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration test for a backend service crashing mid-run."""
+
+import pytest
+
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.core.job import JobState, ServiceState
+from ess.livedata.dashboard.service_registry import SERVICE_HEARTBEAT_TIMEOUT_NS
+from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
+from tests.integration.conftest import IntegrationEnv
+from tests.integration.helpers import (
+    topic_high_watermark,
+    wait_for_backend_condition,
+    wait_for_job_data,
+    wait_for_watermark_stall,
+)
+
+DATA_TOPIC = 'dummy_livedata_data'
+
+WORKFLOW_ID = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
+
+
+@pytest.mark.integration
+@pytest.mark.services('monitor')
+def test_dashboard_flags_crashed_service_worker_stale(
+    integration_env: IntegrationEnv,
+) -> None:
+    """
+    A service killed mid-run surfaces as a stale worker in the dashboard.
+
+    SIGKILL gives the worker no chance to publish its terminal heartbeat, so
+    unlike a clean shutdown (state ``stopped``, never stale) the crash
+    signature is a worker whose last state is still ``running`` while its
+    heartbeat has aged past SERVICE_HEARTBEAT_TIMEOUT (30 s). The job-status
+    tier has a longer staleness window (60 s), so at that point the dashboard
+    still shows the job's last observed state — worker staleness is what
+    flags the loss first. Results cease immediately: the data-topic watermark
+    stalls and stays put through the staleness window.
+    """
+    backend = integration_env.backend
+    job_ids = backend.workflow_controller.start_workflow(
+        workflow_id=WORKFLOW_ID,
+        source_names=['monitor1'],
+        config=MonitorDataParams(),
+    )
+    job_id = job_ids[0]
+    wait_for_job_data(backend, WORKFLOW_ID, job_ids, timeout=30.0)
+
+    def running_monitor_worker_keys() -> list[str]:
+        return [
+            key
+            for key, status in backend.service_registry.worker_statuses.items()
+            if status.service_name == 'monitor_data'
+            and status.state == ServiceState.running
+        ]
+
+    wait_for_backend_condition(
+        backend, lambda: len(running_monitor_worker_keys()) > 0, timeout=30.0
+    )
+    worker_key = running_monitor_worker_keys()[0]
+    assert not backend.service_registry.is_status_stale(worker_key)
+
+    # SIGKILL: no terminal heartbeat, no graceful teardown.
+    integration_env.services['monitor_data'].process.kill()
+
+    # Results cease: no further messages on the data topic.
+    data_watermark = wait_for_watermark_stall(DATA_TOPIC)
+
+    # Heartbeats stopped, so the worker's status ages into staleness.
+    wait_for_backend_condition(
+        backend,
+        lambda: backend.service_registry.is_status_stale(worker_key),
+        timeout=SERVICE_HEARTBEAT_TIMEOUT_NS / 1e9 + 20.0,
+        poll_interval=1.0,
+    )
+    # Stale while still nominally running — the crash signature, as opposed
+    # to a clean shutdown whose terminal heartbeat is never considered stale.
+    assert (
+        backend.service_registry.worker_statuses[worker_key].state
+        == ServiceState.running
+    )
+
+    # The job-status tier still shows the last observed state: its 60 s
+    # staleness window has not elapsed, so the loss is (intentionally) not
+    # yet reflected there.
+    status = backend.job_service.job_statuses.get(job_id)
+    assert status is not None
+    assert status.state == JobState.active
+    assert not backend.job_service.is_status_stale(job_id)
+
+    # Nothing was published during the staleness window either.
+    assert topic_high_watermark(DATA_TOPIC) == data_watermark

--- a/tests/integration/service_process.py
+++ b/tests/integration/service_process.py
@@ -230,14 +230,6 @@ class ServiceProcess:
             logger.warning("Service %s was not running", self.service_module)
             return
 
-        if self.process.poll() is not None:
-            logger.info("Service %s already stopped", self.service_module)
-            return
-
-        logger.info(
-            "Stopping service %s (PID %s)", self.service_module, self.process.pid
-        )
-
         # Use ExitStack to ensure all cleanup happens even if exceptions occur
         with ExitStack() as cleanup_stack:
             # Register pipe cleanup
@@ -263,6 +255,19 @@ class ServiceProcess:
                         )
 
             cleanup_stack.callback(stop_threads)
+
+            if self.process.poll() is not None:
+                # Already dead (clean exit or crash-injection kill): still reap
+                # and run the pipe/thread cleanup, else the unclosed pipe
+                # FileIOs surface as ResourceWarnings that pytest escalates to
+                # an error on the next test.
+                self.process.wait()
+                logger.info("Service %s already stopped", self.service_module)
+                return
+
+            logger.info(
+                "Stopping service %s (PID %s)", self.service_module, self.process.pid
+            )
 
             # Terminate/kill the process (done first, cleanup happens via ExitStack)
             self.process.terminate()


### PR DESCRIPTION
Two real-Kafka integration tests for the remaining automatable items of the #1097 checklist, against ADR 0008 (job adoption / desired-observed reconciliation).

**Stop reconciliation** (`reconciliation_restop_test.py`): freezing the backend service with SIGSTOP makes a commanded stop sit unacted while the job's observed status stays fresh; reconciliation re-issues the stop after `STOP_REISSUE_INTERVAL_SECONDS`, observed as an extra commands-topic message no user action produced. The checklist's restart variant ("stop commanded before the restart is re-stopped by reconciliation") is not what the architecture does: desired-stopped is not persisted, so after a restart an absent `current_job` record is indistinguishable from a record miss, and ADR 0008 resolves that toward adoption ("record misses degrade, they do not lie"). The second test pins that actual guarantee — the still-running job is adopted record-less (no spurious commands, degraded provenance) and remains stoppable. If re-stop-after-restart is the desired semantics instead, the stop intent would need to be persisted (e.g. a tombstone for the stopped job_number); that is a product change, flagged on #1097.

**Service crash mid-run** (`service_crash_test.py`): a SIGKILLed `monitor_data` worker (no terminal heartbeat) surfaces as stale-while-`running` in `ServiceRegistry` after the 30 s heartbeat timeout — the crash signature, distinct from a clean shutdown whose terminal `stopped` status is never stale. The job-status tier (60 s window) intentionally still shows the last state at that point, and the data-topic watermark stalls immediately and stays put.

Helpers: `wait_for_watermark_stall` (proves a producer went quiet) and a `service_registry` accessor on `DashboardBackend`.

Part of #1097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
