### PR TITLE
Show stopped/error status in the cell titlebar pill

### DIFF
--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -49,7 +49,7 @@ from .plot_widgets import (
     get_plot_cell_display_info,
     get_workflow_display_info,
 )
-from .styles import Colors, FreshnessPill, StatusColors
+from .styles import Colors, StatusColors, StatusPill
 
 logger = structlog.get_logger(__name__)
 
@@ -87,10 +87,10 @@ _STALE_MAX_SECONDS = 30.0
 def _freshness_band(age_seconds: float) -> tuple[str, str, str]:
     """Return the ``(background, text, dot)`` pill colors for a data age."""
     if age_seconds < _FRESH_MAX_SECONDS:
-        return FreshnessPill.FRESH
+        return StatusPill.FRESH
     if age_seconds < _STALE_MAX_SECONDS:
-        return FreshnessPill.STALE
-    return FreshnessPill.OLD
+        return StatusPill.STALE
+    return StatusPill.OLD
 
 
 def _format_age_short(age_seconds: float) -> str:
@@ -102,12 +102,39 @@ def _format_age_short(age_seconds: float) -> str:
     return f'{age_seconds / 60:.0f}m'
 
 
-def format_freshness_html(age_seconds: float | None) -> str:
-    """Render the titlebar freshness pill: wall-clock age of the displayed data.
+def _pill_html(
+    band: tuple[str, str, str], label: str, *, square_dot: bool = False
+) -> str:
+    """Render a status pill: colored dot + short label on a tinted background.
 
-    Shows ``now - data_end`` for the oldest layer, color-banded by staleness.
-    Because every cell uses a shared ``now``, ages are directly comparable
-    across plots and grow visibly while a stream is stalled.
+    Shared by the titlebar pill and the per-layer status badges so job state
+    speaks one visual language at both levels. ``square_dot`` renders the dot
+    as a square — the conventional "stop" glyph.
+    """
+    background, text_color, dot_color = band
+    pill_style = (
+        f'display:inline-flex;align-items:center;gap:5px;height:20px;'
+        f'padding:0 8px;border-radius:10px;font-size:11px;'
+        f'font-variant-numeric:tabular-nums;white-space:nowrap;'
+        f'background:{background};color:{text_color};'
+    )
+    dot_radius = '1px' if square_dot else '50%'
+    dot_style = (
+        f'width:7px;height:7px;border-radius:{dot_radius};flex:none;'
+        f'background:{dot_color};'
+    )
+    return f'<span style="{pill_style}"><span style="{dot_style}"></span>{label}</span>'
+
+
+def format_freshness_html(age_seconds: float | None) -> str:
+    """Render the titlebar pill for live data: wall-clock age of what is shown.
+
+    Shows ``now - data_end`` for the oldest live layer, color-banded by
+    staleness. Because every cell uses a shared ``now``, ages are directly
+    comparable across plots and grow visibly while a stream is stalled.
+    Stopped and errored cells freeze the pill via :func:`format_stopped_html`
+    / :func:`format_error_html` instead — a growing age on a deliberately
+    stopped job would read as a pipeline problem.
 
     No hover tooltip: the pill re-renders as the age ticks, which would tear
     down a native ``title`` tooltip on every update. The absolute time range and
