### PR TITLE
Stamp window bounds on AreaDetectorView 'current' output

### DIFF
--- a/src/ess/livedata/workflows/area_detector_view.py
+++ b/src/ess/livedata/workflows/area_detector_view.py
@@ -37,6 +37,7 @@ class AreaDetectorView(Workflow):
         self._cumulative: sc.DataArray | None = None
         self._previous: sc.DataArray | None = None
         self._current_start_time: Timestamp | None = None
+        self._current_end_time: Timestamp | None = None
 
     def accumulate(
         self, data: dict[str, Any], *, start_time: Timestamp, end_time: Timestamp
@@ -53,7 +54,6 @@ class AreaDetectorView(Workflow):
         end_time:
             End time of the data window in nanoseconds since epoch.
         """
-        _ = end_time  # unused
         if len(data) != 1:
             raise ValueError("AreaDetectorView expects exactly one detector data item.")
 
@@ -74,8 +74,10 @@ class AreaDetectorView(Workflow):
                 self._previous = None
                 self._current_start_time = None
 
+        # Track time range of data since last finalize.
         if self._current_start_time is None:
             self._current_start_time = start_time
+        self._current_end_time = end_time
 
     def finalize(self) -> dict[str, sc.DataArray]:
         """
@@ -98,9 +100,18 @@ class AreaDetectorView(Workflow):
             current = current - self._previous
         self._previous = cumulative
 
-        time_coord = self._current_start_time.to_scipp()
-        current = current.assign_coords(time=time_coord)
+        # 'current' covers only the window since the last finalize, so it carries
+        # its own bounds instead of the job-level ones Job._add_time_coords would
+        # otherwise stamp. 'cumulative' has no time coords and gets those.
+        start_time_coord = self._current_start_time.to_scipp()
+        end_time_coord = self._current_end_time.to_scipp()
+        current = current.assign_coords(
+            time=start_time_coord,
+            start_time=start_time_coord,
+            end_time=end_time_coord,
+        )
         self._current_start_time = None
+        self._current_end_time = None
 
         return {'cumulative': cumulative, 'current': current}
 
@@ -109,6 +120,7 @@ class AreaDetectorView(Workflow):
         self._cumulative = None
         self._previous = None
         self._current_start_time = None
+        self._current_end_time = None
 
     @staticmethod
     def view_factory(

--- a/tests/workflows/area_detector_view_test.py
+++ b/tests/workflows/area_detector_view_test.py
@@ -164,3 +164,128 @@ class TestAreaDetectorView:
 
         with pytest.raises(RuntimeError, match="finalize called without"):
             workflow.finalize()
+
+
+def _bounds(da: sc.DataArray) -> tuple[int, int]:
+    return da.coords['start_time'].value, da.coords['end_time'].value
+
+
+class TestAreaDetectorViewWindowBounds:
+    """The 'current' output must carry the bounds of the window it covers.
+
+    The dashboard derives freshness/lag and counts-per-second normalization from
+    start_time/end_time, and Job._add_time_coords deliberately leaves outputs that
+    set their own time coords alone.
+    """
+
+    @pytest.fixture
+    def workflow(self) -> AreaDetectorView:
+        return AreaDetectorView(
+            raw.LogicalView(transform=lambda da: da, input_sizes={'y': 4, 'x': 4})
+        )
+
+    @pytest.fixture
+    def frame(self) -> sc.DataArray:
+        return sc.DataArray(sc.ones(dims=['y', 'x'], shape=[4, 4]))
+
+    def test_current_carries_bounds_of_accumulated_window(self, workflow, frame):
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+
+        current = workflow.finalize()['current']
+
+        assert _bounds(current) == (1000, 2000)
+        # 'time' duplicates start_time until issue #1058 drops it everywhere.
+        assert sc.identical(current.coords['time'], current.coords['start_time'])
+
+    def test_bounds_span_all_accumulates_of_the_window(self, workflow, frame):
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(2000),
+            end_time=Timestamp.from_ns(3000),
+        )
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(3000),
+            end_time=Timestamp.from_ns(4000),
+        )
+
+        assert _bounds(workflow.finalize()['current']) == (1000, 4000)
+
+    def test_bounds_reset_between_finalize_cycles(self, workflow, frame):
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+        workflow.finalize()
+
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(5000),
+            end_time=Timestamp.from_ns(6000),
+        )
+
+        assert _bounds(workflow.finalize()['current']) == (5000, 6000)
+
+    def test_bounds_reset_after_clear(self, workflow, frame):
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+        workflow.clear()
+
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(7000),
+            end_time=Timestamp.from_ns(8000),
+        )
+
+        assert _bounds(workflow.finalize()['current']) == (7000, 8000)
+
+    def test_bounds_restart_with_incompatible_image_structure(self, workflow):
+        def frame(x_offset: float) -> sc.DataArray:
+            return sc.DataArray(
+                sc.ones(dims=['y', 'x'], shape=[4, 4]),
+                coords={
+                    'x': sc.arange('x', 4, dtype='float64') + x_offset,
+                    'y': sc.arange('y', 4, dtype='float64'),
+                },
+            )
+
+        workflow.accumulate(
+            {'detector': frame(0.0)},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+        # Shifted coordinate -> accumulation restarts, and so does the window.
+        workflow.accumulate(
+            {'detector': frame(9.0)},
+            start_time=Timestamp.from_ns(2000),
+            end_time=Timestamp.from_ns(3000),
+        )
+
+        assert _bounds(workflow.finalize()['current']) == (2000, 3000)
+
+    def test_cumulative_has_no_time_coords(self, workflow, frame):
+        """Job._add_time_coords stamps the job-level range on 'cumulative'."""
+        workflow.accumulate(
+            {'detector': frame},
+            start_time=Timestamp.from_ns(1000),
+            end_time=Timestamp.from_ns(2000),
+        )
+
+        cumulative = workflow.finalize()['cumulative']
+
+        assert 'time' not in cumulative.coords
+        assert 'start_time' not in cumulative.coords
+        assert 'end_time' not in cumulative.coords


### PR DESCRIPTION
`AreaDetectorView` discarded the window's `end_time` and stamped only a scalar `time` coord on its `current` output. Because a `time` coord makes `Job._add_time_coords` skip an output (it assumes such data carries its own timestamps), the `current` output reached the dashboard with no temporal bounds at all — neither the workflow's own nor the job-level fallback.

Two dashboard features depend on those bounds and were therefore dead for every area detector view: the cell titlebar freshness/lag pill (`_compute_time_bounds`) and counts-per-second normalization (`_normalize_to_rate`, which needs `end_time - start_time`). Both failed silently, so the plots looked fine while showing no lag and unnormalized counts.

`AreaDetectorView` now tracks the window end time and assigns `time`, `start_time` and `end_time` together, matching the contract every other window output follows (`StreamProcessorWorkflow.finalize`). The `cumulative` output deliberately keeps no time coords so it continues to be stamped with the job-level range.

Found while investigating #1058. The scalar `time` coord is redundant with `start_time` here, but #1058 will drop it from all window outputs uniformly — diverging from the shared contract in this PR would only make that change harder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
