### PR TITLE
Remove reset for workflows where it is meaningless or harmful

### DIFF
--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -589,6 +589,7 @@ class Instrument:
         outputs: type[Any],
         device_outputs: dict[str, str] | None = None,
         reset_on_run_transition: bool = True,
+        supports_reset: bool = True,
     ) -> SpecHandle:
         """
         Register workflow spec, return handle for later factory attachment.
@@ -648,6 +649,7 @@ class Instrument:
             outputs=outputs,
             device_outputs=device_outputs or {},
             reset_on_run_transition=reset_on_run_transition,
+            supports_reset=supports_reset,
         )
         return self.workflow_factory.register_spec(spec, service=service)
 

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -354,6 +354,14 @@ class WorkflowSpec(BaseModel):
             "runs (e.g., timeseries)."
         ),
     )
+    supports_reset: bool = Field(
+        default=True,
+        description=(
+            "Whether jobs of this workflow support the manual reset action. "
+            "When False, the dashboard disables the reset button and the "
+            "backend rejects reset commands."
+        ),
+    )
     params: type[BaseModel] | None = Field(description="Model for workflow param.")
     outputs: type[BaseModel] = Field(
         default=DefaultOutputs,

--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -263,6 +263,7 @@ class Job:
         input_streams: set[str],
         gating_streams: set[str],
         reset_on_run_transition: bool = True,
+        supports_reset: bool = True,
     ) -> None:
         """
         Initialize a Job with the given parameters.
@@ -291,6 +292,9 @@ class Job:
             ADR 0002.
         reset_on_run_transition:
             Whether this job should be reset when a run transition occurs.
+        supports_reset:
+            Whether this job supports the manual reset action. See
+            :attr:`WorkflowSpec.supports_reset`.
         """
         self._job_id = job_id
         self._workflow_id = workflow_id
@@ -299,6 +303,7 @@ class Job:
         self._end_time: Timestamp | None = None
         self._source_names = source_names
         self._reset_on_run_transition = reset_on_run_transition
+        self._supports_reset = supports_reset
         self._input_streams: set[str] = input_streams
         self._gating_streams: set[str] = gating_streams
 
@@ -355,6 +360,10 @@ class Job:
     @property
     def reset_on_run_transition(self) -> bool:
         return self._reset_on_run_transition
+
+    @property
+    def supports_reset(self) -> bool:
+        return self._supports_reset
 
     def add(self, data: JobData) -> JobReply:
         try:

--- a/src/ess/livedata/core/job_manager.py
+++ b/src/ess/livedata/core/job_manager.py
@@ -196,6 +196,7 @@ class JobFactory:
             input_streams=set(aux_streams.values()),
             gating_streams=context_streams,
             reset_on_run_transition=workflow_spec.reset_on_run_transition,
+            supports_reset=workflow_spec.supports_reset,
         )
 
 
@@ -447,10 +448,17 @@ class JobManager:
         """
         Reset a job with the given ID.
         This will clear the processor and reset the start and end times.
+
+        Raises for jobs whose spec declares ``supports_reset=False``: the
+        dashboard does not offer reset for them, so any command reaching this
+        point is a programming error (see the spec sites for why resetting
+        such jobs would corrupt downstream data).
         """
         record = self._jobs.get(job_id)
         if record is None:
             raise KeyError(f"Job {job_id} not found.")
+        if not record.job.supports_reset:
+            raise ValueError(f"Job {job_id} does not support reset.")
         record.job.reset()
 
         # Drop retry state: a finalize error keeps has_primary_data set so the

--- a/src/ess/livedata/dashboard/widgets/buttons.py
+++ b/src/ess/livedata/dashboard/widgets/buttons.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 import panel as pn
+from bokeh.models import Tooltip
 
 from .icons import get_icon
 from .styles import HoverColors, StatusColors
@@ -134,6 +135,8 @@ def create_tool_button(
     hover_color: str,
     on_click_callback: Callable[[], None],
     css_classes: list[str] | None = None,
+    disabled: bool = False,
+    description: str | None = None,
 ) -> pn.widgets.Button:
     """
     Create a styled tool button.
