### PR TITLE
Exclude correlation points predating the axis history

### DIFF
--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -147,24 +147,6 @@ CORRELATION_HISTOGRAM_PLOTTERS = frozenset(
 )
 
 
-def _make_lookup(axis_data: sc.DataArray, data_max_time: sc.Variable) -> sc.bins.Lookup:
-    """Create lookup table with appropriate mode based on time overlap.
-
-    Uses 'previous' mode normally, but falls back to 'nearest' if all data
-    timestamps are before the first axis timestamp (which would produce NaNs).
-    """
-    axis_values = sc.values(axis_data) if axis_data.variances is not None else axis_data
-    axis_min_time = axis_data.coords['time'].min()
-    mode = 'nearest' if data_max_time < axis_min_time else 'previous'
-    if mode == 'nearest':  # scipp>=25.11.0 rejects int coords in this mode
-        dim = axis_values.dim
-        coord = axis_values.coords[dim]
-        # Only convert to float64 if needed; datetime64 coords are accepted as-is
-        if coord.dtype != sc.DType.datetime64:
-            axis_values = axis_values.assign_coords({dim: coord.astype('float64')})
-    return sc.lookup(axis_values, mode=mode)
-
-
 @dataclass(frozen=True)
 class AxisSpec:
     """Specification for a correlation axis."""
@@ -203,6 +185,13 @@ class CorrelationHistogramPlotter:
     Receives role-grouped data from DataSubscriber:
     - "primary": dict[DataKey, DataArray] - data to histogram
     - One or more axis roles (e.g., "x_axis", "y_axis") containing correlation values
+
+    Each point of the primary data is correlated with the axis value in effect at
+    its timestamp, i.e. the most recent axis reading at or before it. Points
+    predating the first reading of any axis have no such value and are excluded
+    from the histogram; correlating them with a reading taken later would be
+    fabricating the axis history. The plot therefore starts empty until the axes
+    and the data overlap in time.
     """
 
     AUTOSCALE_AXES: ClassVar[frozenset[Axis]] = frozenset()
@@ -231,6 +220,10 @@ class CorrelationHistogramPlotter:
     ) -> None:
         """Compute histograms for all data sources and render.
 
+        Data points predating the first reading of any axis are excluded. If that
+        leaves nothing to histogram, the render is skipped and the layer keeps
+        showing its placeholder.
+
         Parameters
         ----------
         data
@@ -256,15 +249,23 @@ class CorrelationHistogramPlotter:
                 )
             axis_data[axis.name] = ax
 
+        lookups = {
+            name: sc.lookup(sc.values(ax), mode='previous')
+            for name, ax in axis_data.items()
+        }
+        # Earliest time at which every axis has a reading. Before it, 'previous'
+        # lookup yields NaN, which hist()/bin() would drop without a trace.
+        start = max(ax.coords['time'].min() for ax in axis_data.values())
+
         histograms: dict[DataKey, sc.DataArray] = {}
         for key, source_data in histogram_data.items():
-            dependent = source_data.copy(deep=False)
-            data_max_time = dependent.coords['time'].max()
+            dependent = source_data['time', start:].copy(deep=False)
+            if dependent.sizes['time'] == 0:
+                continue
 
             # Add all axis coordinates via lookup
