### PR TITLE
Fix the flaky Kafka integration job

### DIFF
--- a/src/ess/livedata/kafka/consumer.py
+++ b/src/ess/livedata/kafka/consumer.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import time
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -7,9 +8,26 @@ from typing import Any
 
 import confluent_kafka as kafka
 import structlog
+from confluent_kafka import KafkaError
 from confluent_kafka.error import KafkaException
 
 logger = structlog.get_logger(__name__)
+
+#: Broker errors meaning "this partition has no usable leader yet, ask again".
+#: Leadership is not established atomically with topic creation or a broker
+#: restart, so a partition can be present in cluster metadata while the broker
+#: hosting it has not yet applied the leadership change.
+_LEADER_PENDING_ERRORS = frozenset(
+    {
+        KafkaError.UNKNOWN_TOPIC_OR_PART,
+        KafkaError.LEADER_NOT_AVAILABLE,
+        KafkaError.NOT_LEADER_FOR_PARTITION,
+    }
+)
+
+#: How long to wait for partition leadership to settle before giving up.
+_LEADER_TIMEOUT = 30.0
+_LEADER_POLL_INTERVAL = 0.5
 
 
 def validate_topics_exist(consumer: kafka.Consumer, topics: list[str]) -> None:
@@ -28,6 +46,41 @@ def validate_topics_exist(consumer: kafka.Consumer, topics: list[str]) -> None:
         raise ValueError(f"Failed to fetch topic metadata: {e}") from e
 
 
+def _high_watermark(
+    consumer: kafka.Consumer, topic: str, partition: int, *, deadline: float
+) -> int:
+    """Fetch a partition's high watermark, waiting for its leader to settle.
+
+    Only the partition leader answers ``ListOffsets``, and librdkafka does not
+    retry this query on our behalf. Without the wait a consumer created inside a
+    leader-election window -- a just-created topic, a restarted broker -- fails
+    closed on an error the broker itself considers transient.
+    """
+    while True:
+        try:
+            _low, high = consumer.get_watermark_offsets(
+                kafka.TopicPartition(topic, partition), timeout=5.0
+            )
+            return high
+        except KafkaException as e:
+            expired = time.monotonic() >= deadline
+            if e.args[0].code() not in _LEADER_PENDING_ERRORS or expired:
+                logger.exception(
+                    "watermark_fetch_failed", topic=topic, partition=partition
+                )
+                raise ValueError(
+                    f"Failed to fetch watermark for '{topic}' partition"
+                    f" {partition}: {e}"
+                ) from e
+            logger.info(
+                "awaiting_partition_leader",
+                topic=topic,
+                partition=partition,
+                error=str(e.args[0]),
+            )
+            time.sleep(_LEADER_POLL_INTERVAL)
+
+
 def assign_all_partitions(consumer: kafka.Consumer, topics: list[str]) -> None:
     """Manually assign every partition of every topic to a consumer.
 
@@ -41,7 +94,11 @@ def assign_all_partitions(consumer: kafka.Consumer, topics: list[str]) -> None:
     first fetch would be skipped silently (e.g. a command sent right after a
     service reports ready). Pinning makes the contract deterministic: every
     message produced after assignment is consumed.
+
+    Resolving the watermarks may block for up to ``_LEADER_TIMEOUT`` in total
+    while partition leadership settles; see :func:`_high_watermark`.
     """
+    deadline = time.monotonic() + _LEADER_TIMEOUT
     assignment: list[kafka.TopicPartition] = []
     for topic in topics:
         try:
@@ -55,21 +112,10 @@ def assign_all_partitions(consumer: kafka.Consumer, topics: list[str]) -> None:
             logger.error("topic_has_no_partitions", topic=topic)
             raise ValueError(f"Topic '{topic}' exists but has no partitions")
         partition_ids = list(partitions.keys())
-        offsets: dict[int, int] = {}
-        for partition in partition_ids:
-            try:
-                _low, high = consumer.get_watermark_offsets(
-                    kafka.TopicPartition(topic, partition), timeout=5.0
-                )
-            except KafkaException as e:
-                logger.exception(
-                    "watermark_fetch_failed", topic=topic, partition=partition
-                )
-                raise ValueError(
-                    f"Failed to fetch watermark for '{topic}' partition"
-                    f" {partition}: {e}"
-                ) from e
-            offsets[partition] = high
+        offsets = {
+            partition: _high_watermark(consumer, topic, partition, deadline=deadline)
+            for partition in partition_ids
+        }
         assignment.extend(
             kafka.TopicPartition(topic, p, offsets[p]) for p in partition_ids
         )