@@ -155,12 +158,27 @@ def create_tool_button(
         ``lt-tool-{icon_name}`` classes; callers pass context (e.g. a workflow
         name) for finer targeting. These classes have no associated style rules
         and are visually inert.
+    disabled:
+        Whether the button is disabled.
+    description:
+        Tooltip text shown on hover. Anchored to the left of the button:
+        tool buttons typically sit at the right edge of their row, where the
+        default right-anchored tooltip would be clipped by the viewport.
 
     Returns
     -------
     :
         Panel Button widget styled as a tool button.
     """
+    tooltip = (
+        Tooltip(
+            content=description,
+            position='left',
+            stylesheets=[':host { white-space: initial; max-width: 300px; }'],
+        )
+        if description is not None
+        else None
+    )
     button = pn.widgets.Button(
         label='',
         icon=get_icon(icon_name),
@@ -170,6 +188,8 @@ def create_tool_button(
         color='light',
         sizing_mode='fixed',
         margin=0,
+        disabled=disabled,
+        description=tooltip,
         css_classes=['lt-tool', f'lt-tool-{icon_name}', *(css_classes or [])],
         stylesheets=create_tool_button_stylesheet(button_color, hover_color),
     )

--- a/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
+++ b/src/ess/livedata/dashboard/widgets/workflow_status_widget.py
@@ -455,12 +455,21 @@ class WorkflowStatusWidget:
             )
             buttons.append(stop_btn)
 
+            supports_reset = self._workflow_spec.supports_reset
             reset_btn = create_tool_button(
                 icon_name='backspace',
                 button_color=StatusColors.MUTED,
                 hover_color=HoverColors.MUTED,
                 on_click_callback=self._on_reset_click,
                 css_classes=[self._tool_css_class],
+                disabled=not supports_reset,
+                description=None
+                if supports_reset
+                else (
+                    'This workflow does not support reset: its outputs '
+                    'represent current state, not data accumulated since '
+                    'a start point.'
+                ),
             )
             buttons.append(reset_btn)
 

--- a/src/ess/livedata/workflows/timeseries_workflow_specs.py
+++ b/src/ess/livedata/workflows/timeseries_workflow_specs.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import pydantic
 import scipp as sc
 
 from ..config.instrument import Instrument
-from ..config.workflow_spec import TIMESERIES, WorkflowOutputsBase
+from ..config.workflow_spec import TIMESERIES, OutputView, WorkflowOutputsBase
 from .workflow_factory import SpecHandle
 
 
@@ -22,6 +24,15 @@ class TimeseriesOutputs(WorkflowOutputsBase):
     it signals that the data carries its own wall-clock timestamps, so
     ``_add_time_coords`` will not attach ``start_time``/``end_time``.
     """
+
+    output_views: ClassVar[tuple[OutputView, ...]] = (
+        OutputView(
+            name='delta',
+            title='Timeseries',
+            fields={'per_update': 'delta'},
+            description='Timestamped device values; plots accumulate the history.',
+        ),
+    )
 
     delta: sc.DataArray = pydantic.Field(
         default_factory=lambda: sc.DataArray(
@@ -66,4 +77,10 @@ def register_timeseries_workflow_specs(
         source_names=source_names,
         outputs=TimeseriesOutputs,
         reset_on_run_transition=False,
+        # Reset would clear only the job's publication bookkeeping while the
+        # shared ToNXlog preprocessor keeps its cumulative buffer, so the next
+        # finalize re-emits the full history as a delta and every downstream
+        # buffer duplicates it. Restarting the workflow already provides
+        # correct clear-and-refill semantics via the generation flip.
+        supports_reset=False,
     )

--- a/src/ess/livedata/workflows/wavelength_lut_workflow_specs.py
+++ b/src/ess/livedata/workflows/wavelength_lut_workflow_specs.py
@@ -287,4 +287,7 @@ def register_wavelength_lut_workflow_spec(
         params=params,
         outputs=WavelengthLutOutputs,
         reset_on_run_transition=False,
+        # The LUT is recomputed from the retained chopper-setpoint history on
+        # the next trigger regardless, so a reset achieves nothing.
+        supports_reset=False,
     )

--- a/tests/core/job_manager_test.py
+++ b/tests/core/job_manager_test.py
@@ -32,12 +32,18 @@ class SimpleTestOutputs(WorkflowOutputsBase):
 class FakeJobFactory(JobFactory):
     """Fake implementation of JobFactory for testing."""
 
-    def __init__(self, reset_on_run_transition: dict[WorkflowId, bool] | None = None):
+    def __init__(
+        self,
+        reset_on_run_transition: dict[WorkflowId, bool] | None = None,
+        supports_reset: dict[WorkflowId, bool] | None = None,
+    ):
         self.created_jobs = []
         self.processors: dict[JobId, FakeProcessor] = {}
-        # Faithful analog of the real factory reading reset_on_run_transition from
-        # the workflow spec: tests configure it per workflow, defaulting to True.
+        # Faithful analog of the real factory reading reset_on_run_transition and
+        # supports_reset from the workflow spec: tests configure them per
+        # workflow, defaulting to True.
         self._reset_on_run_transition = reset_on_run_transition or {}
+        self._supports_reset = supports_reset or {}
 
     def get_workflow_spec(self, workflow_id):
         """Return None for tests - no enrichment needed in test scenarios."""
@@ -67,6 +73,7 @@ class FakeJobFactory(JobFactory):
             reset_on_run_transition=self._reset_on_run_transition.get(
                 config.identifier, True
             ),
+            supports_reset=self._supports_reset.get(config.identifier, True),
         )
 
         self.created_jobs.append((job_id, config))
@@ -368,6 +375,27 @@ class TestJobManager:
 
         with pytest.raises(KeyError, match="Job 999 not found"):
             manager.reset_job(999)
+
+    def test_reset_job_unsupported_raises_and_leaves_job_untouched(self):
+        """A reset command for a supports_reset=False job is rejected."""
+        config = _make_config("test_source")
+        factory = FakeJobFactory(supports_reset={config.identifier: False})
+        manager = JobManager(factory, context_reader=no_cached_context)
+
+        job_id = manager.schedule_job(config)
+        manager.push_data(
+            WorkflowData(
+                start_time=Timestamp.from_ns(100),
+                end_time=Timestamp.from_ns(200),
+                data={StreamId(name="test_source"): sc.scalar(42.0)},
+            )
+        )
+
+        with pytest.raises(ValueError, match="does not support reset"):
+            manager.reset_job(job_id)
+
+        assert factory.processors[job_id].clear_calls == 0
+        assert manager.active_jobs[0].start_time == Timestamp.from_ns(100)
 
     def test_job_command_reset_by_workflow_id_resets_all_its_sources_only(
         self, fake_job_factory

--- a/tests/dashboard/widgets/workflow_status_widget_test.py
+++ b/tests/dashboard/widgets/workflow_status_widget_test.py
@@ -74,6 +74,15 @@ def _has_icon(icons: list[str | None], icon_name: str) -> bool:
     return expected_icon in icons
 
 
+def _get_reset_button(buttons) -> pn.widgets.Button:
+    """Return the reset tool button from a collection of header buttons."""
+    return next(
+        obj
+        for obj in buttons
+        if isinstance(obj, pn.widgets.Button) and 'lt-tool-backspace' in obj.css_classes
+    )
+
+
 @pytest.fixture
 def job_service():
     """Create a JobService for testing."""
@@ -403,6 +412,44 @@ class TestWorkflowStatusWidget:
         button_icons = _get_button_icons(header_buttons)
         assert not _has_icon(button_icons, 'player-play')  # No play button
         assert _has_icon(button_icons, 'player-stop')  # Stop button
+
+    def test_reset_button_enabled_when_spec_supports_reset(
+        self, workflow_status_widget, job_orchestrator, workflow_id
+    ):
+        job_orchestrator.stage_config(
+            workflow_id,
+            source_name='source1',
+            params={'threshold': 100.0},
+            aux_source_names={},
+        )
+        job_orchestrator.commit_workflow(workflow_id)
+        workflow_status_widget._build_widget()
+
+        reset_btn = _get_reset_button(workflow_status_widget._create_header_buttons())
+        assert not reset_btn.disabled
+        assert reset_btn.description is None
+
+    def test_reset_button_disabled_with_tooltip_when_spec_does_not_support_reset(
+        self, workflow_spec, workflow_id, job_orchestrator, job_service
+    ):
+        widget = WorkflowStatusWidget(
+            workflow_id=workflow_id,
+            workflow_spec=workflow_spec.model_copy(update={'supports_reset': False}),
+            orchestrator=job_orchestrator,
+            job_service=job_service,
+        )
+        job_orchestrator.stage_config(
+            workflow_id,
+            source_name='source1',
+            params={'threshold': 100.0},
+            aux_source_names={},
+        )
+        job_orchestrator.commit_workflow(workflow_id)
+        widget._build_widget()
+
+        reset_btn = _get_reset_button(widget._create_header_buttons())
+        assert reset_btn.disabled
+        assert 'does not support reset' in reset_btn.description.content
 
     def test_header_shows_play_button_when_running_with_modified_staged(
         self, workflow_status_widget, job_orchestrator, workflow_id


### PR DESCRIPTION
Addresses finding 3 of #1037.

## Why

`JobAction.reset` clears only the workflow, not the shared `ToNXlog` preprocessor buffer. For a timeseries job this resets the publication index to zero, so the next finalize re-emits the entire history as a `'delta'` that every downstream buffer appends unconditionally — duplicating every point already displayed (and silently double-counting in correlation histograms using the stream as an axis). Clearing the preprocessor instead would be worse: it is shared by reference across all jobs consuming the stream (e.g. BIFROST's angle lookup table).

Timeseries outputs represent state, not accumulation since a start point, so reset has no meaningful semantics for them. Restarting the workflow already provides correct clear-and-refill behavior: the commit path's generation flip clears the dashboard buffers, and the freshly activated job is seeded with the full cached history. The wavelength LUT similarly recomputes from retained chopper history on the next trigger, so reset is a pointless affordance there too.

## What

- New `WorkflowSpec.supports_reset` flag, `False` for the timeseries and wavelength-LUT workflows.
- The dashboard disables the reset button for such workflows, with a tooltip explaining why (left-anchored so it is not clipped at the viewport edge).
- `JobManager.reset_job` rejects reset commands for such jobs — the UI no longer sends them, so any arrival is a programming error and surfaces as a logged `job_command_failed`.
- `TimeseriesOutputs` now declares its output view instead of relying on synthesis, which labelled the delta field `since_start` (run-cumulative — the opposite of its per-update semantics) and exposed the raw field name `delta` as the view name; the view is now titled "Timeseries".

## Test plan

- Unit tests for the backend guard and the disabled-button state.
- Verified in the browser (fake backend, dummy instrument): timeseries reset button renders disabled with the explanatory tooltip; other workflows' reset buttons unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
