### PR TITLE
Apply masks as NaN when serializing to da00

### DIFF
--- a/src/ess/livedata/kafka/scipp_da00_compat.py
+++ b/src/ess/livedata/kafka/scipp_da00_compat.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import operator
+from functools import reduce
+
 import numpy as np
 import scipp as sc
 from streaming_data_types import dataarray_da00
@@ -21,12 +24,13 @@ def scipp_to_da00(
 ) -> list[dataarray_da00.Variable]:
     # Encode DataArray.name in the 'label' field of the signal variable
     label = da.name if da.name is not None else None
-    if da.variances is None:
-        variables = [_to_da00_variable(signal_name, da.data, label=label)]
+    data = _masked_to_nan(da) if da.masks else da.data
+    if data.variances is None:
+        variables = [_to_da00_variable(signal_name, data, label=label)]
     else:
         variables = [
-            _to_da00_variable(signal_name, sc.values(da.data), label=label),
-            _to_da00_variable('errors', sc.stddevs(da.data)),
+            _to_da00_variable(signal_name, sc.values(data), label=label),
+            _to_da00_variable('errors', sc.stddevs(data)),
         ]
     variables.extend(
         [
@@ -64,6 +68,39 @@ def da00_to_scipp(
 
     # scipp expects name to be a string (empty string for "no name")
     return sc.DataArray(data, coords=compatible_coords, name=label)
+
+
+def _masked_to_nan(da: sc.DataArray) -> sc.Variable:
+    """
+    Return the data of ``da`` with masked elements (and their variances) set to NaN.
+
+    Requires ``da`` to have at least one mask.
+
+    Transporting masks is perfectly feasible: da00's variable list is generic enough
+    to carry them by naming convention. The obstacle is the consumer side. Nothing in
+    the dashboard reads ``DataArray.masks`` -- neither the buffering and extraction
+    chain nor the plotters -- so a transported mask would be dropped before it could
+    affect what is drawn. NaN is honored end to end instead: transparent image pixels,
+    gaps in curves, autoscaling and aggregation over finite values only. That is what
+    a mask is meant to convey.
+
+    Applying masks here thus discards the mask/data distinction deliberately. Adding
+    mask support across transport, dashboard data chain, and plotters is a viable
+    option should that distinction be needed.
+
+    Integer data is promoted to float64 since it cannot represent NaN.
+    """
+    mask = reduce(operator.or_, da.masks.values())
+    data = da.data
+    if data.dtype not in (sc.DType.float64, sc.DType.float32):
+        data = data.to(dtype=sc.DType.float64)
+    nan = sc.scalar(
+        np.nan,
+        unit=data.unit,
+        dtype=data.dtype,
+        variance=None if data.variances is None else np.nan,
+    )
+    return sc.where(mask, nan, data)
 
 
 def _to_da00_variable(

--- a/tests/kafka/scipp_da00_compat_test.py
+++ b/tests/kafka/scipp_da00_compat_test.py
@@ -423,3 +423,99 @@ def test_da00_to_scipp_keeps_scalar_coords():
     assert 'x' in da.coords
     assert 'temperature' in da.coords
     assert da.coords['temperature'].dims == ()
+
+
+def _signal(variables: list[dataarray_da00.Variable]) -> np.ndarray:
+    return np.asarray(next(var for var in variables if var.name == 'signal').data)
+
+
+def _errors(variables: list[dataarray_da00.Variable]) -> np.ndarray:
+    return np.asarray(next(var for var in variables if var.name == 'errors').data)
+
+
+def test_scipp_to_da00_replaces_masked_values_with_nan():
+    da = sc.DataArray(
+        data=sc.array(dims=['x'], values=[1.0, 2.0, 3.0], unit='counts'),
+        masks={'bad': sc.array(dims=['x'], values=[False, True, False])},
+    )
+
+    variables = scipp_to_da00(da)
+
+    assert np.array_equal(_signal(variables), [1.0, np.nan, 3.0], equal_nan=True)
+
+
+def test_scipp_to_da00_replaces_masked_errors_with_nan():
+    da = sc.DataArray(
+        data=sc.array(
+            dims=['x'], values=[1.0, 2.0, 3.0], variances=[0.1, 0.2, 0.3], unit='counts'
+        ),
+        masks={'bad': sc.array(dims=['x'], values=[False, True, False])},
+    )
+
+    variables = scipp_to_da00(da)
+
+    assert np.array_equal(_signal(variables), [1.0, np.nan, 3.0], equal_nan=True)
+    expected = [np.sqrt(0.1), np.nan, np.sqrt(0.3)]
+    assert np.allclose(_errors(variables), expected, equal_nan=True)
+
+
+def test_scipp_to_da00_combines_multiple_masks():
+    da = sc.DataArray(
+        data=sc.array(dims=['x'], values=[1.0, 2.0, 3.0], unit='counts'),
+        masks={
+            'a': sc.array(dims=['x'], values=[True, False, False]),
+            'b': sc.array(dims=['x'], values=[False, True, False]),
+        },
+    )
+
+    variables = scipp_to_da00(da)
+
+    assert np.array_equal(_signal(variables), [np.nan, np.nan, 3.0], equal_nan=True)
+
+
+def test_scipp_to_da00_broadcasts_mask_over_missing_dims():
+    da = sc.DataArray(
+        data=sc.ones(dims=['x', 'y'], shape=[2, 3], unit='counts'),
+        masks={'row': sc.array(dims=['x'], values=[False, True])},
+    )
+
+    variables = scipp_to_da00(da)
+
+    expected = np.array([[1.0, 1.0, 1.0], [np.nan, np.nan, np.nan]])
+    assert np.array_equal(_signal(variables), expected, equal_nan=True)
+
+
+def test_scipp_to_da00_promotes_masked_integer_data_to_float():
+    da = sc.DataArray(
+        data=sc.array(dims=['x'], values=[1, 2, 3], unit='counts'),
+        masks={'bad': sc.array(dims=['x'], values=[False, True, False])},
+    )
+
+    variables = scipp_to_da00(da)
+
+    signal = _signal(variables)
+    assert signal.dtype == np.float64
+    assert np.array_equal(signal, [1.0, np.nan, 3.0], equal_nan=True)
+
+
+def test_scipp_to_da00_preserves_dtype_when_unmasked():
+    da = sc.DataArray(data=sc.array(dims=['x'], values=[1, 2, 3], unit='counts'))
+
+    assert np.asarray(_signal(scipp_to_da00(da))).dtype == np.int64
+
+
+def test_roundtrip_with_masks_yields_nan_and_no_masks():
+    da = sc.DataArray(
+        data=sc.array(dims=['x'], values=[1.0, 2.0, 3.0], unit='counts'),
+        coords={'x': sc.array(dims=['x'], values=[10, 20, 30], unit='m')},
+        masks={'bad': sc.array(dims=['x'], values=[False, True, False])},
+    )
+
+    result = da00_to_scipp(scipp_to_da00(da))
+
+    assert len(result.masks) == 0
+    expected = sc.DataArray(
+        data=sc.array(dims=['x'], values=[1.0, np.nan, 3.0], unit='counts'),
+        coords={'x': sc.array(dims=['x'], values=[10, 20, 30], unit='m')},
+    )
+    assert sc.identical(result, expected, equal_nan=True)


### PR DESCRIPTION
Fixes the silent mask drop in `scipp_to_da00` reported in #1106.

Masked elements reached the dashboard indistinguishable from valid data. DREAM's vanadium normalization attaches a `zero_vanadium` mask over bins where the vanadium histogram is zero — in live operation plausibly at range edges while statistics accumulate. Those bins arrived as inf/garbage and were plotted as data.

## Why NaN rather than transporting masks

Not because da00 cannot carry masks — its variable list is generic enough to do so by naming convention. The obstacle is the consumer side: nothing in the dashboard reads `DataArray.masks`, neither the buffering and extraction chain nor the plotters, so a transported mask would be dropped one layer later instead. A time-varying mask would additionally break `TemporalBuffer`, whose `sc.identical` metadata check would then fail on every message and reset the buffer.

NaN, by contrast, is honored end to end: transparent image pixels, gaps in curves, finite-only autoscaling and log-scale clim, `nansum`/`nanmean` window aggregation, `-` in tables. Folding masks into the values is therefore honest on screen and needs no dashboard changes.

This discards the mask/data distinction deliberately. Adding mask support across transport, dashboard data chain, and plotters is very much on the table if that distinction turns out to be needed.

Side effect worth noting: `normalize_by_vanadium` divides by zero and produces `inf` in the masked bins, which previously reached the plots. Those are now NaN gaps.

Scope: serialization is a genuine chokepoint — `scipp_to_da00` is the only path any workflow result takes to Kafka, and nothing in the backend consumes `LIVEDATA_DATA`, so NaN cannot propagate into further reduction. Unmasked data is untouched, so there is no copy and no dtype change on the common path. Masked integer data is promoted to float64, since it cannot hold NaN.

Closes #1106.

## Test plan

- [x] Unit tests for NaN values, NaN errors, multi-mask OR, mask broadcast over missing dims, integer promotion, dtype preserved when unmasked, and full da00 round-trip.
- [x] Full fast suite passes.
