### PR TITLE
Harden batchers against pathological data-derived timestamps

### DIFF
--- a/src/ess/livedata/core/message_batcher.py
+++ b/src/ess/livedata/core/message_batcher.py
@@ -22,6 +22,52 @@ class MessageBatch:
     messages: list[Message[Any]]
 
 
+# Largest jump between consecutive timestamps that still reads as continuous
+# traffic, in multiples of the batch length.  Data-derived timestamps are the
+# batchers' only clock, so window placement must not follow one outlier
+# arbitrarily far into the future: an over-anchored window stalls delivery
+# until wall time catches up, while an under-anchored one self-heals forward
+# as newer traffic arrives.  The cap holds regardless of where a message
+# came from: sources are not trusted to deliver sane timestamps, and the
+# batcher is the one place every message passes through.
+MAX_TIMESTAMP_AHEAD_BATCHES = 3
+
+
+def plausible_anchor(timestamps: list[Timestamp], batch_length: Duration) -> Timestamp:
+    """Newest timestamp still connected to the bulk of the given traffic.
+
+    Batch windows are anchored at the newest timestamp seen.  A bare ``max``
+    lets a single pathological far-future timestamp pin the window (and with
+    it the batcher's data-derived clock), stalling delivery until wall time
+    catches up.
+
+    Splitting the sorted timestamps at every jump wider than the horizon
+    yields groups of mutually-connected traffic; the anchor is the newest
+    timestamp of the largest group.  Membership of the bulk is what marks a
+    timestamp as genuine, not distance from an average: a burst spread evenly
+    over many batch lengths stays one group and keeps its true maximum, while
+    a tight cluster plus one stray yields the cluster -- whether the stray
+    sits ahead of the traffic or behind it, as a stream in a disjoint epoch
+    does.
+
+    Ties go to the later group, and a lone timestamp is necessarily its own
+    anchor.  Neither case has evidence to weigh, and anchoring behind the
+    traffic is not the safe default it appears to be: a window only walks
+    forward one batch length per call, so an anchor stranded in a disjoint
+    past epoch takes astronomically many calls to catch up, where one
+    stranded ahead merely waits out its own distance.
+    """
+    ordered = sorted(timestamps)
+    horizon = MAX_TIMESTAMP_AHEAD_BATCHES * batch_length
+    groups = [[ordered[0]]]
+    for timestamp in ordered[1:]:
+        if timestamp - groups[-1][-1] > horizon:
+            groups.append([])
+        groups[-1].append(timestamp)
+    largest = max(len(group) for group in groups)
+    return next(group for group in reversed(groups) if len(group) == largest)[-1]
+
+
 class MessageBatcher(ABC):
     @abstractmethod
     def batch(self, messages: list[Message[Any]]) -> MessageBatch | None:
@@ -101,6 +147,9 @@ class SimpleMessageBatcher(MessageBatcher):
 
     If messages arrive late, they will be included in the next batch. This means that
     batches may contain messages with timestamps outside (before) the batch time range.
+    The initial batch may also contain messages after its end time, since its end
+    time is an outlier-robust anchor rather than a bare maximum (see
+    :func:`plausible_anchor`).
 
     If no messages are available for a given batch, an empty batch is returned.
 
@@ -150,6 +199,8 @@ class SimpleMessageBatcher(MessageBatcher):
         # batch.
         batch = self._active_batch
         new_end_time = batch.end_time + self._batch_length
+        if not self._may_advance_to(new_end_time):
+            return None
         new_active, self._future_messages = self._split_messages(
             self._future_messages, new_end_time
         )
@@ -159,11 +210,18 @@ class SimpleMessageBatcher(MessageBatcher):
         return batch
 
     def _make_initial_batch(self, messages: list[Message[Any]]) -> MessageBatch | None:
-        """Make initial batch that includes everything."""
+        """Make initial batch that includes everything.
+
+        The end time anchors all subsequent batch boundaries, so it must be
+        robust against a pathological far-future timestamp in the startup
+        backlog (see :func:`plausible_anchor`).
+        """
         if not messages:
             return None
         start_time = min(msg.timestamp for msg in messages)
-        end_time = max(msg.timestamp for msg in messages)
+        end_time = plausible_anchor(
+            [msg.timestamp for msg in messages], self._batch_length
+        )
         batch = MessageBatch(
             start_time=start_time, end_time=end_time, messages=messages
         )
@@ -176,6 +234,29 @@ class SimpleMessageBatcher(MessageBatcher):
             messages=[],
         )
         return batch