-            for axis in self._axes:
-                lut = _make_lookup(axis_data[axis.name], data_max_time)
-                dependent.coords[axis.name] = lut[dependent.coords['time']]
+            for name, lut in lookups.items():
+                dependent.coords[name] = lut[dependent.coords['time']]
 
             bin_spec = {
                 axis.name: _axis_bins(dependent.coords[axis.name], axis)
@@ -280,6 +281,9 @@ class CorrelationHistogramPlotter:
                 histograms[key] = dependent.bin(bin_spec).bins.mean()
             else:
                 histograms[key] = dependent.hist(bin_spec)
+
+        if not histograms:
+            return
 
         self._renderer.compute({PRIMARY: histograms}, title_resolver=title_resolver)
 

--- a/tests/dashboard/correlation_plotter_test.py
+++ b/tests/dashboard/correlation_plotter_test.py
@@ -20,10 +20,9 @@ from ess.livedata.dashboard.correlation_plotter import (
     CorrelationHistogram2dParams,
     CorrelationHistogram2dPlotter,
     CorrelationHistogramPlotter,
-    _make_lookup,
 )
-from ess.livedata.dashboard.plot_params import PlotScaleParams
-from ess.livedata.dashboard.plots import LinePlotter
+from ess.livedata.dashboard.plot_params import PlotScaleParams, PlotScaleParams2d
+from ess.livedata.dashboard.plots import ImagePlotter, LinePlotter
 
 hv.extension('bokeh')
 
@@ -65,79 +64,11 @@ def make_source_data(
     )
 
 
-class TestMakeLookup:
-    """Tests for the _make_lookup helper function."""
-
-    def test_uses_previous_mode_when_data_overlaps_axis(self):
-        """When data timestamps overlap with axis range, uses 'previous' mode."""
-        axis_data = make_axis_data(times=[100, 200, 300], values=[1.0, 2.0, 3.0])
-        data_max_time = sc.scalar(250, unit='ms')
-
-        lookup = _make_lookup(axis_data, data_max_time)
-
-        # 'previous' mode: for time=150, should get value at time=100 (1.0)
-        result = lookup[sc.scalar(150, unit='ms')]
-        assert result.value == 1.0
-
-    def test_uses_nearest_mode_when_data_before_axis(self):
-        """When all data timestamps are before the first axis timestamp,
-        falls back to 'nearest' mode to avoid NaN coordinates.
-        """
-        axis_data = make_axis_data(times=[100, 200, 300], values=[1.0, 2.0, 3.0])
-        data_max_time = sc.scalar(50, unit='ms')  # Before first axis timestamp
-
-        lookup = _make_lookup(axis_data, data_max_time)
-
-        # 'nearest' mode: for time=50, should get value at nearest time=100 (1.0)
-        result = lookup[sc.scalar(50, unit='ms')]
-        assert result.value == 1.0
-
-    def test_handles_axis_data_with_variances(self):
-        """Lookup should work when axis data has variances."""
-        axis_data = sc.DataArray(
-            data=sc.array(
-                dims=['time'],
-                values=[1.0, 2.0, 3.0],
-                variances=[0.1, 0.1, 0.1],
-                unit='m',
-            ),
-            coords={'time': sc.array(dims=['time'], values=[100, 200, 300], unit='ms')},
-        )
-        data_max_time = sc.scalar(250, unit='ms')
-
-        lookup = _make_lookup(axis_data, data_max_time)
-
-        result = lookup[sc.scalar(150, unit='ms')]
-        assert result.value == 1.0
-
-    def test_handles_datetime64_coord_in_nearest_mode(self):
-        """Lookup should work when axis dimension is datetime64 and nearest mode.
-
-        When data timestamps are before the axis range, 'nearest' mode is used.
-        If the axis dimension coordinate is datetime64, the astype('float64')
-        conversion should be skipped since datetime64 is not an int dtype.
-        """
-        # Create datetime64 timestamps using scipp's datetime function
-        base_ns = 1_000_000_000_000_000_000  # Some epoch nanoseconds
-        times = sc.datetimes(
-            dims=['time'],
-            values=[base_ns + i * 1_000_000_000 for i in range(3)],  # 1s apart
-            unit='ns',
-        )
-        axis_data = sc.DataArray(
-            data=sc.array(dims=['time'], values=[1.0, 2.0, 3.0], unit='m'),
-            coords={'time': times},
-        )
-        # Data max time is before the first axis timestamp
-        data_max_time = sc.datetime(base_ns - 1_000_000_000, unit='ns')  # 1s before
-
-        # Should not raise DTypeError about astype not supporting datetime64
-        lookup = _make_lookup(axis_data, data_max_time)
-
-        # 'nearest' mode: should get value at nearest time (the first one)
-        query_time = sc.datetime(base_ns - 500_000_000, unit='ns')  # 500ms before
-        result = lookup[query_time]
-        assert result.value == 1.0
+def histogram_of(plotter: CorrelationHistogramPlotter) -> dict[str, np.ndarray]:
+    """Return the raw data of the single histogram in the plotter's cached state."""
+    state = plotter.get_cached_state()
+    assert state is not None
+    return next(iter(state.values())).data
 
 
 class TestCorrelationHistogramPlotter:
@@ -243,29 +174,171 @@ class TestCorrelationHistogramPlotter:
         assert result is not None
         assert result.label == 'Detector/I(d)'
 
-    def test_handles_data_before_axis_range(self):
-        """When data timestamps are before the first axis timestamp,
-        the plotter falls back to 'nearest' mode to avoid NaN coordinates.
-        """
-        # Axis data starts at t=100
-        axis_data = make_axis_data(times=[100, 200, 300], values=[1.0, 2.0, 3.0])
-        # Source data is all BEFORE the first axis timestamp
-        source_data = make_source_data(times=[50, 60, 70], values=[10.0, 20.0, 30.0])
+    def test_handles_axis_data_with_variances(self):
+        """Axis values with variances are usable as correlation coordinates."""
+        axis_data = sc.DataArray(
+            data=sc.array(
+                dims=['time'],
+                values=[1.0, 2.0, 3.0],
+                variances=[0.1, 0.1, 0.1],
+                unit='m',
+            ),
+            coords={'time': sc.array(dims=['time'], values=[100, 200, 300], unit='ms')},
+        )
+        source_data = make_source_data(times=[150, 250], values=[10.0, 20.0])
 
-        axes = [AxisSpec(role=X_AXIS, name='position', bins=10)]
+        axes = [AxisSpec(role=X_AXIS, name='position', bins=2)]
         plotter = CorrelationHistogramPlotter(
             axes=axes, normalize=False, renderer=_make_line_renderer()
         )
 
-        data = {
-            PRIMARY: {_make_result_key('detector'): source_data},
-            X_AXIS: {_make_result_key('position'): axis_data},
-        }
+        plotter.compute(
+            {
+                PRIMARY: {_make_result_key('detector'): source_data},
+                X_AXIS: {_make_result_key('position'): axis_data},
+            }
+        )
 
-        # Should not raise
-        plotter.compute(data)
-        result = plotter.get_cached_state()
-        assert result is not None
+        assert histogram_of(plotter)['values'].sum() == 30.0
+
+    def test_handles_datetime64_time_coords(self):
+        """Correlation works when timestamps are datetime64 rather than integers."""
+        base_ns = 1_000_000_000_000_000_000
+        axis_data = sc.DataArray(
+            data=sc.array(dims=['time'], values=[1.0, 2.0, 3.0], unit='m'),
+            coords={
+                'time': sc.datetimes(
+                    dims=['time'],
+                    values=[base_ns + i * 1_000_000_000 for i in range(3)],
+                    unit='ns',
+                )
+            },
+        )
+        source_data = sc.DataArray(
+            data=sc.array(dims=['time'], values=[10.0, 20.0], unit='counts'),
+            coords={
+                'time': sc.datetimes(
+                    dims=['time'],
+                    values=[base_ns + 500_000_000, base_ns + 1_500_000_000],
+                    unit='ns',
+                )
+            },
+        )
+
+        axes = [AxisSpec(role=X_AXIS, name='position', bins=2)]
+        plotter = CorrelationHistogramPlotter(
+            axes=axes, normalize=False, renderer=_make_line_renderer()
+        )
+
+        plotter.compute(
+            {
+                PRIMARY: {_make_result_key('detector'): source_data},
+                X_AXIS: {_make_result_key('position'): axis_data},
+            }
+        )
+
+        assert histogram_of(plotter)['values'].sum() == 30.0
+
+
+class TestDataPrecedingAxisHistory:
+    """Points without a known axis value are excluded, consistently over time."""
+
+    axis_data = make_axis_data(times=[100, 200, 300], values=[1.0, 2.0, 3.0])
+
+    def _make_plotter(self) -> CorrelationHistogramPlotter:
+        return CorrelationHistogramPlotter(
+            axes=[AxisSpec(role=X_AXIS, name='position', bins=4)],
+            normalize=False,
+            renderer=_make_line_renderer(),
+        )
+
+    def _compute(
+        self, plotter: CorrelationHistogramPlotter, source_data: sc.DataArray
+    ) -> None:
+        plotter.compute(
+            {
+                PRIMARY: {_make_result_key('detector'): source_data},
+                X_AXIS: {_make_result_key('position'): self.axis_data},
+            }
+        )
+
+    def test_excludes_points_before_first_axis_reading(self):
+        """Points predating the axis history contribute nothing to the histogram."""
+        plotter = self._make_plotter()
+
+        # t=50 precedes the first axis reading at t=100.
+        self._compute(plotter, make_source_data([50, 150, 250], [10.0, 20.0, 30.0]))
+
+        assert histogram_of(plotter)['values'].sum() == 50.0
+
+    def test_renders_nothing_while_all_points_precede_axis(self):
+        """Fully preceding data yields no plot rather than an error or a guess."""
+        plotter = self._make_plotter()
+
+        self._compute(plotter, make_source_data([50, 60, 70], [10.0, 20.0, 30.0]))
+
+        assert not plotter.has_cached_state()
+
+    def test_preceding_points_never_appear_and_then_vanish(self):
+        """Growing history must not retroactively remove already-shown points.
+
+        Correlating pre-axis points against a later reading would make them
+        visible until the streams overlap, at which point they would silently
+        disappear again.
+        """
+        plotter = self._make_plotter()
+
+        self._compute(plotter, make_source_data([50, 60], [10.0, 20.0]))
+        assert not plotter.has_cached_state()
+
+        self._compute(
+            plotter, make_source_data([50, 60, 150, 250], [10.0, 20.0, 30.0, 40.0])
+        )
+
+        assert histogram_of(plotter)['values'].sum() == 70.0
+
+    def test_uses_latest_axis_reading_at_or_before_each_point(self):
+        """Each point is correlated with the axis value in effect at its time."""
+        plotter = self._make_plotter()
+
+        self._compute(plotter, make_source_data([150, 250], [10.0, 20.0]))
+
+        histogram = histogram_of(plotter)
+        # Values 1.0 and 2.0 are in effect at t=150 and t=250, so the histogram
+        # spans [1, 2] with the two counts landing in the outer bins.
+        edges = [1.0, 1.25, 1.5, 1.75, 2.0]
+        assert histogram['position'].tolist() == pytest.approx(edges)
+        assert histogram['values'].tolist() == [10.0, 0.0, 0.0, 20.0]
+
+    def test_excludes_points_preceding_any_axis_in_2d(self):
+        """With multiple axes the latest axis start determines the cutoff."""
+        plotter = CorrelationHistogramPlotter(
+            axes=[
+                AxisSpec(role=X_AXIS, name='position', bins=2),
+                AxisSpec(role=Y_AXIS, name='temperature', bins=2),
+            ],
+            normalize=False,
+            renderer=ImagePlotter(scale_opts=PlotScaleParams2d()),
+        )
+
+        plotter.compute(
+            {
+                PRIMARY: {
+                    _make_result_key('detector'): make_source_data(
+                        [150, 250, 350, 450], [10.0, 20.0, 30.0, 40.0]
+                    )
+                },
+                X_AXIS: {_make_result_key('position'): self.axis_data},
+                # Temperature only starts at t=300, so t=150 and t=250 are excluded.
+                Y_AXIS: {
+                    _make_result_key('temperature'): make_axis_data(
+                        times=[300, 400], values=[10.0, 20.0], value_unit='K'
+                    )
+                },
+            }
+        )
+
+        assert np.nansum(histogram_of(plotter)['values']) == 70.0
 
 
 class TestConstantAxisValues:


### PR DESCRIPTION
Closes #1075.

The lookup mode for correlation histograms was picked from a global comparison of the histogrammed data's latest timestamp against the axis data's earliest one, and re-derived from scratch on every `compute()` over the full accumulated history. While the data still preceded the axis entirely, `'nearest'` correlated those points with the first axis reading — measured after them. Once the two streams' time ranges started to overlap, the whole history flipped to `'previous'` in one step and the early points, now NaN-coordinated, were silently dropped by `hist()`/`bin()`. Displayed totals changed discontinuously with no user action and no error.

This takes the option sketched at the end of the issue: there is no axis value to correlate a point with before the first axis reading, so such points are excluded explicitly and consistently, whatever the rest of the history looks like. They are trimmed up front rather than included and then dropped by the binning — the excluded set is identical, but it no longer depends on how the two streams happened to line up. A plot with nothing left to show renders nothing (the layer keeps its placeholder) rather than showing a guess, which is what the `'nearest'` fallback was originally added to avoid: `hist()` raising "Empty data range". With the mode no longer data-dependent, the mode switch and its scipp int-coord workaround go away, and the lookups are built once instead of per source.

Two consequences worth knowing:

- The cutoff is the first *available* axis reading, not the first ever. `TemporalBuffer` falls back to ring-buffer eviction when memory-capped even at `required_timespan=inf`, so on long runs the cutoff can advance and points can leave the histogram. This already happens today through the silent NaN path, so it is not a regression, and scalar logdata buffers should far outlast the primary's history in practice.
- Non-monotonic primary timestamps now raise instead of producing something. Label-based slicing requires a sorted time coord, where previously only the axis coord had to be sorted (`sc.lookup`'s requirement). Out-of-order results would be our own fault, so failing loudly seemed right, but it does turn a cosmetic anomaly into an ERROR-state plot.

## Test plan

Regression test follows the issue's hint: compute once with a history entirely preceding the axis data, then again with that history plus overlapping data, asserting the early points are consistently absent rather than shown and then silently removed. Tests for `_make_lookup` are replaced by behaviour tests through `compute()`, retaining the datetime64 and variance coverage.

- [ ] Correlation histogram in the live dashboard fills in as usual once the axis timeseries and the data overlap.
