### PR TITLE
Declare output temporality instead of signalling it with a magic coord

### DIFF
--- a/src/ess/livedata/config/instruments/bifrost/factories.py
+++ b/src/ess/livedata/config/instruments/bifrost/factories.py
@@ -9,6 +9,7 @@ from functools import cache
 import scipp as sc
 
 from ess.livedata.config import Instrument
+from ess.livedata.config.workflow_spec import Temporality
 
 from . import specs
 from .specs import (
@@ -114,7 +115,9 @@ def setup_factories(instrument: Instrument) -> None:
                 DetectorRegionCounts[Cumulative]: cumulative,
                 DetectorRegionCounts[Current]: window,
             },
-            window_outputs=['detector_region_counts'],
+            window_outputs=specs.DetectorRatemeterOutputs.fields_with(
+                Temporality.window
+            ),
         )
 
     # Q-map workflow factories

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -12,7 +12,7 @@ for full instrument details.
 """
 
 from enum import StrEnum
-from typing import ClassVar, Literal
+from typing import Annotated, ClassVar, Literal
 
 import pydantic
 import scipp as sc
@@ -23,7 +23,11 @@ from ess.livedata.config import (
     instrument_registry,
     name_streams,
 )
-from ess.livedata.config.workflow_spec import OutputView, WorkflowOutputsBase
+from ess.livedata.config.workflow_spec import (
+    OutputView,
+    Temporality,
+    WorkflowOutputsBase,
+)
 from ess.livedata.parameter_models import EnergyEdges, QEdges
 from ess.livedata.workflows.detector_view_specs import SpectrumViewSpec
 from ess.livedata.workflows.monitor_workflow_specs import (
@@ -114,18 +118,22 @@ class DetectorRatemeterOutputs(WorkflowOutputsBase):
         ),
     )
 
-    detector_region_counts: sc.DataArray = pydantic.Field(
-        default_factory=lambda: sc.DataArray(
-            sc.scalar(0, unit='counts'),
-            coords={'time': sc.scalar(0, unit='ns')},
-        ),
-        title='Detector Region Counts',
-        description=(
-            'Counts for the selected arc and pixel range, for the latest update '
-            'interval only. Resets each update interval.'
-        ),
+    detector_region_counts: Annotated[sc.DataArray, Temporality.window] = (
+        pydantic.Field(
+            default_factory=lambda: sc.DataArray(
+                sc.scalar(0, unit='counts'),
+                coords={'time': sc.scalar(0, unit='ns')},
+            ),
+            title='Detector Region Counts',
+            description=(
+                'Counts for the selected arc and pixel range, for the latest update '
+                'interval only. Resets each update interval.'
+            ),
+        )
     )
-    detector_region_counts_cumulative: sc.DataArray = pydantic.Field(
+    detector_region_counts_cumulative: Annotated[
+        sc.DataArray, Temporality.cumulative
+    ] = pydantic.Field(
         default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
         title='Detector Region Counts',
         description=(

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -12,7 +12,7 @@ for full instrument details.
 """
 
 from enum import StrEnum
-from typing import Annotated, ClassVar, Literal
+from typing import ClassVar, Literal
 
 import pydantic
 import scipp as sc
@@ -24,8 +24,9 @@ from ess.livedata.config import (
     name_streams,
 )
 from ess.livedata.config.workflow_spec import (
+    CumulativeOutput,
     OutputView,
-    Temporality,
+    WindowOutput,
     WorkflowOutputsBase,
 )
 from ess.livedata.parameter_models import EnergyEdges, QEdges
@@ -115,22 +116,18 @@ class DetectorRatemeterOutputs(WorkflowOutputsBase):
         ),
     )
 