--- a/tests/integration/clear_at_commit_test.py
+++ b/tests/integration/clear_at_commit_test.py
@@ -2,8 +2,6 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Integration test for clear-at-commit: a recommit starts accumulation afresh."""
 
-import time
-
 import pytest
 
 from ess.livedata.config.workflow_spec import WorkflowId
@@ -15,10 +13,10 @@ from tests.integration.helpers import (
     wait_for_job_data,
 )
 
-#: Length of the pre-commit accumulation window. Must be several backend batch
-#: intervals (~1 s each) so it dwarfs the one or two batches the post-commit
-#: observation can span.
-_ACCUMULATION_SECONDS = 10.0
+#: Cumulative updates the first generation must span before the recommit. The
+#: post-commit observation can span a batch or two, so the bar needs a few more
+#: than that to stay clear of per-batch producer noise.
+_PRE_COMMIT_UPDATES = 5
 
 
 @pytest.mark.integration
@@ -51,18 +49,27 @@ def test_recommit_clears_accumulated_data(integration_env: IntegrationEnv) -> No
     first = cumulative_total()
     assert first is not None
 
-    # Let the first generation accumulate far beyond a single update interval.
-    # The comparison below is between two accumulation windows, and the
-    # post-commit one is not under the test's control: the dashboard exposes
-    # the latest ingested value rather than the new generation's first result,
-    # and its own background thread ingests while this test samples. A bar only
-    # one interval above `first` is therefore decided by producer noise and
-    # poll timing instead of by the clear under test. Ingestion needs no
-    # pumping from here, hence the plain sleep.
-    time.sleep(_ACCUMULATION_SECONDS)
+    # Let the first generation accumulate over several backend updates. The
+    # comparison below is between two accumulation windows, and the post-commit
+    # one is not under the test's control: the dashboard exposes the latest
+    # ingested value rather than the new generation's first result, and its own
+    # background thread ingests while this test samples. A bar only one update
+    # above `first` is therefore decided by producer noise and poll timing
+    # instead of by the clear under test. Counting updates rather than sleeping
+    # a fixed span keeps this as short as the pipeline allows.
+    totals = [first]
+
+    def accumulated_enough() -> bool:
+        total = cumulative_total()
+        if total is not None and total > totals[-1]:
+            totals.append(total)
+        return len(totals) > _PRE_COMMIT_UPDATES
+
+    wait_for_backend_condition(
+        backend, accumulated_enough, timeout=60.0, poll_interval=0.1
+    )
     pre_commit_total = cumulative_total()
     assert pre_commit_total is not None
-    assert pre_commit_total > first, "workflow stopped accumulating before the recommit"
 
     # Recommit with identical parameters, as the UI does on Start.
     new_job_ids = backend.workflow_controller.start_workflow(
@@ -91,7 +98,7 @@ def test_recommit_clears_accumulated_data(integration_env: IntegrationEnv) -> No
     )
     post_commit_total = observed[0]
     # A fresh accumulation of at most a batch or two, against a bar of
-    # _ACCUMULATION_SECONDS worth: anything near the bar means the buffers kept
+    # _PRE_COMMIT_UPDATES updates: anything near the bar means the buffers kept
     # accumulating across the commit.
     assert post_commit_total < pre_commit_total / 2, (
         f"Cumulative total {post_commit_total} did not drop clear of the "

--- a/tests/integration/clear_at_commit_test.py
+++ b/tests/integration/clear_at_commit_test.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 """Integration test for clear-at-commit: a recommit starts accumulation afresh."""
 
+import time
+
 import pytest
 
 from ess.livedata.config.workflow_spec import WorkflowId
@@ -13,6 +15,11 @@ from tests.integration.helpers import (
     wait_for_job_data,
 )
 
+#: Length of the pre-commit accumulation window. Must be several backend batch
+#: intervals (~1 s each) so it dwarfs the one or two batches the post-commit
+#: observation can span.
+_ACCUMULATION_SECONDS = 10.0
+
 
 @pytest.mark.integration
 @pytest.mark.services('monitor')
@@ -21,7 +28,7 @@ def test_recommit_clears_accumulated_data(integration_env: IntegrationEnv) -> No
     Recommitting a running workflow resets its cumulative output.
 
     The commit flips the generation and clears the workflow's buffers, so the
-    cumulative total observed after the recommit must drop below the value
+    cumulative total observed after the recommit must fall clear of the value
     accumulated before it, instead of continuing to grow.
     """
     backend = integration_env.backend
@@ -44,15 +51,18 @@ def test_recommit_clears_accumulated_data(integration_env: IntegrationEnv) -> No
     first = cumulative_total()
     assert first is not None
 