@@ -120,20 +147,17 @@ def format_freshness_html(age_seconds: float | None) -> str:
     """
     if age_seconds is None:
         return ''
-    background, text_color, dot_color = _freshness_band(age_seconds)
-    pill_style = (
-        f'display:inline-flex;align-items:center;gap:5px;height:20px;'
-        f'padding:0 8px;border-radius:10px;font-size:11px;'
-        f'font-variant-numeric:tabular-nums;white-space:nowrap;'
-        f'background:{background};color:{text_color};'
-    )
-    dot_style = (
-        f'width:7px;height:7px;border-radius:50%;flex:none;background:{dot_color};'
-    )
-    return (
-        f'<span style="{pill_style}">'
-        f'<span style="{dot_style}"></span>{_format_age_short(age_seconds)}</span>'
-    )
+    return _pill_html(_freshness_band(age_seconds), _format_age_short(age_seconds))
+
+
+def format_stopped_html() -> str:
+    """Neutral gray "stopped" pill: the job ended, the snapshot is deliberate."""
+    return _pill_html(StatusPill.STOPPED, 'stopped', square_dot=True)
+
+
+def format_error_html() -> str:
+    """Red "error" pill for a failed layer; details live in the layer tooltip."""
+    return _pill_html(StatusPill.ERROR, 'error')
 
 
 def create_freshness_pane() -> pn.pane.HTML:
@@ -231,6 +255,8 @@ class CellWidget:
         self._toolbars_shown = toolbars_visible
         self._autoscale_controller: CellAutoscaleController | None = None
         self._freshness_pane = create_freshness_pane()
+        self._stopped_layers: frozenset[LayerId] = frozenset()
+        self._pill_frozen = False
         self._layer_time_panes: dict[LayerId, pn.pane.HTML] = {}
         # Composing builds the autoscale controller as a side effect.
         self._plot = self._compose_plot()
@@ -271,9 +297,21 @@ class CellWidget:
         """The cell's autoscale controller, if any layer drives autoscale."""
         return self._autoscale_controller
 
-    def update_freshness(self, bounds_list: list[TimeBounds | None]) -> None:
-        """Update the titlebar freshness pane with the worst-case data age."""
-        merged = merge_time_bounds(bounds_list)
+    def update_freshness(
+        self, bounds_by_layer: Mapping[LayerId, TimeBounds | None]
+    ) -> None:
+        """Update the titlebar pill with the worst-case data age of live layers.
+
+        No-op while the pill is frozen to a status ("stopped"/"error", set at
+        build time). Stopped layers are excluded from the merge so their
+        ever-growing age cannot drag the band to red while other layers are
+        live.
+        """
+        if self._pill_frozen:
+            return
+        merged = merge_time_bounds(
+            b for lid, b in bounds_by_layer.items() if lid not in self._stopped_layers
+        )
         age = merged.age_seconds() if merged is not None else None
         html = format_freshness_html(age)
         if self._freshness_pane.object != html:
@@ -314,9 +352,41 @@ class CellWidget:
             result[layer.layer_id] = state
         return result
 
+    def _freeze_pill_for_status(
+        self, layer_states: dict[LayerId, LayerStateMachine]
+    ) -> None:
+        """Freeze the titlebar pill to a status pill when the cell is not live.
+
+        Any errored layer wins (needs attention); otherwise all dynamic layers
+        stopped means the cell shows a deliberate frozen snapshot. Static
+        overlay layers never run a job, so they are ignored for the stopped
+        aggregate. State changes bump layer versions and rebuild the cell, so
+        deciding at build time is sufficient.
+        """
+        self._stopped_layers = frozenset(
+            layer_id
+            for layer_id, state in layer_states.items()
+            if state.state is LayerState.STOPPED
+        )
+        dynamic_ids = [
+            layer.layer_id
+            for layer in self._cell.layers
+            if not layer.config.is_static()
+        ]
+        if any(s.state is LayerState.ERROR for s in layer_states.values()):
+            frozen = format_error_html()
+        elif dynamic_ids and all(lid in self._stopped_layers for lid in dynamic_ids):
+            frozen = format_stopped_html()
+        else:
+            frozen = None
+        self._pill_frozen = frozen is not None
+        if frozen is not None:
+            self._freshness_pane.object = frozen
+
     def _build(self) -> pn.Column:
         """Assemble the cell widget: titlebar, layer toolbars, and content."""
         layer_states = self._layer_states()
+        self._freeze_pill_for_status(layer_states)
 
         # Per-layer toolbars, wrapped in a column the titlebar toggle can hide.
         layer_toolbars = self._build_layer_toolbars(layer_states)
@@ -449,12 +519,13 @@ class CellWidget:
             )
 
             # Add state info to description using explicit state enum
