### PR TITLE
Accept ev44 payloads with absent event vectors

### DIFF
--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from typing import Any, Generic, Protocol, TypeVar
 
 import numpy as np
+import numpy.typing as npt
 import pydantic
 import scipp as sc
 import streaming_data_types
@@ -193,11 +194,33 @@ class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
         )
 
 
+def _vector_or_empty(vector: np.ndarray | int, dtype: npt.DTypeLike) -> np.ndarray:
+    """Normalize the result of a flatbuffers ``*AsNumpy()`` accessor.
+
+    The accessors return scalar ``0`` for a vector that is *absent* from the
+    buffer, as opposed to present but empty. The ev44 schema does not require
+    the event vectors, so producers may legitimately omit them; without this
+    the sentinel reaches consumers that expect an array and the message is
+    lost instead of being treated as carrying no events.
+    """
+    return vector if isinstance(vector, np.ndarray) else np.empty(0, dtype=dtype)
+
+
+def _normalize_ev44(ev44: eventdata_ev44.EventData) -> eventdata_ev44.EventData:
+    """Replace absent-vector sentinels of a deserialized ev44 payload."""
+    return ev44._replace(
+        reference_time=_vector_or_empty(ev44.reference_time, np.int64),
+        reference_time_index=_vector_or_empty(ev44.reference_time_index, np.int32),
+        time_of_flight=_vector_or_empty(ev44.time_of_flight, np.int32),
+        pixel_id=_vector_or_empty(ev44.pixel_id, np.int32),
+    )
+
+
 class KafkaToEv44Adapter(KafkaAdapter[eventdata_ev44.EventData]):
     schema = 'ev44'
 
     def adapt(self, message: KafkaMessage) -> Message[eventdata_ev44.EventData]:
-        ev44 = eventdata_ev44.deserialise_ev44(message.value())
+        ev44 = _normalize_ev44(eventdata_ev44.deserialise_ev44(message.value()))
         stream = self.get_stream_id(topic=message.topic(), source_name=ev44.source_name)
         # A fallback, useful in particular for testing so serialized data can be reused.
         if ev44.reference_time.size > 0:
@@ -392,8 +415,8 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
         event = Event44Message.Event44Message.GetRootAs(buffer, 0)
         source_name = event.SourceName().decode("utf-8")
         stream = self.get_stream_id(topic=message.topic(), source_name=source_name)
-        reference_time = event.ReferenceTimeAsNumpy()
-        time_of_arrival = event.TimeOfFlightAsNumpy()
+        reference_time = _vector_or_empty(event.ReferenceTimeAsNumpy(), np.int64)
+        time_of_arrival = _vector_or_empty(event.TimeOfFlightAsNumpy(), np.int32)
 
         # A fallback, useful in particular for testing so serialized data can be reused.
         if reference_time.size > 0:
@@ -403,7 +426,7 @@ class KafkaToMonitorEventsAdapter(KafkaAdapter[MonitorEvents | DetectorEvents]):
 
         if stream.name in self._pixellated_sources:
             value: MonitorEvents | DetectorEvents = DetectorEvents(
-                pixel_id=event.PixelIdAsNumpy(),
+                pixel_id=_vector_or_empty(event.PixelIdAsNumpy(), np.int32),
                 time_of_arrival=time_of_arrival,
                 unit='ns',
             )

--- a/src/ess/livedata/preprocessors/to_nxevent_data.py
+++ b/src/ess/livedata/preprocessors/to_nxevent_data.py
@@ -15,8 +15,18 @@ from ess.livedata.core.timestamp import Timestamp
 
 
 def _require_single_pulse(ev44: eventdata_ev44.EventData) -> None:
+    """Reject payloads spanning more than one pulse.
+
+    A payload without reference times carries no pulse at all, which is not
+    multi-pulse and therefore accepted (as an empty event list).
+    """
     index = ev44.reference_time_index
-    if len(index) > 1 or index[0] != 0 or len(ev44.reference_time) > 1:
+    multi_pulse = (
+        len(ev44.reference_time) > 1
+        or len(index) > 1
+        or (len(index) == 1 and index[0] != 0)
+    )
+    if multi_pulse:
         raise NotImplementedError("Processing multi-pulse messages is not supported.")
 
 

--- a/tests/helpers/hostile_wire.py
+++ b/tests/helpers/hostile_wire.py
@@ -95,8 +95,9 @@ def ev44_without_event_vectors(source_name: str) -> bytes:
     ``serialise_ev44`` always writes the vectors, but the flatbuffer schema
     does not require them, so other producers can omit them. The
     flatbuffers-python accessors then return scalar ``0`` instead of an empty