-    detector_region_counts: Annotated[sc.DataArray, Temporality.window] = (
-        pydantic.Field(
-            default_factory=lambda: sc.DataArray(
-                sc.scalar(0, unit='counts'),
-                coords={'time': sc.scalar(0, unit='ns')},
-            ),
-            title='Detector Region Counts',
-            description=(
-                'Counts for the selected arc and pixel range, for the latest update '
-                'interval only. Resets each update interval.'
-            ),
-        )
+    detector_region_counts: WindowOutput = pydantic.Field(
+        default_factory=lambda: sc.DataArray(
+            sc.scalar(0, unit='counts'),
+            coords={'time': sc.scalar(0, unit='ns')},
+        ),
+        title='Detector Region Counts',
+        description=(
+            'Counts for the selected arc and pixel range, for the latest update '
+            'interval only. Resets each update interval.'
+        ),
     )
-    detector_region_counts_cumulative: Annotated[
-        sc.DataArray, Temporality.cumulative
-    ] = pydantic.Field(
+    detector_region_counts_cumulative: CumulativeOutput = pydantic.Field(
         default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
         title='Detector Region Counts',
         description=(

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -104,10 +104,7 @@ class DetectorRatemeterOutputs(WorkflowOutputsBase):
         OutputView(
             name='detector_region_counts',
             title='Detector Region Counts',
-            fields={
-                'since_start': 'detector_region_counts_cumulative',
-                'per_update': 'detector_region_counts',
-            },
+            fields=('detector_region_counts_cumulative', 'detector_region_counts'),
             description=(
                 'Counts for the selected arc and pixel range. With "since run '
                 'start" shows the count accumulated since the start of the run; '

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -26,7 +26,7 @@ import uuid
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal, TypeVar
+from typing import Annotated, Any, ClassVar, Literal, TypeVar
 
 import scipp as sc
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -43,10 +43,11 @@ Windowing = Literal['since_start', 'per_update']
 class Temporality(enum.Enum):
     """How an output field's values relate to time.
 
-    Declared per output field via :class:`typing.Annotated` and read back with
+    Declared per output field by annotating it :data:`WindowOutput`,
+    :data:`CumulativeOutput` or :data:`SeriesOutput`, and read back with
     :meth:`WorkflowOutputsBase.temporality`::
 
-        current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(...)
+        current: WindowOutput = pydantic.Field(...)
 
     Distinct from :data:`Windowing`, which selects *which* backing field a
     user-facing view exposes for the window mode the user picked. Temporality is
@@ -70,6 +71,21 @@ class Temporality(enum.Enum):
     """Carries its own per-point ``time`` axis. Messages are disjoint chunks of
     samples concatenated along that axis, so there is no single window duration
     to normalize by."""
+
+
+WindowOutput = Annotated[sc.DataArray, Temporality.window]
+"""An output field covering one update interval. See :attr:`Temporality.window`."""
+
+CumulativeOutput = Annotated[sc.DataArray, Temporality.cumulative]
+"""An output field accumulating over a job generation.
+
+See :attr:`Temporality.cumulative`. This is also what a bare ``sc.DataArray``
+field means, so reduction outputs need no annotation; spell it out where a
+model mixes temporalities and the contrast carries information.
+"""
+
+SeriesOutput = Annotated[sc.DataArray, Temporality.series]
+"""An output field carrying its own ``time`` axis. See :attr:`Temporality.series`."""
 
 
 WINDOWING_FOR_TEMPORALITY: Mapping[Temporality, Windowing] = {

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -72,16 +72,31 @@ class Temporality(enum.Enum):
     to normalize by."""
 
 
+WINDOWING_FOR_TEMPORALITY: Mapping[Temporality, Windowing] = {
+    Temporality.window: 'per_update',
+    Temporality.series: 'per_update',
+    Temporality.cumulative: 'since_start',
+}
+"""Which window mode each temporality backs.
+
+``Windowing`` is a user-facing mode selector; ``Temporality`` is the property of
+the field that makes it a valid answer for that mode. The mapping is total, so
+views declare their member fields and the binding follows — there is no second
+place to state it and therefore nothing to keep in sync.
+"""
+
+
 @dataclass(frozen=True)
 class OutputView:
     """A user-facing output bundling one or more backend fields.
 
-    Each view represents a single quantity (e.g. "Histogram", "Total")
-    that may be observed over different time windows. The ``fields`` mapping
-    binds windowing flavors to the backend pydantic field names that carry
-    that view of the data — ``since_start`` for run-cumulative fields and
-    ``per_update`` for per-update fields. Window mode (selected by the user)
-    determines which one is subscribed to.
+    Each view represents a single quantity (e.g. "Histogram", "Total") that may
+    be observed over different time windows. ``fields`` names the backend
+    pydantic fields carrying that quantity; which window mode each one serves
+    follows from its declared :class:`Temporality` (see
+    :data:`WINDOWING_FOR_TEMPORALITY`), so a view typically pairs a
+    ``cumulative`` field with a ``window`` one. Resolution needs the outputs
+    model and therefore lives on :class:`WorkflowSpec`, not here.
 
     ``params`` names the workflow parameter fields (top-level fields of the
     workflow's params model) that shape this output. It powers the UI's
@@ -94,21 +109,9 @@ class OutputView:
 
     name: str
     title: str
-    fields: Mapping[Windowing, str]
+    fields: tuple[str, ...]
     description: str | None = None
     params: tuple[str, ...] = ()
-
-    def field_for(self, windowing: Windowing) -> str:
-        """Return the backend field name for the requested windowing.
-
-        Falls back to the other declared windowing when the requested one is
-        absent — handles views that only expose one (e.g. cumulative-only
-        quantities).
-        """
-        if (field_name := self.fields.get(windowing)) is not None:
-            return field_name
-        other: Windowing = 'per_update' if windowing == 'since_start' else 'since_start'
-        return self.fields[other]
 
 
 class WorkflowOutputsBase(BaseModel):
@@ -496,6 +499,33 @@ class WorkflowSpec(BaseModel):
 
         return outputs
 
+    @field_validator('outputs', mode='after')
+    @classmethod
+    def validate_unambiguous_windowing(
+        cls, outputs: type[WorkflowOutputsBase]
+    ) -> type[WorkflowOutputsBase]:
+        """Validate that a view's fields back distinct window modes.
+
+        Two fields of one view resolving to the same :data:`Windowing` would
+        make the view ambiguous: selecting that mode could return either. The
+        usual cause is a missing :class:`Temporality` annotation, since
+        unannotated fields default to ``cumulative``.
+        """
+        for view in _resolve_output_views(outputs):
+            by_windowing: dict[Windowing, list[str]] = defaultdict(list)
+            for field_name in view.fields:
+                windowing = WINDOWING_FOR_TEMPORALITY[outputs.temporality(field_name)]
+                by_windowing[windowing].append(field_name)
+            for windowing, field_names in by_windowing.items():
+                if len(field_names) > 1:
+                    raise ValueError(
+                        f"Output view '{view.name}' has multiple fields backing "
+                        f"'{windowing}': {sorted(field_names)}. Annotate their "
+                        f"Temporality so each field backs a distinct window mode."
+                    )
+
+        return outputs
+
     def get_id(self) -> WorkflowId:
         """
         Get a unique identifier for the workflow.
@@ -511,8 +541,8 @@ class WorkflowSpec(BaseModel):
     def get_output_views(self) -> Sequence[OutputView]:
         """Return the user-facing output views for this workflow.
 
-        Falls back to one view per pydantic field (bound as ``since_start``)
-        when the outputs class does not declare ``output_views``.
+        Falls back to one view per pydantic field when the outputs class does
+        not declare ``output_views``.
         """
         return _resolve_output_views(self.outputs)
 
@@ -523,11 +553,45 @@ class WorkflowSpec(BaseModel):
                 return view
         return None
 
+    def _windowing_by_field(self, view_name: str) -> dict[Windowing, str]:
+        """Map each window mode the named view backs to the field serving it.
+
+        Derived from each member field's :class:`Temporality`; empty for an
+        unknown view. Distinctness is enforced at registration by
+        :meth:`validate_unambiguous_windowing`.
+        """
+        view = self.get_output_view(view_name)
+        if view is None:
+            return {}
+        return {
+            WINDOWING_FOR_TEMPORALITY[self.outputs.temporality(field_name)]: field_name
+            for field_name in view.fields
+        }
+
+    def windowing_options(self, view_name: str) -> frozenset[Windowing]:
+        """Return the window modes the named view has a real backing field for."""
+        return frozenset(self._windowing_by_field(view_name))
+
+    def field_for(self, view_name: str, windowing: Windowing) -> str:
+        """Return the backend field a view exposes for the requested windowing.
+
+        Falls back to the view's other field when the requested windowing has
+        no backing field — handles views exposing only one flavor (e.g.
+        cumulative-only quantities). Unknown views resolve to their own name,
+        which is the field name for workflows that declare no ``output_views``.
+        """
+        by_windowing = self._windowing_by_field(view_name)
+        if not by_windowing:
+            return view_name
+        if (field_name := by_windowing.get(windowing)) is not None:
+            return field_name
+        return next(iter(by_windowing.values()))
+
     def get_output_template(self, view_name: str) -> sc.DataArray | None:
         """Get a template DataArray for the specified output view.
 
         Returns the ``default_factory`` template of the view's canonical
-        backing field (``since_start`` if present, else ``per_update``).
+        backing field (the ``since_start`` one if present, else its other).
         Templates are empty DataArrays demonstrating the expected structure
         (dims, coords, units), used by the dashboard for plotter selection
         before any data has arrived.
@@ -535,10 +599,11 @@ class WorkflowSpec(BaseModel):
         Returns None if the view is unknown or its canonical field has no
         ``default_factory``.
         """
-        view = self.get_output_view(view_name)
-        if view is None:
+        if self.get_output_view(view_name) is None:
             return None
-        field_info = self.outputs.model_fields.get(view.field_for('since_start'))
+        field_info = self.outputs.model_fields.get(
+            self.field_for(view_name, 'since_start')
+        )
         if field_info is None or not field_info.default_factory:
             return None
         return field_info.default_factory()
@@ -750,9 +815,9 @@ def _resolve_output_views(
     """Return the declared ``output_views`` or a default one-view-per-field set.
 
     When an outputs class does not declare ``output_views``, each pydantic
-    field becomes its own view: the bare field name is used as both the
-    view name and (via ``since_start``) the backing field. This keeps
-    reduction-style Outputs classes working without annotation.
+    field becomes its own view, with the bare field name used as both the view
+    name and the backing field. This keeps reduction-style Outputs classes
+    working without annotation.
     """
     declared = getattr(outputs, 'output_views', ())
     if declared:
@@ -761,7 +826,7 @@ def _resolve_output_views(
         OutputView(
             name=field_name,
             title=(field_info.title or field_name),
-            fields={'since_start': field_name},
+            fields=(field_name,),
             description=field_info.description,
         )
         for field_name, field_info in outputs.model_fields.items()
@@ -776,9 +841,8 @@ def find_timeseries_outputs(
 
     A timeseries output is a 0-D field declaring :attr:`Temporality.window` or
     :attr:`Temporality.series` — a scalar that advances along wall-clock time.
-    The backing field for each ``per_update`` (or ``since_start``) entry of an
-    output view is inspected; views with a matching backing field are reported
-    by view name.
+    Every backing field of an output view is inspected; views with at least one
+    matching field are reported by view name.
 
     Parameters
     ----------
@@ -800,7 +864,7 @@ def find_timeseries_outputs(
 
         timeseries_views: list[str] = []
         for view in spec.get_output_views():
-            for field_name in view.fields.values():
+            for field_name in view.fields:
                 if _is_correlatable(spec.outputs, field_name):
                     timeseries_views.append(view.name)
                     break

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -21,6 +21,7 @@ drives the UI's param↔output cross-references in both surfaces.
 
 from __future__ import annotations
 
+import enum
 import uuid
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
@@ -37,6 +38,38 @@ T = TypeVar('T')
 JobNumber = uuid.UUID
 
 Windowing = Literal['since_start', 'per_update']
+
+
+class Temporality(enum.Enum):
+    """How an output field's values relate to time.
+
+    Declared per output field via :class:`typing.Annotated` and read back with
+    :meth:`WorkflowOutputsBase.temporality`::
+
+        current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(...)
+
+    Distinct from :data:`Windowing`, which selects *which* backing field a
+    user-facing view exposes for the window mode the user picked. Temporality is
+    a property of the field itself: what a single message means, and hence which
+    operations over successive messages are valid. The two are not
+    interchangeable — ``since_start`` is the default binding for fields that are
+    not accumulations at all (ROI readbacks, static views).
+    """
+
+    window = 'window'
+    """Covers ``[start_time, end_time)``; successive windows are disjoint and
+    advance. Summing or averaging over consecutive messages is meaningful, as is
+    normalizing counts by the window duration."""
+
+    cumulative = 'cumulative'
+    """Value as of ``end_time``, accumulated since ``start_time``, which stays
+    pinned for the lifetime of a job generation. Plotting the growth curve is
+    meaningful; aggregating over successive messages double-counts."""
+
+    series = 'series'
+    """Carries its own per-point ``time`` axis. Messages are disjoint chunks of
+    samples concatenated along that axis, so there is no single window duration
+    to normalize by."""
 
 
 @dataclass(frozen=True)
@@ -90,6 +123,28 @@ class WorkflowOutputsBase(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     output_views: ClassVar[tuple[OutputView, ...]] = ()
+
+    @classmethod
+    def temporality(cls, field_name: str) -> Temporality:
+        """Return the declared :class:`Temporality` of an output field.
+
+        Fields that do not annotate one are ``cumulative``: a workflow output
+        accumulates over the job's lifetime unless it explicitly resets each
+        window, and the same default applies to outputs that are not
+        accumulations at all (readbacks, static views) — nothing may be summed
+        across their messages either.
+        """
+        for meta in cls.model_fields[field_name].metadata:
+            if isinstance(meta, Temporality):
+                return meta
+        return Temporality.cumulative
+
+    @classmethod
+    def fields_with(cls, temporality: Temporality) -> tuple[str, ...]:
+        """Return the names of output fields declaring the given temporality."""
+        return tuple(
+            name for name in cls.model_fields if cls.temporality(name) is temporality
+        )
 
 
 class DefaultOutputs(WorkflowOutputsBase):
@@ -363,7 +418,7 @@ class WorkflowSpec(BaseModel):
         ),
     )
     params: type[BaseModel] | None = Field(description="Model for workflow param.")
-    outputs: type[BaseModel] = Field(
+    outputs: type[WorkflowOutputsBase] = Field(
         default=DefaultOutputs,
         description=(
             "Pydantic model defining workflow outputs with their metadata. "
@@ -417,7 +472,9 @@ class WorkflowSpec(BaseModel):
 
     @field_validator('outputs', mode='after')
     @classmethod
-    def validate_unique_output_titles(cls, outputs: type[BaseModel]) -> type[BaseModel]:
+    def validate_unique_output_titles(
+        cls, outputs: type[WorkflowOutputsBase]
+    ) -> type[WorkflowOutputsBase]:
         """Validate that user-facing view titles are unique within the workflow."""
         views = _resolve_output_views(outputs)
         title_counts: dict[str, list[str]] = defaultdict(list)
@@ -668,12 +725,28 @@ class WorkflowConfig(BaseModel):
         return cls(**fields)
 
 
-def _is_timeseries_output(da: sc.DataArray) -> bool:
-    """Check if DataArray represents a timeseries (0-D with time coord)."""
-    return da.ndim == 0 and 'time' in da.coords
+_CORRELATABLE = (Temporality.window, Temporality.series)
 
 
-def _resolve_output_views(outputs: type[BaseModel]) -> tuple[OutputView, ...]:
+def _is_correlatable(outputs: type[WorkflowOutputsBase], field_name: str) -> bool:
+    """Check whether an output field can serve as a correlation axis.
+
+    Requires a scalar quantity that advances along wall-clock time: a per-window
+    value or a timestamped series. Cumulative fields are excluded — correlating
+    against a monotonically growing total says more about the run length than
+    about the quantity.
+    """
+    field_info = outputs.model_fields.get(field_name)
+    if field_info is None or not field_info.default_factory:
+        return False
+    if field_info.default_factory().ndim != 0:
+        return False
+    return outputs.temporality(field_name) in _CORRELATABLE
+
+
+def _resolve_output_views(
+    outputs: type[WorkflowOutputsBase],
+) -> tuple[OutputView, ...]:
     """Return the declared ``output_views`` or a default one-view-per-field set.
 
     When an outputs class does not declare ``output_views``, each pydantic
@@ -701,10 +774,11 @@ def find_timeseries_outputs(
     """
     Find all timeseries output views in the workflow registry.
 
-    A timeseries output is a 0-D DataArray with a 'time' coordinate. The
-    backing field for each ``per_update`` (or ``since_start``) entry of an
-    output view is inspected; views whose backing field templates match are
-    reported by view name.
+    A timeseries output is a 0-D field declaring :attr:`Temporality.window` or
+    :attr:`Temporality.series` — a scalar that advances along wall-clock time.
+    The backing field for each ``per_update`` (or ``since_start``) entry of an
+    output view is inspected; views with a matching backing field are reported
+    by view name.
 
     Parameters
     ----------
@@ -727,10 +801,7 @@ def find_timeseries_outputs(
         timeseries_views: list[str] = []
         for view in spec.get_output_views():
             for field_name in view.fields.values():
-                field_info = spec.outputs.model_fields.get(field_name)
-                if field_info is None or not field_info.default_factory:
-                    continue
-                if _is_timeseries_output(field_info.default_factory()):
+                if _is_correlatable(spec.outputs, field_name):
                     timeseries_views.append(view.name)
                     break
 

--- a/src/ess/livedata/dashboard/derived_devices.py
+++ b/src/ess/livedata/dashboard/derived_devices.py
@@ -154,7 +154,7 @@ def view_device_names(
     names = {
         name
         for source_name in source_names
-        for field_name in view.fields.values()
+        for field_name in view.fields
         if (name := contract.device_name(workflow_id, source_name, field_name))
         is not None
     }

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -1036,7 +1036,7 @@ class PlotOrchestrator:
             if spec is None:
                 return field_name
             for view in spec.get_output_views():
-                if field_name in view.fields.values():
+                if field_name in view.fields:
                     return view.title
             return field_name
 

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -203,21 +203,6 @@ def _windowing_for_mode(mode: TimeWindowMode) -> Windowing:
     return 'since_start' if mode is TimeWindowMode.since_start else 'per_update'
 
 
-def resolve_field_name(
-    spec: WorkflowSpec,
-    view_name: str,
-    *,
-    windowing: Windowing = 'since_start',
-) -> str:
-    """Resolve a (view, windowing) pair to the backend pydantic field name.
-
-    Falls back to ``view_name`` as a raw field name when no matching view
-    is declared (lets unannotated reduction outputs work unchanged).
-    """
-    view = spec.get_output_view(view_name)
-    return view.field_for(windowing) if view is not None else view_name
-
-
 def _windowing_for_role(role: str, params: pydantic.BaseModel) -> Windowing:
     """Return the windowing wanted by a data role.
 
@@ -244,9 +229,7 @@ def _build_resolved_data_sources(
     for role, ds in config.data_sources.items():
         spec = registry.get(ds.workflow_id)
         output_name = (
-            resolve_field_name(
-                spec, ds.view_name, windowing=_windowing_for_role(role, config.params)
-            )
+            spec.field_for(ds.view_name, _windowing_for_role(role, config.params))
             if spec is not None
             else ds.view_name
         )

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -284,23 +284,21 @@ def output_view_supports_windowing(workflow_spec: WorkflowSpec, view_name: str) 
     rejected at config time (see :func:`since_start_available`), not by hiding
     the controls -- that would also remove the still-meaningful duration control.
     """
-    view = workflow_spec.get_output_view(view_name)
-    if view is None:
+    if workflow_spec.get_output_view(view_name) is None:
         return True
-    return 'per_update' in view.fields
+    return 'per_update' in workflow_spec.windowing_options(view_name)
 
 
 def since_start_available(workflow_spec: WorkflowSpec, view_name: str) -> bool:
     """Return whether ``since_start`` mode resolves to a real cumulative field.
 
     ``False`` for per-update-only views, where selecting ``since_start`` would
-    silently fall back to the per-update field (see ``OutputView.field_for``).
+    silently fall back to the per-update field (see ``WorkflowSpec.field_for``).
     Permissive for unknown views.
     """
-    view = workflow_spec.get_output_view(view_name)
-    if view is None:
+    if workflow_spec.get_output_view(view_name) is None:
         return True
-    return 'since_start' in view.fields
+    return 'since_start' in workflow_spec.windowing_options(view_name)
 
 
 def create_extractors_from_params(

--- a/src/ess/livedata/glossary.md
+++ b/src/ess/livedata/glossary.md
@@ -67,17 +67,20 @@ The naming stack, from the Kafka wire inwards (see ADR 0004 and
 - **DataKey** — stable identity `(workflow_id, source_name, output_name)`,
   i.e. a ResultKey with the job number stripped. The dashboard data plane and
   NICOS derived devices (ADR 0006) key by DataKey, not ResultKey.
-- **OutputView** — user-facing presentation of a workflow output, bundling
-  backend output fields by `Windowing` (`since_start`/`per_update`)
-  (`config/workflow_spec.py`).
+- **OutputView** — user-facing presentation of a workflow output, bundling the
+  backend output fields that carry one quantity (`config/workflow_spec.py`).
 - **Temporality** — how one output field's values relate to time:
   `window` (covers `[start_time, end_time)`, successive windows disjoint),
   `cumulative` (value as of `end_time`, `start_time` pinned for the
   generation), or `series` (carries its own per-point `time` axis). Declared
-  per field via `Annotated` on the outputs model; decides which aggregations
-  over successive messages are valid. Not the same axis as `Windowing`, which
-  merely selects *which* field a view exposes for the user's window mode
+  per field via `Annotated` on the outputs model. It decides which aggregations
+  over successive messages are valid, and which `Windowing` the field backs —
+  a view states its member fields, and the binding follows
   (`config/workflow_spec.py`).
+- **Windowing** — the user-facing window-mode selector
+  (`since_start`/`per_update`) resolved against a view to pick the backing
+  field. Derived from `Temporality`, never declared alongside it
+  (`WorkflowSpec.field_for`, `WorkflowSpec.windowing_options`).
 
 ### Data kinds and services
 

--- a/src/ess/livedata/glossary.md
+++ b/src/ess/livedata/glossary.md
@@ -70,6 +70,14 @@ The naming stack, from the Kafka wire inwards (see ADR 0004 and
 - **OutputView** — user-facing presentation of a workflow output, bundling
   backend output fields by `Windowing` (`since_start`/`per_update`)
   (`config/workflow_spec.py`).
+- **Temporality** — how one output field's values relate to time:
+  `window` (covers `[start_time, end_time)`, successive windows disjoint),
+  `cumulative` (value as of `end_time`, `start_time` pinned for the
+  generation), or `series` (carries its own per-point `time` axis). Declared
+  per field via `Annotated` on the outputs model; decides which aggregations
+  over successive messages are valid. Not the same axis as `Windowing`, which
+  merely selects *which* field a view exposes for the user's window mode
+  (`config/workflow_spec.py`).
 
 ### Data kinds and services
 
@@ -176,7 +184,8 @@ The naming stack, from the Kafka wire inwards (see ADR 0004 and
   role*: the logical name of an auxiliary workflow input a user selects a
   stream for (`AuxSources`). Qualify the word when ambiguity is possible. The
   time-window flavor of an output field (`since_start`/`per_update`) is
-  `Windowing`, not a role (`config/workflow_spec.py`).
+  `Windowing`, not a role, and how its values relate to time is `Temporality`
+  (`config/workflow_spec.py`).
 - **stream** — (1) a Kafka/internal data stream (`StreamId`); (2) a dashboard
   subscriber pipeline (`StreamManager.make_stream`); (3) an
   `hv.streams.Pipe` per-session channel. Sense (1) is the default; qualify

--- a/src/ess/livedata/workflows/detector_view/factory.py
+++ b/src/ess/livedata/workflows/detector_view/factory.py
@@ -15,11 +15,15 @@ from ess.reduce.unwrap import LookupTableFilename
 from ess.reduce.unwrap.types import LookupTableRelativeErrorThreshold
 from scippnexus import NXdetector
 
-from ...preprocessors.accumulators import make_no_copy_accumulator_pair
-
 # Import types unconditionally for runtime type hint resolution
 # (used by workflow_factory.attach_factory to inspect parameter types)
-from ..detector_view_specs import DetectorViewParams
+from ...config.workflow_spec import Temporality
+from ...preprocessors.accumulators import make_no_copy_accumulator_pair
+from ..detector_view_specs import (
+    DetectorViewOutputs,
+    DetectorViewOutputsBase,
+    DetectorViewParams,
+)
 from ..stream_processor_workflow import StreamProcessorWorkflow
 from .data_source import DetectorDataSource, DetectorNumberSource
 from .providers import spectrum_view
@@ -227,12 +231,6 @@ class DetectorViewFactory:
             else:
                 workflow[SpectrumViewTransform] = raw_transform
             target_keys['spectrum_view'] = SpectrumView
-        window_outputs = (
-            'current',
-            'counts_total',
-            'counts_in_toa_range',
-        )
-
         if roi_support:
             # Add ROI-related outputs only when supported
             target_keys.update(
@@ -255,12 +253,6 @@ class DetectorViewFactory:
                     aux_source_names['roi_polygon']: ROIPolygonRequest,
                 }
             )
-            window_outputs = (
-                'current',
-                'counts_total',
-                'counts_in_toa_range',
-                'roi_spectra_current',
-            )
 
         # Reset the cumulative histogram when the detector moves: summing across a
         # move mixes incompatible geometries (geometric views shift screen bins;
@@ -275,7 +267,9 @@ class DetectorViewFactory:
             dynamic_keys={source_name: NeXusData[NXdetector, SampleRun]},
             context_keys=context_keys,
             target_keys=target_keys,
-            window_outputs=window_outputs,
+            window_outputs=(
+                DetectorViewOutputs if roi_support else DetectorViewOutputsBase
+            ).fields_with(Temporality.window),
             accumulators={
                 AccumulatedHistogram[Cumulative]: cumulative,
                 AccumulatedHistogram[Current]: window,

--- a/src/ess/livedata/workflows/detector_view_specs.py
+++ b/src/ess/livedata/workflows/detector_view_specs.py
@@ -212,7 +212,7 @@ _BASE_DETECTOR_VIEWS: tuple[OutputView, ...] = (
     OutputView(
         name='image',
         title='Image',
-        fields={'since_start': 'cumulative', 'per_update': 'current'},
+        fields=('cumulative', 'current'),
         description=(
             'Detector image. With "since run start" shows accumulated counts; '
             'with "latest update" or a window, shows recent counts.'
@@ -227,19 +227,13 @@ _BASE_DETECTOR_VIEWS: tuple[OutputView, ...] = (
     OutputView(
         name='total_counts',
         title='Total',
-        fields={
-            'since_start': 'counts_total_cumulative',
-            'per_update': 'counts_total',
-        },
+        fields=('counts_total_cumulative', 'counts_total'),
         description='Total number of detector events.',
     ),
     OutputView(
         name='total_in_range',
         title='Total in range',
-        fields={
-            'since_start': 'counts_in_toa_range_cumulative',
-            'per_update': 'counts_in_toa_range',
-        },
+        fields=('counts_in_toa_range_cumulative', 'counts_in_toa_range'),
         description=('Number of detector events within the configured range filter.'),
         params=('coordinate_mode', 'toa_range', 'wavelength_range'),
     ),
@@ -313,23 +307,20 @@ class DetectorViewOutputs(DetectorViewOutputsBase):
         OutputView(
             name='roi_spectra',
             title='ROI spectra',
-            fields={
-                'since_start': 'roi_spectra_cumulative',
-                'per_update': 'roi_spectra_current',
-            },
+            fields=('roi_spectra_cumulative', 'roi_spectra_current'),
             description='Histogram for each active ROI region.',
             params=('coordinate_mode', 'toa_edges', 'wavelength_edges'),
         ),
         OutputView(
             name='roi_rectangle',
             title='ROI Rectangles (readback)',
-            fields={'since_start': 'roi_rectangle'},
+            fields=('roi_rectangle',),
             description='Current rectangle ROI geometries confirmed by backend.',
         ),
         OutputView(
             name='roi_polygon',
             title='ROI Polygons (readback)',
-            fields={'since_start': 'roi_polygon'},
+            fields=('roi_polygon',),
             description='Current polygon ROI geometries confirmed by backend.',
         ),
     )
@@ -464,7 +455,7 @@ def make_detector_view_outputs(
                 OutputView(
                     name='spectrum_view',
                     title=title,
-                    fields={'since_start': 'spectrum_view'},
+                    fields=('spectrum_view',),
                     description=description,
                     params=(
                         'coordinate_mode',

--- a/src/ess/livedata/workflows/detector_view_specs.py
+++ b/src/ess/livedata/workflows/detector_view_specs.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, ClassVar, Literal
+from typing import ClassVar, Literal
 
 import pydantic
 import scipp as sc
@@ -26,9 +26,10 @@ from ..config.instrument import Instrument
 from ..config.workflow_spec import (
     DETECTORS,
     AuxSources,
+    CumulativeOutput,
     JobId,
     OutputView,
-    Temporality,
+    WindowOutput,
     WorkflowOutputsBase,
 )
 from .workflow_factory import SpecHandle
@@ -248,12 +249,12 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
     # Field names are kept stable as wire-format identifiers (ResultKey, da00
     # serialisation) and are referenced by ``output_views``.
 
-    cumulative: Annotated[sc.DataArray, Temporality.cumulative] = pydantic.Field(
+    cumulative: CumulativeOutput = pydantic.Field(
         title='Image',
         description='Detector image accumulated since the start of the run.',
         default_factory=_make_2d_template,
     )
-    current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+    current: WindowOutput = pydantic.Field(
         title='Image update',
         description=(
             'Detector image for the latest update interval only. '
@@ -261,17 +262,14 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
         ),
         default_factory=_make_2d_template_with_time,
     )
-    counts_total_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-        pydantic.Field(
-            title='Total',
-            description=(
-                'Total number of detector events accumulated since the start '
-                'of the run.'
-            ),
-            default_factory=_make_0d_template,
-        )
+    counts_total_cumulative: CumulativeOutput = pydantic.Field(
+        title='Total',
+        description=(
+            'Total number of detector events accumulated since the start of the run.'
+        ),
+        default_factory=_make_0d_template,
     )
-    counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+    counts_total: WindowOutput = pydantic.Field(
         title='Total (update)',
         description=(
             'Total number of detector events for the latest update interval only. '
@@ -279,17 +277,15 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
         ),
         default_factory=_make_0d_template_with_time,
     )
-    counts_in_toa_range_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-        pydantic.Field(
-            title='Total in range',
-            description=(
-                'Number of detector events within the configured range filter '
-                'accumulated since the start of the run.'
-            ),
-            default_factory=_make_0d_template,
-        )
+    counts_in_toa_range_cumulative: CumulativeOutput = pydantic.Field(
+        title='Total in range',
+        description=(
+            'Number of detector events within the configured range filter '
+            'accumulated since the start of the run.'
+        ),
+        default_factory=_make_0d_template,
     )
-    counts_in_toa_range: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+    counts_in_toa_range: WindowOutput = pydantic.Field(
         title='Total in range (update)',
         description=(
             'Number of detector events within the configured range filter '
@@ -326,20 +322,18 @@ class DetectorViewOutputs(DetectorViewOutputsBase):
     )
 
     # Stacked ROI spectra outputs (2D: roi x time_of_arrival)
-    roi_spectra_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-        pydantic.Field(
-            title='ROI spectra',
-            description=(
-                'Histogram for each active ROI region '
-                'accumulated since the start of the run.'
-            ),
-            default_factory=lambda: sc.DataArray(
-                sc.zeros(dims=['roi', 'time_of_arrival'], shape=[0, 0], unit='counts'),
-                coords={'roi': sc.array(dims=['roi'], values=[], unit=None)},
-            ),
-        )
+    roi_spectra_cumulative: CumulativeOutput = pydantic.Field(
+        title='ROI spectra',
+        description=(
+            'Histogram for each active ROI region '
+            'accumulated since the start of the run.'
+        ),
+        default_factory=lambda: sc.DataArray(
+            sc.zeros(dims=['roi', 'time_of_arrival'], shape=[0, 0], unit='counts'),
+            coords={'roi': sc.array(dims=['roi'], values=[], unit=None)},
+        ),
     )
-    roi_spectra_current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+    roi_spectra_current: WindowOutput = pydantic.Field(
         title='ROI spectra update',
         description=(
             'Histogram for each active ROI region '
@@ -419,16 +413,12 @@ def make_detector_view_outputs(
             return _make_nd_template(output_ndim, with_time_coord=True)
 
         class _WithNdim(base_class):  # type: ignore[valid-type,misc]
-            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-                pydantic.Field(
-                    title='Image (cumulative)',
-                    description=(
-                        'Detector image accumulated since the start of the run.'
-                    ),
-                    default_factory=make_cumulative_template,
-                )
+            cumulative: CumulativeOutput = pydantic.Field(
+                title='Image (cumulative)',
+                description=('Detector image accumulated since the start of the run.'),
+                default_factory=make_cumulative_template,
             )
-            current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+            current: WindowOutput = pydantic.Field(
                 title='Image (current)',
                 description=(
                     'Detector image for the latest update interval only. '

--- a/src/ess/livedata/workflows/detector_view_specs.py
+++ b/src/ess/livedata/workflows/detector_view_specs.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import ClassVar, Literal
+from typing import Annotated, ClassVar, Literal
 
 import pydantic
 import scipp as sc
@@ -28,6 +28,7 @@ from ..config.workflow_spec import (
     AuxSources,
     JobId,
     OutputView,
+    Temporality,
     WorkflowOutputsBase,
 )
 from .workflow_factory import SpecHandle
@@ -253,12 +254,12 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
     # Field names are kept stable as wire-format identifiers (ResultKey, da00
     # serialisation) and are referenced by ``output_views``.
 
-    cumulative: sc.DataArray = pydantic.Field(
+    cumulative: Annotated[sc.DataArray, Temporality.cumulative] = pydantic.Field(
         title='Image',
         description='Detector image accumulated since the start of the run.',
         default_factory=_make_2d_template,
     )
-    current: sc.DataArray = pydantic.Field(
+    current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
         title='Image update',
         description=(
             'Detector image for the latest update interval only. '
@@ -266,14 +267,17 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
         ),
         default_factory=_make_2d_template_with_time,
     )
-    counts_total_cumulative: sc.DataArray = pydantic.Field(
-        title='Total',
-        description=(
-            'Total number of detector events accumulated since the start of the run.'
-        ),
-        default_factory=_make_0d_template,
+    counts_total_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+        pydantic.Field(
+            title='Total',
+            description=(
+                'Total number of detector events accumulated since the start '
+                'of the run.'
+            ),
+            default_factory=_make_0d_template,
+        )
     )
-    counts_total: sc.DataArray = pydantic.Field(
+    counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
         title='Total (update)',
         description=(
             'Total number of detector events for the latest update interval only. '
@@ -281,15 +285,17 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
         ),
         default_factory=_make_0d_template_with_time,
     )
-    counts_in_toa_range_cumulative: sc.DataArray = pydantic.Field(
-        title='Total in range',
-        description=(
-            'Number of detector events within the configured range filter '
-            'accumulated since the start of the run.'
-        ),
-        default_factory=_make_0d_template,
+    counts_in_toa_range_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+        pydantic.Field(
+            title='Total in range',
+            description=(
+                'Number of detector events within the configured range filter '
+                'accumulated since the start of the run.'
+            ),
+            default_factory=_make_0d_template,
+        )
     )
-    counts_in_toa_range: sc.DataArray = pydantic.Field(
+    counts_in_toa_range: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
         title='Total in range (update)',
         description=(
             'Number of detector events within the configured range filter '
@@ -329,18 +335,20 @@ class DetectorViewOutputs(DetectorViewOutputsBase):
     )
 
     # Stacked ROI spectra outputs (2D: roi x time_of_arrival)
-    roi_spectra_cumulative: sc.DataArray = pydantic.Field(
-        title='ROI spectra',
-        description=(
-            'Histogram for each active ROI region '
-            'accumulated since the start of the run.'
-        ),
-        default_factory=lambda: sc.DataArray(
-            sc.zeros(dims=['roi', 'time_of_arrival'], shape=[0, 0], unit='counts'),
-            coords={'roi': sc.array(dims=['roi'], values=[], unit=None)},
-        ),
+    roi_spectra_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+        pydantic.Field(
+            title='ROI spectra',
+            description=(
+                'Histogram for each active ROI region '
+                'accumulated since the start of the run.'
+            ),
+            default_factory=lambda: sc.DataArray(
+                sc.zeros(dims=['roi', 'time_of_arrival'], shape=[0, 0], unit='counts'),
+                coords={'roi': sc.array(dims=['roi'], values=[], unit=None)},
+            ),
+        )
     )
-    roi_spectra_current: sc.DataArray = pydantic.Field(
+    roi_spectra_current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
         title='ROI spectra update',
         description=(
             'Histogram for each active ROI region '
@@ -420,12 +428,16 @@ def make_detector_view_outputs(
             return _make_nd_template(output_ndim, with_time_coord=True)
 
         class _WithNdim(base_class):  # type: ignore[valid-type,misc]
-            cumulative: sc.DataArray = pydantic.Field(
-                title='Image (cumulative)',
-                description='Detector image accumulated since the start of the run.',
-                default_factory=make_cumulative_template,
+            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+                pydantic.Field(
+                    title='Image (cumulative)',
+                    description=(
+                        'Detector image accumulated since the start of the run.'
+                    ),
+                    default_factory=make_cumulative_template,
+                )
             )
-            current: sc.DataArray = pydantic.Field(
+            current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
                 title='Image (current)',
                 description=(
                     'Detector image for the latest update interval only. '

--- a/src/ess/livedata/workflows/monitor_workflow.py
+++ b/src/ess/livedata/workflows/monitor_workflow.py
@@ -21,8 +21,10 @@ from ess.reduce.unwrap import GenericUnwrapWorkflow, LookupTableFilename
 from ess.reduce.unwrap.types import LookupTableRelativeErrorThreshold, WavelengthMonitor
 from scippnexus import NXmonitor
 
+from ..config.workflow_spec import Temporality
 from ..preprocessors.accumulation_mode import AccumulationMode, Cumulative, Current
 from .geometry_signal import geometry_signal
+from .monitor_workflow_specs import MonitorHistogramOutputs
 from .monitor_workflow_types import (
     AccumulatedMonitorHistogram,
     HistogramEdges,
@@ -325,5 +327,5 @@ def create_monitor_workflow(
             AccumulatedMonitorHistogram[Cumulative]: cumulative,
             AccumulatedMonitorHistogram[Current]: window,
         },
-        window_outputs=['current', 'counts_total', 'counts_in_toa_range'],
+        window_outputs=MonitorHistogramOutputs.fields_with(Temporality.window),
     )

--- a/src/ess/livedata/workflows/monitor_workflow_specs.py
+++ b/src/ess/livedata/workflows/monitor_workflow_specs.py
@@ -193,7 +193,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
         OutputView(
             name='histogram',
             title='Histogram',
-            fields={'since_start': 'cumulative', 'per_update': 'current'},
+            fields=('cumulative', 'current'),
             description=(
                 'Monitor histogram. With "since run start" shows accumulated '
                 'counts; with "latest update" or a window, shows recent counts.'
@@ -203,10 +203,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
         OutputView(
             name='total_counts',
             title='Total',
-            fields={
-                'since_start': 'counts_total_cumulative',
-                'per_update': 'counts_total',
-            },
+            fields=('counts_total_cumulative', 'counts_total'),
             description=(
                 'Total number of monitor events. With "since run start" shows '
                 'the accumulated total; with "latest update" or a window, shows '
@@ -216,10 +213,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
         OutputView(
             name='total_in_range',
             title='Total in range',
-            fields={
-                'since_start': 'counts_in_toa_range_cumulative',
-                'per_update': 'counts_in_toa_range',
-            },
+            fields=('counts_in_toa_range_cumulative', 'counts_in_toa_range'),
             description=(
                 'Number of monitor events within the configured range filter. '
                 'With "since run start" shows the accumulated total; with '

--- a/src/ess/livedata/workflows/monitor_workflow_specs.py
+++ b/src/ess/livedata/workflows/monitor_workflow_specs.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import abc
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
 import pydantic
 import scipp as sc
@@ -16,6 +16,7 @@ from ..config.workflow_spec import (
     MONITORS,
     AuxSources,
     OutputView,
+    Temporality,
     WorkflowOutputsBase,
 )
 from .detector_view_specs import CoordinateMode, CoordinateModeSettings
@@ -231,7 +232,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
     # Field names are kept stable as wire-format identifiers (ResultKey,
     # da00 serialisation) and are referenced by ``output_views`` above.
 
-    cumulative: sc.DataArray = pydantic.Field(
+    cumulative: Annotated[sc.DataArray, Temporality.cumulative] = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.zeros(dims=['time_of_arrival'], shape=[0], unit='counts'),
             coords={'time_of_arrival': sc.arange('time_of_arrival', 0, unit='ms')},
@@ -243,7 +244,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'TOA mode a move is not detected and counts accumulate across it.'
         ),
     )
-    current: sc.DataArray = pydantic.Field(
+    current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.zeros(dims=['time_of_arrival'], shape=[0], unit='counts'),
             coords={
@@ -257,7 +258,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'Resets each update interval.'
         ),
     )
-    counts_total: sc.DataArray = pydantic.Field(
+    counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.scalar(0, unit='counts'),
             coords={'time': sc.scalar(0, unit='ns')},
@@ -268,7 +269,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'Resets each update interval.'
         ),
     )
-    counts_in_toa_range: sc.DataArray = pydantic.Field(
+    counts_in_toa_range: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.scalar(0, unit='counts'),
             coords={'time': sc.scalar(0, unit='ns')},
@@ -279,17 +280,21 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'for the latest update interval only. Resets each update interval.'
         ),
     )
-    counts_total_cumulative: sc.DataArray = pydantic.Field(
-        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
-        title='Total',
-        description='Total number of monitor events accumulated since the start '
-        'of the run.',
+    counts_total_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+        pydantic.Field(
+            default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
+            title='Total',
+            description='Total number of monitor events accumulated since the start '
+            'of the run.',
+        )
     )
-    counts_in_toa_range_cumulative: sc.DataArray = pydantic.Field(
-        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
-        title='Total in range',
-        description='Number of monitor events within the configured range filter '
-        'accumulated since the start of the run.',
+    counts_in_toa_range_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+        pydantic.Field(
+            default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
+            title='Total in range',
+            description='Number of monitor events within the configured range filter '
+            'accumulated since the start of the run.',
+        )
     )
 
 

--- a/src/ess/livedata/workflows/monitor_workflow_specs.py
+++ b/src/ess/livedata/workflows/monitor_workflow_specs.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Annotated, ClassVar
+from typing import ClassVar
 
 import pydantic
 import scipp as sc
@@ -15,8 +15,9 @@ from ..config.instrument import Instrument
 from ..config.workflow_spec import (
     MONITORS,
     AuxSources,
+    CumulativeOutput,
     OutputView,
-    Temporality,
+    WindowOutput,
     WorkflowOutputsBase,
 )
 from .detector_view_specs import CoordinateMode, CoordinateModeSettings
@@ -226,7 +227,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
     # Field names are kept stable as wire-format identifiers (ResultKey,
     # da00 serialisation) and are referenced by ``output_views`` above.
 
-    cumulative: Annotated[sc.DataArray, Temporality.cumulative] = pydantic.Field(
+    cumulative: CumulativeOutput = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.zeros(dims=['time_of_arrival'], shape=[0], unit='counts'),
             coords={'time_of_arrival': sc.arange('time_of_arrival', 0, unit='ms')},
@@ -238,7 +239,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'TOA mode a move is not detected and counts accumulate across it.'
         ),
     )
-    current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+    current: WindowOutput = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.zeros(dims=['time_of_arrival'], shape=[0], unit='counts'),
             coords={
@@ -252,7 +253,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'Resets each update interval.'
         ),
     )
-    counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+    counts_total: WindowOutput = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.scalar(0, unit='counts'),
             coords={'time': sc.scalar(0, unit='ns')},
@@ -263,7 +264,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'Resets each update interval.'
         ),
     )
-    counts_in_toa_range: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+    counts_in_toa_range: WindowOutput = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.scalar(0, unit='counts'),
             coords={'time': sc.scalar(0, unit='ns')},
@@ -274,21 +275,17 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
             'for the latest update interval only. Resets each update interval.'
         ),
     )
-    counts_total_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-        pydantic.Field(
-            default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
-            title='Total',
-            description='Total number of monitor events accumulated since the start '
-            'of the run.',
-        )
+    counts_total_cumulative: CumulativeOutput = pydantic.Field(
+        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
+        title='Total',
+        description='Total number of monitor events accumulated since the start '
+        'of the run.',
     )
-    counts_in_toa_range_cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-        pydantic.Field(
-            default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
-            title='Total in range',
-            description='Number of monitor events within the configured range filter '
-            'accumulated since the start of the run.',
-        )
+    counts_in_toa_range_cumulative: CumulativeOutput = pydantic.Field(
+        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
+        title='Total in range',
+        description='Number of monitor events within the configured range filter '
+        'accumulated since the start of the run.',
     )
 
 

--- a/src/ess/livedata/workflows/timeseries_workflow_specs.py
+++ b/src/ess/livedata/workflows/timeseries_workflow_specs.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, ClassVar
+from typing import ClassVar
 
 import pydantic
 import scipp as sc
@@ -13,7 +13,7 @@ from ..config.instrument import Instrument
 from ..config.workflow_spec import (
     TIMESERIES,
     OutputView,
-    Temporality,
+    SeriesOutput,
     WorkflowOutputsBase,
 )
 from .workflow_factory import SpecHandle
@@ -39,7 +39,7 @@ class TimeseriesOutputs(WorkflowOutputsBase):
         ),
     )
 
-    delta: Annotated[sc.DataArray, Temporality.series] = pydantic.Field(
+    delta: SeriesOutput = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.scalar(0.0),
             coords={'time': sc.scalar(0, unit='ns')},

--- a/src/ess/livedata/workflows/timeseries_workflow_specs.py
+++ b/src/ess/livedata/workflows/timeseries_workflow_specs.py
@@ -4,13 +4,18 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
 import pydantic
 import scipp as sc
 
 from ..config.instrument import Instrument
-from ..config.workflow_spec import TIMESERIES, OutputView, WorkflowOutputsBase
+from ..config.workflow_spec import (
+    TIMESERIES,
+    OutputView,
+    Temporality,
+    WorkflowOutputsBase,
+)
 from .workflow_factory import SpecHandle
 
 
@@ -18,11 +23,11 @@ class TimeseriesOutputs(WorkflowOutputsBase):
     """Outputs for the timeseries workflow.
 
     The template defines a 0-D DataArray with a scalar ``time`` coordinate.
-    Conceptually, each timeseries value is a timestamped scalar. In practice,
+    Conceptually, each timeseries value is a timestamped scalar; in practice,
     ``TimeseriesStreamProcessor.finalize()`` returns batches (1-D along ``time``)
-    for efficiency, but the ``time`` coordinate remains the defining property:
-    it signals that the data carries its own wall-clock timestamps, so
-    ``_add_time_coords`` will not attach ``start_time``/``end_time``.
+    for efficiency. Either way the ``time`` coordinate is real data — the
+    per-sample wall-clock timestamps — which is what
+    :attr:`Temporality.series` declares.
     """
 
     output_views: ClassVar[tuple[OutputView, ...]] = (
@@ -34,7 +39,7 @@ class TimeseriesOutputs(WorkflowOutputsBase):
         ),
     )
 
-    delta: sc.DataArray = pydantic.Field(
+    delta: Annotated[sc.DataArray, Temporality.series] = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.scalar(0.0),
             coords={'time': sc.scalar(0, unit='ns')},

--- a/src/ess/livedata/workflows/timeseries_workflow_specs.py
+++ b/src/ess/livedata/workflows/timeseries_workflow_specs.py
@@ -34,7 +34,7 @@ class TimeseriesOutputs(WorkflowOutputsBase):
         OutputView(
             name='delta',
             title='Timeseries',
-            fields={'per_update': 'delta'},
+            fields=('delta',),
             description='Timestamped device values; plots accumulate the history.',
         ),
     )

--- a/tests/config/instrument_test.py
+++ b/tests/config/instrument_test.py
@@ -708,7 +708,7 @@ class TestInstrumentRegisterSpec:
         """Test register_spec() with all parameters."""
         import pydantic
 
-        from ess.livedata.config.workflow_spec import AuxSources
+        from ess.livedata.config.workflow_spec import AuxSources, WorkflowOutputsBase
         from ess.livedata.workflows.workflow_factory import SpecHandle
 
         class MyParams(pydantic.BaseModel):
@@ -716,7 +716,7 @@ class TestInstrumentRegisterSpec:
 
         my_aux_sources = AuxSources({'monitor': 'monitor1'})
 
-        class MyOutputs(pydantic.BaseModel):
+        class MyOutputs(WorkflowOutputsBase):
             result: int
 
         instrument = Instrument(name="test_instrument")

--- a/tests/config/registered_workflow_specs_test.py
+++ b/tests/config/registered_workflow_specs_test.py
@@ -17,7 +17,12 @@ import pytest
 
 from ess.livedata.config.instrument import instrument_registry
 from ess.livedata.config.instruments import available_instruments, get_config
-from ess.livedata.config.workflow_spec import JobId, WorkflowConfig, WorkflowId
+from ess.livedata.config.workflow_spec import (
+    JobId,
+    Temporality,
+    WorkflowConfig,
+    WorkflowId,
+)
 from ess.livedata.dashboard.plotter_registry import plotter_registry
 from ess.livedata.dashboard.workflow_configuration_adapter import (
     WorkflowConfigurationAdapter,
@@ -272,4 +277,33 @@ def test_workflow_output_has_compatible_plotter(
         f"View '{view_name}' of {workflow_id} has no compatible plotter. "
         f"Template: ndim={template.ndim}, dims={template.dims}, "
         f"coords={list(template.coords)}"
+    )
+
+
+@pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflow_specs())
+def test_per_update_bindings_agree_with_declared_temporality(
+    instrument_name: str, workflow_id: WorkflowId
+):
+    """Test that ``per_update`` view bindings and ``Temporality.window`` agree.
+
+    The two declare the same fact from opposite ends: ``OutputView.fields``
+    names the field a view exposes when the user asks for a window, and
+    ``Temporality.window`` marks the fields that actually reset each update
+    interval. Drift between them would offer window aggregation over a field
+    that never resets, silently double-counting.
+    """
+    instrument = instrument_registry[instrument_name]
+    spec = instrument.workflow_factory[workflow_id]
+
+    bound_per_update = {
+        field_name
+        for view in spec.get_output_views()
+        if (field_name := view.fields.get('per_update')) is not None
+    }
+    declared_window = set(spec.outputs.fields_with(Temporality.window))
+
+    assert bound_per_update == declared_window, (
+        f"{workflow_id}: fields bound as 'per_update' {sorted(bound_per_update)} "
+        f"disagree with fields declaring Temporality.window "
+        f"{sorted(declared_window)}"
     )

--- a/tests/config/registered_workflow_specs_test.py
+++ b/tests/config/registered_workflow_specs_test.py
@@ -17,12 +17,7 @@ import pytest
 
 from ess.livedata.config.instrument import instrument_registry
 from ess.livedata.config.instruments import available_instruments, get_config
-from ess.livedata.config.workflow_spec import (
-    JobId,
-    Temporality,
-    WorkflowConfig,
-    WorkflowId,
-)
+from ess.livedata.config.workflow_spec import JobId, WorkflowConfig, WorkflowId
 from ess.livedata.dashboard.plotter_registry import plotter_registry
 from ess.livedata.dashboard.workflow_configuration_adapter import (
     WorkflowConfigurationAdapter,
@@ -277,33 +272,4 @@ def test_workflow_output_has_compatible_plotter(
         f"View '{view_name}' of {workflow_id} has no compatible plotter. "
         f"Template: ndim={template.ndim}, dims={template.dims}, "
         f"coords={list(template.coords)}"
-    )
-
-
-@pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflow_specs())
-def test_per_update_bindings_agree_with_declared_temporality(
-    instrument_name: str, workflow_id: WorkflowId
-):
-    """Test that ``per_update`` view bindings and ``Temporality.window`` agree.
-
-    The two declare the same fact from opposite ends: ``OutputView.fields``
-    names the field a view exposes when the user asks for a window, and
-    ``Temporality.window`` marks the fields that actually reset each update
-    interval. Drift between them would offer window aggregation over a field
-    that never resets, silently double-counting.
-    """
-    instrument = instrument_registry[instrument_name]
-    spec = instrument.workflow_factory[workflow_id]
-
-    bound_per_update = {
-        field_name
-        for view in spec.get_output_views()
-        if (field_name := view.fields.get('per_update')) is not None
-    }
-    declared_window = set(spec.outputs.fields_with(Temporality.window))
-
-    assert bound_per_update == declared_window, (
-        f"{workflow_id}: fields bound as 'per_update' {sorted(bound_per_update)} "
-        f"disagree with fields declaring Temporality.window "
-        f"{sorted(declared_window)}"
     )

--- a/tests/config/workflow_spec_test.py
+++ b/tests/config/workflow_spec_test.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import uuid
-from typing import Annotated, ClassVar
+from typing import ClassVar
 
 import pytest
 import scipp as sc
@@ -12,9 +12,12 @@ from ess.livedata.config.workflow_spec import (
     TIMESERIES,
     AuxInput,
     AuxSources,
+    CumulativeOutput,
     JobId,
     OutputView,
+    SeriesOutput,
     Temporality,
+    WindowOutput,
     WorkflowConfig,
     WorkflowId,
     WorkflowOutputsBase,
@@ -716,9 +719,9 @@ class TestTemporality:
     """Tests for the per-field Temporality declaration."""
 
     class Outputs(WorkflowOutputsBase):
-        current: Annotated[sc.DataArray, Temporality.window] = Field(title='Current')
-        total: Annotated[sc.DataArray, Temporality.cumulative] = Field(title='Total')
-        readings: Annotated[sc.DataArray, Temporality.series] = Field(title='Readings')
+        current: WindowOutput = Field(title='Current')
+        total: CumulativeOutput = Field(title='Total')
+        readings: SeriesOutput = Field(title='Readings')
         readback: sc.DataArray = Field(title='Readback')
 
     @pytest.mark.parametrize(
@@ -744,10 +747,8 @@ class TestTemporality:
 
     def test_declaration_is_inherited_and_overridable(self) -> None:
         class Derived(self.Outputs):
-            readback: Annotated[sc.DataArray, Temporality.window] = Field(
-                title='Readback'
-            )
-            extra: Annotated[sc.DataArray, Temporality.window] = Field(title='Extra')
+            readback: WindowOutput = Field(title='Readback')
+            extra: WindowOutput = Field(title='Extra')
 
         assert Derived.temporality('current') is Temporality.window
         assert Derived.fields_with(Temporality.window) == (
@@ -769,7 +770,7 @@ class TestFindTimeseriesOutputs:
         from ess.livedata.config.workflow_spec import find_timeseries_outputs
 
         class TimeseriesOutputs(WorkflowOutputsBase):
-            delta: Annotated[sc.DataArray, Temporality.series] = Field(
+            delta: SeriesOutput = Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
             )
 
@@ -798,7 +799,7 @@ class TestFindTimeseriesOutputs:
         from ess.livedata.config.workflow_spec import find_timeseries_outputs
 
         class NonTimeseriesOutputs(WorkflowOutputsBase):
-            histogram: Annotated[sc.DataArray, Temporality.window] = Field(
+            histogram: WindowOutput = Field(
                 default_factory=lambda: sc.DataArray(sc.zeros(dims=['x'], shape=[10])),
             )
 
@@ -882,7 +883,7 @@ class TestFindTimeseriesOutputs:
         from ess.livedata.config.workflow_spec import find_timeseries_outputs
 
         class TimeseriesOutputs(WorkflowOutputsBase):
-            delta: Annotated[sc.DataArray, Temporality.series] = Field(
+            delta: SeriesOutput = Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
             )
 
@@ -964,12 +965,8 @@ class TestOutputViews:
                     fields=('cumulative', 'current'),
                 ),
             )
-            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = Field(
-                title='cumulative-field'
-            )
-            current: Annotated[sc.DataArray, Temporality.window] = Field(
-                title='current-field'
-            )
+            cumulative: CumulativeOutput = Field(title='cumulative-field')
+            current: WindowOutput = Field(title='current-field')
 
         spec = WorkflowSpec(
             instrument='test',
@@ -1012,12 +1009,12 @@ class TestOutputViews:
                     fields=('cumulative', 'current'),
                 ),
             )
-            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = Field(
+            cumulative: CumulativeOutput = Field(
                 default_factory=lambda: sc.DataArray(
                     sc.zeros(dims=['x'], shape=[3], unit='counts')
                 )
             )
-            current: Annotated[sc.DataArray, Temporality.window] = Field(
+            current: WindowOutput = Field(
                 default_factory=lambda: sc.DataArray(
                     sc.zeros(dims=['x'], shape=[3], unit='counts')
                 )
@@ -1104,8 +1101,8 @@ class TestUnambiguousWindowing:
             output_views: ClassVar[tuple[OutputView, ...]] = (
                 OutputView(name='v', title='V', fields=('a', 'b')),
             )
-            a: Annotated[sc.DataArray, Temporality.window] = Field(title='A')
-            b: Annotated[sc.DataArray, Temporality.window] = Field(title='B')
+            a: WindowOutput = Field(title='A')
+            b: WindowOutput = Field(title='B')
 
         with pytest.raises(ValueError, match="multiple fields backing 'per_update'"):
             self._spec(Outputs)
@@ -1126,8 +1123,8 @@ class TestUnambiguousWindowing:
             output_views: ClassVar[tuple[OutputView, ...]] = (
                 OutputView(name='v', title='V', fields=('a', 'b')),
             )
-            a: Annotated[sc.DataArray, Temporality.cumulative] = Field(title='A')
-            b: Annotated[sc.DataArray, Temporality.window] = Field(title='B')
+            a: CumulativeOutput = Field(title='A')
+            b: WindowOutput = Field(title='B')
 
         spec = self._spec(Outputs)
         assert spec.field_for('v', 'since_start') == 'a'
@@ -1139,7 +1136,7 @@ class TestUnambiguousWindowing:
             output_views: ClassVar[tuple[OutputView, ...]] = (
                 OutputView(name='v', title='V', fields=('delta',)),
             )
-            delta: Annotated[sc.DataArray, Temporality.series] = Field(title='Delta')
+            delta: SeriesOutput = Field(title='Delta')
 
         spec = self._spec(Outputs)
         assert spec.windowing_options('v') == frozenset({'per_update'})

--- a/tests/config/workflow_spec_test.py
+++ b/tests/config/workflow_spec_test.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import uuid
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
 import pytest
 import scipp as sc
@@ -14,6 +14,7 @@ from ess.livedata.config.workflow_spec import (
     AuxSources,
     JobId,
     OutputView,
+    Temporality,
     WorkflowConfig,
     WorkflowId,
     WorkflowOutputsBase,
@@ -711,19 +712,65 @@ class TestJobId:
         assert str(job_id_2) == f'detector_2/{job_number}'
 
 
+class TestTemporality:
+    """Tests for the per-field Temporality declaration."""
+
+    class Outputs(WorkflowOutputsBase):
+        current: Annotated[sc.DataArray, Temporality.window] = Field(title='Current')
+        total: Annotated[sc.DataArray, Temporality.cumulative] = Field(title='Total')
+        readings: Annotated[sc.DataArray, Temporality.series] = Field(title='Readings')
+        readback: sc.DataArray = Field(title='Readback')
+
+    @pytest.mark.parametrize(
+        ('field_name', 'expected'),
+        [
+            ('current', Temporality.window),
+            ('total', Temporality.cumulative),
+            ('readings', Temporality.series),
+        ],
+    )
+    def test_returns_declared_temporality(
+        self, field_name: str, expected: Temporality
+    ) -> None:
+        assert self.Outputs.temporality(field_name) is expected
+
+    def test_undeclared_field_defaults_to_cumulative(self) -> None:
+        assert self.Outputs.temporality('readback') is Temporality.cumulative
+
+    def test_fields_with_selects_by_temporality(self) -> None:
+        assert self.Outputs.fields_with(Temporality.window) == ('current',)
+        assert self.Outputs.fields_with(Temporality.series) == ('readings',)
+        assert self.Outputs.fields_with(Temporality.cumulative) == ('total', 'readback')
+
+    def test_declaration_is_inherited_and_overridable(self) -> None:
+        class Derived(self.Outputs):
+            readback: Annotated[sc.DataArray, Temporality.window] = Field(
+                title='Readback'
+            )
+            extra: Annotated[sc.DataArray, Temporality.window] = Field(title='Extra')
+
+        assert Derived.temporality('current') is Temporality.window
+        assert Derived.fields_with(Temporality.window) == (
+            'current',
+            'readback',
+            'extra',
+        )
+
+    def test_unknown_field_raises(self) -> None:
+        with pytest.raises(KeyError):
+            self.Outputs.temporality('nonexistent')
+
+
 class TestFindTimeseriesOutputs:
     """Tests for find_timeseries_outputs() helper function."""
 
-    def test_finds_timeseries_output_with_time_coord(self) -> None:
-        """Test that outputs with 0-D data and time coord are found."""
+    def test_finds_0d_series_output(self) -> None:
+        """Test that 0-D outputs declaring Temporality.series are found."""
         from ess.livedata.config.workflow_spec import find_timeseries_outputs
 
         class TimeseriesOutputs(WorkflowOutputsBase):
-            delta: sc.DataArray = Field(
-                default_factory=lambda: sc.DataArray(
-                    sc.scalar(0.0),
-                    coords={'time': sc.scalar(0, unit='ns')},
-                ),
+            delta: Annotated[sc.DataArray, Temporality.series] = Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
             )
 
         workflow_id = WorkflowId(instrument='test', name='test', version=1)
@@ -751,11 +798,8 @@ class TestFindTimeseriesOutputs:
         from ess.livedata.config.workflow_spec import find_timeseries_outputs
 
         class NonTimeseriesOutputs(WorkflowOutputsBase):
-            histogram: sc.DataArray = Field(
-                default_factory=lambda: sc.DataArray(
-                    sc.zeros(dims=['x'], shape=[10]),
-                    coords={'time': sc.scalar(0, unit='ns')},
-                ),
+            histogram: Annotated[sc.DataArray, Temporality.window] = Field(
+                default_factory=lambda: sc.DataArray(sc.zeros(dims=['x'], shape=[10])),
             )
 
         workflow_id = WorkflowId(instrument='test', name='test', version=1)
@@ -775,8 +819,8 @@ class TestFindTimeseriesOutputs:
 
         assert len(results) == 0
 
-    def test_ignores_outputs_without_time_coord(self) -> None:
-        """Test that 0-D outputs without time coord are not identified as timeseries."""
+    def test_ignores_cumulative_outputs(self) -> None:
+        """Test that 0-D cumulative outputs are not identified as timeseries."""
         from ess.livedata.config.workflow_spec import find_timeseries_outputs
 
         class NoTimeCoordOutputs(WorkflowOutputsBase):
@@ -838,11 +882,8 @@ class TestFindTimeseriesOutputs:
         from ess.livedata.config.workflow_spec import find_timeseries_outputs
 
         class TimeseriesOutputs(WorkflowOutputsBase):
-            delta: sc.DataArray = Field(
-                default_factory=lambda: sc.DataArray(
-                    sc.scalar(0.0),
-                    coords={'time': sc.scalar(0, unit='ns')},
-                ),
+            delta: Annotated[sc.DataArray, Temporality.series] = Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
             )
 
         class NonTimeseriesOutputs(WorkflowOutputsBase):

--- a/tests/config/workflow_spec_test.py
+++ b/tests/config/workflow_spec_test.py
@@ -286,18 +286,18 @@ class _CouplingOutputs(WorkflowOutputsBase):
         OutputView(
             name='histogram',
             title='Histogram',
-            fields={'since_start': 'histogram'},
+            fields=('histogram',),
             params=('coordinate_mode', 'toa_edges'),
         ),
         OutputView(
             name='total',
             title='Total',
-            fields={'since_start': 'total'},
+            fields=('total',),
         ),
         OutputView(
             name='total_in_range',
             title='Total in range',
-            fields={'since_start': 'total_in_range'},
+            fields=('total_in_range',),
             params=('coordinate_mode', 'toa_range'),
         ),
     )
@@ -324,7 +324,7 @@ class TestParamOutputCoupling:
     """Tests for OutputView.params and the WorkflowSpec coupling resolvers."""
 
     def test_output_view_params_default_empty(self) -> None:
-        view = OutputView(name='x', title='X', fields={'since_start': 'x'})
+        view = OutputView(name='x', title='X', fields=('x',))
         assert view.params == ()
 
     def test_get_output_param_titles_resolves_in_model_order(self) -> None:
@@ -949,8 +949,9 @@ class TestOutputViews:
         views = spec.get_output_views()
         assert [v.name for v in views] == ['result', 'transmission']
         assert [v.title for v in views] == ['I(Q)', 'Transmission']
-        # Default fallback maps the field via `since_start`.
-        assert views[0].fields == {'since_start': 'result'}
+        # Default fallback creates views with field names as tuple; windowing is
+        # derived from field Temporality annotations (defaulting to cumulative).
+        assert views[0].fields == ('result',)
 
     def test_declared_views_take_precedence(self) -> None:
         """When ``output_views`` is declared, it overrides the fallback."""
@@ -960,11 +961,15 @@ class TestOutputViews:
                 OutputView(
                     name='histogram',
                     title='Histogram',
-                    fields={'since_start': 'cumulative', 'per_update': 'current'},
+                    fields=('cumulative', 'current'),
                 ),
             )
-            cumulative: sc.DataArray = Field(title='cumulative-field')
-            current: sc.DataArray = Field(title='current-field')
+            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = Field(
+                title='cumulative-field'
+            )
+            current: Annotated[sc.DataArray, Temporality.window] = Field(
+                title='current-field'
+            )
 
         spec = WorkflowSpec(
             instrument='test',
@@ -1004,15 +1009,15 @@ class TestOutputViews:
                 OutputView(
                     name='histogram',
                     title='Histogram',
-                    fields={'since_start': 'cumulative', 'per_update': 'current'},
+                    fields=('cumulative', 'current'),
                 ),
             )
-            cumulative: sc.DataArray = Field(
+            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = Field(
                 default_factory=lambda: sc.DataArray(
                     sc.zeros(dims=['x'], shape=[3], unit='counts')
                 )
             )
-            current: sc.DataArray = Field(
+            current: Annotated[sc.DataArray, Temporality.window] = Field(
                 default_factory=lambda: sc.DataArray(
                     sc.zeros(dims=['x'], shape=[3], unit='counts')
                 )
@@ -1037,8 +1042,8 @@ class TestOutputViews:
 
         class Outputs(WorkflowOutputsBase):
             output_views: ClassVar[tuple[OutputView, ...]] = (
-                OutputView(name='a', title='Same', fields={'since_start': 'field_a'}),
-                OutputView(name='b', title='Same', fields={'since_start': 'field_b'}),
+                OutputView(name='a', title='Same', fields=('field_a',)),
+                OutputView(name='b', title='Same', fields=('field_b',)),
             )
             field_a: sc.DataArray = Field()
             field_b: sc.DataArray = Field()
@@ -1060,8 +1065,8 @@ class TestOutputViews:
 
         class Outputs(WorkflowOutputsBase):
             output_views: ClassVar[tuple[OutputView, ...]] = (
-                OutputView(name='a', title='A', fields={'since_start': 'field_a'}),
-                OutputView(name='b', title='B', fields={'since_start': 'field_b'}),
+                OutputView(name='a', title='A', fields=('field_a',)),
+                OutputView(name='b', title='B', fields=('field_b',)),
             )
             field_a: sc.DataArray = Field()
             field_b: sc.DataArray = Field()
@@ -1077,3 +1082,65 @@ class TestOutputViews:
             group=REDUCTION,
         )
         assert [v.title for v in spec.get_output_views()] == ['A', 'B']
+
+
+class TestUnambiguousWindowing:
+    """Tests for the view-level windowing ambiguity check."""
+
+    def _spec(self, outputs: type[WorkflowOutputsBase]) -> WorkflowSpec:
+        return WorkflowSpec(
+            instrument='test',
+            name='wf',
+            version=1,
+            title='T',
+            description='D',
+            params=None,
+            outputs=outputs,
+            group=REDUCTION,
+        )
+
+    def test_rejects_two_fields_backing_the_same_windowing(self) -> None:
+        class Outputs(WorkflowOutputsBase):
+            output_views: ClassVar[tuple[OutputView, ...]] = (
+                OutputView(name='v', title='V', fields=('a', 'b')),
+            )
+            a: Annotated[sc.DataArray, Temporality.window] = Field(title='A')
+            b: Annotated[sc.DataArray, Temporality.window] = Field(title='B')
+
+        with pytest.raises(ValueError, match="multiple fields backing 'per_update'"):
+            self._spec(Outputs)
+
+    def test_rejects_missing_annotation_colliding_on_cumulative(self) -> None:
+        class Outputs(WorkflowOutputsBase):
+            output_views: ClassVar[tuple[OutputView, ...]] = (
+                OutputView(name='v', title='V', fields=('a', 'b')),
+            )
+            a: sc.DataArray = Field(title='A')
+            b: sc.DataArray = Field(title='B')
+
+        with pytest.raises(ValueError, match="multiple fields backing 'since_start'"):
+            self._spec(Outputs)
+
+    def test_accepts_distinct_windowings(self) -> None:
+        class Outputs(WorkflowOutputsBase):
+            output_views: ClassVar[tuple[OutputView, ...]] = (
+                OutputView(name='v', title='V', fields=('a', 'b')),
+            )
+            a: Annotated[sc.DataArray, Temporality.cumulative] = Field(title='A')
+            b: Annotated[sc.DataArray, Temporality.window] = Field(title='B')
+
+        spec = self._spec(Outputs)
+        assert spec.field_for('v', 'since_start') == 'a'
+        assert spec.field_for('v', 'per_update') == 'b'
+        assert spec.windowing_options('v') == frozenset({'since_start', 'per_update'})
+
+    def test_series_field_backs_per_update_only(self) -> None:
+        class Outputs(WorkflowOutputsBase):
+            output_views: ClassVar[tuple[OutputView, ...]] = (
+                OutputView(name='v', title='V', fields=('delta',)),
+            )
+            delta: Annotated[sc.DataArray, Temporality.series] = Field(title='Delta')
+
+        spec = self._spec(Outputs)
+        assert spec.windowing_options('v') == frozenset({'per_update'})
+        assert spec.field_for('v', 'since_start') == 'delta'

--- a/tests/dashboard/derived_devices_test.py
+++ b/tests/dashboard/derived_devices_test.py
@@ -65,12 +65,12 @@ class MonitorOutputs(WorkflowOutputsBase):
         OutputView(
             name='total',
             title='Total',
-            fields={'since_start': 'counts_total_cumulative'},
+            fields=('counts_total_cumulative',),
         ),
         OutputView(
             name='histogram',
             title='Histogram',
-            fields={'since_start': 'histogram'},
+            fields=('histogram',),
         ),
     )
 

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -2106,6 +2106,94 @@ class TestTitleResolver:
             assert resolver.include_output_in_label is True
 
 
+class TestTitleResolverOutputViews:
+    """The resolver maps backing field names to their owning view's title."""
+
+    @pytest.fixture
+    def workflow_spec(self, workflow_id):
+        """A spec whose single view bundles a cumulative and a window field."""
+        import scipp as sc
+
+        from ess.livedata.config.workflow_spec import (
+            REDUCTION,
+            CumulativeOutput,
+            OutputView,
+            WindowOutput,
+            WorkflowOutputsBase,
+            WorkflowSpec,
+        )
+
+        class Params(pydantic.BaseModel):
+            threshold: float = 100.0
+
+        class ViewedOutputs(WorkflowOutputsBase):
+            output_views = (
+                OutputView(
+                    name='histogram',
+                    title='Histogram',
+                    fields=('cumulative', 'current'),
+                ),
+            )
+
+            cumulative: CumulativeOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
+                title='Cumulative',
+            )
+            current: WindowOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
+                title='Current',
+            )
+
+        return WorkflowSpec(
+            instrument=workflow_id.instrument,
+            name=workflow_id.name,
+            version=workflow_id.version,
+            title='Test Workflow',
+            description='A test workflow',
+            source_names=['source1'],
+            params=Params,
+            aux_sources=None,
+            outputs=ViewedOutputs,
+            group=REDUCTION,
+        )
+
+    def test_backing_field_resolves_to_view_title(
+        self,
+        plot_orchestrator,
+        workflow_id,
+        workflow_spec,
+        job_orchestrator,
+        fake_plotting_controller,
+        fake_data_service,
+    ):
+        import scipp as sc
+
+        from ess.livedata.config.workflow_spec import DataKey
+
+        commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
+
+        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=1, ncols=1)
+        config = make_plot_config(
+            workflow_id, source_names=['source1'], output_name='histogram'
+        )
+        add_cell_with_layer(plot_orchestrator, grid_id, DEFAULT_GEOMETRY, config)
+
+        fake_data_service[
+            DataKey(
+                workflow_id=workflow_id,
+                source_name='source1',
+                output_name='current',
+            )
+        ] = sc.scalar(1.0)
+        plot_orchestrator.flush_frames()
+
+        (plotter,) = fake_plotting_controller.created_plotters
+        resolver = plotter.compute_calls[0]['title_resolver']
+        assert resolver.output('cumulative') == 'Histogram'
+        assert resolver.output('current') == 'Histogram'
+        assert resolver.output('unknown_field') == 'unknown_field'
+
+
 class TestRenameGrid:
     """Tests for grid rename functionality."""
 

--- a/tests/dashboard/plotting_controller_test.py
+++ b/tests/dashboard/plotting_controller_test.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
+from typing import Annotated, ClassVar
+
 import holoviews as hv
 import pydantic
 import pytest
@@ -8,6 +10,7 @@ import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
     REDUCTION,
+    Temporality,
     WorkflowId,
     WorkflowOutputsBase,
     WorkflowSpec,
@@ -492,8 +495,6 @@ class TestOverlayPatterns:
 
 class TestOutputViewSupportsWindowing:
     def test_true_when_view_has_both_streams(self) -> None:
-        from typing import ClassVar
-
         from ess.livedata.config.workflow_spec import OutputView
 
         class Outputs(WorkflowOutputsBase):
@@ -501,18 +502,20 @@ class TestOutputViewSupportsWindowing:
                 OutputView(
                     name='image',
                     title='Image',
-                    fields={'since_start': 'cumulative', 'per_update': 'current'},
+                    fields=('cumulative', 'current'),
                 ),
             )
 
-            current: sc.DataArray = pydantic.Field(
+            current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
                 default_factory=lambda: sc.DataArray(
                     sc.zeros(dims=['x'], shape=[0]),
                 )
             )
-            cumulative: sc.DataArray = pydantic.Field(
-                default_factory=lambda: sc.DataArray(
-                    sc.zeros(dims=['x'], shape=[0]),
+            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+                pydantic.Field(
+                    default_factory=lambda: sc.DataArray(
+                        sc.zeros(dims=['x'], shape=[0]),
+                    )
                 )
             )
 
@@ -538,7 +541,7 @@ class TestOutputViewSupportsWindowing:
                 OutputView(
                     name='i_of_q',
                     title='I(Q)',
-                    fields={'since_start': 'i_of_q'},
+                    fields=('i_of_q',),
                 ),
             )
             i_of_q: sc.DataArray = pydantic.Field(
@@ -562,8 +565,6 @@ class TestOutputViewSupportsWindowing:
     def test_true_for_per_update_only_view(self) -> None:
         # A per_update-only view still supports the duration/aggregation controls;
         # the since_start mode is rejected at config time, not by hiding controls.
-        from typing import ClassVar
-
         from ess.livedata.config.workflow_spec import OutputView
 
         class Outputs(WorkflowOutputsBase):
@@ -571,10 +572,10 @@ class TestOutputViewSupportsWindowing:
                 OutputView(
                     name='total',
                     title='Total',
-                    fields={'per_update': 'counts_total'},
+                    fields=('counts_total',),
                 ),
             )
-            counts_total: sc.DataArray = pydantic.Field(
+            counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
             )
 
@@ -624,8 +625,6 @@ class TestSinceStartAvailable:
         )
 
     def test_true_when_view_has_since_start_stream(self) -> None:
-        from typing import ClassVar
-
         from ess.livedata.config.workflow_spec import OutputView
 
         class Outputs(WorkflowOutputsBase):
@@ -633,13 +632,15 @@ class TestSinceStartAvailable:
                 OutputView(
                     name='total',
                     title='Total',
-                    fields={'since_start': 'cumulative', 'per_update': 'current'},
+                    fields=('cumulative', 'current'),
                 ),
             )
-            cumulative: sc.DataArray = pydantic.Field(
-                default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
+            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+                pydantic.Field(
+                    default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
+                )
             )
-            current: sc.DataArray = pydantic.Field(
+            current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
             )
 
@@ -647,17 +648,13 @@ class TestSinceStartAvailable:
         assert since_start_available(spec, 'total') is True
 
     def test_false_for_per_update_only_view(self) -> None:
-        from typing import ClassVar
-
         from ess.livedata.config.workflow_spec import OutputView
 
         class Outputs(WorkflowOutputsBase):
             output_views: ClassVar[tuple[OutputView, ...]] = (
-                OutputView(
-                    name='total', title='Total', fields={'per_update': 'counts_total'}
-                ),
+                OutputView(name='total', title='Total', fields=('counts_total',)),
             )
-            counts_total: sc.DataArray = pydantic.Field(
+            counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
             )
 
@@ -727,12 +724,10 @@ class TestCreateExtractorsFromParams:
         )
 
 
-class TestResolveFieldName:
-    """Verify ``resolve_field_name`` maps (view, windowing) to the backing field."""
+class TestWorkflowSpecFieldFor:
+    """Verify ``WorkflowSpec.field_for`` maps (view, windowing) to the backing field."""
 
     def _spec(self) -> WorkflowSpec:
-        from typing import ClassVar
-
         from ess.livedata.config.workflow_spec import OutputView
 
         class Outputs(WorkflowOutputsBase):
@@ -740,17 +735,19 @@ class TestResolveFieldName:
                 OutputView(
                     name='image',
                     title='Image',
-                    fields={'since_start': 'cumulative', 'per_update': 'current'},
+                    fields=('cumulative', 'current'),
                 ),
                 OutputView(
                     name='total_counts',
                     title='Total',
-                    fields={'per_update': 'counts_total'},
+                    fields=('counts_total',),
                 ),
             )
-            cumulative: sc.DataArray = pydantic.Field()
-            current: sc.DataArray = pydantic.Field()
-            counts_total: sc.DataArray = pydantic.Field()
+            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
+                pydantic.Field()
+            )
+            current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field()
+            counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field()
 
         return WorkflowSpec(
             instrument='test',
@@ -764,35 +761,22 @@ class TestResolveFieldName:
         )
 
     def test_since_start_windowing_resolves_to_cumulative(self) -> None:
-        from ess.livedata.dashboard.plot_orchestrator import resolve_field_name
-
-        assert (
-            resolve_field_name(self._spec(), 'image', windowing='since_start')
-            == 'cumulative'
-        )
+        assert self._spec().field_for('image', windowing='since_start') == 'cumulative'
 
     def test_per_update_windowing_resolves_to_current(self) -> None:
-        from ess.livedata.dashboard.plot_orchestrator import resolve_field_name
-
-        assert (
-            resolve_field_name(self._spec(), 'image', windowing='per_update')
-            == 'current'
-        )
+        assert self._spec().field_for('image', windowing='per_update') == 'current'
 
     def test_falls_back_to_other_windowing_when_requested_missing(self) -> None:
         """``total_counts`` only declares ``per_update``; asking for
         ``since_start`` falls back to it."""
-        from ess.livedata.dashboard.plot_orchestrator import resolve_field_name
-
         assert (
-            resolve_field_name(self._spec(), 'total_counts', windowing='since_start')
+            self._spec().field_for('total_counts', windowing='since_start')
             == 'counts_total'
         )
 
     def test_falls_back_to_view_name_when_no_view_declared(self) -> None:
         """For unannotated outputs classes, the view name is treated as the
         backing field name."""
-        from ess.livedata.dashboard.plot_orchestrator import resolve_field_name
 
         class BareOutputs(WorkflowOutputsBase):
             result: sc.DataArray = pydantic.Field()
@@ -809,4 +793,4 @@ class TestResolveFieldName:
         )
         # The auto-generated view maps `result` via since_start. Asking for
         # per_update on this view falls back to since_start.
-        assert resolve_field_name(spec, 'result', windowing='per_update') == 'result'
+        assert spec.field_for('result', windowing='per_update') == 'result'

--- a/tests/dashboard/plotting_controller_test.py
+++ b/tests/dashboard/plotting_controller_test.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
-from typing import Annotated, ClassVar
+from typing import ClassVar
 
 import holoviews as hv
 import pydantic
@@ -10,7 +10,8 @@ import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
     REDUCTION,
-    Temporality,
+    CumulativeOutput,
+    WindowOutput,
     WorkflowId,
     WorkflowOutputsBase,
     WorkflowSpec,
@@ -506,16 +507,14 @@ class TestOutputViewSupportsWindowing:
                 ),
             )
 
-            current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+            current: WindowOutput = pydantic.Field(
                 default_factory=lambda: sc.DataArray(
                     sc.zeros(dims=['x'], shape=[0]),
                 )
             )
-            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-                pydantic.Field(
-                    default_factory=lambda: sc.DataArray(
-                        sc.zeros(dims=['x'], shape=[0]),
-                    )
+            cumulative: CumulativeOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(
+                    sc.zeros(dims=['x'], shape=[0]),
                 )
             )
 
@@ -575,7 +574,7 @@ class TestOutputViewSupportsWindowing:
                     fields=('counts_total',),
                 ),
             )
-            counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+            counts_total: WindowOutput = pydantic.Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
             )
 
@@ -635,12 +634,10 @@ class TestSinceStartAvailable:
                     fields=('cumulative', 'current'),
                 ),
             )
-            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-                pydantic.Field(
-                    default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
-                )
+            cumulative: CumulativeOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
             )
-            current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+            current: WindowOutput = pydantic.Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
             )
 
@@ -654,7 +651,7 @@ class TestSinceStartAvailable:
             output_views: ClassVar[tuple[OutputView, ...]] = (
                 OutputView(name='total', title='Total', fields=('counts_total',)),
             )
-            counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field(
+            counts_total: WindowOutput = pydantic.Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
             )
 
@@ -743,11 +740,9 @@ class TestWorkflowSpecFieldFor:
                     fields=('counts_total',),
                 ),
             )
-            cumulative: Annotated[sc.DataArray, Temporality.cumulative] = (
-                pydantic.Field()
-            )
-            current: Annotated[sc.DataArray, Temporality.window] = pydantic.Field()
-            counts_total: Annotated[sc.DataArray, Temporality.window] = pydantic.Field()
+            cumulative: CumulativeOutput = pydantic.Field()
+            current: WindowOutput = pydantic.Field()
+            counts_total: WindowOutput = pydantic.Field()
 
         return WorkflowSpec(
             instrument='test',

--- a/tests/dashboard/widgets/derived_devices_overview_test.py
+++ b/tests/dashboard/widgets/derived_devices_overview_test.py
@@ -42,7 +42,7 @@ class MonitorOutputs(WorkflowOutputsBase):
         OutputView(
             name='total',
             title='Total',
-            fields={'since_start': 'counts_total_cumulative'},
+            fields=('counts_total_cumulative',),
         ),
     )
 

--- a/tests/dashboard/widgets/workflow_status_device_test.py
+++ b/tests/dashboard/widgets/workflow_status_device_test.py
@@ -60,11 +60,9 @@ class MonitorOutputs(WorkflowOutputsBase):
         OutputView(
             name='total',
             title='Total',
-            fields={'since_start': 'counts_total_cumulative'},
+            fields=('counts_total_cumulative',),
         ),
-        OutputView(
-            name='histogram', title='Histogram', fields={'since_start': 'histogram'}
-        ),
+        OutputView(name='histogram', title='Histogram', fields=('histogram',)),
     )
 
 


### PR DESCRIPTION
Whether a workflow output can be plotted as a history — and whether summing successive messages of it is meaningful — was decided by a coord-name convention: a scalar `time` coord on the data (and on the output template) meant "per-window scalar". Nothing declared it, so the rule was enforced only by a runtime `ValueError` deep inside `TemporalBuffer`, and `find_timeseries_outputs` had to sniff output templates to rediscover it.

`Temporality` states the fact once, per output field: `window` (covers `[start_time, end_time)`, successive windows disjoint), `cumulative` (value as of `end_time`, with `start_time` pinned for the generation), or `series` (carries its own per-point `time` axis). Fields declare it by their annotation — `current: WindowOutput = pydantic.Field(...)` — which is `Annotated` metadata, the documented home for this kind of per-field fact; a bare `sc.DataArray` still means cumulative, so reduction outputs need no annotation.

The three-way split matters because the timeseries path is neither of the first two. Its `time` coord is real per-sample data, and it deliberately carries no `start_time`/`end_time` at all — `Job._add_time_coords` skips it. Issue #1058 proposes two roles and assumes every output already carries both bounds; that assumption does not hold, which is what motivated the third value here.

Three duplicated declarations collapse into it:

- The `window_outputs` lists passed to `StreamProcessorWorkflow` are derived from the outputs model rather than hand-maintained beside it.
- `find_timeseries_outputs` asks for the declaration instead of inspecting template coords.
- `OutputView.fields` no longer keys backing fields by `Windowing`. That key was never independent information — checked across all 157 output views of all instruments, it is a total function of `Temporality` (`window` and `series` back `per_update`, `cumulative` backs `since_start`). Views now list their member fields and the binding follows, so there is no second place to state it and nothing to keep in sync. Resolution needs the outputs model, so it lives on `WorkflowSpec` (`field_for`, `windowing_options`).

Selecting the same window mode from two fields of one view would be ambiguous, so a validator rejects it at registration — usually a missing annotation, since unannotated fields default to `cumulative`.

No behaviour change: the derived `window_outputs` reproduce the previous hand-written lists exactly, the derived windowing bindings reproduce the previously declared ones for every view, and correlation-axis discovery selects the same output views as before.

`WorkflowSpec.outputs` is tightened to `type[WorkflowOutputsBase]`, since every real outputs model already derives from it and the new accessors live there.

## Groundwork for #1058

This is the declaration half of #1058's third proposal. Follow-ups, in order:

- Re-key `TemporalBuffer` on `end_time` rather than the scalar `time`. Note #1058 proposes `start_time`, which does not work: for cumulative outputs `start_time` is pinned at generation start, so every point of a growth curve would land on the same x. `end_time` is the only bound that advances for both window and cumulative outputs.
- Drop the redundant scalar `time` coord and the `with_time_coord` templates, which is where #1058's da00 saving lands.
- Gate window aggregation and rate normalization on `Temporality.window` via `DataRequirements`, turning today's buried `ValueError` into a capability distinction at plot-configuration time.

Depends on #1131 for the second bullet: `AreaDetectorView`'s `current` output currently has no `start_time`/`end_time` at all.

## Test plan

- `pytest` full fast suite green.
- New unit tests for `temporality()` / `fields_with()`, including inheritance and override.
- New cross-check parametrized over all 47 registered workflow specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