-            stopped = False
+            badge = None
             match state.state:
                 case LayerState.ERROR:
+                    badge = format_error_html()
                     description = f"{description}\n\nError: {state.error_message}"
                 case LayerState.STOPPED:
-                    stopped = True
+                    badge = format_stopped_html()
                     description = f"{description}\n\nStatus: Workflow not running"
                 case LayerState.WAITING_FOR_DATA:
                     description = f"{description}\n\nStatus: Waiting for data..."
@@ -468,7 +539,7 @@ class CellWidget:
                 create_layer_info_row(
                     title=title,
                     description=description,
-                    stopped=stopped,
+                    badge=badge,
                     time_pane=time_pane,
                 )
             )

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -814,7 +814,7 @@ class PlotGridTabs:
             if cell_widget is None:
                 continue
             if freshness_due:
-                cell_widget.update_freshness(list(per_layer.values()))
+                cell_widget.update_freshness(per_layer)
             if flush_due:
                 for layer_id, bounds in per_layer.items():
                     cell_widget.update_layer_time(layer_id, bounds)

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -132,7 +132,7 @@ def create_layer_info_row(
     *,
     title: str | None = None,
     description: str | None = None,
-    stopped: bool = False,
+    badge: str | None = None,
     time_pane: pn.pane.HTML | None = None,
 ) -> pn.Row | pn.Column:
     """
@@ -150,8 +150,9 @@ def create_layer_info_row(
         Optional title text to display on the left side of the row.
     description:
         Optional description shown as tooltip when hovering over the title.
-    stopped:
-        If True, adds a visual indicator (border) showing workflow has ended.
+    badge:
+        Optional pre-rendered status pill HTML ("stopped"/"error"), placed at
+        the far left to mirror the titlebar pill position.
     time_pane:
         Optional pane showing this layer's data time range/lag, placed on its
         own line below the title and updated in place by the caller.
@@ -161,8 +162,18 @@ def create_layer_info_row(
     :
         Panel Row (or Column when a time pane is given) for one layer.
     """
-    # Build left content: title and optional tooltip icon
+    # Build left content: status badge, title, and optional tooltip icon
     left_items: list = []
