### PR TITLE
Make the rate-aware batcher the default

### DIFF
--- a/docs/developer/design/message-flow-and-transformation.md
+++ b/docs/developer/design/message-flow-and-transformation.md
@@ -200,9 +200,13 @@ Groups messages into time-aligned windows for time-aligned processing, job sched
 
 `MessageBatch` = `(start_time, end_time, messages)`. Times in nanoseconds, `[start_time, end_time)` (inclusive, exclusive).
 
+### RateAwareMessageBatcher
+
+Default inner batcher (wrapped by `AdaptiveMessageBatcher`, selected via `--batcher`). Per-stream rate estimation and pulse-slot completion; wall-clock liveness backstop re-places a window the buffered traffic cannot close (placement stays data-time driven — see the module's clock policy). See the [rate-aware batcher explainer](rate-aware-batcher.md).
+
 ### SimpleMessageBatcher
 
-Time-aligned batching used by `OrchestratingProcessor`. Initial batch contains all messages; subsequent batches aligned to `batch_length_s` intervals. Late messages included in next batch. Empty batches returned when next batch starts. Batch completion triggered by first message for next batch.
+Fixed time-aligned batching, retained as `--batcher simple` fallback until the rate-aware batcher has proven itself in production. Initial batch contains all messages; subsequent batches aligned to `batch_length_s` intervals. Late messages included in next batch. Empty batches returned when next batch starts. Batch completion triggered by first message for next batch.
 
 **Important**: Relies on message timestamps (not wall-clock time). If messages stop arriving, current batch may never complete.
 

--- a/src/ess/livedata/service_factory.py
+++ b/src/ess/livedata/service_factory.py
@@ -304,10 +304,12 @@ class DataServiceRunner:
         self._parser.add_argument(
             '--batcher',
             choices=list(_INNER_BATCHER_FACTORIES),
-            default='simple',
-            help='Inner batcher wrapped by AdaptiveMessageBatcher: "simple" uses'
-            ' SimpleMessageBatcher (pre-existing default); "rate-aware" uses'
-            ' RateAwareMessageBatcher (per-stream pulse-slot completion).',
+            default='rate-aware',
+            help='Inner batcher wrapped by AdaptiveMessageBatcher: "rate-aware"'
+            ' (default) uses RateAwareMessageBatcher (per-stream pulse-slot'
+            ' completion, wall-clock liveness backstop); "simple" uses'
+            ' SimpleMessageBatcher, retained as a fallback until the rate-aware'
+            ' batcher has proven itself in production.',
         )
         self._parser.add_argument(
             '--check',

--- a/tests/services/hostile_input_liveness_test.py
+++ b/tests/services/hostile_input_liveness_test.py
@@ -7,19 +7,19 @@ poll as a batch and therefore cannot detect the most severe corruption class
 found in the backend audit (#1038): inputs that stall the *production*
 batcher, silently stopping all output service-wide while the process looks
 healthy. This harness runs the monitor service with the production-default
-``AdaptiveMessageBatcher`` (wrapping ``SimpleMessageBatcher``, which uses
-data-derived timestamps as its only clock) and asserts one invariant:
+``AdaptiveMessageBatcher`` and asserts one invariant:
 
     After consuming any single hostile payload, the service still publishes
     results for subsequent well-formed data.
 
 Payloads come from ``tests/helpers/hostile_wire``.
 
-Every test runs against both inner batchers: ``SimpleMessageBatcher`` and
-``RateAwareMessageBatcher``, which production selects per instrument via
-``--batcher``. The two reach batch closure by different mechanisms (fixed
-windows versus per-stream pulse-slot gating), so a hostile input that stalls
-one need not stall the other, and both are deployed.
+Every test runs against both inner batchers, selected in production via
+``--batcher``: ``RateAwareMessageBatcher`` (the default) and
+``SimpleMessageBatcher`` (retained as a fallback until the rate-aware batcher
+has proven itself in production). The two reach batch closure by different
+mechanisms (fixed windows versus per-stream pulse-slot gating), so a hostile
+input that stalls one need not stall the other.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why

The rate-aware batcher prevents oscillation in outputs, steming from a variable number of source messages contributing to a given output message. This has been tested for a while already in PROD for BIFROST. We now switch this on for all instruments.

As a secondary reason, with the hardening and wall-clock liveness backstop from #1122 in place, the rate-aware batcher recovers from every timestamp pathology in the liveness suite, while the simple batcher retains two wedges pinned as strict xfails (lone far-future startup timestamp; parked future message across a silence gap). Flipping the default gives every instrument the backstop and builds production confidence toward removing the simple batcher entirely; `--batcher simple` stays available as a rollback until then.

## What changed

The `--batcher` CLI default flips to `rate-aware`; help text and docs updated to match. The Python-level `AdaptiveMessageBatcher` inner default remains `SimpleMessageBatcher` (`message_batcher.py` cannot import the rate-aware module without a cycle; production wiring goes through the CLI).

## Test plan

The service-level hostile-input liveness suite already runs against both inner batchers, so the new default is covered by the same invariants as before the flip. Deployment configs that pass `--batcher rate-aware` explicitly become redundant but stay valid.

- [ ] After merge and deploy: monitor `batcher_stall_recovery` warnings and per-instrument output cadence for a soak period before opening the simple-batcher removal PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