-    array, which trips code expecting ``.size``/``len()`` — see #1038
-    (finding 2).
+    array. Not in :func:`malformed_corpus`: the payload is well-formed and
+    must be *accepted* as carrying no events, with the timestamp coming from
+    the Kafka broker fallback.
     """
     import flatbuffers
 
@@ -220,7 +221,6 @@ def malformed_corpus(source_name: str) -> dict[str, bytes]:
         'truncated_ev44': truncated(
             ev44_events(source_name, reference_time_ns=REALISTIC_EPOCH_NS)
         ),
-        'ev44_without_event_vectors': ev44_without_event_vectors(source_name),
         'wrong_schema_f144': f144_log(source_name, timestamp_ns=REALISTIC_EPOCH_NS),
         'unmapped_source': ev44_events(
             'not_a_known_source', reference_time_ns=REALISTIC_EPOCH_NS

--- a/tests/kafka/adapter_robustness_test.py
+++ b/tests/kafka/adapter_robustness_test.py
@@ -29,6 +29,8 @@ from ess.livedata.core.message import StreamKind
 from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.kafka.message_adapter import (
     AdaptingMessageSource,
+    ChainedAdapter,
+    Ev44ToDetectorEventsAdapter,
     FakeKafkaMessage,
     KafkaAdapter,
     KafkaMessage,
@@ -101,16 +103,26 @@ def test_ev44_mismatched_event_vectors_accepted_on_plain_monitor_path() -> None:
     assert len(adapted.value.time_of_arrival) == 10
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason='#1038 finding 2: absent event vectors raise deep in the adapter '
-    'and the message is dropped instead of using the Kafka-timestamp fallback',
-)
 def test_ev44_without_event_vectors_falls_back_to_kafka_timestamp() -> None:
     payload = hostile_wire.ev44_without_event_vectors(SOURCE)
     message = _kafka_message(payload, timestamp_ms=5678)
     adapted = _monitor_adapter().adapt(message)
     assert adapted.timestamp == Timestamp.from_ms(5678)
+    assert len(adapted.value.time_of_arrival) == 0
+
+
+def test_ev44_without_event_vectors_reaches_detector_events() -> None:
+    """The absent vectors must survive as empty arrays all the way into the
+    preprocessor input, not just past the timestamp extraction.
+    """
+    payload = hostile_wire.ev44_without_event_vectors(SOURCE)
+    adapter = ChainedAdapter(
+        first=KafkaToEv44Adapter(stream_kind=StreamKind.DETECTOR_EVENTS),
+        second=Ev44ToDetectorEventsAdapter(),
+    )
+    events = adapter.adapt(_kafka_message(payload, timestamp_ms=5678)).value
+    assert len(events.time_of_arrival) == 0
+    assert len(events.pixel_id) == 0
 
 
 def _far_future_cases() -> list[tuple[str, KafkaAdapter, bytes]]:

--- a/tests/preprocessors/to_nxevent_data_test.py
+++ b/tests/preprocessors/to_nxevent_data_test.py
@@ -28,6 +28,22 @@ def test_MonitorEvents_from_ev44() -> None:
 
 
 @pytest.mark.parametrize('events_cls', [MonitorEvents, DetectorEvents])
+def test_from_ev44_accepts_message_without_reference_times(
+    events_cls: MonitorEvents,
+) -> None:
+    """No reference time means no pulse, which is not a multi-pulse message."""
+    ev44 = eventdata_ev44.EventData(
+        source_name='ignored',
+        message_id=0,
+        reference_time=[],
+        reference_time_index=[],
+        pixel_id=[],
+        time_of_flight=[],
+    )
+    assert len(events_cls.from_ev44(ev44).time_of_arrival) == 0
+
+
+@pytest.mark.parametrize('events_cls', [MonitorEvents, DetectorEvents])
 def test_MonitorEvents_from_ev44_raises_with_multi_pulse_message(
     events_cls: MonitorEvents,
 ) -> None:

--- a/tests/services/hostile_input_liveness_test.py
+++ b/tests/services/hostile_input_liveness_test.py
@@ -202,6 +202,19 @@ def test_mismatched_event_vectors_do_not_stall_service(
     assert_service_live(harness)
 
 
+def test_absent_event_vectors_do_not_stall_service(
+    harness: MonitorServiceHarness,
+) -> None:
+    """A payload omitting the event vectors is accepted as carrying no events
+    (timestamp from the Kafka broker), and must neither be dropped nor upset
+    the accumulator that receives the empty chunk.
+    """
+    harness.run_good_cycles(3)
+    harness.publish_payload(hostile_wire.ev44_without_event_vectors(SOURCE))
+    harness.app.step()
+    assert_service_live(harness)
+
+
 @pytest.mark.xfail(
     strict=True,
     reason='#1038 finding 1 / #1047: a far-future data timestamp in the first '


### PR DESCRIPTION
Fixes finding 2 of #1038.

The ev44 schema does not require the event vectors, so a producer may legitimately omit them. When it does, the flatbuffers-python `*AsNumpy()` accessors return scalar `0` rather than an empty array, both ev44 adapters raise on `.size`, and the adapter-level catch-all drops the message and records it as `<error>` — the Kafka-timestamp fallback that exists for exactly this case is never reached.

Such a payload now adapts to an empty event list with the timestamp taken from the broker. Beyond the monitor adapter named in the finding, the same bug was present in `KafkaToEv44Adapter`, and the multi-pulse guard downstream indexed `reference_time_index[0]` unconditionally, so an empty index would have dropped the message anyway one step later. "No reference time" now means "no pulse", which is not multi-pulse.

The payload consequently leaves the malformed-payload corpus in `tests/helpers/hostile_wire.py`: that corpus's contract is "must be contained/dropped", which is no longer what this payload should get. Its service-liveness coverage is replaced by a dedicated test.

Note this is orthogonal to finding 1 (unvalidated data-derived timestamps, #1047) — those strict xfails are untouched and still fail.

## Test plan

- [x] Existing strict xfail `test_ev44_without_event_vectors_falls_back_to_kafka_timestamp` flips to passing, marker removed
- [x] New coverage for the detector adapter chain, `from_ev44` with no reference times, and service liveness after such a payload
- [x] Full fast suite green, with the #1047 xfails still xfailing