+    if badge:
+        left_items.append(
+            pn.pane.HTML(
+                badge,
+                sizing_mode='fixed',
+                height=ButtonStyles.TOOL_BUTTON_SIZE,
+                margin=(0, 6, 0, 0),
+                styles={'display': 'flex', 'align-items': 'center'},
+            )
+        )
     if title:
         title_html = pn.pane.HTML(
             f'<span style="font-size: 12px; color: {Colors.TEXT};">{title}</span>',
@@ -194,12 +205,6 @@ def create_layer_info_row(
 
     margin = ButtonStyles.CELL_MARGIN
 
-    # Add border when workflow is stopped
-    styles = {}
-    if stopped:
-        styles['border'] = f'2px solid {Colors.TEXT}'
-        styles['border-radius'] = '4px'
-
     title_row = pn.Row(
         *left_items,
         pn.Spacer(sizing_mode='stretch_width'),
@@ -210,7 +215,6 @@ def create_layer_info_row(
 
     if time_pane is None:
         title_row.margin = (margin, margin, margin, margin)
-        title_row.styles = styles
         return title_row
 
     # Time info goes on its own line below the title row to avoid competing
@@ -220,7 +224,6 @@ def create_layer_info_row(
         time_pane,
         sizing_mode='stretch_width',
         margin=(margin, margin, margin, margin),
-        styles=styles,
     )
 
 

--- a/src/ess/livedata/dashboard/widgets/styles.py
+++ b/src/ess/livedata/dashboard/widgets/styles.py
@@ -42,15 +42,20 @@ class Colors:
     TAB_ACTIVE_BG = "#e8f4f8"
 
 
-class FreshnessPill:
-    """Color bands for the titlebar freshness/lag pill, by data staleness.
+class StatusPill:
+    """Color bands for the cell status pill and per-layer status badges.
 
-    Each band is ``(background, text, dot)``.
+    ``FRESH``/``STALE``/``OLD`` band live data age. ``STOPPED`` marks a
+    deliberately stopped job whose frozen snapshot is still valid — neutral
+    gray, no alarm. ``ERROR`` flags a failed layer and shares the alarm red
+    with ``OLD``. Each band is ``(background, text, dot)``.
     """
 
     FRESH = ("rgba(40, 167, 69, 0.16)", "#1e7e34", StatusColors.SUCCESS)
     STALE = ("rgba(255, 193, 7, 0.18)", "#946c00", StatusColors.WARNING)
     OLD = ("rgba(220, 53, 69, 0.16)", "#b21f2d", StatusColors.ERROR)
+    STOPPED = ("rgba(108, 117, 125, 0.16)", Colors.TEXT, StatusColors.MUTED)
+    ERROR = OLD
 
 
 class ErrorBox:

--- a/tests/dashboard/widgets/cell_test.py
+++ b/tests/dashboard/widgets/cell_test.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from ess.livedata.dashboard.widgets.cell import (
+    format_error_html,
     format_freshness_html,
     format_layer_time_html,
+    format_stopped_html,
 )
-from ess.livedata.dashboard.widgets.styles import FreshnessPill
+from ess.livedata.dashboard.widgets.styles import StatusPill
 
 
 class TestFreshnessPill:
@@ -13,18 +15,18 @@ class TestFreshnessPill:
 
     def test_fresh_band_colors_and_label(self) -> None:
         html = format_freshness_html(2.3)
-        assert FreshnessPill.FRESH[0] in html  # background
+        assert StatusPill.FRESH[0] in html  # background
         assert '2.3s' in html
         assert 'border-radius' in html
 
     def test_stale_band(self) -> None:
         html = format_freshness_html(12.0)
-        assert FreshnessPill.STALE[0] in html
+        assert StatusPill.STALE[0] in html
         assert '12s' in html
 
     def test_old_band(self) -> None:
         html = format_freshness_html(41.0)
-        assert FreshnessPill.OLD[0] in html
+        assert StatusPill.OLD[0] in html
         assert '41s' in html
 
     def test_minutes_for_large_age(self) -> None:
@@ -34,6 +36,22 @@ class TestFreshnessPill:
         # A native title tooltip cannot survive the pill's per-frame re-renders
         # as the age ticks; detail lives in the toolbar row instead.
         assert 'title=' not in format_freshness_html(2.0)
+
+
+class TestStatusPills:
+    def test_stopped_pill_is_neutral_gray_with_label(self) -> None:
+        html = format_stopped_html()
+        assert StatusPill.STOPPED[0] in html
+        assert 'stopped' in html
+
+    def test_stopped_pill_has_square_stop_glyph(self) -> None:
+        # The dot renders as a square -- the conventional "stop" glyph.
+        assert 'border-radius:50%' not in format_stopped_html()
+
+    def test_error_pill_is_red_with_label(self) -> None:
+        html = format_error_html()
+        assert StatusPill.ERROR[0] in html
+        assert 'error' in html
 
 
 class TestLayerTimeHtml:

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """
-Regression tests for issue #805: polling must handle Layout-producing plotters
-even when their DynamicMap has already been evaluated by Bokeh.
+Behavior tests for the PlotGridTabs poll loop: cell (re)builds for
+Layout-producing plotters (issue #805), the titlebar status pill, and
+per-layer time panes.
 """
 
 from __future__ import annotations
 
+import time
 from uuid import uuid4
 
 import holoviews as hv
@@ -14,6 +16,7 @@ import pydantic
 import pytest
 
 from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.dashboard.data_service import DataService
 from ess.livedata.dashboard.job_service import JobService
 from ess.livedata.dashboard.notification_queue import NotificationQueue
@@ -27,12 +30,13 @@ from ess.livedata.dashboard.plot_orchestrator import (
     PlotConfig,
     PlotOrchestrator,
 )
-from ess.livedata.dashboard.plots import PresenterBase
+from ess.livedata.dashboard.plots import PresenterBase, TimeBounds
 from ess.livedata.dashboard.plotting_controller import PlottingController
 from ess.livedata.dashboard.session_registry import SessionId, SessionRegistry
 from ess.livedata.dashboard.session_updater import SessionUpdater
 from ess.livedata.dashboard.stream_manager import StreamManager
 from ess.livedata.dashboard.widgets.plot_grid_tabs import PlotGridTabs
+from ess.livedata.dashboard.widgets.styles import StatusPill
 from ess.livedata.dashboard.widgets.workflow_status_widget import (
     WorkflowStatusListWidget,
 )
@@ -149,6 +153,18 @@ def _make_layout() -> hv.Layout:
     )
 
 
+def _make_bounds(age_seconds: float) -> TimeBounds:
+    """Bounds whose data age is ``age_seconds`` relative to now."""
+    now_ns = time.time_ns()
+    end_ns = now_ns - int(age_seconds * 1e9)
+    return TimeBounds(
+        min_end=Timestamp.from_ns(end_ns),
+        created_at=Timestamp.from_ns(now_ns),
+        min_start=Timestamp.from_ns(end_ns - int(1e9)),
+        max_end=Timestamp.from_ns(end_ns),
+    )
+
+
 def _inject_layer(
     plot_orchestrator: PlotOrchestrator,
     plot_data_service: PlotDataService,
@@ -184,6 +200,43 @@ def _inject_layer(
     plot_data_service.job_started(layer_id, plotter)
     plot_data_service.data_arrived(layer_id)
     return layer_id
+
+
+def _inject_two_layer_cell(
+    plot_orchestrator: PlotOrchestrator,
+    plot_data_service: PlotDataService,
+    grid_id,
+    plotters: tuple[FakePlotter, FakePlotter],
+) -> tuple[LayerId, LayerId]:
+    """Add one cell with two layers, registering one plotter per layer."""
+    cell_id = CellId(uuid4())
+    layer_ids = (LayerId(uuid4()), LayerId(uuid4()))
+
+    def cfg(view):
+        return PlotConfig(
+            data_sources={
+                'primary': DataSourceConfig(
+                    workflow_id=WorkflowId(instrument='test', name='wf', version=1),
+                    source_names=['src'],
+                    view_name=view,
+                )
+            },
+            plot_name='image',
+            params=_Params(),
+        )
+
+    cell = PlotCell(
+        geometry=CellGeometry(row=0, col=0, row_span=1, col_span=1),
+        layers=[
+            Layer(layer_id=lid, config=cfg(view))
+            for lid, view in zip(layer_ids, ('a', 'b'), strict=True)
+        ],
+    )
+    plot_orchestrator.peek_grid(grid_id).cells[cell_id] = cell
+    for lid, plotter in zip(layer_ids, plotters, strict=True):
+        plot_data_service.job_started(lid, plotter)
+        plot_data_service.data_arrived(lid)
+    return layer_ids
 
 
 # -- Tests -----------------------------------------------------------------
@@ -261,19 +314,9 @@ class TestFreshnessIndicator:
         self, plot_orchestrator, plot_data_service, plot_grid_tabs
     ):
         """A poll on the active grid fills the cell's freshness pane with lag."""
-        import time
-
-        from ess.livedata.core.timestamp import Timestamp
-        from ess.livedata.dashboard.plots import TimeBounds
-
-        now_ns = time.time_ns()
-        bounds = TimeBounds(
-            min_end=Timestamp.from_ns(now_ns - int(2e9)),
-            created_at=Timestamp.from_ns(now_ns),
-            min_start=Timestamp.from_ns(now_ns - int(3e9)),
-            max_end=Timestamp.from_ns(now_ns - int(1e9)),
+        plotter = FakePlotter(
+            cached_state=_make_layout(), time_bounds=_make_bounds(2.0)
         )
-        plotter = FakePlotter(cached_state=_make_layout(), time_bounds=bounds)
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
         _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
 
@@ -305,49 +348,17 @@ class TestFreshnessIndicator:
         self, plot_orchestrator, plot_data_service, plot_grid_tabs
     ):
         """Both layers in a multi-layer cell get their time pane populated."""
-        import time
-
-        from ess.livedata.core.timestamp import Timestamp
-        from ess.livedata.dashboard.plots import TimeBounds
-
-        now_ns = time.time_ns()
-        bounds = TimeBounds(
-            min_end=Timestamp.from_ns(now_ns - int(2e9)),
-            created_at=Timestamp.from_ns(now_ns),
-            min_start=Timestamp.from_ns(now_ns - int(3e9)),
-            max_end=Timestamp.from_ns(now_ns - int(1e9)),
-        )
+        bounds = _make_bounds(2.0)
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
-
-        cell_id = CellId(uuid4())
-        l1, l2 = LayerId(uuid4()), LayerId(uuid4())
-
-        def cfg(view):
-            return PlotConfig(
-                data_sources={
-                    'primary': DataSourceConfig(
-                        workflow_id=WorkflowId(instrument='test', name='wf', version=1),
-                        source_names=['src'],
-                        view_name=view,
-                    )
-                },
-                plot_name='image',
-                params=_Params(),
-            )
-
-        cell = PlotCell(
-            geometry=CellGeometry(row=0, col=0, row_span=1, col_span=1),
-            layers=[
-                Layer(layer_id=l1, config=cfg('a')),
-                Layer(layer_id=l2, config=cfg('b')),
-            ],
+        l1, l2 = _inject_two_layer_cell(
+            plot_orchestrator,
+            plot_data_service,
+            grid_id,
+            (
+                FakePlotter(cached_state=_make_layout(), time_bounds=bounds),
+                FakePlotter(cached_state=_make_layout(), time_bounds=bounds),
+            ),
         )
-        plot_orchestrator.peek_grid(grid_id).cells[cell_id] = cell
-        for lid in (l1, l2):
-            plot_data_service.job_started(
-                lid, FakePlotter(cached_state=_make_layout(), time_bounds=bounds)
-            )
-            plot_data_service.data_arrived(lid)
 
         # First poll adds the tab and builds the cell; activate then poll again
         # so the per-layer time panes fill for the now-active grid.
@@ -355,13 +366,11 @@ class TestFreshnessIndicator:
         plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         plot_grid_tabs._poll_for_plot_updates()
 
-        cell_widget = plot_grid_tabs._cells[cell_id]
+        (cell_widget,) = plot_grid_tabs._cells.values()
         assert 'Lag:' in cell_widget.layer_time_panes[l1].object
         assert 'Lag:' in cell_widget.layer_time_panes[l2].object
         # The cell pill must still show with two layers.
-        pill_panes = [cw.freshness_pane for cw in plot_grid_tabs._cells.values()]
-        assert len(pill_panes) == 1
-        assert 'border-radius' in pill_panes[0].object
+        assert 'border-radius' in cell_widget.freshness_pane.object
 
     def test_hidden_grid_does_not_update_freshness(
         self, plot_orchestrator, plot_data_service, plot_grid_tabs
@@ -377,3 +386,71 @@ class TestFreshnessIndicator:
 
         for cell_widget in plot_grid_tabs._cells.values():
             assert cell_widget.freshness_pane.object in ('', None)
+
+
+class TestStoppedJobIndication:
+    """The titlebar pill freezes to a status when jobs stop or error (#1120)."""
+
+    def _poll_active(self, plot_grid_tabs):
+        """Poll once to build, activate the grid tab, poll again to refresh."""
+        plot_grid_tabs._poll_for_plot_updates()
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+        plot_grid_tabs._poll_for_plot_updates()
+        (cell_widget,) = plot_grid_tabs._cells.values()
+        return cell_widget
+
+    def test_stopped_job_shows_stopped_pill_despite_fresh_bounds(
+        self, plot_orchestrator, plot_data_service, plot_grid_tabs
+    ):
+        plotter = FakePlotter(
+            cached_state=_make_layout(), time_bounds=_make_bounds(2.0)
+        )
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        layer_id = _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
+        plot_data_service.job_stopped(layer_id)
+
+        cell_widget = self._poll_active(plot_grid_tabs)
+
+        # Frozen "stopped" pill; the fresh bounds seen by the freshness update
+        # above must not overwrite it with an age band.
+        pill = cell_widget.freshness_pane.object
+        assert 'stopped' in pill
+        assert StatusPill.STOPPED[0] in pill
+        assert StatusPill.FRESH[0] not in pill
+
+    def test_errored_layer_shows_error_pill(
+        self, plot_orchestrator, plot_data_service, plot_grid_tabs
+    ):
+        plotter = FakePlotter(
+            cached_state=_make_layout(), time_bounds=_make_bounds(2.0)
+        )
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        layer_id = _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
+        plot_data_service.error_occurred(layer_id, 'boom')
+
+        cell_widget = self._poll_active(plot_grid_tabs)
+
+        assert 'error' in cell_widget.freshness_pane.object
+
+    def test_partial_stop_excludes_stopped_layer_from_freshness(
+        self, plot_orchestrator, plot_data_service, plot_grid_tabs
+    ):
+        """A stopped layer's growing age must not drag the live pill to red."""
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        stopped_layer, _live_layer = _inject_two_layer_cell(
+            plot_orchestrator,
+            plot_data_service,
+            grid_id,
+            (
+                FakePlotter(cached_state=_make_layout(), time_bounds=_make_bounds(120)),
+                FakePlotter(cached_state=_make_layout(), time_bounds=_make_bounds(2.0)),
+            ),
+        )
+        plot_data_service.job_stopped(stopped_layer)
+
+        cell_widget = self._poll_active(plot_grid_tabs)
+
+        pill = cell_widget.freshness_pane.object
+        assert StatusPill.FRESH[0] in pill
+        assert StatusPill.OLD[0] not in pill
+        assert 'stopped' not in pill


### PR DESCRIPTION
Fixes #1120.

## Motivation

The titlebar pill only showed data age, so a stopped job decayed to the same red as a broken pipeline. That signal is wrong twice: stopping is deliberate and the frozen snapshot is valid (no alarm warranted), and once users learn "red often just means stopped" they start ignoring red — alarm fatigue masking real staleness problems. Meanwhile the actual stopped indication (a dark border on per-layer rows) was only visible in the expanded state, and errors on layers that still had a plot were invisible entirely.

## Example

<img width="448" height="437" alt="image" src="https://github.com/user-attachments/assets/b7d6047a-f4dc-46cd-9420-e0665afd1e95" />

## What changed

The pill now speaks one status language at both cell and layer level:

- Any layer errored: red "error" pill in the titlebar (previously invisible while a plot was still shown).
- All dynamic layers stopped: neutral gray "stopped" pill with a square stop glyph, frozen — no age counting on a deliberate snapshot. Static overlays are ignored for the aggregate.
- Otherwise: freshness bands as before, with stopped layers excluded from the age merge so a partial stop cannot drag the band to red while other layers are live.

The stopped border on expanded per-layer rows is replaced by the same pill in miniature ("stopped"/"error" badge at the row's far left, mirroring the titlebar), so the expanded view is detail, not a different encoding. `FreshnessPill` is renamed to `StatusPill` accordingly.

## Test plan

Behavior tests cover the frozen pill (fresh bounds must not overwrite it), the error pill, and partial-stop age filtering, driven through the real poll loop. Verified visually against the fake backend (stopped workflows show gray pills collapsed and expanded, plots retained).

- [x] Manual check on a live instrument: stop a workflow, confirm the titlebar shows the gray "stopped" pill and expanded rows show the badge instead of the border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