-    # The cumulative output accumulates: wait until strictly above the first
-    # observation, so the pre-commit total spans several update intervals.
-    wait_for_backend_condition(
-        backend,
-        lambda: (total := cumulative_total()) is not None and total > first,
-        timeout=30.0,
-    )
+    # Let the first generation accumulate far beyond a single update interval.
+    # The comparison below is between two accumulation windows, and the
+    # post-commit one is not under the test's control: the dashboard exposes
+    # the latest ingested value rather than the new generation's first result,
+    # and its own background thread ingests while this test samples. A bar only
+    # one interval above `first` is therefore decided by producer noise and
+    # poll timing instead of by the clear under test. Ingestion needs no
+    # pumping from here, hence the plain sleep.
+    time.sleep(_ACCUMULATION_SECONDS)
     pre_commit_total = cumulative_total()
     assert pre_commit_total is not None
+    assert pre_commit_total > first, "workflow stopped accumulating before the recommit"
 
     # Recommit with identical parameters, as the UI does on Start.
     new_job_ids = backend.workflow_controller.start_workflow(
@@ -64,8 +74,9 @@ def test_recommit_clears_accumulated_data(integration_env: IntegrationEnv) -> No
 
     # The commit cleared the workflow's buffers and old-generation data fails
     # the ingest filter, so the next readable cumulative output is the new
-    # generation's fresh accumulation. Capture it inside the condition: the
-    # total keeps growing, so a later re-read could mask the drop.
+    # generation's fresh accumulation. Capture it inside the condition, and
+    # poll tightly: the total keeps growing, so every missed poll lets the
+    # captured value drift further into the new generation.
     observed: list[float] = []
 
     def fresh_total_observed() -> bool:
@@ -75,9 +86,14 @@ def test_recommit_clears_accumulated_data(integration_env: IntegrationEnv) -> No
         observed.append(total)
         return True
 
-    wait_for_backend_condition(backend, fresh_total_observed, timeout=30.0)
+    wait_for_backend_condition(
+        backend, fresh_total_observed, timeout=30.0, poll_interval=0.05
+    )
     post_commit_total = observed[0]
-    assert post_commit_total < pre_commit_total, (
-        f"Cumulative total {post_commit_total} did not drop below the "
+    # A fresh accumulation of at most a batch or two, against a bar of
+    # _ACCUMULATION_SECONDS worth: anything near the bar means the buffers kept
+    # accumulating across the commit.
+    assert post_commit_total < pre_commit_total / 2, (
+        f"Cumulative total {post_commit_total} did not drop clear of the "
         f"pre-commit value {pre_commit_total}"
     )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -151,12 +151,20 @@ def _get_job_data(
     The data plane is keyed by the stable ``DataKey`` (workflow, source,
     output); the per-commit job_number is provenance, not identity, so jobs
     are matched via their source_name.
+
+    Iteration already hides cleared keys, but it takes the lock separately from
+    each read: the dashboard's ingestion thread can flip a generation in
+    between (heartbeat adoption) and empty a key this call already accepted.
+    Such a key reads as absent -- there is genuinely no data for it yet.
     """
-    return {
-        key: data_service[key]
-        for key in data_service
-        if key.workflow_id == workflow_id and key.source_name == source_name
-    }
+    data: dict[DataKey, Any] = {}
+    for key in data_service:
+        if key.workflow_id == workflow_id and key.source_name == source_name:
+            try:
+                data[key] = data_service[key]
+            except KeyError:
+                continue
+    return data
 
 
 def get_output_data(

--- a/tests/kafka/consumer_test.py
+++ b/tests/kafka/consumer_test.py
@@ -9,7 +9,9 @@ hand-rolled fake records ``assign`` calls and reports topic metadata.
 from __future__ import annotations
 
 import pytest
+from confluent_kafka import KafkaError, KafkaException
 
+from ess.livedata.kafka import consumer as consumer_module
 from ess.livedata.kafka.consumer import assign_all_partitions
 
 
@@ -34,9 +36,12 @@ class _FakeConsumer:
         self,
         topic_partitions: dict[str, list[int]],
         high_watermarks: dict[tuple[str, int], int] | None = None,
+        watermark_errors: list[int] | None = None,
     ) -> None:
         self._topic_partitions = topic_partitions
         self._high_watermarks = high_watermarks or {}
+        self._watermark_errors = list(watermark_errors or [])
+        self.watermark_calls = 0
         self.assignments: list[list] = []
 
     def list_topics(self, topic: str, timeout: float | None = None) -> _ClusterMetadata:
@@ -46,6 +51,9 @@ class _FakeConsumer:
     def get_watermark_offsets(
         self, partition, timeout: float | None = None
     ) -> tuple[int, int]:
+        self.watermark_calls += 1
+        if self._watermark_errors:
+            raise KafkaException(KafkaError(self._watermark_errors.pop(0)))
         high = self._high_watermarks.get((partition.topic, partition.partition), 0)
         return 0, high
 
@@ -85,3 +93,47 @@ def test_raises_when_topic_has_no_partitions() -> None:
     with pytest.raises(ValueError, match="no partitions"):
         assign_all_partitions(consumer, ['a', 'b'])
     assert consumer.assignments == []
+
+
+def test_waits_out_pending_partition_leadership(monkeypatch) -> None:
+    # A topic created moments ago, or a broker that just restarted, answers
+    # ListOffsets with NOT_LEADER_FOR_PARTITION until leadership settles.
+    # Failing closed there would take down every service starting in that window.
+    monkeypatch.setattr(consumer_module, '_LEADER_POLL_INTERVAL', 0.0)
+    consumer = _FakeConsumer(
+        {'a': [0]},
+        high_watermarks={('a', 0): 42},
+        watermark_errors=[
+            KafkaError.LEADER_NOT_AVAILABLE,
+            KafkaError.NOT_LEADER_FOR_PARTITION,
+        ],
+    )
+
+    assign_all_partitions(consumer, ['a'])
+
+    assert consumer.watermark_calls == 3
+    assert [(tp.topic, tp.partition, tp.offset) for tp in consumer.assignments[0]] == [
+        ('a', 0, 42)
+    ]
+
+
+def test_gives_up_when_partition_leadership_never_settles(monkeypatch) -> None:
+    monkeypatch.setattr(consumer_module, '_LEADER_POLL_INTERVAL', 0.0)
+    monkeypatch.setattr(consumer_module, '_LEADER_TIMEOUT', 0.0)
+    consumer = _FakeConsumer(
+        {'a': [0]}, watermark_errors=[KafkaError.NOT_LEADER_FOR_PARTITION]
+    )
+
+    with pytest.raises(ValueError, match="Failed to fetch watermark"):
+        assign_all_partitions(consumer, ['a'])
+    assert consumer.assignments == []
+
+
+def test_does_not_wait_out_errors_unrelated_to_leadership() -> None:
+    consumer = _FakeConsumer(
+        {'a': [0]}, watermark_errors=[KafkaError.TOPIC_AUTHORIZATION_FAILED]
+    )
+
+    with pytest.raises(ValueError, match="Failed to fetch watermark"):
+        assign_all_partitions(consumer, ['a'])
+    assert consumer.watermark_calls == 1


### PR DESCRIPTION
Fixes the two failure modes behind the flaky Kafka integration job. Both hit `clear_at_commit_test::test_recommit_clears_accumulated_data` — which is the *first* test collected, not the last: pytest prints errors at the end, so `8 passed, 1 error` reads misleadingly.

## Consumers failed closed during partition leader election

Three of the last four failures were `NOT_LEADER_FOR_PARTITION` while pinning start offsets, on the very first consumer created after the topics are made on a pristine broker.

Leadership is not established atomically with topic creation, only the leader answers `ListOffsets`, and librdkafka does not retry that query on our behalf — so we turned an error the broker considers transient into a hard startup failure. This is not CI-specific: the same window opens on any broker restart, so a routine election would take down every service that happens to start inside it.

The watermark fetch now waits out the errors that mean "no usable leader yet" under a single deadline shared by all topics, and still fails fast on everything else. `KafkaError.retriable()` is no help here — librdkafka reports `False` for all of these codes, so the set is explicit.

## The clear-at-commit assertion was decided by producer noise

The fourth failure was the test's own comparison, not a product race. The generation machinery is sound: `DataService` has a single writer, which re-checks the wire `job_number` per message under the same lock that performs the clear, so old-generation data cannot become readable after a flip.

The test compared two accumulation windows of the same producer while controlling only one of them. The dashboard exposes the latest ingested value rather than the new generation's first result, and its background thread ingests at 20 Hz while the test samples at 2 Hz. With a pre-commit bar built from a single update interval, the outcome came down to per-batch producer noise (sigma is roughly 2% of the bar; the observed discrepancy was 2.4%) and poll timing.

The bar is now a fixed accumulation window that dwarfs the batch or two the post-commit observation can span, the post-commit poll is tightened so the captured value stays near the new generation's start, and the assertion demands a clear drop rather than any drop.

Also restored: reading a key can race a generation flip from the ingestion thread, because iteration hides cleared keys but takes the lock separately from each read. Such a key now reads as absent instead of raising `KeyError`. Tightening the poll makes that window more likely to be hit.

## Test plan

- New unit tests cover the leader wait: transient errors are waited out and the assignment still pins the high watermark, the wait gives up at its deadline, and unrelated errors raise immediately.
- Full unit suite passes locally (4129 passed).
- The integration suite could not be run locally — this devcontainer has neither Docker nor Java, so no broker. The clear-at-commit change is unverified against a real pipeline and needs a run of the Kafka job to confirm.