+
+    def _may_advance_to(self, end_time: Timestamp) -> bool:
+        """Whether advancing the window to ``end_time`` keeps it near the data.
+
+        Closing a batch is driven by the mere presence of a future message, so
+        a message parked implausibly far ahead advances the window on every
+        call -- once per poll rather than once per batch length. The window
+        then overruns the live data and comes to rest at the outlier, and
+        nothing closes a batch until wall time catches up: the #1038 wedge.
+        Refusing to advance past
+        the frontier of the data in hand keeps the window with the traffic,
+        and the frontier moves forward as real messages arrive.
+
+        The active batch's own messages are the frontier: they landed before
+        its end time by construction, so they mark where the traffic actually
+        is, and no future-dated value can inflate them. An empty active batch
+        raises no objection -- that is a genuine silence gap, which advances
+        window by window as it always has.
+        """
+        if not self._active_batch.messages:
+            return True
+        frontier = max(msg.timestamp for msg in self._active_batch.messages)
+        return end_time <= frontier + MAX_TIMESTAMP_AHEAD_BATCHES * self._batch_length
 
     def _split_messages(
         self, messages: list[Message[Any]], timestamp: Timestamp

--- a/src/ess/livedata/core/message_batcher.py
+++ b/src/ess/livedata/core/message_batcher.py
@@ -17,6 +17,16 @@ logger = structlog.get_logger(__name__)
 
 @dataclass(slots=True, kw_only=True)
 class MessageBatch:
+    """Messages delivered together, spanning the given time range.
+
+    The time range is load-bearing beyond delivery cadence: downstream it is
+    the service's data clock -- job activation and run resets fire once these
+    times advance past their scheduled points (``JobManager._advance_to_time``).
+    Window placement is therefore a correctness concern, not only a liveness
+    one: an end time in a wrong epoch fires or parks every pending schedule,
+    even while batches keep flowing.
+    """
+
     start_time: Timestamp
     end_time: Timestamp
     messages: list[Message[Any]]

--- a/src/ess/livedata/core/message_batcher.py
+++ b/src/ess/livedata/core/message_batcher.py
@@ -167,9 +167,10 @@ class SimpleMessageBatcher(MessageBatcher):
     and returned, even if no messages were received for it.
 
     Attention: This means that if messages arrive very infrequently, the batcher may
-    return messages very late (or never, if the stream stops). This might cause issues
-    but for now we want to avoid relying on wall-clock time. Instead, raw data messages
-    serve as our clock.
+    return messages very late (or never, if the stream stops). Raw data messages serve
+    as this batcher's only clock; unlike :class:`RateAwareMessageBatcher` it has no
+    wall-clock liveness backstop (see that module's clock policy), so a window
+    misplaced by a pathological timestamp can only heal by data time catching up.
     """
 
     def __init__(self, batch_length_s: float = 1.0) -> None:

--- a/src/ess/livedata/core/rate_aware_batcher.py
+++ b/src/ess/livedata/core/rate_aware_batcher.py
@@ -16,7 +16,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ess.livedata.core.message import Message, StreamId, StreamKind
-from ess.livedata.core.message_batcher import MessageBatch, MessageBatcher
+from ess.livedata.core.message_batcher import (
+    MAX_TIMESTAMP_AHEAD_BATCHES,
+    MessageBatch,
+    MessageBatcher,
+    plausible_anchor,
+)
 from ess.livedata.core.timestamp import Duration, Timestamp
 
 GATED_STREAM_KINDS = frozenset(
@@ -31,6 +36,17 @@ GATED_STREAM_KINDS = frozenset(
 MIN_DIFFS_FOR_GATE = 4
 DIFF_BUFFER_SIZE = 32
 ABSENT_BATCHES_FOR_EVICTION = 5
+
+# Quorum for window re-anchoring (see ``_should_reanchor``): the minimum
+# number of buffered messages that must unanimously contradict the window
+# placement before the window follows them.
+_MIN_REANCHOR_MESSAGES = 4
+
+# Consecutive non-closing calls before re-anchoring is even considered.  The
+# pathologies it corrects never resolve on their own, so this only delays an
+# unavoidable correction, while keeping the scan off the healthy hot path and
+# ignoring momentary buffer states such as a single poll of lagging traffic.
+_REANCHOR_STALLED_CALLS = 20
 
 # Tolerance for snapping the raw rate to its nearest integer Hz.  Uses
 # the larger of a relative bound and an absolute floor: relative scales
@@ -52,39 +68,30 @@ _INTEGER_SNAP_ABSOLUTE_TOLERANCE_HZ = 0.1
 # refusing to absorb true phase offsets at low rates.
 _DRIFT_TOLERANCE_NS = 1_000_000
 
-# Max allowed distance between a new grid's origin and the active
-# batch_start, in multiples of batch_length.  Protects against streams
-# whose timestamps live in a disjoint epoch (wrong schema field, unit
-# mismatch, run-local clock): such a stream's grid would place every
-# slot billions of slots away from batch_start, pinning the bucket's
-# max_slot at -1 and vetoing every slot-gate closure for the whole batcher.
-# 1000 batches (>=16 min at 1 s batches) is well above any legitimate
-# cold-start or post-eviction origin offset but below any real epoch
-# mismatch by many orders of magnitude.
+# Disjoint-epoch horizon, in multiples of batch_length: the maximum distance
+# between a timestamp and the active window at which the timestamp is still
+# treated as belonging to the same epoch.  Beyond it, the timestamp is
+# assumed pathological (wrong schema field, unit mismatch, run-local clock)
+# rather than a legitimate silence gap.  Used to bound the distance between
+# a new grid's origin and the active batch_start -- a disjoint-epoch grid
+# would place every slot billions of slots away from batch_start, pinning
+# the bucket's max_slot at -1 and vetoing every slot-gate closure for the
+# whole batcher -- and to divert disjoint-epoch messages out of routing
+# (see ``_route_message``).  1000 batches (>=16 min at 1 s batches) is well
+# above any legitimate cold-start, post-eviction, or silence-gap offset but
+# below any real epoch mismatch by many orders of magnitude.
 _MAX_ORIGIN_OFFSET_BATCHES = 1000
 
-# Max distance ``_high_water_mark`` is allowed to sit past
-# ``_active_window.start``, in multiples of batch_length.  Protects
-# against a single malformed timestamp (e.g. upstream epoch bug
-# producing a value years ahead) permanently pinning the HWM in the
-# future, which would otherwise force every subsequent ``batch()`` call
-# to close a batch via the timeout path for millions of iterations --
-# effectively a DoS until the process restarts.
-#
-# Bounding HWM relative to the active window (rather than to the prior
-# HWM) keeps HWM self-healing: each batch close advances the window by
-# one batch_length, so after a bounded number of cascading empty
-# closures the HWM is no longer past the timeout threshold and timeout
-# firing stops on its own.  An absolute per-call cap doesn't self-heal
-# because the window keeps moving away from the clamped HWM.
-#
-# Must be >= ``timeout_factor`` (default 1.2) for the timeout path to
-# ever fire -- and comfortably above that for sub-Hz-only streams whose
-# sparse arrivals rely on multi-batch HWM jumps to trigger cascading
-# timeout closes of empty batches between pulses.  Three batches allows
-# one pulse's worth of HWM advance to cover the preceding empty batch,
-# matching the natural cadence of 0.5 Hz-and-below gated streams.
-_MAX_HWM_PAST_WINDOW_BATCHES = 3
+# ``MAX_TIMESTAMP_AHEAD_BATCHES`` (imported from message_batcher) is the
+# plausibility horizon shared by all uses in this module: the HWM clamp,
+# the future-message hold-back cap, and the outlier absorption in
+# ``_route_message``.  It must be >= ``timeout_factor`` (default 1.2) for
+# the timeout path to ever fire -- and comfortably above that for
+# sub-Hz-only streams whose sparse arrivals rely on multi-batch HWM jumps
+# to trigger cascading timeout closes of empty batches between pulses.
+# Three batches allows one pulse's worth of HWM advance to cover the
+# preceding empty batch, matching the natural cadence of 0.5 Hz-and-below
+# gated streams.
 
 
 @dataclass(slots=True)
@@ -392,6 +399,7 @@ class RateAwareMessageBatcher(MessageBatcher):
         self._overflow: list[Message[Any]] = []
         self._non_gated: list[Message[Any]] = []
         self._future: list[Message[Any]] = []
+        self._stalled_calls = 0
 
     @property
     def batch_length_s(self) -> float:
@@ -443,16 +451,34 @@ class RateAwareMessageBatcher(MessageBatcher):
 
         if self._should_recover_from_gap(window):
             window = self._recover_from_gap(window)
+        elif self._should_reanchor(window):
+            window = self._reanchor(window)
+            self._stalled_calls = 0
 
         if self._is_batch_complete(window):
+            self._stalled_calls = 0
             return self._close_batch(window)
+        self._stalled_calls += 1
         return None
 
     def _clamped_hwm(self, latest: Timestamp) -> Timestamp:
         """Clamp an HWM update to a bounded distance past the active window.
 
-        See ``_MAX_HWM_PAST_WINDOW_BATCHES``.  Cold start (no window or no
-        prior HWM) accepts ``latest`` as-is.  Otherwise the new value is
+        Protects against a single malformed timestamp (e.g. upstream epoch
+        bug producing a value years ahead) permanently pinning the HWM in
+        the future, which would otherwise force every subsequent ``batch()``
+        call to close a batch via the timeout path for millions of
+        iterations -- effectively a DoS until the process restarts.
+
+        Bounding HWM relative to the active window (rather than to the
+        prior HWM) keeps HWM self-healing: each batch close advances the
+        window by one batch_length, so after a bounded number of cascading
+        empty closures the HWM is no longer past the timeout threshold and
+        timeout firing stops on its own.  An absolute per-call cap doesn't
+        self-heal because the window keeps moving away from the clamped HWM.
+
+        Cold start (no window or no prior HWM) accepts ``latest`` as-is;
+        ``_bootstrap_batch`` re-anchors it.  Otherwise the new value is
         capped at ``window.start + cap`` and floored at the current HWM
         so it never regresses -- a window advance (close or gap advance)
         may briefly leave HWM past the cap, and the next update must hold
@@ -460,9 +486,7 @@ class RateAwareMessageBatcher(MessageBatcher):
         """
         if self._active_window is None or self._high_water_mark is None:
             return latest
-        cap = Duration.from_ns(
-            _MAX_HWM_PAST_WINDOW_BATCHES * self._batch_length.to_ns()
-        )
+        cap = MAX_TIMESTAMP_AHEAD_BATCHES * self._batch_length
         ceiling = self._active_window.start + cap
         return max(self._high_water_mark, min(latest, ceiling))
 
@@ -470,18 +494,24 @@ class RateAwareMessageBatcher(MessageBatcher):
         """Flush the startup backlog and open the active window.
 
         Seeds estimators from gated-stream arrivals, opens the window at
-        the max input timestamp (so it starts immediately after the
-        flush), builds grids for any streams whose estimators already
-        converged, and returns the flushed messages as the first batch.
+        the newest plausible input timestamp (so it starts immediately
+        after the flush; see :func:`plausible_anchor` for why a bare max
+        must not be used), builds grids for any streams whose estimators
+        already converged, and returns the flushed messages as the first
+        batch.  The high-water mark is re-anchored likewise, since at cold
+        start ``_clamped_hwm`` accepted the raw maximum unclamped.
+        Outlier timestamps beyond the anchor are excluded from estimator
+        seeding so they cannot pin ``last_ts_ns`` in the far future.
         """
         start_time = min(m.timestamp for m in messages)
-        end_time = max(m.timestamp for m in messages)
+        end_time = plausible_anchor([m.timestamp for m in messages], self._batch_length)
         for msg in messages:
-            if msg.stream.kind in GATED_STREAM_KINDS:
+            if msg.stream.kind in GATED_STREAM_KINDS and msg.timestamp <= end_time:
                 self._streams[msg.stream].observe(msg)
         self._active_window = _ActiveWindow(
             start=end_time, end=end_time + self._batch_length
         )
+        self._high_water_mark = end_time
         for stream in self._streams.values():
             stream.refresh_grid(end_time, self._batch_length)
         return MessageBatch(start_time=start_time, end_time=end_time, messages=messages)
@@ -489,19 +519,34 @@ class RateAwareMessageBatcher(MessageBatcher):
     def _route_message(self, msg: Message[Any], window: _ActiveWindow) -> None:
         """Bucket a message by stream kind and timestamp relative to the window.
 
-        Ungridded streams (non-gated kind OR sub-Hz gated without a grid) hold
-        messages with ``window.end < ts <= window.end + K * batch_length`` in
-        ``_future`` so batch contents stay bounded by the batch's time range.
-        ``K`` reuses ``_MAX_HWM_PAST_WINDOW_BATCHES``: beyond that, a timestamp
-        is implausibly far and the message falls through to the active batch,
-        preventing a pathological timestamp (epoch bug, unit mismatch) from
-        caching messages indefinitely.
+        Messages beyond the disjoint-epoch horizon
+        (``_MAX_ORIGIN_OFFSET_BATCHES`` past ``window.end``) are delivered
+        with the active batch, bypassing estimators, slot gates, overflow,
+        and the future hold-back: such a timestamp cannot come from a
+        legitimate silence gap and must not be cached indefinitely, drive
+        gap recovery, or pin a stream's estimator.
+
+        Ungridded streams (non-gated kind OR sub-Hz gated without a grid)
+        hold messages with ``window.end < ts <= window.end + K * batch_length``
+        in ``_future`` so batch contents stay bounded by the batch's time
+        range.  ``K`` is ``MAX_TIMESTAMP_AHEAD_BATCHES``: beyond that, the
+        message falls through to the active batch instead of being cached.
 
         Gridded gated streams use the slot-based overflow path instead, which
-        drives gap recovery via ``_should_recover_from_gap``.
+        drives gap recovery via ``_should_recover_from_gap``; overflow
+        timestamps are therefore bounded by the disjoint-epoch horizon, and
+        so is the gap-recovery jump.
         """
         is_gated = msg.stream.kind in GATED_STREAM_KINDS
         stream = self._streams[msg.stream] if is_gated else None
+        if self._is_disjoint_epoch(msg, window):
+            # Deliberately not placed in the stream's own bucket: that would
+            # mark the stream as having contributed to the batch (vetoing gap
+            # recovery for every other stream) while never satisfying its slot
+            # gate, since the message has no slot. Delivery is unaffected --
+            # both buffers drain into the same batch.
+            self._non_gated.append(msg)
+            return
         if (stream is None or not stream.is_gating) and self._is_future(msg, window):
             self._future.append(msg)
             return
@@ -512,11 +557,16 @@ class RateAwareMessageBatcher(MessageBatcher):
         if overflow is not None:
             self._overflow.append(overflow)
 
+    def _is_disjoint_epoch(self, msg: Message[Any], window: _ActiveWindow) -> bool:
+        """True if ``msg`` is implausibly far ahead of the active window."""
+        cap = _MAX_ORIGIN_OFFSET_BATCHES * self._batch_length
+        return msg.timestamp - window.end > cap
+
     def _is_future(self, msg: Message[Any], window: _ActiveWindow) -> bool:
         """True if ``msg`` belongs in a future window within the hold-back cap."""
-        if not (msg.timestamp > window.end):
+        if msg.timestamp <= window.end:
             return False
-        cap = _MAX_HWM_PAST_WINDOW_BATCHES * self._batch_length
+        cap = MAX_TIMESTAMP_AHEAD_BATCHES * self._batch_length
         return msg.timestamp - window.end <= cap
 
     def _is_batch_complete(self, window: _ActiveWindow) -> bool:
@@ -578,6 +628,77 @@ class RateAwareMessageBatcher(MessageBatcher):
             self._route_message(msg, window)
         return window
 
+    def _should_reanchor(self, window: _ActiveWindow) -> bool:
+        """True if buffered traffic consistently contradicts the window placement.
+
+        Two mirror-image pathologies share this signature:
+
+        - Every buffered message is beyond the disjoint-epoch horizon ahead
+          of the window: traffic lives in a later epoch than the window
+          (e.g. an upstream clock jumped, or the plausible part of a
+          poisoned bootstrap backlog was stale).  Such messages bypass slot
+          gates and overflow, so neither gate closure nor gap recovery
+          would ever move the window to them.
+        - The newest buffered message is implausibly far behind the window:
+          the window was anchored ahead of real traffic (e.g. by a poisoned
+          gap jump), so no slot gate can ever be satisfied and the
+          high-water mark can never reach the timeout threshold.
+
+        Held-back future or overflow messages disprove both conditions,
+        since they sit near the window by construction.  The quorum keeps a
+        lone stray (one late replayed message, one poisoned timestamp) from
+        re-anchoring the window that all other traffic agrees with; below
+        the quorum, strays simply ride along with the next batch close.
+
+        Only a batcher that has failed to close for ``_REANCHOR_STALLED_CALLS``
+        consecutive calls is considered.  Both pathologies are permanent
+        until corrected, so waiting costs nothing, whereas evaluating every
+        call would scan the whole buffer on the healthy hot path and would
+        also let one poll carrying only a lagging partition's backlog --
+        every message of it legitimately behind the window -- drag the
+        window backwards and emit a batch starting before its predecessor
+        ended.
+        """
+        if self._stalled_calls < _REANCHOR_STALLED_CALLS:
+            return False
+        if self._future or self._overflow:
+            return False
+        buffered = self._buffered_messages()
+        if len(buffered) < _MIN_REANCHOR_MESSAGES:
+            return False
+        # The message that misplaced the window is itself buffered, so a bare
+        # max would let it veto the recovery it caused.
+        newest = plausible_anchor([m.timestamp for m in buffered], self._batch_length)
+        if window.start - newest > MAX_TIMESTAMP_AHEAD_BATCHES * self._batch_length:
+            return True
+        oldest = min(m.timestamp for m in buffered)
+        return oldest - window.end > _MAX_ORIGIN_OFFSET_BATCHES * self._batch_length
+
+    def _reanchor(self, window: _ActiveWindow) -> _ActiveWindow:
+        """Re-anchor the window at the buffered traffic and re-route it.
+
+        The high-water mark is reset to the new anchor: it was derived from
+        the same implausible timestamps that misplaced the window, and
+        keeping it would force a long cascade of empty timeout closures
+        instead of an immediate recovery.  Grids with implausible origins
+        rebuild at the next close via ``_refresh_stream_registry``.
+        """
+        stashed = self._drain_window()
+        anchor = plausible_anchor([m.timestamp for m in stashed], self._batch_length)
+        window = _ActiveWindow(start=anchor, end=anchor + self._batch_length)
+        self._active_window = window
+        self._high_water_mark = anchor
+        for msg in stashed:
+            self._route_message(msg, window)
+        return window
+
+    def _buffered_messages(self) -> list[Message[Any]]:
+        """All messages currently buffered for the active batch."""
+        messages = list(self._non_gated)
+        for stream in self._streams.values():
+            messages.extend(stream.messages)
+        return messages
+
     def _drain_window(self) -> list[Message[Any]]:
         """Remove and return all messages buffered for the active batch."""
         messages = self._non_gated
@@ -602,12 +723,19 @@ class RateAwareMessageBatcher(MessageBatcher):
             # leave the batch's timestamps behind the data when traffic spans
             # several batch_lengths per call.  Mirror ``SimpleMessageBatcher``:
             # include all held-back traffic and set ``end_time`` to the newest
-            # message so the batch covers its real time range.
+            # plausible message so the batch covers its real time range -- a
+            # bare max would let one absorbed outlier anchor the next window
+            # in the far future (see ``plausible_anchor``).
             messages += self._future + self._overflow
             self._future = []
             self._overflow = []
-            end_time = max((m.timestamp for m in messages), default=window.end)
-            end_time = max(end_time, window.end)
+            if messages:
+                anchor = plausible_anchor(
+                    [m.timestamp for m in messages], self._batch_length
+                )
+                end_time = max(anchor, window.end)
+            else:
+                end_time = window.end
 
         batch = MessageBatch(
             start_time=window.start, end_time=end_time, messages=messages

--- a/src/ess/livedata/core/rate_aware_batcher.py
+++ b/src/ess/livedata/core/rate_aware_batcher.py
@@ -6,14 +6,37 @@ Batches messages based on per-stream rate estimation and slot-based completion.
 A batch is considered complete for a given stream when a message arrives whose
 timestamp falls in the last expected "pulse slot" for that stream within the
 batch window — not when a fixed message count is reached.
+
+Clock policy
+------------
+Data-derived timestamps are the batcher's clock for *placement*: where windows
+sit, when gates and timeouts close them, how far gap recovery jumps.  Wall
+time never influences placement or window sizing — during Kafka backlog
+catch-up, hours of data time pass in seconds of wall time, and wall-clock
+windows would batch that backlog wrongly.
+
+Wall time is consulted for exactly one thing: *liveness*.  A window placed by
+a pathological timestamp can make closure impossible (no slot gate satisfiable,
+the timeout threshold unreachable), and no data-derived signal distinguishes
+that from a quiet stream — the data clock is the very thing that broke.  So
+when no batch has closed for a bounded wall-clock interval while traffic is
+buffered, the window is re-placed at the plausible anchor of that traffic
+(see ``_recover_from_stall``).  The backstop is self-correcting: a wrong
+re-placement is just another stall, corrected the same way, so it needs no
+per-pathology analysis of *how* the window got misplaced.
 """
 
 from __future__ import annotations
 
+import math
 import statistics
+import time
 from collections import defaultdict, deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
+
+import structlog
 
 from ess.livedata.core.message import Message, StreamId, StreamKind
 from ess.livedata.core.message_batcher import (
@@ -23,6 +46,8 @@ from ess.livedata.core.message_batcher import (
     plausible_anchor,
 )
 from ess.livedata.core.timestamp import Duration, Timestamp
+
+logger = structlog.get_logger(__name__)
 
 GATED_STREAM_KINDS = frozenset(
     {
@@ -37,16 +62,13 @@ MIN_DIFFS_FOR_GATE = 4
 DIFF_BUFFER_SIZE = 32
 ABSENT_BATCHES_FOR_EVICTION = 5
 
-# Quorum for window re-anchoring (see ``_should_reanchor``): the minimum
-# number of buffered messages that must unanimously contradict the window
-# placement before the window follows them.
-_MIN_REANCHOR_MESSAGES = 4
-
-# Consecutive non-closing calls before re-anchoring is even considered.  The
-# pathologies it corrects never resolve on their own, so this only delays an
-# unavoidable correction, while keeping the scan off the healthy hot path and
-# ignoring momentary buffer states such as a single poll of lagging traffic.
-_REANCHOR_STALLED_CALLS = 20
+# Wall-clock stall threshold for the liveness backstop, in multiples of the
+# batch length (see the module docstring's clock policy).  It must sit above
+# the slowest legitimate close so healthy operation never triggers it: the
+# timeout path closes within ``timeout_factor`` batch lengths of data time,
+# which under live traffic is roughly wall time.  Scaling with the batch
+# length keeps the margin when the adaptive wrapper escalates the window.
+_STALL_THRESHOLD_BATCHES = 10
 
 # Tolerance for snapping the raw rate to its nearest integer Hz.  Uses
 # the larger of a relative bound and an absolute floor: relative scales
@@ -86,7 +108,10 @@ _MAX_ORIGIN_OFFSET_BATCHES = 1000
 # plausibility horizon shared by all uses in this module: the HWM clamp,
 # the future-message hold-back cap, and the outlier absorption in
 # ``_route_message``.  It must be >= ``timeout_factor`` (default 1.2) for
-# the timeout path to ever fire -- and comfortably above that for
+# the timeout path to ever fire -- the HWM clamp caps how far past the
+# window the HWM can reach, so a larger timeout_factor would starve the
+# timeout permanently; the constructor and setter enforce the invariant.
+# It should also sit comfortably above the default for
 # sub-Hz-only streams whose sparse arrivals rely on multi-batch HWM jumps
 # to trigger cascading timeout closes of empty batches between pulses.
 # Three batches allows one pulse's worth of HWM advance to cover the
@@ -352,6 +377,24 @@ def _origin_too_far(
     return abs(origin_ns - batch_start.to_ns()) > max_offset_ns
 
 
+def _validate_timeout_factor(timeout_factor: float) -> None:
+    """Reject a timeout the HWM clamp makes unreachable.
+
+    The clamp caps the high-water mark at ``MAX_TIMESTAMP_AHEAD_BATCHES``
+    past the window start, so a finite timeout threshold beyond that can
+    never be reached and the timeout path would silently never fire.  An
+    explicit ``inf`` states the intent instead: closure by slot gates only.
+    """
+    if math.isinf(timeout_factor) and timeout_factor > 0:
+        return
+    if not 0.0 < timeout_factor <= MAX_TIMESTAMP_AHEAD_BATCHES:
+        raise ValueError(
+            f"timeout_factor must be in (0, {MAX_TIMESTAMP_AHEAD_BATCHES}] "
+            f"(the HWM plausibility horizon) or inf to disable the timeout, "
+            f"got {timeout_factor}"
+        )
+
+
 class RateAwareMessageBatcher(MessageBatcher):
     """A batcher that uses per-stream rate estimation and slot-based completion.
 
@@ -385,11 +428,13 @@ class RateAwareMessageBatcher(MessageBatcher):
         self,
         batch_length_s: float = 1.0,
         timeout_s: float | None = None,
+        clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._batch_length = Duration.from_seconds(batch_length_s)
         self._timeout_factor = (
             timeout_s / batch_length_s if timeout_s is not None else 1.2
         )
+        _validate_timeout_factor(self._timeout_factor)
 
         self._streams: defaultdict[StreamId, _GatedStream] = defaultdict(_GatedStream)
 
@@ -399,7 +444,8 @@ class RateAwareMessageBatcher(MessageBatcher):
         self._overflow: list[Message[Any]] = []
         self._non_gated: list[Message[Any]] = []
         self._future: list[Message[Any]] = []
-        self._stalled_calls = 0
+        self._clock = clock
+        self._last_close_wall = clock()
 
     @property
     def batch_length_s(self) -> float:
@@ -421,6 +467,7 @@ class RateAwareMessageBatcher(MessageBatcher):
 
     @timeout_factor.setter
     def timeout_factor(self, value: float) -> None:
+        _validate_timeout_factor(value)
         self._timeout_factor = value
 
     @property
@@ -451,14 +498,11 @@ class RateAwareMessageBatcher(MessageBatcher):
 
         if self._should_recover_from_gap(window):
             window = self._recover_from_gap(window)
-        elif self._should_reanchor(window):
-            window = self._reanchor(window)
-            self._stalled_calls = 0
+        elif self._is_stalled():
+            window = self._recover_from_stall(window)
 
         if self._is_batch_complete(window):
-            self._stalled_calls = 0
             return self._close_batch(window)
-        self._stalled_calls += 1
         return None
 
     def _clamped_hwm(self, latest: Timestamp) -> Timestamp:
@@ -512,6 +556,7 @@ class RateAwareMessageBatcher(MessageBatcher):
             start=end_time, end=end_time + self._batch_length
         )
         self._high_water_mark = end_time
+        self._last_close_wall = self._clock()
         for stream in self._streams.values():
             stream.refresh_grid(end_time, self._batch_length)
         return MessageBatch(start_time=start_time, end_time=end_time, messages=messages)
@@ -570,7 +615,7 @@ class RateAwareMessageBatcher(MessageBatcher):
         return msg.timestamp - window.end <= cap
 
     def _is_batch_complete(self, window: _ActiveWindow) -> bool:
-        if self._high_water_mark is not None:
+        if self._high_water_mark is not None and not math.isinf(self._timeout_factor):
             threshold = window.start + Duration.from_seconds(self.timeout_s)
             if self._high_water_mark >= threshold:
                 return True
@@ -628,66 +673,57 @@ class RateAwareMessageBatcher(MessageBatcher):
             self._route_message(msg, window)
         return window
 
-    def _should_reanchor(self, window: _ActiveWindow) -> bool:
-        """True if buffered traffic consistently contradicts the window placement.
+    def _is_stalled(self) -> bool:
+        """True if traffic is buffered but no batch has closed for too long.
 
-        Two mirror-image pathologies share this signature:
+        This is the liveness backstop of the module docstring's clock
+        policy: it makes no attempt to diagnose *why* nothing closes (a
+        window misplaced by a poisoned bootstrap, a poisoned gap jump, an
+        upstream clock jump, ...) -- any placement the buffered traffic
+        cannot close is corrected the same way, by re-placing the window
+        at that traffic.
 
-        - Every buffered message is beyond the disjoint-epoch horizon ahead
-          of the window: traffic lives in a later epoch than the window
-          (e.g. an upstream clock jumped, or the plausible part of a
-          poisoned bootstrap backlog was stale).  Such messages bypass slot
-          gates and overflow, so neither gate closure nor gap recovery
-          would ever move the window to them.
-        - The newest buffered message is implausibly far behind the window:
-          the window was anchored ahead of real traffic (e.g. by a poisoned
-          gap jump), so no slot gate can ever be satisfied and the
-          high-water mark can never reach the timeout threshold.
-
-        Held-back future or overflow messages disprove both conditions,
-        since they sit near the window by construction.  The quorum keeps a
-        lone stray (one late replayed message, one poisoned timestamp) from
-        re-anchoring the window that all other traffic agrees with; below
-        the quorum, strays simply ride along with the next batch close.
-
-        Only a batcher that has failed to close for ``_REANCHOR_STALLED_CALLS``
-        consecutive calls is considered.  Both pathologies are permanent
-        until corrected, so waiting costs nothing, whereas evaluating every
-        call would scan the whole buffer on the healthy hot path and would
-        also let one poll carrying only a lagging partition's backlog --
-        every message of it legitimately behind the window -- drag the
-        window backwards and emit a batch starting before its predecessor
-        ended.
+        The wall-clock threshold is what makes this safe against ordinary
+        buffer states: a healthy batcher closes several times per threshold
+        interval, so a single poll carrying only a lagging partition's
+        backlog -- every message of it legitimately behind the window --
+        can never drag the window backwards.  Without buffered traffic
+        there is nothing to re-place onto: a quiet stream is not a stall,
+        and the data clock must not advance on wall-time evidence alone.
         """
-        if self._stalled_calls < _REANCHOR_STALLED_CALLS:
+        threshold = _STALL_THRESHOLD_BATCHES * self.batch_length_s
+        if self._clock() - self._last_close_wall < threshold:
             return False
-        if self._future or self._overflow:
-            return False
-        buffered = self._buffered_messages()
-        if len(buffered) < _MIN_REANCHOR_MESSAGES:
-            return False
-        # The message that misplaced the window is itself buffered, so a bare
-        # max would let it veto the recovery it caused.
-        newest = plausible_anchor([m.timestamp for m in buffered], self._batch_length)
-        if window.start - newest > MAX_TIMESTAMP_AHEAD_BATCHES * self._batch_length:
-            return True
-        oldest = min(m.timestamp for m in buffered)
-        return oldest - window.end > _MAX_ORIGIN_OFFSET_BATCHES * self._batch_length
+        return bool(self._buffered_messages())
 
-    def _reanchor(self, window: _ActiveWindow) -> _ActiveWindow:
-        """Re-anchor the window at the buffered traffic and re-route it.
+    def _recover_from_stall(self, window: _ActiveWindow) -> _ActiveWindow:
+        """Re-place the window at the buffered traffic and re-route it.
 
-        The high-water mark is reset to the new anchor: it was derived from
-        the same implausible timestamps that misplaced the window, and
-        keeping it would force a long cascade of empty timeout closures
-        instead of an immediate recovery.  Grids with implausible origins
-        rebuild at the next close via ``_refresh_stream_registry``.
+        The anchor follows the bulk of the buffered traffic, not a bare
+        max: the message that misplaced the window may itself be buffered,
+        and must not veto the recovery it caused.  The high-water mark is
+        reset likewise -- it was derived from the same timestamps that
+        misplaced the window, and keeping it would force a long cascade of
+        empty timeout closures instead of an immediate recovery.  Grids
+        with implausible origins rebuild at the next close via
+        ``_refresh_stream_registry``.
+
+        A wrong re-placement (e.g. onto a lone stray while real traffic is
+        silent) is not a hazard: it is just another stall, corrected the
+        same way once real traffic buffers up again.
         """
         stashed = self._drain_window()
         anchor = plausible_anchor([m.timestamp for m in stashed], self._batch_length)
+        logger.warning(
+            'batcher_stall_recovery',
+            window_start_ns=window.start.to_ns(),
+            anchor_ns=anchor.to_ns(),
+            buffered_messages=len(stashed),
+        )
         window = _ActiveWindow(start=anchor, end=anchor + self._batch_length)
         self._active_window = window
         self._high_water_mark = anchor
+        self._last_close_wall = self._clock()
         for msg in stashed:
             self._route_message(msg, window)
         return window
@@ -712,6 +748,7 @@ class RateAwareMessageBatcher(MessageBatcher):
         return any(stream.is_gating for stream in self._streams.values())
 
     def _close_batch(self, window: _ActiveWindow) -> MessageBatch:
+        self._last_close_wall = self._clock()
         self._refresh_stream_registry(window)
         messages = self._drain_window()
 

--- a/src/ess/livedata/core/rate_aware_batcher.py
+++ b/src/ess/livedata/core/rate_aware_batcher.py
@@ -506,11 +506,18 @@ class RateAwareMessageBatcher(MessageBatcher):
 
         if self._should_recover_from_gap(window):
             window = self._recover_from_gap(window)
-        elif self._is_stalled():
-            window = self._recover_from_stall(window)
 
+        # Stall recovery is a last resort, checked only when nothing closes:
+        # checking it first would preempt the timeout close of a stream
+        # sparser than the stall threshold (e.g. a log value every 15 s),
+        # re-placing the window and resetting the HWM on every arrival
+        # instead of delivering it.
         if self._is_batch_complete(window):
             return self._close_batch(window)
+        if self._is_stalled():
+            window = self._recover_from_stall(window)
+            if self._is_batch_complete(window):
+                return self._close_batch(window)
         return None
 
     def _clamped_hwm(self, latest: Timestamp) -> Timestamp:
@@ -726,11 +733,23 @@ class RateAwareMessageBatcher(MessageBatcher):
         stall proves the placement such messages drove was wrong, and
         re-caching the driver would re-trigger the same wrong gap jump --
         and with it a stall per encounter -- until data time reaches it.
+
+        An anchor already inside the active window means placement agrees
+        with the buffered traffic and the stall is mere quietness (e.g. the
+        trailing partial batch after a stream stops -- deliberately not
+        delivered, since the data clock must not advance on wall time
+        alone).  Re-placing would only shift the boundaries and log a
+        recovery per threshold interval, so the backstop re-arms instead.
         """
+        anchor = plausible_anchor(
+            [m.timestamp for m in self._buffered_messages()], self._batch_length
+        )
+        self._last_close_wall = self._clock()
+        if window.start <= anchor < window.end:
+            return window
         stashed = self._drain_window() + self._overflow + self._future
         self._overflow = []
         self._future = []
-        anchor = plausible_anchor([m.timestamp for m in stashed], self._batch_length)
         logger.warning(
             'batcher_stall_recovery',
             window_start_ns=window.start.to_ns(),
@@ -740,7 +759,6 @@ class RateAwareMessageBatcher(MessageBatcher):
         window = _ActiveWindow(start=anchor, end=anchor + self._batch_length)
         self._active_window = window
         self._high_water_mark = anchor
-        self._last_close_wall = self._clock()
         hold_back = MAX_TIMESTAMP_AHEAD_BATCHES * self._batch_length
         for msg in stashed:
             if msg.timestamp - window.end > hold_back:

--- a/src/ess/livedata/core/rate_aware_batcher.py
+++ b/src/ess/livedata/core/rate_aware_batcher.py
@@ -260,8 +260,14 @@ class _GatedStream:
     def route(self, msg: Message[Any], window_start: Timestamp) -> Message[Any] | None:
         """Place ``msg`` in the bucket; return it unchanged if it overflows.
 
-        Overflow still bumps ``max_slot`` to the last grid slot so the
-        slot gate observes that the window's final pulse was reached.
+        Overflow *near* the window bumps ``max_slot`` to the last grid slot:
+        a pulse just past the window is evidence that the window's final
+        pulse was reached.  A pulse implausibly far ahead is no such
+        evidence, and because overflow is re-routed into every new window at
+        close, an unbounded bump would pre-satisfy the gate on every window
+        -- the batcher then closes a batch per *call*, racing the window
+        toward the outlier at poll rate with time ranges detached from the
+        traffic it delivers.
         """
         self.observe(msg)
         if self.grid is None:
@@ -269,9 +275,11 @@ class _GatedStream:
             return None
         slot = self.grid.slot_in_batch(msg.timestamp, window_start)
         if slot >= self.grid.slots_per_batch:
-            last = self.grid.slots_per_batch - 1
-            if last > self.max_slot:
-                self.max_slot = last
+            horizon = self.grid.slots_per_batch * (1 + MAX_TIMESTAMP_AHEAD_BATCHES)
+            if slot < horizon:
+                last = self.grid.slots_per_batch - 1
+                if last > self.max_slot:
+                    self.max_slot = last
             return msg
         self._add(msg, slot)
         return None
@@ -711,8 +719,17 @@ class RateAwareMessageBatcher(MessageBatcher):
         A wrong re-placement (e.g. onto a lone stray while real traffic is
         silent) is not a hazard: it is just another stall, corrected the
         same way once real traffic buffers up again.
+
+        Held-back and overflow messages are drained along with the window
+        buckets, and any message still implausibly far ahead of the
+        recovered window is diverted to delivery rather than re-cached: a
+        stall proves the placement such messages drove was wrong, and
+        re-caching the driver would re-trigger the same wrong gap jump --
+        and with it a stall per encounter -- until data time reaches it.
         """
-        stashed = self._drain_window()
+        stashed = self._drain_window() + self._overflow + self._future
+        self._overflow = []
+        self._future = []
         anchor = plausible_anchor([m.timestamp for m in stashed], self._batch_length)
         logger.warning(
             'batcher_stall_recovery',
@@ -724,8 +741,12 @@ class RateAwareMessageBatcher(MessageBatcher):
         self._active_window = window
         self._high_water_mark = anchor
         self._last_close_wall = self._clock()
+        hold_back = MAX_TIMESTAMP_AHEAD_BATCHES * self._batch_length
         for msg in stashed:
-            self._route_message(msg, window)
+            if msg.timestamp - window.end > hold_back:
+                self._non_gated.append(msg)
+            else:
+                self._route_message(msg, window)
         return window
 
     def _buffered_messages(self) -> list[Message[Any]]:

--- a/tests/core/message_batcher_test.py
+++ b/tests/core/message_batcher_test.py
@@ -8,8 +8,10 @@ from ess.livedata.core.message_batcher import (
     DEESCALATION_IDLE_WINDOWS,
     DEESCALATION_UNDERLOAD_THRESHOLD,
     ESCALATION_OVERLOAD_THRESHOLD,
+    MAX_TIMESTAMP_AHEAD_BATCHES,
     AdaptiveMessageBatcher,
     SimpleMessageBatcher,
+    plausible_anchor,
 )
 from ess.livedata.core.timestamp import Duration, Timestamp
 
@@ -20,6 +22,65 @@ def make_message(timestamp_ns: int, value: str = "test") -> Message[str]:
     return Message(
         timestamp=Timestamp.from_ns(timestamp_ns), stream=stream, value=value
     )
+
+
+class TestPlausibleAnchor:
+    """Window anchors must follow the bulk of the traffic, not a stray value.
+
+    Anchoring on an outlier parks the batcher's data-derived clock away from
+    the live data, which is the #1038 wedge. Both directions hurt: ahead of
+    the traffic the window waits out the outlier's distance, behind it the
+    window walks forward only one batch length per call.
+    """
+
+    BATCH_LENGTH = Duration.from_seconds(1.0)
+    HORIZON_S = MAX_TIMESTAMP_AHEAD_BATCHES
+
+    def anchor(self, *seconds: float) -> float:
+        stamps = [Timestamp.from_ns(int(s * 1e9)) for s in seconds]
+        return plausible_anchor(stamps, self.BATCH_LENGTH).to_ns() / 1e9
+
+    def test_single_timestamp_is_its_own_anchor(self):
+        """One message carries no evidence against itself."""
+        assert self.anchor(500.0) == 500.0
+
+    def test_contiguous_traffic_keeps_its_maximum(self):
+        assert self.anchor(100.0, 100.1, 100.2, 100.3) == 100.3
+
+    def test_burst_spread_over_many_batches_keeps_its_maximum(self):
+        """Evenly-spread traffic is legitimate however wide it spans; only
+        gaps wider than the horizon mark a discontinuity."""
+        assert self.anchor(*[float(t) for t in range(1, 11)]) == 10.0
+
+    def test_far_future_stray_yields_the_cluster(self):
+        assert self.anchor(100.0, 100.1, 100.2, 100.3, 1e6) == 100.3
+
+    def test_far_past_stray_yields_the_cluster(self):
+        """A stream in a disjoint past epoch must not drag the anchor back."""
+        assert self.anchor(-1e6, 100.0, 100.1, 100.2, 100.3) == 100.3
+
+    def test_two_disconnected_timestamps_prefer_the_later(self):
+        """With one message on each side there is nothing to weigh. Anchoring
+        behind the traffic is the worse failure -- the window walks forward
+        only one batch length per call, so a disjoint past epoch never catches
+        up."""
+        assert self.anchor(100.0, 1e6) == 1e6
+
+    def test_gap_just_within_horizon_stays_connected(self):
+        assert self.anchor(100.0, 100.1, 100.1 + self.HORIZON_S) == (
+            100.1 + self.HORIZON_S
+        )
+
+    def test_gap_just_beyond_horizon_disconnects(self):
+        assert self.anchor(100.0, 100.1, 100.1 + self.HORIZON_S + 0.1) == 100.1
+
+    def test_identical_timestamps(self):
+        assert self.anchor(100.0, 100.0, 100.0) == 100.0
+
+    def test_order_of_input_does_not_matter(self):
+        assert self.anchor(1e6, 100.2, 100.0, 100.1) == self.anchor(
+            100.0, 100.1, 100.2, 1e6
+        )
 
 
 class TestSimpleMessageBatcher:
@@ -781,3 +842,54 @@ class TestAdaptiveMessageBatcher:
         for _ in range(DEESCALATION_UNDERLOAD_THRESHOLD - 1):
             batcher.report_batch(100, processing_time_s=underloaded_time)
         assert batcher.state.level == 2
+
+
+class TestSimpleBatcherFutureTimestampLiveness:
+    """A timestamp parked ahead of the traffic must not silence delivery.
+
+    Closing a batch is driven by the presence of a future message, so a parked
+    one advances the window once per call rather than once per batch length.
+    The service polls faster than the batch length, so the window outruns the
+    live data and comes to rest at the outlier; from there nothing closes a
+    batch until wall time catches up (#1038 finding 1, #1047).
+
+    The batcher cannot assume anything upstream sanitized timestamps, so this
+    band must be survivable on its own.
+    """
+
+    RATE_HZ = 14
+    POLLS_PER_BATCH = 10
+
+    def longest_silence(
+        self, batcher: SimpleMessageBatcher, poison_ahead_s: float, cycles: int = 300
+    ) -> float:
+        """Longest stretch of data time yielding no messages, in seconds."""
+        second = 1_000_000_000
+        per_poll = self.RATE_HZ // self.POLLS_PER_BATCH
+        step = second // self.POLLS_PER_BATCH
+        t = 100 * second
+        for _ in range(20 * self.POLLS_PER_BATCH):  # establish steady traffic
+            batcher.batch([make_message(t + i * step) for i in range(per_poll)])
+            t += step
+        batcher.batch([make_message(t + int(poison_ahead_s * second))])
+        last_delivery = t
+        worst = 0
+        for _ in range(cycles * self.POLLS_PER_BATCH):
+            batch = batcher.batch([make_message(t + i * step) for i in range(per_poll)])
+            t += step
+            if batch is not None and batch.messages:
+                last_delivery = t
+            worst = max(worst, t - last_delivery)
+        return worst / second
+
+    @pytest.mark.parametrize('ahead_s', [10.0, 60.0, 240.0])
+    def test_future_timestamp_stall_is_brief(self, ahead_s: float):
+        batcher = SimpleMessageBatcher(batch_length_s=1.0)
+        gap = self.longest_silence(batcher, poison_ahead_s=ahead_s)
+        assert gap < 10.0, f"delivery silent for {gap:.1f}s of data time"
+
+    def test_future_timestamp_does_not_buffer_unboundedly(self):
+        batcher = SimpleMessageBatcher(batch_length_s=1.0)
+        self.longest_silence(batcher, poison_ahead_s=240.0)
+        buffered = len(batcher._active_batch.messages) + len(batcher._future_messages)
+        assert buffered < self.RATE_HZ * 10, f"messages accumulating: {buffered}"

--- a/tests/core/message_batcher_test.py
+++ b/tests/core/message_batcher_test.py
@@ -893,3 +893,54 @@ class TestSimpleBatcherFutureTimestampLiveness:
         self.longest_silence(batcher, poison_ahead_s=240.0)
         buffered = len(batcher._active_batch.messages) + len(batcher._future_messages)
         assert buffered < self.RATE_HZ * 10, f"messages accumulating: {buffered}"
+
+    def test_parked_future_message_is_eventually_delivered(self):
+        """The parked outlier rides along once the window reaches it --
+        dropping is the adapter's job, not the batcher's."""
+        second = 1_000_000_000
+        batcher = SimpleMessageBatcher(batch_length_s=1.0)
+        t = 100 * second
+        batcher.batch([make_message(t)])
+        poison = make_message(t + 30 * second, value="poison")
+        batcher.batch([poison])
+        step = second // self.POLLS_PER_BATCH
+        for _ in range(60 * self.POLLS_PER_BATCH):
+            batch = batcher.batch([make_message(t)])
+            t += step
+            if batch is not None and poison in batch.messages:
+                return
+        raise AssertionError("parked future message was never delivered")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason='#1047: the empty-batch exemption in _may_advance_to lets a '
+        'parked future message fast-forward the window one batch per poll '
+        'through a silence gap; once traffic resumes, every message is '
+        '"late", no future message exists, and nothing closes a batch until '
+        'data time reaches the outlier. Indistinguishable from a legitimate '
+        'silence gap without arrival-time evidence at the adapter boundary; '
+        'the rate-aware batcher recovers via its wall-clock backstop.',
+    )
+    def test_poison_then_silence_then_resumed_traffic_recovers(self):
+        second = 1_000_000_000
+        per_poll = self.RATE_HZ // self.POLLS_PER_BATCH
+        step = second // self.POLLS_PER_BATCH
+        batcher = SimpleMessageBatcher(batch_length_s=1.0)
+        t = 100 * second
+        for _ in range(20 * self.POLLS_PER_BATCH):  # establish steady traffic
+            batcher.batch([make_message(t + i * step) for i in range(per_poll)])
+            t += step
+        batcher.batch([make_message(t + 240 * second)])
+        for _ in range(30 * self.POLLS_PER_BATCH):  # silence gap
+            batcher.batch([])
+        t += 30 * second
+        last_delivery = t
+        worst = 0
+        for _ in range(300 * self.POLLS_PER_BATCH):
+            batch = batcher.batch([make_message(t + i * step) for i in range(per_poll)])
+            t += step
+            if batch is not None and batch.messages:
+                last_delivery = t
+            worst = max(worst, t - last_delivery)
+        gap = worst / second
+        assert gap < 10.0, f"delivery silent for {gap:.1f}s of data time"

--- a/tests/core/rate_aware_batcher_test.py
+++ b/tests/core/rate_aware_batcher_test.py
@@ -54,6 +54,32 @@ def msgs_at(
     return [msg(start + i * period, stream) for i in range(count)]
 
 
+def longest_silence(
+    batcher: RateAwareMessageBatcher,
+    start: float,
+    cycles: int,
+    rate_hz: float = 14.0,
+    polls_per_batch: int = 10,
+) -> float:
+    """Longest stretch of data time yielding no messages, in seconds.
+
+    Polls faster than the batch length, as the service loop does: batch() is
+    called once per poll cycle, not once per batch length, so a window that
+    advances per call outruns the live data.
+    """
+    step = 1.0 / polls_per_batch
+    t = start
+    last_delivery = start
+    worst = 0.0
+    for _ in range(cycles * polls_per_batch):
+        batch = batcher.batch(msgs_at(rate_hz, t, step))
+        t += step
+        if batch is not None and batch.messages:
+            last_delivery = t
+        worst = max(worst, t - last_delivery)
+    return worst
+
+
 def make_converged_batcher(
     rate_hz: float = 14.0,
     batch_length_s: float = 1.0,
@@ -2263,3 +2289,163 @@ class TestNonGatedEndTimeProgression:
         assert max_lag < cycle_s + mon_period_s + 1.0, (
             f"Freshness lag grew unbounded at {rate_hz} Hz: {max_lag}"
         )
+
+
+class TestFarFutureTimestampLiveness:
+    """A single implausibly-far-future timestamp must not stall the batcher.
+
+    Data-derived timestamps are the batcher's only clock, so an outlier that
+    anchors the active window (or the high-water mark) parks that clock in the
+    future: real traffic then looks perpetually early, no slot gate is ever
+    satisfied, the timeout threshold is never reached, and delivery stops
+    permanently while messages accumulate (#1038 finding 1, #1047).
+
+    The adapter boundary clamps such timestamps before they reach a batcher;
+    these tests pin the batcher's own defense, which also covers non-Kafka
+    sources and values inside the adapter's bound.
+    """
+
+    ONE_YEAR_S = 365 * 24 * 3600.0
+    # Inside the adapter boundary's future bound, so this band is exactly what
+    # reaches a batcher in production. It is also far enough ahead to be
+    # implausible as live traffic, and -- unlike year-scale values -- it stays
+    # within the disjoint-epoch horizon, so it exercises the ordinary routing
+    # path rather than the outlier-absorption one.
+    IN_BAND_S = 240.0
+
+    def _drive(
+        self, batcher: RateAwareMessageBatcher, start: float, cycles: int
+    ) -> tuple[int, int]:
+        """Feed *cycles* seconds of 14 Hz traffic; return (closed, delivered)."""
+        closed = delivered = 0
+        for k in range(cycles):
+            for batch in (
+                batcher.batch(msgs_at(14.0, start + k, 1.0)),
+                batcher.batch([]),
+            ):
+                if batch is not None:
+                    closed += 1
+                    delivered += len(batch.messages)
+        return closed, delivered
+
+    def test_far_future_timestamp_in_bootstrap_does_not_stall(self):
+        batcher = RateAwareMessageBatcher(batch_length_s=1.0)
+        batcher.batch([*msgs_at(14.0, 100.0, 1.0), msg(100.0 + self.ONE_YEAR_S)])
+        closed, delivered = self._drive(batcher, start=101.0, cycles=60)
+        assert closed > 0, "batcher stalled after a poisoned bootstrap backlog"
+        assert delivered > 0
+
+    def test_far_future_timestamp_mid_stream_does_not_stall(self):
+        batcher, start = make_converged_batcher(rate_hz=14.0)
+        batcher.batch([msg(start + self.ONE_YEAR_S)])
+        closed, delivered = self._drive(batcher, start=start, cycles=60)
+        assert closed > 0, "batcher stalled after a mid-stream far-future timestamp"
+        assert delivered > 0
+
+    def test_far_future_timestamp_does_not_buffer_unboundedly(self):
+        """The wedge's second symptom: messages pile up in un-emitted batches."""
+        batcher = RateAwareMessageBatcher(batch_length_s=1.0)
+        batcher.batch([*msgs_at(14.0, 100.0, 1.0), msg(100.0 + self.ONE_YEAR_S)])
+        self._drive(batcher, start=101.0, cycles=100)
+        buffered = (
+            sum(len(s.messages) for s in batcher._streams.values())
+            + len(batcher._non_gated)
+            + len(batcher._overflow)
+            + len(batcher._future)
+        )
+        assert buffered < 14 * 10, f"messages accumulating un-emitted: {buffered}"
+
+    def test_poisoned_message_is_still_delivered(self):
+        """Outliers ride along with a batch rather than being held forever --
+        dropping is the adapter's job, not the batcher's."""
+        batcher, start = make_converged_batcher(rate_hz=14.0)
+        poison = msg(start + self.ONE_YEAR_S, value="poison")
+        seen = poison in batcher.batch([poison]).messages
+        for k in range(60):
+            for batch in (
+                batcher.batch(msgs_at(14.0, start + k, 1.0)),
+                batcher.batch([]),
+            ):
+                if batch is not None and poison in batch.messages:
+                    seen = True
+        assert seen, "poisoned message was neither delivered nor dropped"
+
+    def test_window_tracks_real_traffic_after_poison(self):
+        """Recovery must re-anchor the window at real traffic, not merely
+        resume closing batches somewhere in the far future."""
+        batcher = RateAwareMessageBatcher(batch_length_s=1.0)
+        batcher.batch([*msgs_at(14.0, 100.0, 1.0), msg(100.0 + self.ONE_YEAR_S)])
+        self._drive(batcher, start=101.0, cycles=60)
+        window_start_s = batcher._active_window.start.to_ns() / 1e9
+        assert abs(window_start_s - 160.0) < 10.0, (
+            f"window at {window_start_s:.1f}s, real traffic near 160s"
+        )
+
+    def test_in_band_future_timestamp_does_not_stall(self):
+        """The band between the batcher's horizon and the adapter's future
+        bound is the one that reaches a batcher in production."""
+        batcher, start = make_converged_batcher(rate_hz=14.0)
+        batcher.batch([msg(start + self.IN_BAND_S)])
+        closed, delivered = self._drive(batcher, start=start, cycles=60)
+        assert closed > 0, "batcher stalled after an in-band future timestamp"
+        assert delivered > 0
+
+    def test_in_band_future_timestamp_stall_is_brief(self):
+        """Delivery must resume promptly, not merely eventually: the wedge
+        this guards against is bounded by the poison's distance ahead, which
+        for an in-band value is minutes of silent data loss."""
+        batcher, start = make_converged_batcher(rate_hz=14.0)
+        batcher.batch([msg(start + self.IN_BAND_S)])
+        gap = longest_silence(batcher, start=start, cycles=300)
+        assert gap < 10.0, f"delivery silent for {gap:.1f}s of data time"
+
+
+class TestWindowReanchoring:
+    """Re-anchoring corrects a window that traffic contradicts, but must not
+    fire on ordinary buffer states or cost anything when nothing is wrong.
+    """
+
+    LAGGING = StreamId(kind=StreamKind.DETECTOR_EVENTS, name="lagging")
+
+    def test_lagging_partition_does_not_drag_the_window_backwards(self):
+        """Kafka returns per-partition chunks, so one poll can carry only a
+        lagging partition's backlog -- every message legitimately behind the
+        window. Following it would emit a batch starting before the previous
+        one ended."""
+        batcher, start = make_converged_batcher(rate_hz=14.0)
+        for _ in range(5):  # drain, as just after a close
+            batcher.batch([])
+        before = batcher._active_window.start
+        batcher.batch(msgs_at(14.0, start - 20.0, 0.5))
+        assert batcher._active_window.start >= before
+
+    def test_batch_boundaries_stay_monotonic_across_lagging_traffic(self):
+        batcher, start = make_converged_batcher(rate_hz=14.0)
+        previous_end: Timestamp | None = None
+        for k in range(40):
+            for batch in (
+                batcher.batch(msgs_at(14.0, start + k, 1.0)),
+                batcher.batch(msgs_at(14.0, start - 30.0 + k, 0.3)),
+            ):
+                if batch is None:
+                    continue
+                if previous_end is not None:
+                    assert batch.start_time >= previous_end, (
+                        "batch starts before its predecessor ended"
+                    )
+                previous_end = batch.end_time
+
+    def test_disjoint_epoch_message_is_still_delivered(self):
+        batcher, start = make_converged_batcher(rate_hz=14.0)
+        stray = msg(start + 10_000.0, value="stray")
+        first = batcher.batch([stray])
+        if first is not None and stray in first.messages:
+            return
+        for k in range(40):
+            for batch in (
+                batcher.batch(msgs_at(14.0, start + k, 1.0)),
+                batcher.batch([]),
+            ):
+                if batch is not None and stray in batch.messages:
+                    return
+        raise AssertionError("disjoint-epoch message was never delivered")

--- a/tests/core/rate_aware_batcher_test.py
+++ b/tests/core/rate_aware_batcher_test.py
@@ -2427,12 +2427,49 @@ class TestFarFutureTimestampLiveness:
     def test_in_band_future_timestamp_stall_is_brief(self):
         """Delivery must resume promptly, not merely eventually: the wedge
         this guards against is bounded by the poison's distance ahead, which
-        for an in-band value is minutes of silent data loss."""
+        for an in-band value is minutes of silent data loss.  The observed
+        stall is the backstop threshold (~10 s): the poison triggers a gap
+        jump that a lone in-band value right after a close is
+        indistinguishable from, and only the stall backstop can undo it."""
         clock = FakeClock()
         batcher, start = make_converged_batcher(rate_hz=14.0, clock=clock)
         batcher.batch([msg(start + self.IN_BAND_S)])
         gap = longest_silence(batcher, start=start, cycles=300, clock=clock)
         assert gap < 15.0, f"delivery silent for {gap:.1f}s of data time"
+
+    def test_in_band_future_timestamp_costs_one_stall_and_no_clock_skew(self):
+        """The wrong gap jump must cost its one backstop interval and nothing
+        more.  Stall recovery evicts the poison to delivery instead of
+        re-caching it, and overflow implausibly far ahead carries no slot-gate
+        evidence -- otherwise the retained poison pre-satisfies the gate at
+        every close, racing the window (and with it the data clock, which
+        fires job schedules) toward the outlier at poll rate, then stalling
+        ~10 s at every encounter until data time reaches the poison."""
+        clock = FakeClock()
+        batcher, start = make_converged_batcher(rate_hz=14.0, clock=clock)
+        poison = msg(start + self.IN_BAND_S, value="poison")
+        batcher.batch([poison])
+        step = 0.1
+        t = start
+        last_delivery = t
+        stalls = 0
+        delivered_poison = False
+        for _ in range(300 * 10):
+            out = batcher.batch(msgs_at(14.0, t, step))
+            t += step
+            clock.advance(step)
+            if out is None or not out.messages:
+                continue
+            if t - last_delivery > 5.0:
+                stalls += 1
+            last_delivery = t
+            end_s = out.end_time.to_ns() / 1e9
+            assert abs(end_s - t) < 5.0, (
+                f"batch end_time {end_s:.1f}s detached from traffic at {t:.1f}s"
+            )
+            delivered_poison |= poison in out.messages
+        assert stalls <= 1, f"{stalls} separate >5s delivery stalls"
+        assert delivered_poison, "poison was neither delivered nor dropped"
 
 
 class TestStallBackstop:

--- a/tests/core/rate_aware_batcher_test.py
+++ b/tests/core/rate_aware_batcher_test.py
@@ -2567,3 +2567,119 @@ class TestTimeoutFactorValidation:
     def test_horizon_boundary_is_accepted(self):
         batcher = RateAwareMessageBatcher(batch_length_s=1.0, timeout_s=3.0)
         assert batcher.timeout_factor == 3.0
+
+
+class TestClockCreep:
+    """One device clock creeping relative to another must not disturb delivery.
+
+    Production devices creep by O(1 s/day) against the shared pulse clock.
+    Unlike the jump pathologies above, creep crosses every bound gradually:
+    the timeout margin (0.2 s), the timeout threshold (1.2 s), the
+    plausibility horizon (3 s), eventually the disjoint-epoch horizon.  The
+    creep rate here is accelerated (10 ms/s) so one simulation sweeps all
+    the near-term crossings.
+
+    These tests pin liveness and delivery through every crossing.  They do
+    not assert batch-content alignment: once the offset exceeds the timeout
+    margin, closure degenerates to the timeout path and the non-anchor
+    stream's messages land outside their batch's time range.  That is a
+    known quality degradation, not a liveness failure; detecting skew needs
+    arrival-time evidence at the adapter boundary, which placement
+    deliberately has no access to (see the module's clock policy).
+    """
+
+    CREEP_PER_S = 0.010
+    SIM_S = 600  # final offset 6 s: past the 3 s plausibility horizon
+
+    def _drive_with_creep(
+        self, creep_per_s: float
+    ) -> tuple[RateAwareMessageBatcher, dict[str, float]]:
+        """Feed a healthy 14 Hz stream plus a creeping 10 Hz stream.
+
+        Returns the batcher and stats: longest data-time silence, delivered
+        fraction per stream, and the final window offset from true time.
+        """
+        clock = FakeClock()
+        batcher = RateAwareMessageBatcher(batch_length_s=1.0, clock=clock)
+        polls = 10
+        step = 1.0 / polls
+        t = 100.0
+        fed: dict[StreamId, int] = {DETECTOR: 0, MONITOR: 0}
+        delivered: dict[StreamId, int] = {DETECTOR: 0, MONITOR: 0}
+        last_delivery = t
+        worst = 0.0
+        for _ in range(self.SIM_S * polls):
+            offset = creep_per_s * (t - 100.0)
+            batch_msgs = [msg(t + i * step / 2, DETECTOR) for i in range(2)]
+            batch_msgs.append(msg(t + offset, MONITOR))
+            fed[DETECTOR] += 2
+            fed[MONITOR] += 1
+            out = batcher.batch(batch_msgs)
+            t += step
+            clock.advance(step)
+            if out is not None and out.messages:
+                last_delivery = t
+                for m in out.messages:
+                    delivered[m.stream] += 1
+            worst = max(worst, t - last_delivery)
+        stats = {
+            'silence': worst,
+            'detector_fraction': delivered[DETECTOR] / fed[DETECTOR],
+            'monitor_fraction': delivered[MONITOR] / fed[MONITOR],
+            'window_offset': batcher._active_window.start.to_ns() / 1e9 - t,
+        }
+        return batcher, stats
+
+    @pytest.mark.parametrize('sign', [1.0, -1.0], ids=['ahead', 'behind'])
+    def test_creep_keeps_delivery_flowing(self, sign: float):
+        _, stats = self._drive_with_creep(sign * self.CREEP_PER_S)
+        assert stats['silence'] < 5.0, (
+            f"delivery silent for {stats['silence']:.1f}s of data time"
+        )
+        assert stats['detector_fraction'] > 0.99
+        assert stats['monitor_fraction'] > 0.99
+
+    def test_window_adopts_the_fastest_clock(self):
+        """Documents (not endorses) the ahead-creep equilibrium: the timeout
+        path follows the high-water mark, a bare max over all streams, so
+        the window tracks the fastest clock and with it the service's data
+        clock (batch end times drive job activation and run resets).  If
+        skew handling ever prefers the majority clock, flipping this test
+        is the deliberate act."""
+        _, stats = self._drive_with_creep(self.CREEP_PER_S)
+        final_offset = self.CREEP_PER_S * self.SIM_S
+        assert stats['window_offset'] > final_offset / 2, (
+            f"window {stats['window_offset']:+.1f}s from true time; expected it "
+            f"to track the creeping clock (~{final_offset:+.1f}s)"
+        )
+
+    def test_persistent_offset_with_quiet_spells_does_not_ping_pong(self):
+        """Months of accumulated creep is a static offset of minutes.  During
+        a majority quiet spell the offset stream's overflow is the only
+        pending traffic, so gap recovery jumps the window to the wrong
+        clock; resumed majority traffic must then keep flowing as late
+        deliveries rather than triggering repeated stall/recovery cycles."""
+        offset_s = 240.0
+        clock = FakeClock()
+        batcher = RateAwareMessageBatcher(batch_length_s=1.0, clock=clock)
+        polls = 10
+        step = 1.0 / polls
+        t = 100.0
+        last_delivery = t
+        worst = 0.0
+        for _ in range(6):
+            for phase_dur, quiet in ((60, False), (20, True)):
+                for _ in range(phase_dur * polls):
+                    batch_msgs = [msg(t + offset_s, MONITOR)]
+                    if not quiet:
+                        detector_msgs = [
+                            msg(t + i * step / 2, DETECTOR) for i in range(2)
+                        ]
+                        batch_msgs += detector_msgs
+                    out = batcher.batch(batch_msgs)
+                    t += step
+                    clock.advance(step)
+                    if out is not None and out.messages:
+                        last_delivery = t
+                    worst = max(worst, t - last_delivery)
+        assert worst < 5.0, f"delivery silent for {worst:.1f}s of data time"

--- a/tests/core/rate_aware_batcher_test.py
+++ b/tests/core/rate_aware_batcher_test.py
@@ -19,6 +19,7 @@ service would experience.
 import random
 
 import pytest
+from structlog.testing import capture_logs
 
 from ess.livedata.core.message import Message, StreamId, StreamKind
 from ess.livedata.core.message_batcher import MessageBatch
@@ -2522,6 +2523,42 @@ class TestStallBackstop:
                 if batch is not None and stray in batch.messages:
                     return
         raise AssertionError("disjoint-epoch message was never delivered")
+
+    def test_sparse_stream_closes_via_timeout_not_backstop(self):
+        """A stream sparser than the stall threshold (e.g. a log value every
+        15 s) must keep closing via the timeout on each arrival.  The stall
+        check runs only when nothing closes; checked first, it would preempt
+        the timeout, re-place the window, and reset the HWM on every arrival
+        -- deferring each delivery by a full period and logging a recovery
+        per message."""
+        clock = FakeClock()
+        batcher = RateAwareMessageBatcher(batch_length_s=1.0, clock=clock)
+        delivered = 0
+        with capture_logs() as logs:
+            for i in range(3000):
+                batch_msgs = [hwm_trigger(100.0 + i * 0.1)] if i % 150 == 0 else []
+                out = batcher.batch(batch_msgs)
+                clock.advance(0.1)
+                if out is not None:
+                    delivered += len(out.messages)
+        assert delivered == 20, f"delivered {delivered} of 20 sparse messages"
+        assert not [e for e in logs if e['event'] == 'batcher_stall_recovery']
+
+    def test_quiet_trailing_batch_does_not_thrash(self):
+        """A partial batch left by a stopped stream is quietness, not a
+        stall: placement already agrees with the buffered traffic, so the
+        backstop must re-arm silently instead of re-placing the window and
+        logging a recovery every threshold interval."""
+        clock = FakeClock()
+        batcher, start = make_converged_batcher(rate_hz=14.0, clock=clock)
+        batcher.batch(msgs_at(14.0, start, 0.5))  # half a window, no close
+        before = batcher._active_window.start
+        with capture_logs() as logs:
+            for _ in range(1000):
+                clock.advance(0.1)
+                assert batcher.batch([]) is None
+        assert batcher._active_window.start == before
+        assert not [e for e in logs if e['event'] == 'batcher_stall_recovery']
 
     def test_quiet_stream_does_not_trigger_the_backstop(self):
         """Without buffered traffic there is nothing to re-place onto: a

--- a/tests/core/rate_aware_batcher_test.py
+++ b/tests/core/rate_aware_batcher_test.py
@@ -6,9 +6,14 @@ Tests use 'seconds' as the natural unit: timestamps are in seconds (converted
 to nanoseconds via helpers), batch lengths are in seconds.
 
 The batcher uses a logical clock (high-water mark of observed message
-timestamps) rather than wall time.  Where tests need to trigger the timeout
-fallback, they feed a non-gated "trigger" message whose timestamp advances the
-high-water mark past the threshold.
+timestamps) for placement.  Where tests need to trigger the timeout fallback,
+they feed a non-gated "trigger" message whose timestamp advances the
+high-water mark past the threshold. Trigger timestamps must stay within the
+HWM clamp's plausibility horizon (window.start + 3 * batch_length), so tests
+use a timeout factor of 2.5 with triggers just past the timeout threshold.
+Wall time enters only through the liveness backstop; tests that exercise it
+inject a ``FakeClock`` and advance it in lockstep with data time, as a live
+service would experience.
 """
 
 import random
@@ -42,6 +47,19 @@ def hwm_trigger(t: float) -> Message[str]:
     return Message(timestamp=ts(t), stream=_HWM, value="")
 
 
+class FakeClock:
+    """Injectable monotonic clock for driving the liveness backstop."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
 def msgs_at(
     rate_hz: float,
     start: float,
@@ -60,12 +78,14 @@ def longest_silence(
     cycles: int,
     rate_hz: float = 14.0,
     polls_per_batch: int = 10,
+    clock: FakeClock | None = None,
 ) -> float:
     """Longest stretch of data time yielding no messages, in seconds.
 
     Polls faster than the batch length, as the service loop does: batch() is
     called once per poll cycle, not once per batch length, so a window that
-    advances per call outruns the live data.
+    advances per call outruns the live data.  With ``clock``, wall time
+    advances in lockstep with data time, as for a live (non-replay) service.
     """
     step = 1.0 / polls_per_batch
     t = start
@@ -74,6 +94,8 @@ def longest_silence(
     for _ in range(cycles * polls_per_batch):
         batch = batcher.batch(msgs_at(rate_hz, t, step))
         t += step
+        if clock is not None:
+            clock.advance(step)
         if batch is not None and batch.messages:
             last_delivery = t
         worst = max(worst, t - last_delivery)
@@ -85,6 +107,7 @@ def make_converged_batcher(
     batch_length_s: float = 1.0,
     streams: dict[StreamId, float] | None = None,
     timeout_s: float | None = None,
+    clock: FakeClock | None = None,
 ) -> tuple[RateAwareMessageBatcher, float]:
     """Create a batcher with converged rate estimates.
 
@@ -107,6 +130,7 @@ def make_converged_batcher(
     batcher = RateAwareMessageBatcher(
         batch_length_s=batch_length_s,
         timeout_s=convergence_timeout,
+        clock=clock if clock is not None else FakeClock(),
     )
 
     # Initial batch seeds the timeline
@@ -215,7 +239,7 @@ class TestSingleStreamCompletion:
         assert len(result.messages) == 14
 
     def test_batch_does_not_complete_without_last_slot(self):
-        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=float('inf'))
         # Only first 6 of 14 messages — well before last slot
         partial = msgs_at(14.0, start=t0, duration=1.0)[:6]
         result = batcher.batch(partial)
@@ -233,7 +257,7 @@ class TestSingleStreamCompletion:
 
     def test_split_message_does_not_cause_premature_completion(self):
         """Two messages with the same early timestamp don't trick the slot check."""
-        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=float('inf'))
         # Only first 6 messages, but duplicate one of them
         partial = msgs_at(14.0, start=t0, duration=1.0)[:6]
         dup = msg(partial[2].timestamp.to_ns() / 1e9)
@@ -273,7 +297,7 @@ class TestTimeout:
 class TestMultiStream:
     def test_waits_for_all_gated_streams(self):
         streams = {DETECTOR: 14.0, MONITOR: 1.0}
-        batcher, t0 = make_converged_batcher(streams=streams, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(streams=streams, timeout_s=float('inf'))
 
         # Feed only detector messages — should not complete
         det_full = msgs_at(14.0, start=t0, duration=1.0, stream=DETECTOR)
@@ -309,7 +333,7 @@ class TestOverflow:
         """A future message proves the batch window passed, even if the last
         slot was never delivered. Completion should be immediate (slot-based),
         not delayed until the high-water-mark timeout fires."""
-        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=float('inf'))
 
         # All 14 messages except the last one, plus one future message
         all_msgs = msgs_at(14.0, start=t0, duration=1.0)
@@ -331,7 +355,7 @@ class TestPhaseOffset:
         rate_hz: float = 14.0,
         offset: float = 0.04,
         batch_length_s: float = 1.0,
-        timeout_s: float = 999.0,
+        timeout_s: float = float('inf'),
     ) -> tuple[RateAwareMessageBatcher, float]:
         """Converge a single DETECTOR stream that has a phase offset.
 
@@ -413,7 +437,7 @@ class TestPhaseOffset:
             result = batcher.batch(batch_msgs)
             assert result is not None
 
-        batcher.timeout_factor = 999.0
+        batcher.timeout_factor = float('inf')
 
         # Post-convergence: both streams present
         t_test = batch_start + MIN_DIFFS_FOR_GATE * 1.0
@@ -465,7 +489,7 @@ class TestJitterResilience:
         jitter_max = 0.010
         n_batches = 50
 
-        batcher, t0 = make_converged_batcher(rate_hz=rate, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=rate, timeout_s=2.5)
 
         counts: list[int] = []
         for b in range(n_batches):
@@ -479,7 +503,7 @@ class TestJitterResilience:
                 counts.append(len(result.messages))
             else:
                 # Trigger timeout via logical clock
-                result = batcher.batch([hwm_trigger(batch_t0 + 999.01)])
+                result = batcher.batch([hwm_trigger(batch_t0 + 2.51)])
                 if result is not None:
                     counts.append(len(result.messages))
 
@@ -512,7 +536,7 @@ class TestOneHzEdgeCase:
         ``self._overflow = []`` wiped it.
         """
         batcher, t0 = make_converged_batcher(
-            rate_hz=1.0, streams={MONITOR: 1.0}, timeout_s=999.0
+            rate_hz=1.0, streams={MONITOR: 1.0}, timeout_s=2.5
         )
         # Pulse at batch_start + 0.6 s: ``pulse_index`` rounds to 1,
         # slot 1 = overflow at ``slots_per_batch = 1``.  No other gated
@@ -524,7 +548,7 @@ class TestOneHzEdgeCase:
         # Drive one real pulse + timeout tick — the stray must appear
         # in one of these batches, not be silently dropped.
         r2 = batcher.batch([msg(t0 + 1.0, stream=MONITOR)])
-        r3 = batcher.batch([hwm_trigger(t0 + 999.01)])
+        r3 = batcher.batch([hwm_trigger(t0 + 2.51)])
 
         stray_seen = sum(
             any(m.timestamp == ts(stray_ts) for m in r.messages)
@@ -543,7 +567,7 @@ class TestOneHzEdgeCase:
         """
         log_stream = StreamId(kind=StreamKind.LOG, name="log")
         batcher, t0 = make_converged_batcher(
-            rate_hz=1.0, streams={MONITOR: 1.0}, timeout_s=999.0
+            rate_hz=1.0, streams={MONITOR: 1.0}, timeout_s=2.5
         )
         log_msg = Message(timestamp=ts(t0 + 0.3), stream=log_stream, value="log_1")
         # MON pulse at t0+0.6 s: slot 1 at slots_per_batch=1 → overflow.
@@ -552,7 +576,7 @@ class TestOneHzEdgeCase:
         stray = msg(t0 + 0.6, stream=MONITOR, value="mon_stray")
         r1 = batcher.batch([log_msg, stray])
         r2 = batcher.batch([msg(t0 + 1.0, stream=MONITOR)])
-        r3 = batcher.batch([hwm_trigger(t0 + 999.01)])
+        r3 = batcher.batch([hwm_trigger(t0 + 2.51)])
         results = [r for r in (r1, r2, r3) if r is not None]
         log_count = sum(1 for r in results for m in r.messages if m.value == "log_1")
         assert log_count == 1, f"LOG message duplicated (count={log_count})"
@@ -563,13 +587,13 @@ class TestOneHzEdgeCase:
         """
         slow_mon = StreamId(kind=StreamKind.MONITOR_COUNTS, name="slow_mon")
         batcher, t0 = make_converged_batcher(
-            rate_hz=1.0, streams={MONITOR: 1.0}, timeout_s=999.0
+            rate_hz=1.0, streams={MONITOR: 1.0}, timeout_s=2.5
         )
         slow_msg = msg(t0 + 0.3, stream=slow_mon, value="slow_first")
         stray = msg(t0 + 0.6, stream=MONITOR, value="mon_stray")
         r1 = batcher.batch([slow_msg, stray])
         r2 = batcher.batch([msg(t0 + 1.0, stream=MONITOR)])
-        r3 = batcher.batch([hwm_trigger(t0 + 999.01)])
+        r3 = batcher.batch([hwm_trigger(t0 + 2.51)])
         results = [r for r in (r1, r2, r3) if r is not None]
         slow_count = sum(
             1 for r in results for m in r.messages if m.value == "slow_first"
@@ -597,7 +621,7 @@ class TestOneHzEdgeCase:
         batcher, t0 = make_converged_batcher(
             rate_hz=1.0,
             streams={MONITOR: 1.0, DETECTOR: 1.0},
-            timeout_s=999.0,
+            timeout_s=float('inf'),
         )
         slow_msg = msg(t0 + 0.3, stream=slow_mon, value="slow_first")
         stray = msg(t0 + 0.6, stream=MONITOR, value="mon_stray")
@@ -614,7 +638,7 @@ class TestTimeGaps:
 
     def test_gap_of_5_batches_recovers_without_timeout(self):
         """After a 5s gap, the batcher advances and delivers the next batch."""
-        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=float('inf'))
 
         # Skip 5 batch periods, then send normal-rate messages
         gap_batches = 5
@@ -628,7 +652,7 @@ class TestTimeGaps:
 
     def test_gap_preserves_batch_continuity(self):
         """After a gap, the next batch starts at or before the resumed data."""
-        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=float('inf'))
 
         gap_batches = 10
         t_resume = t0 + gap_batches * 1.0
@@ -731,7 +755,7 @@ class TestDriftCorrection:
         period = 1.0 / actual_rate
         n_batches = 100
 
-        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=2.5)
 
         total_messages_in = 0
         total_messages_out = 0
@@ -744,7 +768,7 @@ class TestDriftCorrection:
             if result is not None:
                 total_messages_out += len(result.messages)
             else:
-                result = batcher.batch([hwm_trigger(batch_t0 + 999.01)])
+                result = batcher.batch([hwm_trigger(batch_t0 + 2.51)])
                 if result is not None:
                     total_messages_out += len(result.messages)
 
@@ -836,7 +860,7 @@ class TestSetBatchLength:
     def test_multistream_slots_per_batch_updates(self):
         """Grids for all converged streams recompute slots_per_batch on resize."""
         streams = {DETECTOR: 14.0, MONITOR: 5.0}
-        batcher, t0 = make_converged_batcher(streams=streams, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(streams=streams, timeout_s=float('inf'))
 
         batcher.set_batch_length(2.0)
         det = msgs_at(14.0, start=t0, duration=1.0, stream=DETECTOR)
@@ -918,7 +942,7 @@ class TestEnvelopeBoundaries:
             result = batcher.batch(batch_msgs)
             assert result is not None
 
-        batcher.timeout_factor = 999.0
+        batcher.timeout_factor = float('inf')
         t0 = batch_start + MIN_DIFFS_FOR_GATE * 1.0
         result = batcher.batch(stream_msgs(t0))
         assert result is not None
@@ -950,7 +974,7 @@ class TestEnvelopeBoundaries:
             result = batcher.batch(batch_msgs)
             assert result is not None
 
-        batcher.timeout_factor = 999.0
+        batcher.timeout_factor = float('inf')
         t0 = batch_start + MIN_DIFFS_FOR_GATE * 1.0
         result = batcher.batch(stream_msgs(t0))
         assert result is not None
@@ -964,7 +988,7 @@ class TestEnvelopeBoundaries:
         rate = 14.0
         period = 1.0 / rate
         jitter_max = 0.030  # 42% of period
-        timeout = 999.0
+        timeout = 2.5
 
         batcher, t0 = make_converged_batcher(rate_hz=rate, timeout_s=timeout)
 
@@ -991,7 +1015,7 @@ class TestEnvelopeBoundaries:
 
     def test_out_of_order_messages_before_batch_start(self):
         """Messages with timestamps before batch_start (late arrivals)."""
-        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=float('inf'))
 
         # 14 normal messages + 2 "late" messages from the previous batch
         normal = msgs_at(14.0, start=t0, duration=1.0)
@@ -1032,7 +1056,7 @@ class TestEnvelopeBoundaries:
 
         # Post-convergence: detector-only should complete
         # (sub-Hz has no grid, doesn't gate)
-        batcher.timeout_factor = 999.0
+        batcher.timeout_factor = float('inf')
         t_test = batch_start + MIN_DIFFS_FOR_GATE * 1.0
         det = msgs_at(14.0, start=t_test, duration=1.0, stream=DETECTOR)
         result = batcher.batch(det)
@@ -1053,7 +1077,7 @@ class TestEnvelopeBoundaries:
     def test_high_rate_short_batch_loses_second_message(self):
         """14 Hz with 0.1s batch: second message in the period overflows."""
         batcher, t0 = make_converged_batcher(
-            rate_hz=14.0, batch_length_s=0.1, timeout_s=999.0
+            rate_hz=14.0, batch_length_s=0.1, timeout_s=float('inf')
         )
 
         # Two messages within 0.1s at 14 Hz spacing (0.0714s apart)
@@ -1070,7 +1094,7 @@ class TestEnvelopeBoundaries:
         rate = 14.5
         period = 1.0 / rate
         n_batches = 100
-        timeout = 999.0
+        timeout = 2.5
 
         convergence_timeout = 0.8
         batcher = RateAwareMessageBatcher(
@@ -1180,7 +1204,7 @@ class TestEnvelopeBoundaries:
         rate = 14.0
         period = 1.0 / rate
         jitter_max = period * 0.50
-        timeout = 999.0
+        timeout = 2.5
 
         batcher, t0 = make_converged_batcher(rate_hz=rate, timeout_s=timeout)
 
@@ -1228,7 +1252,7 @@ class TestEnvelopeBoundaries:
     def test_overflow_does_not_accumulate(self):
         """Over 200 batches, overflow never grows unboundedly."""
         rate = 14.0
-        batcher, t0 = make_converged_batcher(rate_hz=rate, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=rate, timeout_s=2.5)
 
         max_overflow = 0
         for b in range(200):
@@ -1238,7 +1262,7 @@ class TestEnvelopeBoundaries:
             overflow_size = len(batcher._overflow)
             max_overflow = max(max_overflow, overflow_size)
             if result is None:
-                result = batcher.batch([hwm_trigger(batch_t0 + 999.01)])
+                result = batcher.batch([hwm_trigger(batch_t0 + 2.51)])
                 if result is not None:
                     overflow_size = len(batcher._overflow)
                     max_overflow = max(max_overflow, overflow_size)
@@ -1257,7 +1281,9 @@ class TestEnvelopeBoundaries:
         # next window. Gap-recovery cannot fire because DETECTOR has
         # in-window messages.
         batcher, t0 = make_converged_batcher(
-            rate_hz=14.0, streams={DETECTOR: 14.0, MONITOR: 14.0}, timeout_s=999.0
+            rate_hz=14.0,
+            streams={DETECTOR: 14.0, MONITOR: 14.0},
+            timeout_s=float('inf'),
         )
         # One DETECTOR pulse at slot 0 — incomplete gate for DETECTOR.
         batcher.batch([msg(t0 + 0.05, stream=DETECTOR)])
@@ -1641,7 +1667,7 @@ class TestSubRateExclusion:
         """1 Hz MON gridded at 1 s batch.  Shrink to 0.6 s → excluded from grids."""
         streams = {DETECTOR: 14.0, MONITOR: 1.0}
         batcher, t0 = make_converged_batcher(
-            batch_length_s=1.0, streams=streams, timeout_s=999.0
+            batch_length_s=1.0, streams=streams, timeout_s=float('inf')
         )
         assert batcher.is_gating(MONITOR)
 
@@ -1659,7 +1685,7 @@ class TestSubRateExclusion:
         """Restoring 1 s batch length re-admits the 1 Hz stream to gating."""
         streams = {DETECTOR: 14.0, MONITOR: 1.0}
         batcher, t0 = make_converged_batcher(
-            batch_length_s=1.0, streams=streams, timeout_s=999.0
+            batch_length_s=1.0, streams=streams, timeout_s=float('inf')
         )
         # Shrink: MON excluded.
         batcher.set_batch_length(0.6)
@@ -1828,7 +1854,7 @@ class TestBrokenTimestampStream:
                 warmup.append(r)
 
         # Measurement phase: disable timeout, require slot-gate closure.
-        batcher.timeout_factor = 999.0
+        batcher.timeout_factor = float('inf')
         measured: list[MessageBatch] = []
         offset = (warmup_batches + 1) * 1_000_000_000
         for k in range(measured_batches):
@@ -1983,7 +2009,7 @@ class TestNonGatedStreams:
         assert len(result.messages) == 15  # 14 detector + 1 log
 
     def test_does_not_affect_gate(self):
-        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=999.0)
+        batcher, t0 = make_converged_batcher(rate_hz=14.0, timeout_s=float('inf'))
         # Only log messages, no detector — gate not satisfied
         result = batcher.batch([msg(t0 + 0.5, stream=self.LOG)])
         assert result is None
@@ -2294,15 +2320,16 @@ class TestNonGatedEndTimeProgression:
 class TestFarFutureTimestampLiveness:
     """A single implausibly-far-future timestamp must not stall the batcher.
 
-    Data-derived timestamps are the batcher's only clock, so an outlier that
-    anchors the active window (or the high-water mark) parks that clock in the
-    future: real traffic then looks perpetually early, no slot gate is ever
-    satisfied, the timeout threshold is never reached, and delivery stops
+    Data-derived timestamps place the batcher's windows, so an outlier that
+    anchors the active window (or the high-water mark) parks that placement in
+    the future: real traffic then looks perpetually early, no slot gate is
+    ever satisfied, the timeout threshold is never reached, and delivery stops
     permanently while messages accumulate (#1038 finding 1, #1047).
 
     The adapter boundary clamps such timestamps before they reach a batcher;
     these tests pin the batcher's own defense, which also covers non-Kafka
-    sources and values inside the adapter's bound.
+    sources and values inside the adapter's bound.  Wall time advances in
+    lockstep with data time, as a live service experiences it.
     """
 
     ONE_YEAR_S = 365 * 24 * 3600.0
@@ -2314,11 +2341,17 @@ class TestFarFutureTimestampLiveness:
     IN_BAND_S = 240.0
 
     def _drive(
-        self, batcher: RateAwareMessageBatcher, start: float, cycles: int
+        self,
+        batcher: RateAwareMessageBatcher,
+        start: float,
+        cycles: int,
+        clock: FakeClock | None = None,
     ) -> tuple[int, int]:
         """Feed *cycles* seconds of 14 Hz traffic; return (closed, delivered)."""
         closed = delivered = 0
         for k in range(cycles):
+            if clock is not None:
+                clock.advance(1.0)
             for batch in (
                 batcher.batch(msgs_at(14.0, start + k, 1.0)),
                 batcher.batch([]),
@@ -2384,9 +2417,10 @@ class TestFarFutureTimestampLiveness:
     def test_in_band_future_timestamp_does_not_stall(self):
         """The band between the batcher's horizon and the adapter's future
         bound is the one that reaches a batcher in production."""
-        batcher, start = make_converged_batcher(rate_hz=14.0)
+        clock = FakeClock()
+        batcher, start = make_converged_batcher(rate_hz=14.0, clock=clock)
         batcher.batch([msg(start + self.IN_BAND_S)])
-        closed, delivered = self._drive(batcher, start=start, cycles=60)
+        closed, delivered = self._drive(batcher, start=start, cycles=60, clock=clock)
         assert closed > 0, "batcher stalled after an in-band future timestamp"
         assert delivered > 0
 
@@ -2394,18 +2428,20 @@ class TestFarFutureTimestampLiveness:
         """Delivery must resume promptly, not merely eventually: the wedge
         this guards against is bounded by the poison's distance ahead, which
         for an in-band value is minutes of silent data loss."""
-        batcher, start = make_converged_batcher(rate_hz=14.0)
+        clock = FakeClock()
+        batcher, start = make_converged_batcher(rate_hz=14.0, clock=clock)
         batcher.batch([msg(start + self.IN_BAND_S)])
-        gap = longest_silence(batcher, start=start, cycles=300)
-        assert gap < 10.0, f"delivery silent for {gap:.1f}s of data time"
+        gap = longest_silence(batcher, start=start, cycles=300, clock=clock)
+        assert gap < 15.0, f"delivery silent for {gap:.1f}s of data time"
 
 
-class TestWindowReanchoring:
-    """Re-anchoring corrects a window that traffic contradicts, but must not
-    fire on ordinary buffer states or cost anything when nothing is wrong.
+class TestStallBackstop:
+    """The wall-clock liveness backstop corrects any window placement the
+    buffered traffic cannot close, but must not fire on ordinary buffer
+    states and must not advance the data clock on wall-time evidence alone.
     """
 
-    LAGGING = StreamId(kind=StreamKind.DETECTOR_EVENTS, name="lagging")
+    IN_BAND_S = 240.0
 
     def test_lagging_partition_does_not_drag_the_window_backwards(self):
         """Kafka returns per-partition chunks, so one poll can carry only a
@@ -2449,3 +2485,85 @@ class TestWindowReanchoring:
                 if batch is not None and stray in batch.messages:
                     return
         raise AssertionError("disjoint-epoch message was never delivered")
+
+    def test_quiet_stream_does_not_trigger_the_backstop(self):
+        """Without buffered traffic there is nothing to re-place onto: a
+        quiet stream is not a stall, and the data clock must not advance on
+        wall-time evidence alone."""
+        clock = FakeClock()
+        batcher, _ = make_converged_batcher(rate_hz=14.0, clock=clock)
+        for _ in range(5):  # drain pending timeout closes
+            batcher.batch([])
+        before = batcher._active_window.start
+        for _ in range(50):
+            clock.advance(10.0)
+            assert batcher.batch([]) is None
+        assert batcher._active_window.start == before
+
+    def test_backstop_waits_out_the_threshold(self):
+        """A window parked ahead of traffic recovers via the backstop, but
+        only once the wall-clock threshold has elapsed -- momentary
+        non-closing states must not move the window."""
+        clock = FakeClock()
+        batcher, start = make_converged_batcher(rate_hz=14.0, clock=clock)
+        # Poisoned gap jump: gated overflow with silent streams parks the
+        # window at the poison.
+        batcher.batch([msg(start + self.IN_BAND_S)])
+        parked = batcher._active_window.start
+        assert parked.to_ns() / 1e9 >= start + self.IN_BAND_S - 1.0
+
+        clock.advance(1.0)
+        batcher.batch(msgs_at(14.0, start, 1.0))
+        assert batcher._active_window.start == parked, (
+            "window moved before the stall threshold elapsed"
+        )
+        clock.advance(15.0)
+        batcher.batch([])
+        window_s = batcher._active_window.start.to_ns() / 1e9
+        assert abs(window_s - (start + 1.0)) < 2.0, (
+            f"window at {window_s:.1f}s, buffered traffic near {start:.1f}s"
+        )
+
+    def test_poison_then_silence_then_resumed_traffic_recovers(self):
+        """A poisoned gap jump during a silence gap parks the window far
+        ahead with nothing buffered to contradict it; the backstop must
+        recover once resumed traffic buffers up."""
+        clock = FakeClock()
+        batcher, start = make_converged_batcher(rate_hz=14.0, clock=clock)
+        batcher.batch([msg(start + self.IN_BAND_S)])
+        for _ in range(300):  # 30 s of empty polls
+            clock.advance(0.1)
+            batcher.batch([])
+        gap = longest_silence(batcher, start=start + 30.0, cycles=120, clock=clock)
+        assert gap < 15.0, f"delivery silent for {gap:.1f}s of data time"
+
+    def test_forward_epoch_jump_recovers(self):
+        """All traffic jumping to a disjoint later epoch (upstream clock
+        jump) must not stall delivery; the window follows via timeout
+        closes and stream eviction."""
+        clock = FakeClock()
+        batcher, start = make_converged_batcher(rate_hz=14.0, clock=clock)
+        gap = longest_silence(batcher, start=start + 1e6, cycles=60, clock=clock)
+        assert gap < 15.0, f"delivery silent for {gap:.1f}s of data time"
+        window_s = batcher._active_window.start.to_ns() / 1e9
+        assert window_s > 1e6, "window never followed the epoch jump"
+
+
+class TestTimeoutFactorValidation:
+    """A timeout beyond the HWM plausibility horizon can never fire: the
+    HWM clamp caps the high-water mark below the threshold. Such a
+    configuration must be rejected, not silently degrade to gate-only
+    closure."""
+
+    def test_constructor_rejects_timeout_beyond_horizon(self):
+        with pytest.raises(ValueError, match="timeout_factor"):
+            RateAwareMessageBatcher(batch_length_s=1.0, timeout_s=5.0)
+
+    def test_setter_rejects_timeout_beyond_horizon(self):
+        batcher = RateAwareMessageBatcher(batch_length_s=1.0)
+        with pytest.raises(ValueError, match="timeout_factor"):
+            batcher.timeout_factor = 4.0
+
+    def test_horizon_boundary_is_accepted(self):
+        batcher = RateAwareMessageBatcher(batch_length_s=1.0, timeout_s=3.0)
+        assert batcher.timeout_factor == 3.0

--- a/tests/services/hostile_input_liveness_test.py
+++ b/tests/services/hostile_input_liveness_test.py
@@ -13,28 +13,39 @@ data-derived timestamps as its only clock) and asserts one invariant:
     After consuming any single hostile payload, the service still publishes
     results for subsequent well-formed data.
 
-Payloads come from ``tests/helpers/hostile_wire``. Cases the current code
-survives are regression guards; the reproduced wedge (#1038 finding 1) is a
-strict xfail that doubles as the acceptance test for the adapter-boundary
-validation proposed in #1047.
+Payloads come from ``tests/helpers/hostile_wire``.
+
+Every test runs against both inner batchers: ``SimpleMessageBatcher`` and
+``RateAwareMessageBatcher``, which production selects per instrument via
+``--batcher``. The two reach batch closure by different mechanisms (fixed
+windows versus per-stream pulse-slot gating), so a hostile input that stalls
+one need not stall the other, and both are deployed.
 """
 
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 
 import pytest
 
 from ess.livedata.config import instrument_registry, workflow_spec
 from ess.livedata.config.workflow_spec import JobId
 from ess.livedata.core.message import StreamKind
-from ess.livedata.core.message_batcher import AdaptiveMessageBatcher
+from ess.livedata.core.message_batcher import (
+    AdaptiveMessageBatcher,
+    MessageBatcher,
+    SimpleMessageBatcher,
+)
+from ess.livedata.core.rate_aware_batcher import RateAwareMessageBatcher
 from ess.livedata.services.monitor_data import make_monitor_service_builder
 from tests.helpers import hostile_wire
 from tests.helpers.livedata_app import LivedataApp
 
 SOURCE = 'monitor1'
 SECOND_NS = 1_000_000_000
+
+InnerBatcherFactory = Callable[[float], MessageBatcher]
 
 
 def _monitor_workflow_id(instrument: str) -> workflow_spec.WorkflowId:
@@ -52,11 +63,11 @@ class MonitorServiceHarness:
     timestamps (the batcher's clock) and observes published workflow results.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, inner_factory: InnerBatcherFactory) -> None:
         builder = make_monitor_service_builder(instrument='dummy')
         # Production default; LivedataApp would otherwise install the naive
         # batcher, which hides batching-level failure modes.
-        builder.message_batcher = AdaptiveMessageBatcher()
+        builder.message_batcher = AdaptiveMessageBatcher(inner_factory=inner_factory)
         self.app = LivedataApp.from_service_builder(
             builder, use_naive_message_batcher=False
         )
@@ -103,9 +114,12 @@ class MonitorServiceHarness:
         return self.result_count() - before
 
 
-@pytest.fixture
-def harness() -> MonitorServiceHarness:
-    return MonitorServiceHarness()
+@pytest.fixture(
+    params=[SimpleMessageBatcher, RateAwareMessageBatcher],
+    ids=['simple', 'rate_aware'],
+)
+def harness(request: pytest.FixtureRequest) -> MonitorServiceHarness:
+    return MonitorServiceHarness(inner_factory=request.param)
 
 
 def assert_service_live(harness: MonitorServiceHarness, cycles: int = 10) -> None:
@@ -139,16 +153,19 @@ def test_malformed_payload_does_not_stall_service(
 def test_far_future_timestamp_mid_stream_does_not_stall_service(
     harness: MonitorServiceHarness,
 ) -> None:
-    """A far-future timestamp *after* the first batch degrades the batcher
-    (the message lingers as a pending future message) but must not stop
-    output. Guards the boundary of the wedge in #1038 finding 1.
+    """A far-future timestamp *after* the first batch must not stop output.
+
+    The batchers must refuse to let the insane value steer window placement,
+    however far ahead it sits. The rate-aware batcher may stay silent for up
+    to ``_REANCHOR_STALLED_CALLS`` polls before re-anchoring, so the liveness
+    window must exceed that.
     """
     harness.run_good_cycles(3)
     harness.publish_payload(
         hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.FAR_FUTURE_NS)
     )
     harness.app.step()
-    assert_service_live(harness)
+    assert_service_live(harness, cycles=40)
 
 
 @pytest.mark.parametrize(
@@ -202,18 +219,41 @@ def test_mismatched_event_vectors_do_not_stall_service(
     assert_service_live(harness)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='#1038 finding 1 / #1047: a far-future data timestamp in the first '
-    'consumed batch becomes the batch boundary, after which no batch is ever '
-    'emitted — the service goes silent while appearing healthy',
+@pytest.mark.parametrize(
+    'harness',
+    [
+        pytest.param(
+            SimpleMessageBatcher,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason='#1038 finding 1 / #1047: a lone far-future timestamp in '
+                'the startup backlog wins plausible_anchor\'s tie-break (one '
+                'message on each side carries no evidence), anchors the first '
+                'batch boundary, and the simple batcher has no recovery path — '
+                'the service goes silent while appearing healthy. Telling a '
+                'lone outlier from real traffic needs arrival-time evidence, '
+                'i.e. validation where messages enter (#1047).',
+            ),
+        ),
+        pytest.param(RateAwareMessageBatcher),
+    ],
+    indirect=True,
+    ids=['simple', 'rate_aware'],
 )
 def test_far_future_timestamp_in_first_batch_does_not_stall_service(
     harness: MonitorServiceHarness,
 ) -> None:
+    """The startup backlog is where a far-future timestamp is most dangerous:
+    it would anchor the first batch boundary, and every real message would
+    then look early forever. With only one good message beside the outlier,
+    ``plausible_anchor`` has no bulk of traffic to weigh against it, so the
+    first anchor lands on the outlier. The rate-aware batcher recovers by
+    re-anchoring once the buffered traffic unanimously contradicts the
+    window; the simple batcher stays wedged (see the xfail).
+    """
     harness.publish_payload(
         hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.FAR_FUTURE_NS)
     )
     harness.publish_good()
     harness.app.step()
-    assert_service_live(harness, cycles=20)
+    assert_service_live(harness, cycles=60)

--- a/tests/services/hostile_input_liveness_test.py
+++ b/tests/services/hostile_input_liveness_test.py
@@ -45,7 +45,35 @@ from tests.helpers.livedata_app import LivedataApp
 SOURCE = 'monitor1'
 SECOND_NS = 1_000_000_000
 
-InnerBatcherFactory = Callable[[float], MessageBatcher]
+
+class _FakeWallClock:
+    """Wall clock the harness advances in lockstep with the data clock.
+
+    The rate-aware batcher's liveness backstop is wall-clock driven; a real
+    monotonic clock would need the test to sleep through the stall threshold.
+    """
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+InnerBatcherFactory = Callable[[float, Callable[[], float]], MessageBatcher]
+
+
+def _simple_inner(batch_length_s: float, clock: Callable[[], float]) -> MessageBatcher:
+    return SimpleMessageBatcher(batch_length_s)
+
+
+def _rate_aware_inner(
+    batch_length_s: float, clock: Callable[[], float]
+) -> MessageBatcher:
+    return RateAwareMessageBatcher(batch_length_s, clock=clock)
 
 
 def _monitor_workflow_id(instrument: str) -> workflow_spec.WorkflowId:
@@ -65,9 +93,14 @@ class MonitorServiceHarness:
 
     def __init__(self, inner_factory: InnerBatcherFactory) -> None:
         builder = make_monitor_service_builder(instrument='dummy')
+        self.clock = _FakeWallClock()
         # Production default; LivedataApp would otherwise install the naive
         # batcher, which hides batching-level failure modes.
-        builder.message_batcher = AdaptiveMessageBatcher(inner_factory=inner_factory)
+        builder.message_batcher = AdaptiveMessageBatcher(
+            inner_factory=lambda batch_length_s: inner_factory(
+                batch_length_s, self.clock
+            )
+        )
         self.app = LivedataApp.from_service_builder(
             builder, use_naive_message_batcher=False
         )
@@ -90,8 +123,13 @@ class MonitorServiceHarness:
         return self._time_ns
 
     def publish_good(self) -> None:
-        """Queue a well-formed event message one second after the previous."""
+        """Queue a well-formed event message one second after the previous.
+
+        Wall time advances in lockstep with the data clock, as a live
+        (non-replay) service experiences it.
+        """
         self._seed += 1
+        self.clock.advance(1.0)
         self.publish_payload(
             hostile_wire.ev44_events(
                 SOURCE, reference_time_ns=self.next_time_ns(), seed=self._seed
@@ -115,7 +153,7 @@ class MonitorServiceHarness:
 
 
 @pytest.fixture(
-    params=[SimpleMessageBatcher, RateAwareMessageBatcher],
+    params=[_simple_inner, _rate_aware_inner],
     ids=['simple', 'rate_aware'],
 )
 def harness(request: pytest.FixtureRequest) -> MonitorServiceHarness:
@@ -157,8 +195,8 @@ def test_far_future_timestamp_mid_stream_does_not_stall_service(
 
     The batchers must refuse to let the insane value steer window placement,
     however far ahead it sits. The rate-aware batcher may stay silent for up
-    to ``_REANCHOR_STALLED_CALLS`` polls before re-anchoring, so the liveness
-    window must exceed that.
+    to its wall-clock stall threshold before the liveness backstop re-places
+    the window, so the liveness window must exceed that.
     """
     harness.run_good_cycles(3)
     harness.publish_payload(
@@ -223,7 +261,7 @@ def test_mismatched_event_vectors_do_not_stall_service(
     'harness',
     [
         pytest.param(
-            SimpleMessageBatcher,
+            _simple_inner,
             marks=pytest.mark.xfail(
                 strict=True,
                 reason='#1038 finding 1 / #1047: a lone far-future timestamp in '
@@ -235,7 +273,7 @@ def test_mismatched_event_vectors_do_not_stall_service(
                 'i.e. validation where messages enter (#1047).',
             ),
         ),
-        pytest.param(RateAwareMessageBatcher),
+        pytest.param(_rate_aware_inner),
     ],
     indirect=True,
     ids=['simple', 'rate_aware'],
@@ -247,9 +285,9 @@ def test_far_future_timestamp_in_first_batch_does_not_stall_service(
     it would anchor the first batch boundary, and every real message would
     then look early forever. With only one good message beside the outlier,
     ``plausible_anchor`` has no bulk of traffic to weigh against it, so the
-    first anchor lands on the outlier. The rate-aware batcher recovers by
-    re-anchoring once the buffered traffic unanimously contradicts the
-    window; the simple batcher stays wedged (see the xfail).
+    first anchor lands on the outlier. The rate-aware batcher's wall-clock
+    backstop re-places the window at the buffered traffic; the simple
+    batcher stays wedged (see the xfail).
     """
     harness.publish_payload(
         hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.FAR_FUTURE_NS)


### PR DESCRIPTION
## Why

A single message carrying a far-future timestamp could silence a backend service indefinitely (#1038 finding 1). The batchers use data-derived timestamps as their only clock, so such a value became that clock: it anchored the batch window in the future, after which all real traffic looked early, no batch ever closed, and the process kept reporting itself healthy. Restarting re-consumed the same offset and wedged again. Both production batchers were affected; `RateAwareMessageBatcher` — already the configured choice for some instruments — wedged permanently even from a mid-stream timestamp, where `SimpleMessageBatcher` merely degraded.

## What changed

Window placement no longer follows a single outlier arbitrarily far. Batch anchors come from the bulk of the traffic rather than a bare maximum (`plausible_anchor`), the simple batcher refuses to advance its window past the frontier of the data in hand, and the rate-aware batcher diverts disjoint-epoch messages straight to delivery and bounds its high-water mark relative to the active window.

The rate-aware batcher additionally gains a wall-clock liveness backstop (#1123): it takes an injectable monotonic clock, and when no batch has closed for a bounded wall-clock interval while traffic is buffered, the window is re-placed at the plausible anchor of that traffic. This replaces an earlier per-pathology re-anchoring mechanism whose trigger conditions needed individual reachability proofs (one turned out to be dead code); the backstop corrects any placement the buffered traffic cannot close, without diagnosing how the window got misplaced. Wall time gates liveness only, never window placement or sizing, so replay/catch-up batching is unaffected — the module docstring documents this clock policy. `timeout_factor` is now validated against the high-water-mark plausibility horizon (a larger finite value could never fire); an explicit `inf` requests gate-only closure.

No timestamps are modified anywhere: this layer only constrains how window placement reacts to them, so it is safe for any source, Kafka or not.

Two holes remain in the simple batcher, each pinned by a strict xfail: a lone far-future timestamp in the startup backlog (one message on each side of a gap carries no evidence to weigh), and a parked future message that fast-forwards the window through a silence gap. Both need arrival-time evidence where messages enter the system; a follow-up PR adds that validation at the adapter boundary and closes #1047. The rate-aware batcher recovers from both via the backstop.

## Test plan

Unit tests for the anchor selection, the window-advance guard, the backstop (fires only after the wall-clock threshold with traffic buffered; quiet streams never advance the data clock on wall-time evidence), recovery from a poisoned gap jump plus silence gap, and a full forward epoch jump; wall time is driven by an injected fake clock in lockstep with data time. Slowly creeping device clocks (seen in production at ~1 s/day) are pinned separately: delivery flows through every threshold crossing in both directions, a persistent minutes-scale offset with intermittent traffic does not ping-pong, and the window-tracks-the-fastest-clock equilibrium is documented as current behavior — the resulting alignment/data-clock skew is a known quality degradation whose detection belongs at the adapter boundary. The service-level liveness tests run against both `SimpleMessageBatcher` and `RateAwareMessageBatcher`, so the batcher already deployed in production is covered by the same invariants as the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
