### PR TITLE
Enable cumulative history plots: stamp every output with a 'time' coord

### DIFF
--- a/docs/developer/adr/0006-nicos-derived-devices.md
+++ b/docs/developer/adr/0006-nicos-derived-devices.md
@@ -1,6 +1,6 @@
 # ADR 0006: Expose designated workflow outputs to NICOS as derived devices
 
-- Status: accepted
+- Status: accepted (amended 2026-07-29)
 - Deciders: Simon
 - Date: 2026-06-29
 
@@ -45,7 +45,8 @@ device.
   is not part of the external identity.
 - **Wire schema**: `da00`. It carries the signal, its error bar, and the
   `start_time` coordinate as named variables. `f144` is a lone scalar and cannot
-  carry the marker; it is not used.
+  carry the marker; it is not used. (See the 2026-07-29 amendment for the upper
+  time bound this also carries.)
 - **Eligibility**: decided by the workflow registry (`WorkflowSpec.device_outputs`).
   The extractor trusts the contract and emits whatever it designates; there is no
   runtime scalar/cumulative check. Devices are scalar cumulative outputs by
@@ -240,3 +241,20 @@ job-level generation marker is a reliable signal. That notification is deferred.
   heartbeat; `ep01` is not used) and a separate validity channel (the `da00` error
   bar carries the uncertainty; NICOS scripts its own statistic). The internal
   `ResultKey` / `job_number` refactor is off this critical path.
+
+## Amendment 2026-07-29: the upper time bound is echoed as `end_time`
+
+The wire schema above names only `start_time`, but the device topic has always
+also carried the upper bound of the accumulation: `Job._add_time_coords` stamps
+it next to `start_time`, and `DeviceExtractor` republishes the output verbatim.
+
+That bound is now called `time` internally. It is the instant the value refers
+to, which for a cumulative device is when the total was observed, not when
+anything ended — `end_time` was a poor name for a still-running accumulation, and
+that is why it was renamed. It is, however, the name NICOS's consumer reads.
+
+`DeviceExtractor` therefore *adds* `end_time` alongside `time` rather than
+renaming it, so the device topic publishes `signal`, `start_time`, `end_time`,
+and now `time` as well. NICOS's contract is unchanged and it can adopt `time` on
+its own schedule; the decision above — `start_time` as the sole generation
+marker — is untouched.

--- a/src/ess/livedata/config/instruments/bifrost/factories.py
+++ b/src/ess/livedata/config/instruments/bifrost/factories.py
@@ -347,8 +347,8 @@ def _create_base_reduction_workflow():
         """Sum detector counts in the selected arc and pixel range for one update.
 
         Emits bare per-update counts with no time coords: ``StreamProcessorWorkflow``
-        stamps ``start_time``/``end_time`` (needed for the dashboard's rate
-        normalization) on the accumulated outputs, per the window/cumulative
+        stamps ``start_time``/``time`` (the bounds the dashboard's rate
+        normalization needs) on the accumulated outputs, per the window/cumulative
         convention. Stamping here instead would suppress that (see
         ``_add_time_coords``) and break coord matching across the accumulator sum.
         """

--- a/src/ess/livedata/config/instruments/bifrost/specs.py
+++ b/src/ess/livedata/config/instruments/bifrost/specs.py
@@ -117,10 +117,7 @@ class DetectorRatemeterOutputs(WorkflowOutputsBase):
     )
 
     detector_region_counts: WindowOutput = pydantic.Field(
-        default_factory=lambda: sc.DataArray(
-            sc.scalar(0, unit='counts'),
-            coords={'time': sc.scalar(0, unit='ns')},
-        ),
+        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
         title='Detector Region Counts',
         description=(
             'Counts for the selected arc and pixel range, for the latest update '

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -55,22 +55,30 @@ class Temporality(enum.Enum):
     operations over successive messages are valid. The two are not
     interchangeable — ``since_start`` is the default binding for fields that are
     not accumulations at all (ROI readbacks, static views).
+
+    Every emitted DataArray carries a ``time`` coord: the instant its value
+    refers to. What differs per temporality is what that instant means and what
+    accompanies it, and this is the one place that says so. Code holding data
+    but not the declaration sniffs for those coords; it is answering this
+    question.
     """
 
     window = 'window'
-    """Covers ``[start_time, end_time)``; successive windows are disjoint and
-    advance. Summing or averaging over consecutive messages is meaningful, as is
-    normalizing counts by the window duration."""
+    """Covers ``[start_time, time]``, where ``time`` is when the window closed.
+    Successive windows are disjoint and advance. Summing or averaging over
+    consecutive messages is meaningful, as is normalizing counts by the window
+    duration."""
 
     cumulative = 'cumulative'
-    """Value as of ``end_time``, accumulated since ``start_time``, which stays
-    pinned for the lifetime of a job generation. Plotting the growth curve is
-    meaningful; aggregating over successive messages double-counts."""
+    """Value as observed at ``time``, accumulated since ``start_time``, which
+    stays pinned for the lifetime of a job generation. Plotting the growth curve
+    against ``time`` is meaningful; aggregating over successive messages
+    double-counts."""
 
     series = 'series'
-    """Carries its own per-point ``time`` axis. Messages are disjoint chunks of
-    samples concatenated along that axis, so there is no single window duration
-    to normalize by."""
+    """``time`` is the per-sample axis rather than a bound, and there is no
+    ``start_time``. Messages are disjoint chunks of samples concatenated along
+    that axis, so there is no single window duration to normalize by."""
 
 
 WindowOutput = Annotated[sc.DataArray, Temporality.window]

--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -213,39 +213,45 @@ def _add_time_coords(
     data: sc.DataGroup, start_time: Timestamp | None, end_time: Timestamp | None
 ) -> sc.DataGroup:
     """
-    Add start_time and end_time as 0-D coordinates to all DataArrays in a DataGroup.
+    Add start_time and time as 0-D coordinates to all DataArrays in a DataGroup.
 
-    These coordinates provide temporal provenance for each output, enabling lag
-    calculation in the dashboard (lag = current_time - end_time).
+    ``time`` is the instant the value refers to — here, the job's latest
+    observation — and ``start_time`` says since when the value accumulated. The
+    dashboard buffers and plots against ``time`` and derives lag from it
+    (lag = current_time - time).
 
-    DataArrays are skipped in two cases:
+    DataArrays already carrying ``start_time`` or ``time`` are skipped. One rule,
+    two reasons:
 
-    - Already have start_time or end_time coordinates. This allows workflows to
-      set their own time coords for outputs that represent different time ranges
-      (e.g., "current" outputs that only cover the period since the last finalize,
-      not the entire job duration).
-    - Have a 'time' coordinate. A 'time' coordinate means the data carries its
-      own timestamps (e.g., timeseries log data), making start_time/end_time
-      redundant. Adding scalar start_time/end_time to such data would also cause
-      a dimension mismatch in TemporalBuffer, which accumulates data along the
-      'time' dimension.
+    - A workflow may stamp its own bounds for an output covering a different
+      interval than the job (a window output, whose ``time`` is when the
+      interval closed rather than when the job last saw data). We have no idea
+      what those bounds mean, so pairing one of ours with one of theirs would be
+      inconsistent — hence skipping on ``start_time`` alone, too.
+    - A series output's ``time`` is per-sample data, not a bound. Adding scalar
+      coords there would also cause a dimension mismatch in TemporalBuffer,
+      which accumulates data along the 'time' dimension.
+
+    Raises
+    ------
+    ValueError
+        If the job has no time bounds. Every output must be stamped or the
+        dashboard cannot buffer it, and a job finalizing before it accumulated
+        any primary data is a scheduling fault rather than a state to paper over
+        by emitting untimestamped data.
     """
     if start_time is None or end_time is None:
-        return data
+        raise ValueError(
+            "Job has no time bounds to stamp on its outputs: finalized before "
+            "accumulating any primary data."
+        )
     start_coord = start_time.to_scipp()
-    end_coord = end_time.to_scipp()
+    time_coord = end_time.to_scipp()
 
     def maybe_add_coords(val: sc.DataArray) -> sc.DataArray:
-        # Skip if workflow already set time coords - we have no idea what they
-        # mean, and adding our own would create an inconsistent pair.
-        if 'start_time' in val.coords or 'end_time' in val.coords:
+        if 'start_time' in val.coords or 'time' in val.coords:
             return val
-        # Skip if data carries a 'time' coordinate. A 'time' coordinate means
-        # the data has its own timestamps (e.g., timeseries log data), making
-        # start_time/end_time redundant.
-        if 'time' in val.coords:
-            return val
-        return val.assign_coords(start_time=start_coord, end_time=end_coord)
+        return val.assign_coords(start_time=start_coord, time=time_coord)
 
     return sc.DataGroup(
         {

--- a/src/ess/livedata/core/nicos_devices.py
+++ b/src/ess/livedata/core/nicos_devices.py
@@ -16,6 +16,12 @@ coordinate (stamped by the JobManager at production time, ns since epoch). It is
 constant for the lifetime of a generation and changes on reset or reconfigure,
 so NICOS uses it as a change-detector to distinguish a post-reset zero from a
 genuine low reading.
+
+The upper bound — the instant the value was observed — is spelled ``time``
+internally, but NICOS's consumer expects ``end_time``. The echo therefore *adds*
+``end_time`` alongside ``time`` rather than renaming it, so that the published
+contract is decoupled from our internal naming and NICOS can migrate on its own
+schedule.
 """
 
 from __future__ import annotations
@@ -56,7 +62,8 @@ class DeviceExtractor:
             One message per device output, keyed by device name on the
             :attr:`~ess.livedata.core.message.StreamKind.LIVEDATA_NICOS_DATA`
             stream. The output's ``start_time`` coordinate rides along as the
-            generation change-detector.
+            generation change-detector, and its ``time`` is echoed under the
+            ``end_time`` name NICOS reads (see the module docstring).
         """
         messages: list[Message[sc.DataArray]] = []
         for result in results:
@@ -68,6 +75,8 @@ class DeviceExtractor:
                 da = result.data.get(entry.output_name)
                 if da is None:
                     continue
+                if (observed_at := da.coords.get('time')) is not None:
+                    da = da.assign_coords(end_time=observed_at)
                 messages.append(
                     Message(
                         timestamp=result.start_time or Timestamp.from_ns(0),

--- a/src/ess/livedata/dashboard/extractors.py
+++ b/src/ess/livedata/dashboard/extractors.py
@@ -16,12 +16,12 @@ def _extract_time_bounds_as_scalars(data: sc.DataArray) -> dict[str, sc.Variable
     """
     Capture the covered time range as the scalar ``(start_time, end_time)`` pair.
 
-    This is the naming boundary between wire and dashboard. On the wire an
-    output's upper bound is its ``time``: the instant the value refers to,
-    whether that is when a window closed, when a cumulative total was observed,
-    or when a series sample was taken. Downstream of here the pair is spelled
-    ``(start_time, end_time)``, which is what :mod:`ess.livedata.dashboard.plots`
-    reads for the freshness/lag readout and for rate normalization.
+    This is the naming boundary between wire and dashboard. On the wire a
+    bounded output's upper bound is its ``time``: the instant the value refers
+    to, whether that is when a window closed or when a cumulative total was
+    observed. Downstream of here the pair is spelled ``(start_time, end_time)``,
+    which is what :mod:`ess.livedata.dashboard.plots` reads for the
+    freshness/lag readout and for rate normalization.
 
     Every extractor applies this, so the pair reaches the plotters with the same
     meaning whichever buffer and extractor the data came through. Callers must
@@ -29,20 +29,24 @@ def _extract_time_bounds_as_scalars(data: sc.DataArray) -> dict[str, sc.Variable
     the local timezone for Bokeh's benefit, and bounds taken after that shift
     would misreport wall-clock provenance by the UTC offset.
 
+    The pair is minted whole or not at all, and ``start_time`` is what tells a
+    bounded output from a series one. A series output has no bounds to capture:
+    its ``time`` is the per-sample axis, so its age is already on the plot, and
+    an ``end_time`` minted from it would drive the freshness pill and the lag
+    readout off the device's sampling rate rather than the pipeline's latency.
+
     Coords already scalar (a single message, or a slice out of a buffer) are
     taken as they are; 1-D coords from a ``TemporalBuffer`` are reduced to their
-    chronological ends. Bounds the data does not carry are omitted, so a series
-    output yields ``end_time`` only.
+    chronological ends.
     """
-    bounds: dict[str, sc.Variable] = {}
-    for name, source, end in [
-        ('start_time', 'start_time', 0),
-        ('end_time', 'time', -1),
-    ]:
-        coord = data.coords.get(source)
-        if coord is not None:
-            bounds[name] = coord[end] if coord.ndim == 1 else coord
-    return bounds
+    start_time = data.coords.get('start_time')
+    time = data.coords.get('time')
+    if start_time is None or time is None:
+        return {}
+    return {
+        'start_time': start_time[0] if start_time.ndim == 1 else start_time,
+        'end_time': time[-1] if time.ndim == 1 else time,
+    }
 
 
 class UpdateExtractor(ABC):
@@ -95,13 +99,8 @@ class LatestValueExtractor(UpdateExtractor):
         """Latest value requires zero history."""
         return 0.0
 
-    def extract(self, data: Any) -> Any:
+    def extract(self, data: sc.DataArray) -> Any:
         """Extract the latest value from the data, unwrapped."""
-        if not isinstance(data, sc.DataArray):
-            # This extractor's buffer is a SingleValueBuffer, which holds
-            # whatever was published — bare Variables included. Nothing to
-            # slice, and no coords to translate.
-            return data
         if self._concat_dim in data.dims:
             # Extract last slice - this also gets the last value from any 1-D coords
             data = data[self._concat_dim, -1]

--- a/src/ess/livedata/dashboard/extractors.py
+++ b/src/ess/livedata/dashboard/extractors.py
@@ -14,18 +14,34 @@ from .time_utils import get_local_timezone_offset_ns
 
 def _extract_time_bounds_as_scalars(data: sc.DataArray) -> dict[str, sc.Variable]:
     """
-    Extract start_time/end_time as scalar values from 1-D coords.
+    Capture the covered time range as the scalar ``(start_time, end_time)`` pair.
 
-    When data comes from a TemporalBuffer, start_time and end_time are 1-D
-    coordinates (one value per time slice) in chronological order. This function
-    extracts the overall time range for use in plot titles.
+    This is the naming boundary between wire and dashboard. On the wire an
+    output's upper bound is its ``time``: the instant the value refers to,
+    whether that is when a window closed, when a cumulative total was observed,
+    or when a series sample was taken. Downstream of here the pair is spelled
+    ``(start_time, end_time)``, which is what :mod:`ess.livedata.dashboard.plots`
+    reads for the freshness/lag readout and for rate normalization.
 
-    Returns an empty dict if coords don't exist or are already scalar.
+    Every extractor applies this, so the pair reaches the plotters with the same
+    meaning whichever buffer and extractor the data came through. Callers must
+    apply it to *pristine* data: ``FullHistoryExtractor`` shifts ``time`` into
+    the local timezone for Bokeh's benefit, and bounds taken after that shift
+    would misreport wall-clock provenance by the UTC offset.
+
+    Coords already scalar (a single message, or a slice out of a buffer) are
+    taken as they are; 1-D coords from a ``TemporalBuffer`` are reduced to their
+    chronological ends. Bounds the data does not carry are omitted, so a series
+    output yields ``end_time`` only.
     """
     bounds: dict[str, sc.Variable] = {}
-    for name, index in [('start_time', 0), ('end_time', -1)]:
-        if name in data.coords and data.coords[name].ndim == 1:
-            bounds[name] = data.coords[name][index]
+    for name, source, end in [
+        ('start_time', 'start_time', 0),
+        ('end_time', 'time', -1),
+    ]:
+        coord = data.coords.get(source)
+        if coord is not None:
+            bounds[name] = coord[end] if coord.ndim == 1 else coord
     return bounds
 
 
@@ -79,12 +95,17 @@ class LatestValueExtractor(UpdateExtractor):
         """Latest value requires zero history."""
         return 0.0
 
-    def extract(self, data: sc.DataArray) -> Any:
+    def extract(self, data: Any) -> Any:
         """Extract the latest value from the data, unwrapped."""
-        if self._concat_dim not in data.dims:
+        if not isinstance(data, sc.DataArray):
+            # This extractor's buffer is a SingleValueBuffer, which holds
+            # whatever was published — bare Variables included. Nothing to
+            # slice, and no coords to translate.
             return data
-        # Extract last slice - this also gets the last value from any 1-D coords
-        return data[self._concat_dim, -1]
+        if self._concat_dim in data.dims:
+            # Extract last slice - this also gets the last value from any 1-D coords
+            data = data[self._concat_dim, -1]
+        return data.assign_coords(**_extract_time_bounds_as_scalars(data))
 
 
 class FullHistoryExtractor(UpdateExtractor):
@@ -108,8 +129,9 @@ class FullHistoryExtractor(UpdateExtractor):
 
     def extract(self, data: sc.DataArray) -> Any:
         """Extract all data from the buffer, converting time to datetime64."""
-        result = self._to_local_datetime(data)
-        return result.assign_coords(**_extract_time_bounds_as_scalars(result))
+        # Capture bounds before the timezone shift, which rewrites `time`.
+        bounds = _extract_time_bounds_as_scalars(data)
+        return self._to_local_datetime(data).assign_coords(**bounds)
 
     def _to_local_datetime(self, data: sc.DataArray) -> sc.DataArray:
         """Convert int64 time coordinate to datetime64 in local time.

--- a/src/ess/livedata/dashboard/fake_backend.py
+++ b/src/ess/livedata/dashboard/fake_backend.py
@@ -39,6 +39,7 @@ from ..config.roi_names import get_roi_mapper
 from ..config.workflow_spec import (
     JobId,
     ResultKey,
+    Temporality,
     WorkflowConfig,
     WorkflowId,
     WorkflowSpec,
@@ -128,9 +129,9 @@ def expand_template(
     sized dimensions are preserved. Coordinates and synthetic values are
     generated to match the template's dims, units, and dtype.
 
-    A scalar ``time`` coordinate (carried by per-update and timeseries outputs)
-    is stamped with the current time. The backend emits a fresh scalar each
-    update; the dashboard accumulates these into the time series.
+    A scalar ``time`` coordinate (carried by series outputs, whose ``time`` is
+    real per-sample data) is stamped with the current time. The backend emits a
+    fresh scalar each update; the dashboard accumulates these into the series.
 
     Parameters
     ----------
@@ -234,6 +235,7 @@ class _Job:
         self.variant = source_variant(config.job_id.source_name)
         self.start_time = Timestamp.now()
         self.rois: dict[str, sc.DataArray] = {}
+        self.previous_emit = self.start_time
 
     def output_templates(self) -> Mapping[str, sc.DataArray]:
         """Templates for every output field that declares one."""
@@ -335,6 +337,7 @@ class FakeBackend:
     def _emit_data(self, job: _Job) -> list[Message]:
         timestamp_ns = time.time_ns()
         variants = roi_variants(job.rois)
+        now = Timestamp.from_ns(timestamp_ns)
         messages = []
         for output_name, template in job.output_templates().items():
             key = ResultKey(
@@ -351,8 +354,27 @@ class FakeBackend:
                 value = expand_roi_spectra(template, variants, job.update, timestamp_ns)
             else:
                 value = expand_template(template, job.update, timestamp_ns, job.variant)
+            # Production arrives at these coords by a different route:
+            # `StreamProcessorWorkflow.finalize` and `AreaDetectorView.finalize`
+            # assign per-interval bounds to the outputs their factory names in
+            # `window_outputs=`, then `Job._add_time_coords` stamps one (job start,
+            # latest observation) pair on whatever is left carrying neither. Keying
+            # off the `Temporality` declaration reproduces the composite, but more
+            # forgivingly: in production only a named `window_outputs=` entry gets
+            # per-interval bounds, whatever it declares.
+            temporality = job.spec.outputs.temporality(output_name)
+            if temporality is not Temporality.series:
+                start_time = (
+                    job.start_time
+                    if temporality is Temporality.cumulative
+                    else job.previous_emit
+                )
+                value = value.assign_coords(
+                    start_time=start_time.to_scipp(), time=now.to_scipp()
+                )
             messages.append(Message(stream=stream, value=value))
         job.update += 1
+        job.previous_emit = now
         return messages
 
 

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -40,7 +40,7 @@ from .data_roles import PRIMARY
 from .data_service import DataService
 from .frame_clock import FrameClock
 from .plot_data_service import LayerId, PlotDataService
-from .plot_params import TimeWindowMixin, TimeWindowMode
+from .plot_params import WindowModeMixin
 from .plotting_controller import PlottingController
 
 if TYPE_CHECKING:
@@ -129,7 +129,6 @@ class PlotConfig:
     data_sources: dict[str, DataSourceConfig]
     plot_name: str
     params: pydantic.BaseModel
-    supports_windowing: bool = True
 
     @property
     def workflow_id(self) -> WorkflowId:
@@ -201,11 +200,6 @@ class PlotGridConfig:
     enabled: bool = True
 
 
-def _windowing_for_mode(mode: TimeWindowMode) -> Windowing:
-    """Map a window mode to the windowing its data is subscribed from."""
-    return 'since_start' if mode is TimeWindowMode.since_start else 'per_update'
-
-
 def _windowing_for_role(role: str, params: pydantic.BaseModel) -> Windowing:
     """Return the windowing wanted by a data role.
 
@@ -214,8 +208,7 @@ def _windowing_for_role(role: str, params: pydantic.BaseModel) -> Windowing:
     """
     if role != PRIMARY:
         return 'per_update'
-    window = params.time_window if isinstance(params, TimeWindowMixin) else None
-    return _windowing_for_mode(window.mode) if window is not None else 'per_update'
+    return params.windowing() if isinstance(params, WindowModeMixin) else 'per_update'
 
 
 def _build_resolved_data_sources(
@@ -272,26 +265,6 @@ def _build_keys_by_role(
         ]
         for role, ds in data_sources.items()
     }
-
-
-def _resolve_supports_windowing(
-    data_sources: dict[str, DataSourceConfig],
-    registry: Mapping[WorkflowId, WorkflowSpec],
-) -> bool:
-    """Determine whether the primary view exposes window/latest modes.
-
-    Returns ``False`` for cumulative-only views (no ``per_update`` stream),
-    in which case only ``TimeWindowMode.since_start`` is meaningful.
-    """
-    if PRIMARY not in data_sources:
-        return True
-    from .plotting_controller import output_view_supports_windowing
-
-    primary = data_sources[PRIMARY]
-    spec = registry.get(primary.workflow_id)
-    if spec is None:
-        return True
-    return output_view_supports_windowing(spec, primary.view_name)
 
 
 @dataclass
@@ -1481,15 +1454,10 @@ class PlotOrchestrator:
             for role, ds in layer_data['data_sources'].items()
         }
 
-        supports_windowing = _resolve_supports_windowing(
-            data_sources, self._job_orchestrator.get_workflow_registry()
-        )
-
         config = PlotConfig(
             data_sources=data_sources,
             plot_name=plot_name,
             params=params,
-            supports_windowing=supports_windowing,
         )
 
         return Layer(layer_id=LayerId(uuid4()), config=config)

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -29,6 +29,7 @@ from ess.livedata.config.grid_template import GridSpec
 from ess.livedata.config.workflow_spec import (
     DataKey,
     JobNumber,
+    Temporality,
     Windowing,
     WorkflowId,
     WorkflowSpec,
@@ -97,12 +98,14 @@ class ResolvedDataSource:
     Produced by :func:`_build_resolved_data_sources` from a
     :class:`DataSourceConfig`: ``output_name`` carries the backend pydantic
     field name selected for the current window mode, ready to key a
-    :class:`DataKey`. Runtime-only — never persisted.
+    :class:`DataKey`, and ``temporality`` what that field's messages mean.
+    Runtime-only — never persisted.
     """
 
     workflow_id: WorkflowId
     source_names: list[str]
     output_name: str
+    temporality: Temporality | None = None
 
 
 @dataclass
@@ -223,20 +226,29 @@ def _build_resolved_data_sources(
 
     Falls back to the view name verbatim when the data source's workflow is
     not in the registry (lets a layer whose workflow has not been seen yet
-    still set up a pipeline, keyed by whatever name it was given).
+    still set up a pipeline, keyed by whatever name it was given); its
+    temporality is unknown in that case.
     """
     resolved: dict[str, ResolvedDataSource] = {}
     for role, ds in config.data_sources.items():
         spec = registry.get(ds.workflow_id)
-        output_name = (
-            spec.field_for(ds.view_name, _windowing_for_role(role, config.params))
-            if spec is not None
-            else ds.view_name
-        )
+        if spec is None:
+            output_name, temporality = ds.view_name, None
+        else:
+            output_name = spec.field_for(
+                ds.view_name, _windowing_for_role(role, config.params)
+            )
+            # An unknown view resolves to its own name, which need not be a field.
+            temporality = (
+                spec.outputs.temporality(output_name)
+                if output_name in spec.outputs.model_fields
+                else None
+            )
         resolved[role] = ResolvedDataSource(
             workflow_id=ds.workflow_id,
             source_names=ds.source_names,
             output_name=output_name,
+            temporality=temporality,
         )
     return resolved
 
@@ -1279,6 +1291,10 @@ class PlotOrchestrator:
                     plot_name=config.plot_name,
                     params=config.params,
                     on_update=lambda: self._mark_layer_dirty(layer_id),
+                    temporality_by_role={
+                        role: ds.temporality
+                        for role, ds in resolved_data_sources.items()
+                    },
                 )
                 self._data_subscriptions[layer_id] = subscriber
                 self._mark_layer_dirty(layer_id)

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -246,16 +246,19 @@ def _build_resolved_data_sources(
     return resolved
 
 
-def _build_keys_by_role(
+def _build_subscription_keys(
     data_sources: dict[str, ResolvedDataSource],
-) -> dict[str, list[DataKey]]:
-    """Build stable DataKeys grouped by role.
+) -> tuple[dict[str, list[DataKey]], dict[DataKey, Temporality | None]]:
+    """Build stable DataKeys grouped by role, plus what each key's data means.
 
     Keys carry no job identity — they are fully determined by the plot
-    config.
+    config. The temporality map is minted in the same pass, so the two cannot
+    disagree about which keys exist.
     """
-    return {
-        role: [
+    keys_by_role: dict[str, list[DataKey]] = {}
+    temporality: dict[DataKey, Temporality | None] = {}
+    for role, ds in data_sources.items():
+        keys = [
             DataKey(
                 workflow_id=ds.workflow_id,
                 source_name=sn,
@@ -263,8 +266,9 @@ def _build_keys_by_role(
             )
             for sn in ds.source_names
         ]
-        for role, ds in data_sources.items()
-    }
+        keys_by_role[role] = keys
+        temporality.update(dict.fromkeys(keys, ds.temporality))
+    return keys_by_role, temporality
 
 
 @dataclass
@@ -1258,16 +1262,14 @@ class PlotOrchestrator:
             # Set up data pipeline - updates mark the layer dirty; flush_frames
             # pulls and rebuilds. The immediate mark covers retained data
             # already present, so the plot shows without waiting for a delta.
+            keys_by_role, temporality = _build_subscription_keys(resolved_data_sources)
             try:
                 subscriber = self._plotting_controller.setup_pipeline(
-                    keys_by_role=_build_keys_by_role(resolved_data_sources),
+                    keys_by_role=keys_by_role,
                     plot_name=config.plot_name,
                     params=config.params,
                     on_update=lambda: self._mark_layer_dirty(layer_id),
-                    temporality_by_role={
-                        role: ds.temporality
-                        for role, ds in resolved_data_sources.items()
-                    },
+                    temporality=temporality,
                 )
                 self._data_subscriptions[layer_id] = subscriber
                 self._mark_layer_dirty(layer_id)

--- a/src/ess/livedata/dashboard/plot_params.py
+++ b/src/ess/livedata/dashboard/plot_params.py
@@ -255,6 +255,15 @@ class TimeWindowParams(pydantic.BaseModel):
         title="Aggregation",
     )
 
+    def aggregates_updates(self) -> bool:
+        """Whether these params combine several updates into one value.
+
+        ``since_start`` and a zero duration both reduce to taking the most
+        recent value of the subscribed stream; only window mode with a nonzero
+        duration sums or averages across updates.
+        """
+        return self.mode is TimeWindowMode.window and self.window_duration_seconds > 0
+
 
 class PlotParamsBase(pydantic.BaseModel):
     """Base class for plot parameters."""

--- a/src/ess/livedata/dashboard/plot_params.py
+++ b/src/ess/livedata/dashboard/plot_params.py
@@ -4,10 +4,13 @@
 
 from __future__ import annotations
 
+import abc
 import enum
 from enum import StrEnum
 
 import pydantic
+
+from ..config.workflow_spec import Windowing
 
 
 class TimeWindowMode(enum.StrEnum):
@@ -327,7 +330,43 @@ class RateNormalizationParams(pydantic.BaseModel):
     )
 
 
-class TimeWindowMixin(pydantic.BaseModel):
+class WindowModeMixin(pydantic.BaseModel, abc.ABC):
+    """Mixin for params selecting which windowing their data is drawn from.
+
+    Plotters expose the choice differently -- full window controls for the
+    general plots, a single cumulative toggle for the timeseries plotter -- but
+    consumers downstream need only the resulting ``Windowing``, so that is what
+    the interface offers.
+
+    Because the control differs, so does what a view must back for it to mean
+    anything, and so does the field that carries it. Each implementation
+    therefore names its own fields to hide (see
+    ``plotting_controller.hidden_window_fields``).
+    """
+
+    @abc.abstractmethod
+    def windowing(self) -> Windowing:
+        """Return the windowing the primary data role subscribes to."""
+
+    @classmethod
+    @abc.abstractmethod
+    def hidden_fields(cls, options: frozenset[Windowing]) -> frozenset[str]:
+        """Return this class's fields whose control the view cannot back.
+
+        Parameters
+        ----------
+        options:
+            Windowing options the view has a real backing field for.
+
+        Returns
+        -------
+        :
+            Names of fields to omit from the config UI. Hidden fields keep their
+            default, which resolves to the view's only field either way.
+        """
+
+
+class TimeWindowMixin(WindowModeMixin):
     """Mixin adding a time-windowing/aggregation section to plot parameters."""
 
     time_window: TimeWindowParams = pydantic.Field(
@@ -348,6 +387,24 @@ class TimeWindowMixin(pydantic.BaseModel):
         ),
         title="Time Window",
     )
+
+    def windowing(self) -> Windowing:
+        return (
+            'since_start'
+            if self.time_window.mode is TimeWindowMode.since_start
+            else 'per_update'
+        )
+
+    @classmethod
+    def hidden_fields(cls, options: frozenset[Windowing]) -> frozenset[str]:
+        """Hide the whole group unless the view has something to window over.
+
+        The duration control aggregates a span of the per-update field and stays
+        meaningful on a view with no cumulative flavor; selecting ``since_start``
+        there is rejected at config time instead, which keeps the duration
+        control available (see ``plotting_controller.since_start_available``).
+        """
+        return frozenset() if 'per_update' in options else frozenset({'time_window'})
 
 
 class RateMixin(pydantic.BaseModel):
@@ -405,9 +462,35 @@ class TimeseriesScaleParams(pydantic.BaseModel):
     )
 
 
-class PlotParamsTimeseries(PlotDisplayParams1d):
+class TimeseriesAccumulationParams(pydantic.BaseModel):
+    """Which flavor of an output view the timeseries history follows."""
+
+    cumulative: bool = pydantic.Field(
+        default=False,
+        description=(
+            "Plot the total accumulated since the run started, instead of the "
+            "value of each individual update."
+        ),
+        title="Cumulative",
+    )
+
+
+class PlotParamsTimeseries(WindowModeMixin, PlotDisplayParams1d):
     """Parameters for the timeseries plotter (downsampling + display)."""
 
+    accumulation: TimeseriesAccumulationParams = pydantic.Field(
+        default_factory=TimeseriesAccumulationParams,
+        description=(
+            "Which flavor of the output this plot follows over time: the value "
+            "of each update as it arrives, or the total accumulated since the "
+            "run started."
+            "<br><br>"
+            "The window duration and aggregation offered by the other plotters "
+            "have no counterpart here: this plot shows every sample the buffer "
+            "holds, thinned only by <em>Downsampling</em>."
+        ),
+        title="Accumulation",
+    )
     plot_scale: TimeseriesScaleParams = pydantic.Field(
         default_factory=TimeseriesScaleParams,
         description="Scaling options for the plot axes.",
@@ -433,6 +516,21 @@ class PlotParamsTimeseries(PlotDisplayParams1d):
             "Period</em> of 1 h keeps the count below 4 000."
         ),
     )
+
+    def windowing(self) -> Windowing:
+        return 'since_start' if self.accumulation.cumulative else 'per_update'
+
+    @classmethod
+    def hidden_fields(cls, options: frozenset[Windowing]) -> frozenset[str]:
+        """Hide the toggle unless the view backs both flavors.
+
+        The toggle offers nothing but the choice between them, so on a view
+        backing only one, one of its two states either lies about the data shown
+        or is rejected at config time.
+        """
+        if {'per_update', 'since_start'} <= options:
+            return frozenset()
+        return frozenset({'accumulation'})
 
 
 class PlotParams1d(RateMixin, TimeWindowMixin, PlotDisplayParams1d):

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -728,6 +728,8 @@ class Plotter:
 
         # Time bounds drive the cell titlebar's freshness indicator; they are
         # kept off the plot title to avoid minting an OptionTree entry per tick.
+        # Computed outside the try so a render failure still stamps the bounds
+        # of the data that was received.
         self._time_bounds = _compute_time_bounds(data)
         self._set_cached_state(result)
 
@@ -835,7 +837,16 @@ class Plotter:
 
     @property
     def time_bounds(self) -> TimeBounds | None:
-        """Time bounds of the most recently computed data, or None if absent."""
+        """Time bounds of the most recently computed data, or None if absent.
+
+        The freshness pill must describe exactly the extract currently
+        displayed, so its bounds are derived from the payload ``update()``
+        consumed rather than by a parallel subscriber — which could observe an
+        update the plot does not yet show, and would need a duplicate of the
+        subscription's extractor configuration to see the same bounds. The
+        plotter caches them for the same reason it caches the render: it is
+        the one shared point the per-session titlebar polls can pull from.
+        """
         return self._time_bounds
 
     def has_cached_state(self) -> bool:

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -2,13 +2,14 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Hashable, Mapping
 from typing import TypeVar
 
 import pydantic
 
 from ess.livedata.config.workflow_spec import (
     DataKey,
+    Temporality,
     WorkflowSpec,
 )
 
@@ -18,7 +19,7 @@ from .extractors import (
     UpdateExtractor,
     WindowAggregatingExtractor,
 )
-from .plot_params import TimeWindowMixin, TimeWindowMode, TimeWindowParams
+from .plot_params import TimeWindowMixin, TimeWindowParams
 from .plotter_registry import (
     OVERLAY_PATTERNS,
     PlotterSpec,
@@ -178,6 +179,7 @@ class PlottingController:
         plot_name: str,
         params: dict | pydantic.BaseModel,
         on_update: Callable[[], None],
+        temporality_by_role: Mapping[str, Temporality | None],
     ) -> DataSubscriber:
         """
         Set up data pipeline for any plot type.
@@ -198,6 +200,10 @@ class PlottingController:
         on_update
             Callback invoked when any of the keys changed; see
             :py:class:`DataSubscriber`.
+        temporality_by_role
+            Declared :class:`Temporality` of the field each role resolved to,
+            ``None`` where the workflow is not in the registry. Aggregation is
+            rejected for the keys it must not be applied to.
 
         Returns
         -------
@@ -214,11 +220,17 @@ class PlottingController:
         spec = plotter_registry.get_spec(plot_name)
         window = params.time_window if isinstance(params, TimeWindowMixin) else None
 
-        # Flatten keys for extractor creation
+        # Flatten keys for extractor creation; each carries the temporality of
+        # the field its role resolved to.
         all_keys = [key for keys in keys_by_role.values() for key in keys]
+        temporality = {
+            key: temporality_by_role[role]
+            for role, keys in keys_by_role.items()
+            for key in keys
+        }
 
         # Standard path: single subscription with role-aware assembly
-        extractors = create_extractors_from_params(all_keys, window, spec)
+        extractors = create_extractors_from_params(all_keys, window, temporality, spec)
         return self._stream_manager.make_stream(
             keys_by_role=keys_by_role,
             on_update=on_update,
@@ -271,6 +283,34 @@ class PlottingController:
         return getattr(plotter, 'is_overlayable', True)
 
 
+def _reject_cumulative_aggregation(
+    temporality: Mapping[DataKey, Temporality | None],
+) -> None:
+    """Raise if a window aggregation would be applied to a cumulative field.
+
+    Every message of a cumulative field carries the whole history, so summing
+    consecutive ones double-counts. The window controls are hidden for views
+    without a per-update field, but ``WorkflowSpec.field_for`` falls back to the
+    cumulative field, so a persisted config built when the view still had a
+    per-update field would otherwise aggregate one silently.
+    """
+    outputs = sorted(
+        {
+            key.output_name
+            for key, declared in temporality.items()
+            if declared is Temporality.cumulative
+        }
+    )
+    if not outputs:
+        return
+    raise ValueError(
+        f"Cannot aggregate a time window over {', '.join(outputs)}: each message "
+        "holds the total accumulated since the run started, so summing them counts "
+        "the same events repeatedly. Select 'since run start' mode, or a window "
+        "over a per-update output."
+    )
+
+
 def output_view_supports_windowing(workflow_spec: WorkflowSpec, view_name: str) -> bool:
     """Return whether the window controls (mode, duration, aggregation) apply.
 
@@ -304,6 +344,7 @@ def since_start_available(workflow_spec: WorkflowSpec, view_name: str) -> bool:
 def create_extractors_from_params(
     keys: list[DataKey],
     window: TimeWindowParams | None,
+    temporality: Mapping[DataKey, Temporality | None],
     spec: PlotterSpec | None = None,
 ) -> dict[DataKey, UpdateExtractor]:
     """
@@ -316,6 +357,10 @@ def create_extractors_from_params(
     window:
         Window parameters for extraction mode and aggregation.
         If None, falls back to LatestValueExtractor.
+    temporality:
+        Declared :class:`Temporality` per key, ``None`` where unknown. Only
+        consulted when an aggregating extractor would be built, since that is
+        the only construction a cumulative field cannot survive.
     spec:
         Optional plotter specification. If provided and contains a required
         extractor, that extractor type is used.
@@ -330,15 +375,11 @@ def create_extractors_from_params(
         extractor_type = spec.data_requirements.required_extractor
         return {key: extractor_type() for key in keys}
 
-    # No fixed requirement - check if window params provided.
-    # `since_start` and window mode with duration==0 both reduce to taking the
-    # most recent value of the subscribed stream (stream choice is encoded in
-    # the DataKey). Only window mode with duration>0 needs aggregation.
-    if (
-        window is not None
-        and window.mode is TimeWindowMode.window
-        and window.window_duration_seconds > 0
-    ):
+    # No fixed requirement - check if window params provided. Stream choice is
+    # encoded in the DataKey, so only aggregation over several updates needs a
+    # dedicated extractor.
+    if window is not None and window.aggregates_updates():
+        _reject_cumulative_aggregation(temporality)
         return {
             key: WindowAggregatingExtractor(
                 window_duration_seconds=window.window_duration_seconds,

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -19,7 +19,7 @@ from .extractors import (
     UpdateExtractor,
     WindowAggregatingExtractor,
 )
-from .plot_params import TimeWindowMixin, TimeWindowParams
+from .plot_params import TimeWindowMixin, TimeWindowParams, WindowModeMixin
 from .plotter_registry import (
     OVERLAY_PATTERNS,
     PlotterSpec,
@@ -311,22 +311,23 @@ def _reject_cumulative_aggregation(
     )
 
 
-def output_view_supports_windowing(workflow_spec: WorkflowSpec, view_name: str) -> bool:
-    """Return whether the window controls (mode, duration, aggregation) apply.
+def hidden_window_fields(
+    params_class: type[pydantic.BaseModel], workflow_spec: WorkflowSpec, view_name: str
+) -> frozenset[str]:
+    """Return the params fields to hide because the view cannot back them.
 
-    Windowing applies when the view exposes a ``per_update`` field: the window
-    duration aggregates a span of that field, independent of whether a
-    ``since_start`` field also exists. Cumulative-only views (e.g. ``I(Q)``)
-    have no per-update field to window over, so the controls are hidden and the
-    view locks to ``since_start``.
+    Which fields those are is the params class's business -- see
+    :meth:`WindowModeMixin.hidden_fields`; this only supplies the windowing
+    options the named view has real backing fields for.
 
-    Offering ``since_start`` mode on a view that lacks a cumulative field is
-    rejected at config time (see :func:`since_start_available`), not by hiding
-    the controls -- that would also remove the still-meaningful duration control.
+    Permissive for unknown views and for params without a window mode.
     """
-    if workflow_spec.get_output_view(view_name) is None:
-        return True
-    return 'per_update' in workflow_spec.windowing_options(view_name)
+    if not issubclass(params_class, WindowModeMixin):
+        return frozenset()
+    options = workflow_spec.windowing_options(view_name)
+    if not options:
+        return frozenset()
+    return params_class.hidden_fields(options)
 
 
 def since_start_available(workflow_spec: WorkflowSpec, view_name: str) -> bool:

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -179,7 +179,7 @@ class PlottingController:
         plot_name: str,
         params: dict | pydantic.BaseModel,
         on_update: Callable[[], None],
-        temporality_by_role: Mapping[str, Temporality | None],
+        temporality: Mapping[DataKey, Temporality | None],
     ) -> DataSubscriber:
         """
         Set up data pipeline for any plot type.
@@ -200,8 +200,8 @@ class PlottingController:
         on_update
             Callback invoked when any of the keys changed; see
             :py:class:`DataSubscriber`.
-        temporality_by_role
-            Declared :class:`Temporality` of the field each role resolved to,
+        temporality
+            Declared :class:`Temporality` of the field each key resolved to,
             ``None`` where the workflow is not in the registry. Aggregation is
             rejected for the keys it must not be applied to.
 
@@ -220,14 +220,8 @@ class PlottingController:
         spec = plotter_registry.get_spec(plot_name)
         window = params.time_window if isinstance(params, TimeWindowMixin) else None
 
-        # Flatten keys for extractor creation; each carries the temporality of
-        # the field its role resolved to.
+        # Flatten keys for extractor creation
         all_keys = [key for keys in keys_by_role.values() for key in keys]
-        temporality = {
-            key: temporality_by_role[role]
-            for role, keys in keys_by_role.items()
-            for key in keys
-        }
 
         # Standard path: single subscription with role-aware assembly
         extractors = create_extractors_from_params(all_keys, window, temporality, spec)

--- a/src/ess/livedata/dashboard/temporal_buffers.py
+++ b/src/ess/livedata/dashboard/temporal_buffers.py
@@ -314,7 +314,7 @@ class TemporalBuffer(BufferProtocol[sc.DataArray]):
 
     # 0-D coord names that are still treated as per-sample on a single-slice
     # message (where ``time`` dim is absent, so the dim signal can't be used).
-    _SCALAR_ACCUMULATED_NAMES = ('time', 'start_time', 'end_time')
+    _SCALAR_ACCUMULATED_NAMES = ('time', 'start_time')
 
     DEFAULT_MAX_MEMORY = 20 * 1024 * 1024  # 20 MB
 

--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -119,6 +119,7 @@ def _resolve_output_display_hints(
     is_static: bool,
     workflow_spec: WorkflowSpec | None,
     view_name: str,
+    params_class: type[pydantic.BaseModel],
 ) -> OutputDisplayHints:
     """Derive UI hints from the workflow output view.
 
@@ -134,6 +135,9 @@ def _resolve_output_display_hints(
         for static overlays.
     view_name:
         Name of the selected output view.
+    params_class:
+        Params model of the selected plotter. Which window-mode control it
+        carries decides what the view must back for that control to apply.
 
     Returns
     -------
@@ -142,18 +146,11 @@ def _resolve_output_display_hints(
     """
     if is_static:
         return OutputDisplayHints(hidden_fields=frozenset(), preselect_all_sources=True)
-    from ess.livedata.dashboard.plotting_controller import (
-        output_view_supports_windowing,
-    )
+    from ess.livedata.dashboard.plotting_controller import hidden_window_fields
 
-    supports_windowing = output_view_supports_windowing(workflow_spec, view_name)
-    hidden = frozenset({'time_window'}) if not supports_windowing else frozenset()
+    hidden = hidden_window_fields(params_class, workflow_spec, view_name)
 
-    template = (
-        workflow_spec.get_output_template(view_name)
-        if workflow_spec is not None
-        else None
-    )
+    template = workflow_spec.get_output_template(view_name)
     preselect_all = template is None or template.ndim < 2
 
     return OutputDisplayHints(hidden_fields=hidden, preselect_all_sources=preselect_all)
@@ -1046,7 +1043,6 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
         self._last_axis_sources: dict[str, DataSourceConfig] | None = None
         # Store result from callback
         self._last_config_result: PlotConfig | None = None
-        self._supports_windowing: bool = True
 
     @property
     def name(self) -> str:
@@ -1197,8 +1193,8 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
             is_static=is_static,
             workflow_spec=workflow_spec if not is_static else None,
             view_name=self._plotter_selection.view_name,
+            params_class=plot_spec.params,
         )
-        self._supports_windowing = 'time_window' not in hints.hidden_fields
 
         # For new plots, use display hints to decide source pre-selection.
         # 2D+ outputs (images) default to empty so the user picks one source.
@@ -1273,7 +1269,6 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
             data_sources=data_sources,
             plot_name=self._plotter_selection.plot_name,
             params=params,
-            supports_windowing=self._supports_windowing,
         )
 
     def _validate_window_mode(
@@ -1284,11 +1279,13 @@ class SpecBasedConfigurationStep(WizardStep[PlotterSelection | None, PlotConfig]
         Returns ``True`` if the configuration may proceed. Otherwise shows an
         error and returns ``False`` so the modal stays open.
         """
-        from ess.livedata.dashboard.plot_params import TimeWindowMixin, TimeWindowMode
+        from ess.livedata.dashboard.plot_params import WindowModeMixin
         from ess.livedata.dashboard.plotting_controller import since_start_available
 
-        window = params.time_window if isinstance(params, TimeWindowMixin) else None
-        if window is None or window.mode is not TimeWindowMode.since_start:
+        if (
+            not isinstance(params, WindowModeMixin)
+            or params.windowing() != 'since_start'
+        ):
             return True
         if self._plotter_selection is None:
             return True

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import panel as pn
 
 from ...config.workflow_spec import WorkflowId, WorkflowSpec
-from ..plot_params import TimeWindowMixin, TimeWindowMode
+from ..plot_params import WindowModeMixin
 from .buttons import ButtonStyles, create_tool_button, create_tool_button_stylesheet
 from .icons import get_icon
 from .styles import Colors, HoverColors, StatusColors
@@ -529,12 +529,9 @@ def _format_window_info(params) -> str:
     a target, not a truth, so showing it in the static title would lie when
     backend cadence exceeds the requested lookback.
     """
-    window = params.time_window if isinstance(params, TimeWindowMixin) else None
-    if window is None:
+    if not isinstance(params, WindowModeMixin):
         return ''
-    if window.mode == TimeWindowMode.since_start:
-        return 'since run start'
-    return ''
+    return 'since run start' if params.windowing() == 'since_start' else ''
 
 
 def _get_static_overlay_display_info(config: PlotConfig) -> tuple[str, str]:

--- a/src/ess/livedata/glossary.md
+++ b/src/ess/livedata/glossary.md
@@ -69,10 +69,12 @@ The naming stack, from the Kafka wire inwards (see ADR 0004 and
   NICOS derived devices (ADR 0006) key by DataKey, not ResultKey.
 - **OutputView** — user-facing presentation of a workflow output, bundling the
   backend output fields that carry one quantity (`config/workflow_spec.py`).
-- **Temporality** — how one output field's values relate to time:
-  `window` (covers `[start_time, end_time)`, successive windows disjoint),
-  `cumulative` (value as of `end_time`, `start_time` pinned for the
-  generation), or `series` (carries its own per-point `time` axis). Declared
+- **Temporality** — how one output field's values relate to time. Every output
+  carries a `time` coord — the instant its value refers to — but what that
+  instant means differs: `window` (covers `[start_time, time]`, `time` is when
+  the window closed, successive windows disjoint), `cumulative` (value as
+  observed at `time`, `start_time` pinned for the generation), or `series`
+  (`time` is the per-point axis, no `start_time`). Declared
   per field via `Annotated` on the outputs model. It decides which aggregations
   over successive messages are valid, and which `Windowing` the field backs —
   a view states its member fields, and the binding follows

--- a/src/ess/livedata/workflows/area_detector_view.py
+++ b/src/ess/livedata/workflows/area_detector_view.py
@@ -103,12 +103,9 @@ class AreaDetectorView(Workflow):
         # 'current' covers only the window since the last finalize, so it carries
         # its own bounds instead of the job-level ones Job._add_time_coords would
         # otherwise stamp. 'cumulative' has no time coords and gets those.
-        start_time_coord = self._current_start_time.to_scipp()
-        end_time_coord = self._current_end_time.to_scipp()
         current = current.assign_coords(
-            time=start_time_coord,
-            start_time=start_time_coord,
-            end_time=end_time_coord,
+            start_time=self._current_start_time.to_scipp(),
+            time=self._current_end_time.to_scipp(),
         )
         self._current_start_time = None
         self._current_end_time = None

--- a/src/ess/livedata/workflows/detector_view_specs.py
+++ b/src/ess/livedata/workflows/detector_view_specs.py
@@ -178,35 +178,30 @@ class SpectrumViewSpec:
         return base
 
 
-def _make_nd_template(ndim: int, *, with_time_coord: bool = False) -> sc.DataArray:
+def _make_nd_template(ndim: int) -> sc.DataArray:
     """Create an empty template with the specified number of dimensions."""
-    coords = {'time': sc.scalar(0, unit='ns')} if with_time_coord else {}
     if ndim == 0:
-        return sc.DataArray(sc.scalar(0, unit='counts'), coords=coords)
+        return sc.DataArray(sc.scalar(0, unit='counts'))
     dims = [f'dim_{i}' for i in range(ndim)]
-    return sc.DataArray(
-        sc.zeros(dims=dims, shape=[0] * ndim, unit='counts'), coords=coords
-    )
+    return sc.DataArray(sc.zeros(dims=dims, shape=[0] * ndim, unit='counts'))
 
 
 def _make_2d_template() -> sc.DataArray:
-    """Create an empty 2D template for cumulative outputs (no time coord)."""
+    """Create an empty 2D template."""
     return _make_nd_template(2)
 
 
-def _make_2d_template_with_time() -> sc.DataArray:
-    """Create an empty 2D template with time coord for current outputs."""
-    return _make_nd_template(2, with_time_coord=True)
-
-
 def _make_0d_template() -> sc.DataArray:
-    """Create an empty 0D template for cumulative scalar outputs (no time coord)."""
+    """Create an empty 0D template for scalar outputs."""
     return _make_nd_template(0)
 
 
-def _make_0d_template_with_time() -> sc.DataArray:
-    """Create an empty 0D template with time coord for scalar outputs."""
-    return _make_nd_template(0, with_time_coord=True)
+def _make_roi_spectra_template() -> sc.DataArray:
+    """Create an empty template for stacked per-ROI spectra."""
+    return sc.DataArray(
+        sc.zeros(dims=['roi', 'time_of_arrival'], shape=[0, 0], unit='counts'),
+        coords={'roi': sc.array(dims=['roi'], values=[], unit=None)},
+    )
 
 
 _BASE_DETECTOR_VIEWS: tuple[OutputView, ...] = (
@@ -260,7 +255,7 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
             'Detector image for the latest update interval only. '
             'Resets each update interval.'
         ),
-        default_factory=_make_2d_template_with_time,
+        default_factory=_make_2d_template,
     )
     counts_total_cumulative: CumulativeOutput = pydantic.Field(
         title='Total',
@@ -275,7 +270,7 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
             'Total number of detector events for the latest update interval only. '
             'Resets each update interval.'
         ),
-        default_factory=_make_0d_template_with_time,
+        default_factory=_make_0d_template,
     )
     counts_in_toa_range_cumulative: CumulativeOutput = pydantic.Field(
         title='Total in range',
@@ -291,7 +286,7 @@ class DetectorViewOutputsBase(WorkflowOutputsBase):
             'Number of detector events within the configured range filter '
             'for the latest update interval only. Resets each update interval.'
         ),
-        default_factory=_make_0d_template_with_time,
+        default_factory=_make_0d_template,
     )
 
 
@@ -328,10 +323,7 @@ class DetectorViewOutputs(DetectorViewOutputsBase):
             'Histogram for each active ROI region '
             'accumulated since the start of the run.'
         ),
-        default_factory=lambda: sc.DataArray(
-            sc.zeros(dims=['roi', 'time_of_arrival'], shape=[0, 0], unit='counts'),
-            coords={'roi': sc.array(dims=['roi'], values=[], unit=None)},
-        ),
+        default_factory=_make_roi_spectra_template,
     )
     roi_spectra_current: WindowOutput = pydantic.Field(
         title='ROI spectra update',
@@ -339,13 +331,7 @@ class DetectorViewOutputs(DetectorViewOutputsBase):
             'Histogram for each active ROI region '
             'for the latest update interval only. Resets each update interval.'
         ),
-        default_factory=lambda: sc.DataArray(
-            sc.zeros(dims=['roi', 'time_of_arrival'], shape=[0, 0], unit='counts'),
-            coords={
-                'roi': sc.array(dims=['roi'], values=[], unit=None),
-                'time': sc.scalar(0, unit='ns'),
-            },
-        ),
+        default_factory=_make_roi_spectra_template,
     )
 
     # ROI geometry readbacks
@@ -381,8 +367,7 @@ def make_detector_view_outputs(
     ----------
     output_ndim:
         Number of dimensions for spatial outputs (cumulative, current).
-        The counts outputs remain 0D scalars with time coord.
-        If None, uses 2D default.
+        The counts outputs remain 0D scalars. If None, uses 2D default.
     roi_support:
         Whether to include ROI-related outputs. If False, the returned class
         will not include roi_spectra_current, roi_spectra_cumulative,
@@ -406,17 +391,14 @@ def make_detector_view_outputs(
 
     if output_ndim is not None:
 
-        def make_cumulative_template() -> sc.DataArray:
+        def make_template() -> sc.DataArray:
             return _make_nd_template(output_ndim)
-
-        def make_current_template() -> sc.DataArray:
-            return _make_nd_template(output_ndim, with_time_coord=True)
 
         class _WithNdim(base_class):  # type: ignore[valid-type,misc]
             cumulative: CumulativeOutput = pydantic.Field(
                 title='Image (cumulative)',
                 description=('Detector image accumulated since the start of the run.'),
-                default_factory=make_cumulative_template,
+                default_factory=make_template,
             )
             current: WindowOutput = pydantic.Field(
                 title='Image (current)',
@@ -424,7 +406,7 @@ def make_detector_view_outputs(
                     'Detector image for the latest update interval only. '
                     'Resets each update interval.'
                 ),
-                default_factory=make_current_template,
+                default_factory=make_template,
             )
 
         base_class = _WithNdim

--- a/src/ess/livedata/workflows/monitor_workflow_specs.py
+++ b/src/ess/livedata/workflows/monitor_workflow_specs.py
@@ -242,10 +242,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
     current: WindowOutput = pydantic.Field(
         default_factory=lambda: sc.DataArray(
             sc.zeros(dims=['time_of_arrival'], shape=[0], unit='counts'),
-            coords={
-                'time_of_arrival': sc.arange('time_of_arrival', 0, unit='ms'),
-                'time': sc.scalar(0, unit='ns'),
-            },
+            coords={'time_of_arrival': sc.arange('time_of_arrival', 0, unit='ms')},
         ),
         title='Histogram update',
         description=(
@@ -254,10 +251,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
         ),
     )
     counts_total: WindowOutput = pydantic.Field(
-        default_factory=lambda: sc.DataArray(
-            sc.scalar(0, unit='counts'),
-            coords={'time': sc.scalar(0, unit='ns')},
-        ),
+        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
         title='Total',
         description=(
             'Total number of monitor events for the latest update interval only. '
@@ -265,10 +259,7 @@ class MonitorHistogramOutputs(WorkflowOutputsBase):
         ),
     )
     counts_in_toa_range: WindowOutput = pydantic.Field(
-        default_factory=lambda: sc.DataArray(
-            sc.scalar(0, unit='counts'),
-            coords={'time': sc.scalar(0, unit='ns')},
-        ),
+        default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts')),
         title='Total in range',
         description=(
             'Number of monitor events within the configured range filter '

--- a/src/ess/livedata/workflows/stream_processor_workflow.py
+++ b/src/ess/livedata/workflows/stream_processor_workflow.py
@@ -77,7 +77,8 @@ class StreamProcessorWorkflow(Workflow):
             Mapping from output names to sciline keys for target outputs.
         window_outputs:
             Output names representing the current window (delta since last finalize).
-            These receive time, start_time, end_time coords.
+            These receive their own ``start_time``/``time`` coords, bounding the
+            window rather than the job.
         **kwargs:
             Additional arguments passed to StreamProcessor.
         """
@@ -228,14 +229,12 @@ class StreamProcessorWorkflow(Workflow):
         # Add time coords to window outputs
         if self._window_outputs and self._current_start_time is not None:
             start_time_coord = self._current_start_time.to_scipp()
-            end_time_coord = self._current_end_time.to_scipp()
+            time_coord = self._current_end_time.to_scipp()
 
             for name in self._window_outputs:
                 if name in results:
                     results[name] = results[name].assign_coords(
-                        time=start_time_coord,
-                        start_time=start_time_coord,
-                        end_time=end_time_coord,
+                        start_time=start_time_coord, time=time_coord
                     )
 
         # Reset time tracking for next period

--- a/tests/bifrost_test.py
+++ b/tests/bifrost_test.py
@@ -205,9 +205,9 @@ class TestDetectorRatemeter:
     def test_ratemeter_raw_counts_carry_no_time_coords(self, bifrost_workflow):
         """Per-update counts are bare: time coords are stamped on accumulation.
 
-        Stamping a ``time`` coord here would suppress the ``start_time``/
-        ``end_time`` the dashboard's rate normalization needs (see
-        ``_add_time_coords``) and break coord matching across the accumulator sum.
+        Stamping a ``time`` coord here would suppress the ``start_time``/``time``
+        bounds the dashboard's rate normalization needs (see ``_add_time_coords``)
+        and break coord matching across the accumulator sum.
         """
         reduction_workflow, DetectorRegionCountsRaw = bifrost_workflow
         nexus_data = _make_test_event_data(arc_events={1: 50})
@@ -225,7 +225,6 @@ class TestDetectorRatemeter:
         assert result.unit == 'counts'
         assert 'time' not in result.coords
         assert 'start_time' not in result.coords
-        assert 'end_time' not in result.coords
 
     @pytest.mark.slow
     def test_ratemeter_current_output_normalizes_to_rate(self):
@@ -235,6 +234,7 @@ class TestDetectorRatemeter:
         builds it) and checks the current output can be normalized to a rate,
         while the cumulative output defers its time bounds to the job layer.
         """
+        from ess.livedata.dashboard.extractors import LatestValueExtractor
         from ess.livedata.dashboard.plots import _normalize_to_rate
         from ess.livedata.preprocessors.accumulation_mode import Cumulative, Current
         from ess.livedata.preprocessors.accumulators import (
@@ -273,8 +273,10 @@ class TestDetectorRatemeter:
 
         current = results['detector_region_counts']
         assert current.value == 100
-        assert {'time', 'start_time', 'end_time'} <= set(current.coords)
-        rate = _normalize_to_rate(current)
+        assert {'start_time', 'time'} <= set(current.coords)
+        # `_normalize_to_rate` reads the dashboard's `(start_time, end_time)` pair,
+        # which is minted at the extractor boundary rather than carried on the wire.
+        rate = _normalize_to_rate(LatestValueExtractor().extract(current))
         assert rate.unit == 'counts/s'
         assert rate.value == 50  # 100 counts / 2 s
 

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -405,7 +405,7 @@ class TestJob:
     def test_get_adds_time_coords_to_data_arrays(
         self, fake_processor, sample_workflow_id
     ):
-        """Test that get() adds start_time and end_time coords to DataArrays."""
+        """Test that get() adds start_time and time coords to DataArrays."""
         job_id = JobId(source_name="test_source", job_number=1)
         job = Job(
             job_id=job_id,
@@ -433,12 +433,10 @@ class TestJob:
         result = job.get()
         output = result.data["output"]
 
-        assert "start_time" in output.coords
-        assert "end_time" in output.coords
         assert output.coords["start_time"].value == 1000
-        assert output.coords["end_time"].value == 2000
+        assert output.coords["time"].value == 2000
         assert output.coords["start_time"].unit == "ns"
-        assert output.coords["end_time"].unit == "ns"
+        assert output.coords["time"].unit == "ns"
 
     def test_get_preserves_existing_time_coords_on_data_arrays(
         self, fake_processor, sample_workflow_id
@@ -466,7 +464,7 @@ class TestJob:
         fake_processor.data = {
             "delta_output": sc.DataArray(
                 data=sc.scalar(1.0),
-                coords={'start_time': workflow_start, 'end_time': workflow_end},
+                coords={'start_time': workflow_start, 'time': workflow_end},
             ),
             "cumulative_output": sc.DataArray(data=sc.scalar(2.0)),
         }
@@ -485,20 +483,20 @@ class TestJob:
         # Delta output should preserve workflow-set times
         delta = result.data["delta_output"]
         assert delta.coords["start_time"].value == 500
-        assert delta.coords["end_time"].value == 1500
+        assert delta.coords["time"].value == 1500
 
         # Cumulative output should get job-level times
         cumulative = result.data["cumulative_output"]
         assert cumulative.coords["start_time"].value == 1000
-        assert cumulative.coords["end_time"].value == 2000
+        assert cumulative.coords["time"].value == 2000
 
     def test_get_does_not_add_time_coords_to_data_with_time_coordinate(
         self, fake_processor, sample_workflow_id
     ):
-        """Data with a 'time' coordinate already carries its own timestamps.
+        """A series output's 'time' is per-sample data, not a bound to overwrite.
 
-        Adding start_time/end_time would be redundant and causes structural
-        issues in TemporalBuffer (scalar coord vs multi-element time dim).
+        Stamping the job's own scalars would also cause structural issues in
+        TemporalBuffer (scalar coord vs multi-element time dim).
         """
         job_id = JobId(source_name="test_source", job_number=1)
         job = Job(
@@ -532,12 +530,15 @@ class TestJob:
         output = result.data["delta"]
 
         assert "start_time" not in output.coords
-        assert "end_time" not in output.coords
+        assert sc.identical(
+            output.coords["time"],
+            sc.array(dims=["time"], values=[100, 200, 300], unit="ns"),
+        )
 
     def test_get_does_not_add_time_coords_to_data_with_scalar_time_coordinate(
         self, fake_processor, sample_workflow_id
     ):
-        """Even a scalar 'time' coordinate signals timestamped data."""
+        """A workflow that stamped its own 'time' keeps it, bounds and all."""
         job_id = JobId(source_name="test_source", job_number=1)
         job = Job(
             job_id=job_id,
@@ -567,12 +568,18 @@ class TestJob:
         output = result.data["delta"]
 
         assert "start_time" not in output.coords
-        assert "end_time" not in output.coords
+        assert output.coords["time"].value == 100
 
-    def test_get_does_not_add_time_coords_when_no_data_added(
+    def test_get_without_accumulated_data_reports_the_missing_bounds(
         self, fake_processor, sample_workflow_id
     ):
-        """Test that get() does not add time coords when job has no timing info."""
+        """Finalizing before any primary data arrived is a fault, not an empty result.
+
+        The JobManager only finalizes jobs that accumulated primary data, so
+        this is unreachable in production. Emitting untimestamped outputs
+        instead would push the failure to the dashboard, where TemporalBuffer
+        rejects them far from the cause.
+        """
         job_id = JobId(source_name="test_source", job_number=1)
         job = Job(
             job_id=job_id,
@@ -582,18 +589,14 @@ class TestJob:
             input_streams=set(),
             gating_streams=set(),
         )
-
-        # Set up processor to return a DataArray
         fake_processor.data = {
             "output": sc.DataArray(data=sc.array(dims=["x"], values=[1, 2, 3]))
         }
 
-        # Don't add any data, so start_time and end_time remain None
         result = job.get()
-        output = result.data["output"]
 
-        assert "start_time" not in output.coords
-        assert "end_time" not in output.coords
+        assert result.data is None
+        assert "no time bounds" in result.error_message
 
     def test_get_calls_processor_finalize(self, sample_job, fake_processor):
         """Test that get() calls processor.finalize()."""
@@ -700,15 +703,17 @@ class TestJob:
             input_streams=set(),
             gating_streams=set(),
         )
-
-        # Cause an error
-        fake_processor.should_fail_accumulate = True
         data = JobData(
             start_time=Timestamp.from_ns(100),
             end_time=Timestamp.from_ns(200),
             primary_data={"test_source": sc.scalar(42.0)},
             aux_data={},
         )
+        job.add(data)
+
+        # Cause an error on a later batch, as the JobManager's retry path does:
+        # it finalizes a job whose latest push failed but which holds earlier data.
+        fake_processor.should_fail_accumulate = True
         job.add(data)
 
         result = job.get()

--- a/tests/core/nicos_devices_test.py
+++ b/tests/core/nicos_devices_test.py
@@ -3,9 +3,10 @@
 """Tests for NICOS device extraction.
 
 Uses the real ``dummy`` instrument registry and real workflow specs, so the
-extractor needs no live registry. Devices are cumulative outputs carrying a
-``start_time`` coordinate (stamped by the JobManager); the extractor republishes
-them under their stable device name with that coordinate riding along.
+extractor needs no live registry. Devices are cumulative outputs carrying
+``start_time`` and ``time`` coordinates (stamped by the JobManager); the
+extractor republishes them under their stable device name with those riding
+along, plus ``end_time`` under the name NICOS's consumer reads.
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ from ess.livedata.kafka.sink_serializers import make_default_sink_serializer
 MONITOR_WORKFLOW = 'dummy/monitor_histogram/1'
 DEVICE_NAME = 'monitor1_counts_total'
 START_TIME = Timestamp.from_ns(1000)
+OBSERVED_AT = Timestamp.from_ns(2000)
 
 
 @pytest.fixture(scope='module')
@@ -62,11 +64,14 @@ def job_id() -> JobId:
 def result(job_id: JobId) -> JobResult:
     data = sc.DataGroup(
         {
-            # (a) in the contract -> extracted. Carries the start_time coord the
+            # (a) in the contract -> extracted. Carries the coord pair the
             # JobManager stamps on cumulative outputs.
             'counts_total_cumulative': sc.DataArray(
                 sc.scalar(42, unit='counts'),
-                coords={'start_time': START_TIME.to_scipp()},
+                coords={
+                    'start_time': START_TIME.to_scipp(),
+                    'time': OBSERVED_AT.to_scipp(),
+                },
             ),
             # (b), (c) not in the contract -> skipped, regardless of shape.
             'cumulative': sc.DataArray(
@@ -80,7 +85,7 @@ def result(job_id: JobId) -> JobResult:
         job_id=job_id,
         workflow_id=WorkflowId.from_string(MONITOR_WORKFLOW),
         start_time=START_TIME,
-        end_time=Timestamp.from_ns(2000),
+        end_time=OBSERVED_AT,
         data=data,
     )
 
@@ -115,6 +120,18 @@ def test_extraction_carries_start_time_coord(
     coord = message.value.coords['start_time']
     assert coord.value == START_TIME.to_ns()
     assert coord.unit == 'ns'
+
+
+def test_echoes_time_under_the_end_time_name_nicos_reads(
+    extractor: DeviceExtractor, result: JobResult
+) -> None:
+    # Added rather than renamed, so the published contract is decoupled from
+    # our internal naming and NICOS can migrate on its own schedule.
+    (message,) = extractor.extract([result])
+
+    coords = message.value.coords
+    assert coords['end_time'].value == OBSERVED_AT.to_ns()
+    assert sc.identical(coords['time'], coords['end_time'])
 
 
 def test_result_without_data_is_skipped(

--- a/tests/dashboard/active_job_registry_test.py
+++ b/tests/dashboard/active_job_registry_test.py
@@ -63,7 +63,7 @@ class TestBeginGeneration:
     def test_clears_workflow_buffers(self):
         registry, ds, _js = _make_registry()
         key = _make_data_key()
-        ds[key] = sc.scalar(1.0)
+        ds[key] = sc.DataArray(sc.scalar(1.0))
 
         registry.begin_generation(_workflow_id, uuid.uuid4(), config={})
 
@@ -73,8 +73,8 @@ class TestBeginGeneration:
         registry, ds, _js = _make_registry()
         key = _make_data_key()
         other_key = _make_data_key(workflow_id=_other_workflow_id)
-        ds[key] = sc.scalar(1.0)
-        ds[other_key] = sc.scalar(2.0)
+        ds[key] = sc.DataArray(sc.scalar(1.0))
+        ds[other_key] = sc.DataArray(sc.scalar(2.0))
 
         registry.begin_generation(_workflow_id, uuid.uuid4(), config={})
 
@@ -107,8 +107,8 @@ class TestBeginGeneration:
         registry, ds, _ = _make_registry()
         key_a = _make_data_key(source_name="det1")
         key_b = _make_data_key(source_name="det2")
-        ds[key_a] = sc.scalar(1.0)
-        ds[key_b] = sc.scalar(2.0)
+        ds[key_a] = sc.DataArray(sc.scalar(1.0))
+        ds[key_b] = sc.DataArray(sc.scalar(2.0))
 
         snapshots: list[dict] = []
 
@@ -146,7 +146,7 @@ class TestDeactivate:
         job_number = uuid.uuid4()
         key = _make_data_key()
         registry.begin_generation(_workflow_id, job_number, config={})
-        ds[key] = sc.scalar(1.0)
+        ds[key] = sc.DataArray(sc.scalar(1.0))
 
         registry.deactivate(_workflow_id)
 
@@ -224,7 +224,7 @@ class TestRecordStale:
         key = _make_data_key()
         current = uuid.uuid4()
         registry.begin_generation(_workflow_id, current, config={})
-        ds[key] = sc.scalar(1.0)
+        ds[key] = sc.DataArray(sc.scalar(1.0))
 
         for _ in range(3):
             registry.record_stale(_workflow_id, uuid.uuid4())

--- a/tests/dashboard/correlation_plotter_test.py
+++ b/tests/dashboard/correlation_plotter_test.py
@@ -21,8 +21,10 @@ from ess.livedata.dashboard.correlation_plotter import (
     CorrelationHistogram2dPlotter,
     CorrelationHistogramPlotter,
 )
+from ess.livedata.dashboard.extractors import FullHistoryExtractor
 from ess.livedata.dashboard.plot_params import PlotScaleParams, PlotScaleParams2d
 from ess.livedata.dashboard.plots import ImagePlotter, LinePlotter
+from ess.livedata.dashboard.temporal_buffers import TemporalBuffer
 
 hv.extension('bokeh')
 
@@ -69,6 +71,58 @@ def histogram_of(plotter: CorrelationHistogramPlotter) -> dict[str, np.ndarray]:
     state = plotter.get_cached_state()
     assert state is not None
     return next(iter(state.values())).data
+
+
+class TestWallClockJoinConvention:
+    """Which instant of a window output the correlation join uses for x."""
+
+    def test_window_output_joins_at_its_time_not_its_start_time(self):
+        """A window is correlated against the axis as of when it closed.
+
+        ``time`` is the interval's right edge, so a window straddling a step in
+        the axis picks up the value after the step. Driven through the real
+        buffer and extractor, since it is the buffered ``time`` coord — not the
+        raw message — that the join reads.
+        """
+        axis_buffer = TemporalBuffer()
+        for sample_time, value in [(100, 1.0), (250, 5.0)]:
+            axis_buffer.add(
+                sc.DataArray(
+                    sc.scalar(value, unit='m'),
+                    coords={'time': sc.scalar(sample_time, unit='ms')},
+                )
+            )
+
+        source_buffer = TemporalBuffer()
+        # The second window opens before the axis steps to 5.0 and closes after.
+        for start_time, close_time, counts in [(100, 150, 10.0), (150, 300, 20.0)]:
+            source_buffer.add(
+                sc.DataArray(
+                    sc.scalar(counts, unit='counts'),
+                    coords={
+                        'start_time': sc.scalar(start_time, unit='ms'),
+                        'time': sc.scalar(close_time, unit='ms'),
+                    },
+                )
+            )
+
+        key = _make_result_key('detector')
+        plotter = CorrelationHistogramPlotter(
+            axes=[AxisSpec(role=X_AXIS, name='position', bins=2)],
+            normalize=False,
+            renderer=_make_line_renderer(),
+        )
+        plotter.compute(
+            {
+                PRIMARY: {key: FullHistoryExtractor().extract(source_buffer.get())},
+                X_AXIS: {key: FullHistoryExtractor().extract(axis_buffer.get())},
+            }
+        )
+
+        (histogram,) = plotter.get_cached_state()
+        # Positions 1.0 and 5.0 over two bins: one window on each side. Joining
+        # on start_time would put both at 1.0 and collapse this to a single bin.
+        assert list(histogram.dimension_values('result')) == [10.0, 20.0]
 
 
 class TestCorrelationHistogramPlotter:

--- a/tests/dashboard/extractor_time_coords_test.py
+++ b/tests/dashboard/extractor_time_coords_test.py
@@ -8,11 +8,13 @@ Extractors are the naming boundary: on the wire a value's upper bound is its
 ``(start_time, end_time)`` pair the plotters read. The pair must reflect the
 actual range of the extracted data, not stale coordinates from the buffer
 reference, and must be pristine wall-clock time even where ``time`` itself is
-shifted for display.
+shifted for display. A series output has no such range: its ``time`` is the
+per-sample axis, so it is left alone.
 """
 
 import time
 
+import pytest
 import scipp as sc
 
 from ess.livedata.dashboard.extractors import (
@@ -263,3 +265,37 @@ class TestLatestValueExtractor:
 
         assert sc.identical(result.coords['start_time'], sc.scalar(1000, unit='ns'))
         assert sc.identical(result.coords['end_time'], sc.scalar(3000, unit='ns'))
+
+
+class TestSeriesOutputsCarryNoBounds:
+    """A series output's ``time`` is its x axis, not a bound to translate.
+
+    Its age is already legible on the plot, so minting ``end_time`` from the
+    last sample would drive the freshness pill and the lag readout off the
+    device's sampling rate rather than the pipeline's latency. ``start_time``
+    is what separates a bounded output from a series one, so the pair is
+    minted whole or not at all.
+    """
+
+    @pytest.fixture
+    def samples(self) -> sc.DataArray:
+        return sc.DataArray(
+            sc.array(dims=['time'], values=[1.0, 2.0, 3.0], unit='K'),
+            coords={
+                'time': sc.array(
+                    dims=['time'], values=[100, 200, 300], unit='ns', dtype='int64'
+                )
+            },
+        )
+
+    def test_full_history_mints_no_bounds(self, samples: sc.DataArray) -> None:
+        result = FullHistoryExtractor().extract(samples)
+
+        assert 'end_time' not in result.coords
+        assert 'start_time' not in result.coords
+
+    def test_latest_value_mints_no_bounds(self, samples: sc.DataArray) -> None:
+        result = LatestValueExtractor().extract(samples)
+
+        assert 'end_time' not in result.coords
+        assert 'start_time' not in result.coords

--- a/tests/dashboard/extractor_time_coords_test.py
+++ b/tests/dashboard/extractor_time_coords_test.py
@@ -3,9 +3,12 @@
 """
 Tests for time coordinate handling in extractors.
 
-Extractors should ensure that extracted data has correct start_time/end_time
-coordinates reflecting the actual time range of the extracted data, not stale
-coordinates from the buffer reference.
+Extractors are the naming boundary: on the wire a value's upper bound is its
+``time``, and every extractor turns the covered range into the scalar
+``(start_time, end_time)`` pair the plotters read. The pair must reflect the
+actual range of the extracted data, not stale coordinates from the buffer
+reference, and must be pristine wall-clock time even where ``time`` itself is
+shifted for display.
 """
 
 import time
@@ -17,6 +20,7 @@ from ess.livedata.dashboard.extractors import (
     LatestValueExtractor,
     WindowAggregatingExtractor,
 )
+from ess.livedata.dashboard.time_utils import get_local_timezone_offset_ns
 
 
 def _make_buffered_data(
@@ -24,34 +28,29 @@ def _make_buffered_data(
     time_span_seconds: float = 5.0,
 ) -> sc.DataArray:
     """
-    Create data simulating what comes from a TemporalBuffer.
+    Create data simulating what a TemporalBuffer holds for a window output.
 
-    The data has:
-    - A 'time' dimension with actual timestamps (recent)
-    - 1-D start_time/end_time coords (one per time slice, as TemporalBuffer stores them)
+    Each buffered slice covers ``[start_time, time]``: ``time`` is the instant
+    the window closed, one second after it opened. Both are 1-D, one value per
+    slice. The two are deliberately distinct, so that a test cannot pass by
+    reading the wrong one.
     """
     now_ns = time.time_ns()
 
-    # Time values: spanning the last `time_span_seconds`
+    # Window close times: spanning the last `time_span_seconds`
     time_step_ns = int(time_span_seconds * 1e9 / num_points)
     time_values = [
         now_ns - (num_points - 1 - i) * time_step_ns for i in range(num_points)
     ]
-
-    # Each frame has its own start_time/end_time (1-D coords)
-    # Assume each frame covers 1 second
     frame_duration_ns = int(1e9)
-    start_time_values = time_values  # start_time == time for each frame
-    end_time_values = [t + frame_duration_ns for t in time_values]
+    start_time_values = [t - frame_duration_ns for t in time_values]
 
     return sc.DataArray(
         data=sc.array(dims=['time', 'x'], values=[[1.0, 2.0]] * num_points),
         coords={
             'time': sc.array(dims=['time'], values=time_values, unit='ns'),
             'x': sc.array(dims=['x'], values=[0.0, 1.0]),
-            # 1-D coords as TemporalBuffer produces
             'start_time': sc.array(dims=['time'], values=start_time_values, unit='ns'),
-            'end_time': sc.array(dims=['time'], values=end_time_values, unit='ns'),
         },
     )
 
@@ -72,18 +71,57 @@ class TestFullHistoryExtractor:
         assert result.coords['start_time'].ndim == 0  # Scalar
         assert sc.identical(result.coords['start_time'], expected_start)
 
-    def test_sets_end_time_from_max_of_1d_coord(self):
-        """end_time should be max of the 1-D end_time coord."""
+    def test_sets_end_time_from_last_of_1d_time_coord(self):
+        """end_time is minted from the wire's upper bound, the 'time' coord."""
         data = _make_buffered_data(num_points=5, time_span_seconds=5.0)
         extractor = FullHistoryExtractor()
 
         result = extractor.extract(data)
 
-        # Result should have scalar end_time = max of input 1-D end_time
-        expected_end = data.coords['end_time'][-1]
-        assert 'end_time' in result.coords
         assert result.coords['end_time'].ndim == 0  # Scalar
-        assert sc.identical(result.coords['end_time'], expected_end)
+        assert sc.identical(result.coords['end_time'], data.coords['time'][-1])
+
+    def test_end_time_is_pristine_wall_clock_despite_the_display_shift(self):
+        """The bounds are provenance, so the timezone shift must not reach them.
+
+        ``time`` is shifted into the local timezone for Bokeh's axis; taking the
+        bounds afterwards would misreport them by the UTC offset.
+        """
+        data = _make_buffered_data(num_points=5, time_span_seconds=5.0)
+
+        result = FullHistoryExtractor().extract(data)
+
+        assert sc.identical(result.coords['end_time'], data.coords['time'][-1])
+        assert sc.identical(result.coords['start_time'], data.coords['start_time'][0])
+
+    def test_time_axis_survives_as_the_1d_dim_coord(self):
+        """Minting the scalar bounds must not overwrite the plotted x axis.
+
+        ``assign_coords`` replaces a 1-D dim coord with a scalar silently, so a
+        bound accidentally emitted under the name ``time`` would kill the axis
+        with no error anywhere.
+        """
+        data = _make_buffered_data(num_points=5, time_span_seconds=5.0)
+
+        result = FullHistoryExtractor().extract(data)
+
+        assert result.coords['time'].ndim == 1
+        assert result.coords['time'].sizes['time'] == 5
+
+    def test_plotted_axis_is_the_window_close_not_its_start(self):
+        """A window output's wall-clock x is its right edge.
+
+        The axis is the wire's ``time``, offset into the local timezone for
+        Bokeh and nothing else — in particular not the interval's ``start_time``.
+        """
+        data = _make_buffered_data(num_points=5, time_span_seconds=5.0)
+        origin = sc.epoch(unit='ns') + get_local_timezone_offset_ns().to_scipp().to(
+            unit='ns', dtype='int64'
+        )
+
+        result = FullHistoryExtractor().extract(data)
+
+        assert sc.identical(result.coords['time'], origin + data.coords['time'])
 
     def test_end_time_reflects_actual_data_range(self):
         """end_time should reflect the actual data, giving recent lag."""
@@ -106,10 +144,8 @@ class TestFullHistoryExtractor:
             dims=['time'], values=time_values, unit='ns'
         )
 
-        # Create with 1-D start_time/end_time coords
         frame_duration_ns = int(1e9)
-        start_time_values = time_values
-        end_time_values = [t + frame_duration_ns for t in time_values]
+        start_time_values = [t - frame_duration_ns for t in time_values]
 
         data = sc.DataArray(
             data=sc.array(dims=['time', 'x'], values=[[1.0, 2.0]] * 5),
@@ -119,7 +155,6 @@ class TestFullHistoryExtractor:
                 'start_time': sc.array(
                     dims=['time'], values=start_time_values, unit='ns'
                 ),
-                'end_time': sc.array(dims=['time'], values=end_time_values, unit='ns'),
             },
         )
         extractor = FullHistoryExtractor()
@@ -200,14 +235,31 @@ class TestLatestValueExtractor:
         assert lag_seconds < 5.0, f"end_time lag {lag_seconds}s should be ~0s"
 
     def test_extracts_last_value_from_1d_coords(self):
-        """Should extract the last value from 1-D start_time/end_time coords."""
+        """Should extract the last slice's bounds, end_time minted from 'time'."""
         data = _make_buffered_data(num_points=5, time_span_seconds=5.0)
         extractor = LatestValueExtractor()
 
         result = extractor.extract(data)
 
-        # Verify coords are from the last slice
-        expected_start = data.coords['start_time'][-1]
-        expected_end = data.coords['end_time'][-1]
-        assert sc.identical(result.coords['start_time'], expected_start)
-        assert sc.identical(result.coords['end_time'], expected_end)
+        assert sc.identical(result.coords['start_time'], data.coords['start_time'][-1])
+        assert sc.identical(result.coords['end_time'], data.coords['time'][-1])
+
+    def test_mints_end_time_for_an_unbuffered_message(self):
+        """A single message reaches this extractor via SingleValueBuffer.
+
+        It carries the wire's ``(start_time, time)`` and no time dim, so the
+        plotters would see no ``end_time`` at all without the boundary applying
+        here too.
+        """
+        message = sc.DataArray(
+            sc.scalar(5.0, unit='counts'),
+            coords={
+                'start_time': sc.scalar(1000, unit='ns'),
+                'time': sc.scalar(3000, unit='ns'),
+            },
+        )
+
+        result = LatestValueExtractor().extract(message)
+
+        assert sc.identical(result.coords['start_time'], sc.scalar(1000, unit='ns'))
+        assert sc.identical(result.coords['end_time'], sc.scalar(3000, unit='ns'))

--- a/tests/dashboard/extractors_test.py
+++ b/tests/dashboard/extractors_test.py
@@ -41,7 +41,7 @@ class TestLatestValueExtractor:
 
         # Should extract only the last time slice
         assert 'time' not in result.dims
-        assert sc.identical(result, data['time', -1])
+        assert sc.identical(result.drop_coords(['end_time']), data['time', -1])
 
     def test_extract_from_data_without_concat_dimension(self):
         """Extract from data that doesn't have concat dimension (single frame)."""
@@ -106,8 +106,9 @@ class TestFullHistoryExtractor:
 
         result = extractor.extract(data)
 
-        # Should return all data unchanged
-        assert sc.identical(result, data)
+        # All data, plus the scalar upper bound every extractor mints from 'time'.
+        assert sc.identical(result.drop_coords(['end_time']), data)
+        assert sc.identical(result.coords['end_time'], data.coords['time'][-1])
 
     def test_extract_with_multidimensional_data(self):
         """Extract with complex multidimensional data."""
@@ -128,7 +129,7 @@ class TestFullHistoryExtractor:
 
         result = extractor.extract(data)
 
-        assert sc.identical(result, data)
+        assert sc.identical(result.drop_coords(['end_time']), data)
 
     def test_extract_converts_int64_nanoseconds_to_datetime64(self):
         """Int64 nanosecond timestamps are converted to datetime64 for plotting."""
@@ -204,7 +205,7 @@ class TestFullHistoryExtractor:
 
         result = extractor.extract(data)
 
-        assert sc.identical(result, data)
+        assert sc.identical(result.drop_coords(['end_time']), data)
 
     def test_extract_with_custom_concat_dim(self):
         """Test extraction with custom concat dimension name."""

--- a/tests/dashboard/extractors_test.py
+++ b/tests/dashboard/extractors_test.py
@@ -41,7 +41,7 @@ class TestLatestValueExtractor:
 
         # Should extract only the last time slice
         assert 'time' not in result.dims
-        assert sc.identical(result.drop_coords(['end_time']), data['time', -1])
+        assert sc.identical(result, data['time', -1])
 
     def test_extract_from_data_without_concat_dimension(self):
         """Extract from data that doesn't have concat dimension (single frame)."""
@@ -75,7 +75,7 @@ class TestLatestValueExtractor:
     def test_extract_scalar_data(self):
         """Extract from scalar data."""
         extractor = LatestValueExtractor()
-        data = sc.scalar(42.0, unit='counts')
+        data = sc.DataArray(sc.scalar(42.0, unit='counts'))
 
         result = extractor.extract(data)
 
@@ -106,9 +106,8 @@ class TestFullHistoryExtractor:
 
         result = extractor.extract(data)
 
-        # All data, plus the scalar upper bound every extractor mints from 'time'.
-        assert sc.identical(result.drop_coords(['end_time']), data)
-        assert sc.identical(result.coords['end_time'], data.coords['time'][-1])
+        # Should return all data unchanged
+        assert sc.identical(result, data)
 
     def test_extract_with_multidimensional_data(self):
         """Extract with complex multidimensional data."""
@@ -129,7 +128,7 @@ class TestFullHistoryExtractor:
 
         result = extractor.extract(data)
 
-        assert sc.identical(result.drop_coords(['end_time']), data)
+        assert sc.identical(result, data)
 
     def test_extract_converts_int64_nanoseconds_to_datetime64(self):
         """Int64 nanosecond timestamps are converted to datetime64 for plotting."""
@@ -205,7 +204,7 @@ class TestFullHistoryExtractor:
 
         result = extractor.extract(data)
 
-        assert sc.identical(result.drop_coords(['end_time']), data)
+        assert sc.identical(result, data)
 
     def test_extract_with_custom_concat_dim(self):
         """Test extraction with custom concat dimension name."""

--- a/tests/dashboard/fake_backend_test.py
+++ b/tests/dashboard/fake_backend_test.py
@@ -16,8 +16,11 @@ from ess.livedata.config.models import Interval, PolygonROI, RectangleROI
 from ess.livedata.config.roi_names import ROIGeometryType, get_roi_mapper
 from ess.livedata.config.workflow_spec import (
     REDUCTION,
+    CumulativeOutput,
     JobId,
     ResultKey,
+    SeriesOutput,
+    WindowOutput,
     WorkflowConfig,
     WorkflowId,
     WorkflowOutputsBase,
@@ -71,6 +74,31 @@ class OutputsTimeseries(WorkflowOutputsBase):
 
 class OutputsNoTemplate(WorkflowOutputsBase):
     result: sc.DataArray = Field(title='Result')
+
+
+def _scalar_template() -> sc.DataArray:
+    return sc.DataArray(sc.zeros(dims=[], shape=[], unit='counts'))
+
+
+class OutputsTemporality(WorkflowOutputsBase):
+    per_update: WindowOutput = Field(default_factory=_scalar_template, title='Window')
+    total: CumulativeOutput = Field(default_factory=_scalar_template, title='Total')
+    reading: SeriesOutput = Field(
+        default_factory=lambda: sc.DataArray(
+            sc.zeros(dims=[], shape=[], unit='K'),
+            coords={'time': sc.scalar(0, unit='ns', dtype='int64')},
+        ),
+        title='Reading',
+    )
+
+
+def _outputs(messages) -> dict[str, sc.DataArray]:
+    """Map output name to emitted data for the data messages in ``messages``."""
+    return {
+        ResultKey.model_validate_json(m.stream.name).output_name: m.value
+        for m in messages
+        if m.stream.kind is StreamKind.LIVEDATA_DATA
+    }
 
 
 def _spec(outputs: type[WorkflowOutputsBase], name: str) -> WorkflowSpec:
@@ -409,6 +437,41 @@ class TestROILoopback:
         session.publisher.set_job_number_resolver(lambda _: uuid.uuid4())
         session.publish({0: _rectangle(0.0, 0.0)})
         assert session.results()['roi_spectra_cumulative'].sizes['roi'] == 0
+
+
+class TestEmittedTimeCoords:
+    """The dashboard keys and ages its buffers by these coords."""
+
+    @pytest.fixture
+    def polls(self, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, sc.DataArray]]:
+        # Zero update period makes every poll due, so each poll emits fresh data.
+        monkeypatch.setattr(
+            'ess.livedata.dashboard.fake_backend._UPDATE_PERIOD_SECONDS', 0.0
+        )
+        spec = _spec(OutputsTemporality, 'temporal')
+        backend = FakeBackend(_registry(spec))
+        backend.submit(_config(spec))
+        return [_outputs(backend.poll()) for _ in range(2)]
+
+    @pytest.mark.parametrize('output_name', ['per_update', 'total'])
+    def test_bounded_outputs_carry_start_time_and_time(self, polls, output_name: str):
+        coords = polls[0][output_name].coords
+        assert coords['start_time'].unit == sc.Unit('ns')
+        assert coords['time'].value >= coords['start_time'].value
+
+    def test_series_output_carries_time_but_no_start_time(self, polls) -> None:
+        coords = polls[0]['reading'].coords
+        assert 'time' in coords
+        assert 'start_time' not in coords
+
+    def test_cumulative_start_time_stays_pinned(self, polls) -> None:
+        first, second = (poll['total'].coords for poll in polls)
+        assert sc.identical(first['start_time'], second['start_time'])
+        assert second['time'].value >= first['time'].value
+
+    def test_window_covers_interval_since_previous_update(self, polls) -> None:
+        first, second = (poll['per_update'].coords for poll in polls)
+        assert sc.identical(second['start_time'], first['time'])
 
 
 @pytest.mark.parametrize('update', [0, 1, 7])

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -159,7 +159,7 @@ class FakePlottingController:
         plot_name: str,
         params,
         on_update,
-        temporality_by_role,
+        temporality,
     ):
         """Set up data pipeline using real StreamManager (unified interface)."""
         from ess.livedata.dashboard.data_roles import PRIMARY
@@ -175,7 +175,7 @@ class FakePlottingController:
                 'source_names': source_names,
                 'output_name': output_name,
                 'plot_name': plot_name,
-                'temporality_by_role': temporality_by_role,
+                'temporality': temporality,
             }
         )
 
@@ -643,7 +643,7 @@ class TestWorkflowIntegrationAndPlotCreationTiming:
                 source_name=source_name,
                 output_name=plot_cell[1].view_name,
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
 
         # Plotter count unchanged (no new plotter created on data arrival)
         assert fake_plotting_controller.call_count() == 1
@@ -678,7 +678,7 @@ class TestWorkflowIntegrationAndPlotCreationTiming:
                 source_name=source_name,
                 output_name=plot_cell[1].view_name,
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
 
         # Verify plot was created
         assert fake_plotting_controller.call_count() == 1
@@ -730,7 +730,7 @@ class TestWorkflowIntegrationAndPlotCreationTiming:
                 source_name=config.source_names[0],
                 output_name=config.view_name,
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
 
         # Both plots should be created
         assert fake_plotting_controller.call_count() == 2
@@ -813,7 +813,7 @@ class TestWorkflowIntegrationAndPlotCreationTiming:
             source_name='new_source',
             output_name='new_output',
         )
-        fake_data_service[result_key] = sc.scalar(1.0)
+        fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.flush_frames()
 
         plotter = fake_plotting_controller.created_plotters[-1]
@@ -945,7 +945,7 @@ class TestTopologyVersion:
                     source_name=source_name,
                     output_name=plot_cell[1].view_name,
                 )
-            ] = sc.scalar(1.0)
+            ] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.sync_job_states()
         plot_orchestrator.flush_frames()
 
@@ -1102,7 +1102,7 @@ def feed_result_data(data_service, config, workflow_id):
             source_name=source_name,
             output_name=config.view_name,
         )
-        data_service[result_key] = sc.scalar(1.0)
+        data_service[result_key] = sc.DataArray(sc.scalar(1.0))
 
 
 class TestBuildRobustness:
@@ -1346,7 +1346,7 @@ class TestCellRetrieval:
                 source_name=source_name,
                 output_name=plot_cell[1].view_name,
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.flush_frames()
 
         # PlotDataService should have data for the layer
@@ -1454,7 +1454,7 @@ class TestCellRetrieval:
                 source_name=f'source_{i}',
                 output_name=f'output_{i}',
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.flush_frames()
 
         # Simulate late subscriber (new session, page reload, etc.)
@@ -1512,7 +1512,7 @@ class TestCellRetrieval:
                 source_name=source_name,
                 output_name=config.view_name,
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.flush_frames()
 
         # Verify layer has data in PlotDataService
@@ -1536,7 +1536,7 @@ class TestCellRetrieval:
             source_name='new_source',
             output_name='new_output',
         )
-        fake_data_service[result_key2] = sc.scalar(2.0)
+        fake_data_service[result_key2] = sc.DataArray(sc.scalar(2.0))
 
         # Verify plotter was recreated with new config
         assert fake_plotting_controller.call_count() == 2
@@ -1577,7 +1577,7 @@ class TestCellRetrieval:
                 source_name=source_name,
                 output_name=plot_cell[1].view_name,
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.flush_frames()
 
         # Verify layer has data in PlotDataService
@@ -1681,7 +1681,7 @@ class TestSourceNameFiltering:
             source_name='source_A',
             output_name='test_output',
         )
-        fake_data_service[result_key_A] = sc.scalar(1.0)
+        fake_data_service[result_key_A] = sc.DataArray(sc.scalar(1.0))
 
         # Plotter SHOULD be created with partial data (progressive plotting)
         assert fake_plotting_controller.call_count() == 1, (
@@ -1698,7 +1698,7 @@ class TestSourceNameFiltering:
             source_name='source_B',
             output_name='test_output',
         )
-        fake_data_service[result_key_B] = sc.scalar(2.0)
+        fake_data_service[result_key_B] = sc.DataArray(sc.scalar(2.0))
 
         # Still only 1 create_plot call (plot updates via streaming, not recreation)
         assert fake_plotting_controller.call_count() == 1
@@ -1731,7 +1731,7 @@ class TestSourceNameFiltering:
             source_name='source_A',
             output_name='test_output',
         )
-        fake_data_service[result_key_A] = sc.scalar(1.0)
+        fake_data_service[result_key_A] = sc.DataArray(sc.scalar(1.0))
 
         # NOW add the plot (late subscription)
         grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
@@ -1956,7 +1956,7 @@ class TestPlotAfterWorkflowStopped:
                 source_name=source_name,
                 output_name=config.view_name,
             )
-            fake_data_service[key] = sc.scalar(1.0)
+            fake_data_service[key] = sc.DataArray(sc.scalar(1.0))
 
     def test_new_layer_after_stop_displays_retained_data(
         self,
@@ -2098,7 +2098,7 @@ class TestTitleResolver:
                 source_name='monitor_0',
                 output_name=output_name,
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.flush_frames()
 
         assert len(fake_plotting_controller.created_plotters) == 2
@@ -2187,7 +2187,7 @@ class TestTitleResolverOutputViews:
                 source_name='source1',
                 output_name='current',
             )
-        ] = sc.scalar(1.0)
+        ] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.flush_frames()
 
         (plotter,) = fake_plotting_controller.created_plotters
@@ -2278,7 +2278,6 @@ class TestTemporalityOfResolvedField:
         expected,
     ):
         from ess.livedata.config.workflow_spec import Temporality
-        from ess.livedata.dashboard.data_roles import PRIMARY
 
         commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
         grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=1, ncols=1)
@@ -2288,7 +2287,7 @@ class TestTemporalityOfResolvedField:
         add_cell_with_layer(plot_orchestrator, grid_id, DEFAULT_GEOMETRY, config)
 
         (setup,) = fake_plotting_controller.get_pipeline_setups()
-        assert setup['temporality_by_role'][PRIMARY] is Temporality(expected)
+        assert set(setup['temporality'].values()) == {Temporality(expected)}
 
 
 class TestWindowingSelectedByParams:
@@ -2929,8 +2928,8 @@ class TestDeliveryPausedForHiddenLayers:
             source_name='monitor_0',
             output_name='output_a',
         )
-        fake_data_service[key] = sc.scalar(1.0)
-        fake_data_service[key] = sc.scalar(2.0)
+        fake_data_service[key] = sc.DataArray(sc.scalar(1.0))
+        fake_data_service[key] = sc.DataArray(sc.scalar(2.0))
         plot_orchestrator.flush_frames()
 
         (plotter,) = fake_plotting_controller.created_plotters
@@ -2946,7 +2945,7 @@ class TestDeliveryPausedForHiddenLayers:
 
         # Releasing the last token pauses delivery again.
         plot_orchestrator.activate_layer(layer_id, viewer, False)
-        fake_data_service[key] = sc.scalar(3.0)
+        fake_data_service[key] = sc.DataArray(sc.scalar(3.0))
         plot_orchestrator.flush_frames()
         assert len(plotter.compute_calls) == 1
 
@@ -2982,7 +2981,7 @@ class TestFrameGeneration:
                 source_name=source_name,
                 output_name=plot_cell[1].view_name,
             )
-            fake_data_service[result_key] = sc.scalar(1.0)
+            fake_data_service[result_key] = sc.DataArray(sc.scalar(1.0))
 
     def test_visible_data_arrival_advances_generation_on_flush(
         self,
@@ -3159,7 +3158,7 @@ class TestSyncJobStates:
             source_name='source1',
             output_name=config.view_name,
         )
-        fake_data_service[key] = sc.scalar(1.0)
+        fake_data_service[key] = sc.DataArray(sc.scalar(1.0))
         plot_orchestrator.flush_frames()
         return layer_id, key
 
@@ -3215,7 +3214,7 @@ class TestSyncJobStates:
         commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
         plot_orchestrator.sync_job_states()
 
-        fake_data_service[key] = sc.scalar(2.0)
+        fake_data_service[key] = sc.DataArray(sc.scalar(2.0))
         plot_orchestrator.flush_frames()
 
         state = plot_data_service.get(layer_id)

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -158,6 +158,7 @@ class FakePlottingController:
         plot_name: str,
         params,
         on_update,
+        temporality_by_role,
     ):
         """Set up data pipeline using real StreamManager (unified interface)."""
         from ess.livedata.dashboard.data_roles import PRIMARY
@@ -173,6 +174,7 @@ class FakePlottingController:
                 'source_names': source_names,
                 'output_name': output_name,
                 'plot_name': plot_name,
+                'temporality_by_role': temporality_by_role,
             }
         )
 
@@ -2192,6 +2194,92 @@ class TestTitleResolverOutputViews:
         assert resolver.output('cumulative') == 'Histogram'
         assert resolver.output('current') == 'Histogram'
         assert resolver.output('unknown_field') == 'unknown_field'
+
+
+class TestTemporalityOfResolvedField:
+    """The pipeline is told what the field a view resolved to means.
+
+    ``PlottingController`` refuses to aggregate a window over a cumulative
+    field; without this wiring the guard would never see one.
+    """
+
+    @pytest.fixture
+    def workflow_spec(self, workflow_id):
+        import scipp as sc
+
+        from ess.livedata.config.workflow_spec import (
+            REDUCTION,
+            CumulativeOutput,
+            OutputView,
+            WindowOutput,
+            WorkflowOutputsBase,
+            WorkflowSpec,
+        )
+
+        class Params(pydantic.BaseModel):
+            threshold: float = 100.0
+
+        class MixedOutputs(WorkflowOutputsBase):
+            output_views = (
+                OutputView(
+                    name='histogram',
+                    title='Histogram',
+                    fields=('cumulative', 'current'),
+                ),
+                OutputView(name='total', title='Total', fields=('total',)),
+            )
+
+            cumulative: CumulativeOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
+                title='Cumulative',
+            )
+            current: WindowOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0.0)), title='Current'
+            )
+            total: CumulativeOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0.0)), title='Total'
+            )
+
+        return WorkflowSpec(
+            instrument=workflow_id.instrument,
+            name=workflow_id.name,
+            version=workflow_id.version,
+            title='Test Workflow',
+            description='A test workflow',
+            source_names=['source1'],
+            params=Params,
+            aux_sources=None,
+            outputs=MixedOutputs,
+            group=REDUCTION,
+        )
+
+    @pytest.mark.parametrize(
+        ('view_name', 'expected'),
+        [('histogram', 'window'), ('total', 'cumulative')],
+        ids=['per_update_field', 'cumulative_only_view_falls_back'],
+    )
+    def test_temporality_follows_the_resolved_field(
+        self,
+        plot_orchestrator,
+        workflow_id,
+        workflow_spec,
+        job_orchestrator,
+        fake_plotting_controller,
+        view_name,
+        expected,
+    ):
+        from ess.livedata.config.workflow_spec import Temporality
+        from ess.livedata.dashboard.data_roles import PRIMARY
+
+        commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
+        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=1, ncols=1)
+        config = make_plot_config(
+            workflow_id, source_names=['source1'], output_name=view_name
+        )
+        add_cell_with_layer(plot_orchestrator, grid_id, DEFAULT_GEOMETRY, config)
+
+        (setup,) = fake_plotting_controller.get_pipeline_setups()
+        assert setup['temporality_by_role'][PRIMARY] is Temporality(expected)
 
 
 class TestRenameGrid:

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -20,6 +20,7 @@ from ess.livedata.dashboard.plot_orchestrator import (
     PlotConfig,
     PlotOrchestrator,
 )
+from ess.livedata.dashboard.plot_params import PlotParams1d, PlotParamsTimeseries
 from ess.livedata.dashboard.plots import PresenterBase
 
 
@@ -2196,6 +2197,58 @@ class TestTitleResolverOutputViews:
         assert resolver.output('unknown_field') == 'unknown_field'
 
 
+@pytest.fixture
+def mixed_temporality_spec(workflow_id):
+    """A spec whose ``histogram`` view backs both window modes, ``total`` one."""
+    import scipp as sc
+
+    from ess.livedata.config.workflow_spec import (
+        REDUCTION,
+        CumulativeOutput,
+        OutputView,
+        WindowOutput,
+        WorkflowOutputsBase,
+        WorkflowSpec,
+    )
+
+    class Params(pydantic.BaseModel):
+        threshold: float = 100.0
+
+    class MixedOutputs(WorkflowOutputsBase):
+        output_views = (
+            OutputView(
+                name='histogram',
+                title='Histogram',
+                fields=('cumulative', 'current'),
+            ),
+            OutputView(name='total', title='Total', fields=('total',)),
+        )
+
+        cumulative: CumulativeOutput = pydantic.Field(
+            default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
+            title='Cumulative',
+        )
+        current: WindowOutput = pydantic.Field(
+            default_factory=lambda: sc.DataArray(sc.scalar(0.0)), title='Current'
+        )
+        total: CumulativeOutput = pydantic.Field(
+            default_factory=lambda: sc.DataArray(sc.scalar(0.0)), title='Total'
+        )
+
+    return WorkflowSpec(
+        instrument=workflow_id.instrument,
+        name=workflow_id.name,
+        version=workflow_id.version,
+        title='Test Workflow',
+        description='A test workflow',
+        source_names=['source1'],
+        params=Params,
+        aux_sources=None,
+        outputs=MixedOutputs,
+        group=REDUCTION,
+    )
+
+
 class TestTemporalityOfResolvedField:
     """The pipeline is told what the field a view resolved to means.
 
@@ -2204,54 +2257,10 @@ class TestTemporalityOfResolvedField:
     """
 
     @pytest.fixture
-    def workflow_spec(self, workflow_id):
-        import scipp as sc
-
-        from ess.livedata.config.workflow_spec import (
-            REDUCTION,
-            CumulativeOutput,
-            OutputView,
-            WindowOutput,
-            WorkflowOutputsBase,
-            WorkflowSpec,
-        )
-
-        class Params(pydantic.BaseModel):
-            threshold: float = 100.0
-
-        class MixedOutputs(WorkflowOutputsBase):
-            output_views = (
-                OutputView(
-                    name='histogram',
-                    title='Histogram',
-                    fields=('cumulative', 'current'),
-                ),
-                OutputView(name='total', title='Total', fields=('total',)),
-            )
-
-            cumulative: CumulativeOutput = pydantic.Field(
-                default_factory=lambda: sc.DataArray(sc.scalar(0.0)),
-                title='Cumulative',
-            )
-            current: WindowOutput = pydantic.Field(
-                default_factory=lambda: sc.DataArray(sc.scalar(0.0)), title='Current'
-            )
-            total: CumulativeOutput = pydantic.Field(
-                default_factory=lambda: sc.DataArray(sc.scalar(0.0)), title='Total'
-            )
-
-        return WorkflowSpec(
-            instrument=workflow_id.instrument,
-            name=workflow_id.name,
-            version=workflow_id.version,
-            title='Test Workflow',
-            description='A test workflow',
-            source_names=['source1'],
-            params=Params,
-            aux_sources=None,
-            outputs=MixedOutputs,
-            group=REDUCTION,
-        )
+    def workflow_spec(self, mixed_temporality_spec):
+        # Overrides the conftest fixture, which feeds the registry backing
+        # job_orchestrator.
+        return mixed_temporality_spec
 
     @pytest.mark.parametrize(
         ('view_name', 'expected'),
@@ -2280,6 +2289,66 @@ class TestTemporalityOfResolvedField:
 
         (setup,) = fake_plotting_controller.get_pipeline_setups()
         assert setup['temporality_by_role'][PRIMARY] is Temporality(expected)
+
+
+class TestWindowingSelectedByParams:
+    """Which backing field a view resolves to follows the params' window mode.
+
+    The general plots spell the choice as a mode selector, the timeseries
+    plotter as a cumulative checkbox; both must reach the same resolution.
+    """
+
+    @pytest.fixture
+    def workflow_spec(self, mixed_temporality_spec):
+        # Overrides the conftest fixture, which feeds the registry backing
+        # job_orchestrator.
+        return mixed_temporality_spec
+
+    @pytest.mark.parametrize(
+        ('params', 'expected_field'),
+        [
+            (PlotParamsTimeseries(), 'current'),
+            (
+                PlotParamsTimeseries.model_validate(
+                    {'accumulation': {'cumulative': True}}
+                ),
+                'cumulative',
+            ),
+            (PlotParams1d(), 'current'),
+            (
+                PlotParams1d.model_validate({'time_window': {'mode': 'since_start'}}),
+                'cumulative',
+            ),
+        ],
+        ids=[
+            'timeseries_per_update',
+            'timeseries_cumulative',
+            'plot_window',
+            'plot_since_start',
+        ],
+    )
+    def test_primary_subscribes_to_the_field_the_mode_selects(
+        self,
+        plot_orchestrator,
+        workflow_id,
+        workflow_spec,
+        job_orchestrator,
+        fake_plotting_controller,
+        params,
+        expected_field,
+    ):
+        commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
+        grid_id = plot_orchestrator.add_grid(title='Test Grid', nrows=1, ncols=1)
+        config = make_plot_config(
+            workflow_id,
+            source_names=['source1'],
+            output_name='histogram',
+            params=params,
+        )
+        add_cell_with_layer(plot_orchestrator, grid_id, DEFAULT_GEOMETRY, config)
+
+        (setup,) = fake_plotting_controller.get_pipeline_setups()
+        assert setup['output_name'] == expected_field
 
 
 class TestRenameGrid:

--- a/tests/dashboard/plot_params_test.py
+++ b/tests/dashboard/plot_params_test.py
@@ -26,7 +26,9 @@ class TestCreateExtractorsFromParams:
         """Test fallback to LatestValueExtractor when no window params provided."""
         keys = ['key1', 'key2']
 
-        extractors = create_extractors_from_params(keys=keys, window=None, spec=None)
+        extractors = create_extractors_from_params(
+            keys=keys, window=None, temporality={}, spec=None
+        )
 
         assert len(extractors) == 2
         assert all(isinstance(ext, LatestValueExtractor) for ext in extractors.values())
@@ -39,7 +41,9 @@ class TestCreateExtractorsFromParams:
             mode=TimeWindowMode.window, window_duration_seconds=0.0
         )
 
-        extractors = create_extractors_from_params(keys=keys, window=window, spec=None)
+        extractors = create_extractors_from_params(
+            keys=keys, window=window, temporality={}, spec=None
+        )
 
         assert len(extractors) == 1
         assert isinstance(extractors['key1'], LatestValueExtractor)
@@ -49,7 +53,9 @@ class TestCreateExtractorsFromParams:
         keys = ['key1']
         window = TimeWindowParams(mode=TimeWindowMode.since_start)
 
-        extractors = create_extractors_from_params(keys=keys, window=window, spec=None)
+        extractors = create_extractors_from_params(
+            keys=keys, window=window, temporality={}, spec=None
+        )
 
         assert len(extractors) == 1
         assert isinstance(extractors['key1'], LatestValueExtractor)
@@ -63,7 +69,9 @@ class TestCreateExtractorsFromParams:
             aggregation=WindowAggregation.nansum,
         )
 
-        extractors = create_extractors_from_params(keys=keys, window=window, spec=None)
+        extractors = create_extractors_from_params(
+            keys=keys, window=window, temporality={}, spec=None
+        )
 
         assert len(extractors) == 2
         assert all(
@@ -83,7 +91,9 @@ class TestCreateExtractorsFromParams:
         spec = Mock()
         spec.data_requirements.required_extractor = FullHistoryExtractor
 
-        extractors = create_extractors_from_params(keys=keys, window=window, spec=spec)
+        extractors = create_extractors_from_params(
+            keys=keys, window=window, temporality={}, spec=spec
+        )
 
         # Should use FullHistoryExtractor despite window params
         assert len(extractors) == 2
@@ -100,7 +110,9 @@ class TestCreateExtractorsFromParams:
         spec = Mock()
         spec.data_requirements.required_extractor = None
 
-        extractors = create_extractors_from_params(keys=keys, window=window, spec=spec)
+        extractors = create_extractors_from_params(
+            keys=keys, window=window, temporality={}, spec=spec
+        )
 
         assert isinstance(extractors['key1'], WindowAggregatingExtractor)
         assert extractors['key1'].get_required_timespan() == 3.0
@@ -110,7 +122,9 @@ class TestCreateExtractorsFromParams:
         keys = ['result1', 'result2', 'result3']
         window = TimeWindowParams(mode=TimeWindowMode.since_start)
 
-        extractors = create_extractors_from_params(keys=keys, window=window, spec=None)
+        extractors = create_extractors_from_params(
+            keys=keys, window=window, temporality={}, spec=None
+        )
 
         assert len(extractors) == 3
         assert set(extractors.keys()) == {'result1', 'result2', 'result3'}
@@ -121,7 +135,9 @@ class TestCreateExtractorsFromParams:
         keys = []
         window = TimeWindowParams(mode=TimeWindowMode.since_start)
 
-        extractors = create_extractors_from_params(keys=keys, window=window, spec=None)
+        extractors = create_extractors_from_params(
+            keys=keys, window=window, temporality={}, spec=None
+        )
 
         assert extractors == {}
 
@@ -134,7 +150,9 @@ class TestCreateExtractorsFromParams:
             aggregation=WindowAggregation.mean,
         )
 
-        extractors = create_extractors_from_params(keys=keys, window=window, spec=None)
+        extractors = create_extractors_from_params(
+            keys=keys, window=window, temporality={}, spec=None
+        )
 
         extractor = extractors['key1']
         assert isinstance(extractor, WindowAggregatingExtractor)

--- a/tests/dashboard/plotting_controller_test.py
+++ b/tests/dashboard/plotting_controller_test.py
@@ -785,7 +785,7 @@ class TestAggregationOfCumulativeIsRejected:
             plot_name='lines',
             params=params,
             on_update=lambda: None,
-            temporality_by_role={PRIMARY: temporality},
+            temporality=dict.fromkeys(keys, temporality),
         )
 
     def test_aggregating_a_cumulative_field_raises(self, plotting_controller):

--- a/tests/dashboard/plotting_controller_test.py
+++ b/tests/dashboard/plotting_controller_test.py
@@ -11,11 +11,14 @@ import scipp as sc
 from ess.livedata.config.workflow_spec import (
     REDUCTION,
     CumulativeOutput,
+    DataKey,
+    Temporality,
     WindowOutput,
     WorkflowId,
     WorkflowOutputsBase,
     WorkflowSpec,
 )
+from ess.livedata.dashboard.data_roles import PRIMARY
 from ess.livedata.dashboard.data_service import DataService
 from ess.livedata.dashboard.plotting_controller import (
     PlottingController,
@@ -687,7 +690,7 @@ class TestCreateExtractorsFromParams:
 
         keys = self._make_keys()
         params = TimeWindowParams(mode=TimeWindowMode.since_start)
-        extractors = create_extractors_from_params(keys, params)
+        extractors = create_extractors_from_params(keys, params, {})
         assert all(isinstance(e, LatestValueExtractor) for e in extractors.values())
 
     def test_window_with_zero_duration_uses_latest_value_extractor(self) -> None:
@@ -701,7 +704,7 @@ class TestCreateExtractorsFromParams:
         params = TimeWindowParams(
             mode=TimeWindowMode.window, window_duration_seconds=0.0
         )
-        extractors = create_extractors_from_params(keys, params)
+        extractors = create_extractors_from_params(keys, params, {})
         assert all(isinstance(e, LatestValueExtractor) for e in extractors.values())
 
     def test_window_uses_window_aggregating_extractor(self) -> None:
@@ -715,10 +718,78 @@ class TestCreateExtractorsFromParams:
         params = TimeWindowParams(
             mode=TimeWindowMode.window, window_duration_seconds=5.0
         )
-        extractors = create_extractors_from_params(keys, params)
+        extractors = create_extractors_from_params(keys, params, {})
         assert all(
             isinstance(e, WindowAggregatingExtractor) for e in extractors.values()
         )
+
+    def test_required_extractor_ignores_cumulative_temporality(self) -> None:
+        # A plotter fixing its extractor never aggregates, so the window params
+        # it was handed say nothing about what its data will be put through.
+        from ess.livedata.dashboard.extractors import FullHistoryExtractor
+        from ess.livedata.dashboard.plot_params import TimeWindowMode, TimeWindowParams
+        from ess.livedata.dashboard.plotter_registry import plotter_registry
+        from ess.livedata.dashboard.plotting_controller import (
+            create_extractors_from_params,
+        )
+
+        keys = self._make_keys()
+        params = TimeWindowParams(
+            mode=TimeWindowMode.window, window_duration_seconds=5.0
+        )
+        extractors = create_extractors_from_params(
+            keys,
+            params,
+            dict.fromkeys(keys, Temporality.cumulative),
+            plotter_registry.get_spec('timeseries'),
+        )
+        assert all(isinstance(e, FullHistoryExtractor) for e in extractors.values())
+
+
+class TestAggregationOfCumulativeIsRejected:
+    """Summing consecutive messages of a cumulative field double-counts.
+
+    The window controls are hidden for views without a per-update field, but
+    ``field_for`` falls back to the cumulative field, so a persisted config can
+    still ask for it.
+    """
+
+    def _setup(self, controller, temporality, duration_seconds: float):
+        from ess.livedata.dashboard.plot_params import (
+            PlotParams1d,
+            TimeWindowMode,
+            TimeWindowParams,
+        )
+
+        wf_id = WorkflowId(instrument='test', name='wf', version=1)
+        keys = [DataKey(workflow_id=wf_id, source_name='src', output_name='total')]
+        params = PlotParams1d(
+            time_window=TimeWindowParams(
+                mode=TimeWindowMode.window, window_duration_seconds=duration_seconds
+            )
+        )
+        return controller.setup_pipeline(
+            keys_by_role={PRIMARY: keys},
+            plot_name='lines',
+            params=params,
+            on_update=lambda: None,
+            temporality_by_role={PRIMARY: temporality},
+        )
+
+    def test_aggregating_a_cumulative_field_raises(self, plotting_controller):
+        with pytest.raises(ValueError, match='total'):
+            self._setup(plotting_controller, Temporality.cumulative, 5.0)
+
+    @pytest.mark.parametrize(
+        'temporality', [Temporality.window, Temporality.series, None]
+    )
+    def test_aggregating_other_temporalities_is_allowed(
+        self, plotting_controller, temporality
+    ):
+        assert self._setup(plotting_controller, temporality, 5.0) is not None
+
+    def test_cumulative_without_aggregation_is_allowed(self, plotting_controller):
+        assert self._setup(plotting_controller, Temporality.cumulative, 0.0) is not None
 
 
 class TestWorkflowSpecFieldFor:

--- a/tests/dashboard/plotting_controller_test.py
+++ b/tests/dashboard/plotting_controller_test.py
@@ -12,6 +12,7 @@ from ess.livedata.config.workflow_spec import (
     REDUCTION,
     CumulativeOutput,
     DataKey,
+    OutputView,
     Temporality,
     WindowOutput,
     WorkflowId,
@@ -20,9 +21,14 @@ from ess.livedata.config.workflow_spec import (
 )
 from ess.livedata.dashboard.data_roles import PRIMARY
 from ess.livedata.dashboard.data_service import DataService
+from ess.livedata.dashboard.plot_params import (
+    PlotDisplayParams1d,
+    PlotParams1d,
+    PlotParamsTimeseries,
+)
 from ess.livedata.dashboard.plotting_controller import (
     PlottingController,
-    output_view_supports_windowing,
+    hidden_window_fields,
     since_start_available,
 )
 from ess.livedata.dashboard.stream_manager import StreamManager
@@ -497,120 +503,126 @@ class TestOverlayPatterns:
                 assert all('request' in name for name in overlays)
 
 
-class TestOutputViewSupportsWindowing:
-    def test_true_when_view_has_both_streams(self) -> None:
-        from ess.livedata.config.workflow_spec import OutputView
+class TestHiddenWindowFields:
+    """The window-mode control is hidden when the view cannot back its options."""
 
-        class Outputs(WorkflowOutputsBase):
-            output_views: ClassVar[tuple[OutputView, ...]] = (
-                OutputView(
-                    name='image',
-                    title='Image',
-                    fields=('cumulative', 'current'),
-                ),
-            )
-
-            current: WindowOutput = pydantic.Field(
-                default_factory=lambda: sc.DataArray(
-                    sc.zeros(dims=['x'], shape=[0]),
-                )
-            )
-            cumulative: CumulativeOutput = pydantic.Field(
-                default_factory=lambda: sc.DataArray(
-                    sc.zeros(dims=['x'], shape=[0]),
-                )
-            )
-
-        spec = WorkflowSpec(
+    def _spec(self, outputs: type[WorkflowOutputsBase]) -> WorkflowSpec:
+        return WorkflowSpec(
             instrument='test',
             name='wf',
             version=1,
             title='T',
             description='D',
-            outputs=Outputs,
+            outputs=outputs,
             params=None,
             group=REDUCTION,
         )
-        assert output_view_supports_windowing(spec, 'image') is True
 
-    def test_false_for_cumulative_only_view(self) -> None:
-        from typing import ClassVar
-
-        from ess.livedata.config.workflow_spec import OutputView
-
+    @pytest.fixture
+    def both_flavors(self) -> WorkflowSpec:
         class Outputs(WorkflowOutputsBase):
             output_views: ClassVar[tuple[OutputView, ...]] = (
                 OutputView(
-                    name='i_of_q',
-                    title='I(Q)',
-                    fields=('i_of_q',),
+                    name='total', title='Total', fields=('cumulative', 'current')
                 ),
+            )
+            current: WindowOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
+            )
+            cumulative: CumulativeOutput = pydantic.Field(
+                default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
+            )
+
+        return self._spec(Outputs)
+
+    @pytest.fixture
+    def cumulative_only(self) -> WorkflowSpec:
+        class Outputs(WorkflowOutputsBase):
+            output_views: ClassVar[tuple[OutputView, ...]] = (
+                OutputView(name='i_of_q', title='I(Q)', fields=('i_of_q',)),
             )
             i_of_q: sc.DataArray = pydantic.Field(
                 default_factory=lambda: sc.DataArray(
-                    sc.zeros(dims=['Q'], shape=[0], unit='counts'),
+                    sc.zeros(dims=['Q'], shape=[0], unit='counts')
                 )
             )
 
-        spec = WorkflowSpec(
-            instrument='test',
-            name='wf',
-            version=1,
-            title='T',
-            description='D',
-            outputs=Outputs,
-            params=None,
-            group=REDUCTION,
-        )
-        assert output_view_supports_windowing(spec, 'i_of_q') is False
+        return self._spec(Outputs)
 
-    def test_true_for_per_update_only_view(self) -> None:
-        # A per_update-only view still supports the duration/aggregation controls;
-        # the since_start mode is rejected at config time, not by hiding controls.
-        from ess.livedata.config.workflow_spec import OutputView
-
+    @pytest.fixture
+    def per_update_only(self) -> WorkflowSpec:
         class Outputs(WorkflowOutputsBase):
             output_views: ClassVar[tuple[OutputView, ...]] = (
-                OutputView(
-                    name='total',
-                    title='Total',
-                    fields=('counts_total',),
-                ),
+                OutputView(name='total', title='Total', fields=('counts_total',)),
             )
             counts_total: WindowOutput = pydantic.Field(
                 default_factory=lambda: sc.DataArray(sc.scalar(0, unit='counts'))
             )
 
-        spec = WorkflowSpec(
-            instrument='test',
-            name='wf',
-            version=1,
-            title='T',
-            description='D',
-            outputs=Outputs,
-            params=None,
-            group=REDUCTION,
-        )
-        assert output_view_supports_windowing(spec, 'total') is True
+        return self._spec(Outputs)
 
-    def test_true_when_view_unknown(self) -> None:
+    @pytest.mark.parametrize('params_class', [PlotParams1d, PlotParamsTimeseries])
+    def test_shown_when_view_has_both_flavors(
+        self, both_flavors: WorkflowSpec, params_class: type[pydantic.BaseModel]
+    ) -> None:
+        assert hidden_window_fields(params_class, both_flavors, 'total') == frozenset()
+
+    @pytest.mark.parametrize(
+        ('params_class', 'field'),
+        [(PlotParams1d, 'time_window'), (PlotParamsTimeseries, 'accumulation')],
+    )
+    def test_hidden_for_cumulative_only_view(
+        self,
+        cumulative_only: WorkflowSpec,
+        params_class: type[pydantic.BaseModel],
+        field: str,
+    ) -> None:
+        assert hidden_window_fields(
+            params_class, cumulative_only, 'i_of_q'
+        ) == frozenset({field})
+
+    def test_shown_for_per_update_only_view_with_duration_control(
+        self, per_update_only: WorkflowSpec
+    ) -> None:
+        # The duration/aggregation controls still apply; since_start is rejected at
+        # config time rather than by hiding them.
+        assert (
+            hidden_window_fields(PlotParams1d, per_update_only, 'total') == frozenset()
+        )
+
+    def test_hidden_for_per_update_only_view_with_cumulative_toggle(
+        self, per_update_only: WorkflowSpec
+    ) -> None:
+        # The toggle offers nothing but the two flavors, so with one missing there
+        # is nothing to toggle.
+        assert hidden_window_fields(
+            PlotParamsTimeseries, per_update_only, 'total'
+        ) == frozenset({'accumulation'})
+
+    def test_shown_when_view_unknown(self, both_flavors: WorkflowSpec) -> None:
+        assert (
+            hidden_window_fields(PlotParamsTimeseries, both_flavors, 'nonexistent')
+            == frozenset()
+        )
+
+    def test_shown_for_params_without_window_mode(
+        self, cumulative_only: WorkflowSpec
+    ) -> None:
+        # Correlation histograms have no window-mode control to hide.
+        assert (
+            hidden_window_fields(PlotDisplayParams1d, cumulative_only, 'i_of_q')
+            == frozenset()
+        )
+
+    def test_hidden_for_default_view_of_unannotated_field(self) -> None:
         class Outputs(WorkflowOutputsBase):
             result: sc.DataArray = pydantic.Field(title='Result')
 
-        spec = WorkflowSpec(
-            instrument='test',
-            name='wf',
-            version=1,
-            title='T',
-            description='D',
-            outputs=Outputs,
-            params=None,
-            group=REDUCTION,
-        )
-        # Default (fallback) view per field uses `since_start`, so no windowing.
-        assert output_view_supports_windowing(spec, 'result') is False
-        # Unknown view name → True (be permissive).
-        assert output_view_supports_windowing(spec, 'nonexistent') is True
+        # A field with no Temporality annotation is cumulative, and the fallback
+        # one-view-per-field resolution therefore backs since_start only.
+        assert hidden_window_fields(
+            PlotParams1d, self._spec(Outputs), 'result'
+        ) == frozenset({'time_window'})
 
 
 class TestSinceStartAvailable:

--- a/tests/dashboard/restart_cleanup_test.py
+++ b/tests/dashboard/restart_cleanup_test.py
@@ -167,7 +167,7 @@ class TestRestartCleanup:
         job_ids = job_orchestrator.commit_workflow(workflow_id)
         for source_name in workflow_spec.source_names:
             key = _make_result_key(workflow_id, source_name, job_ids[0].job_number)
-            message_pump.forward(_data_stream_id(key), sc.scalar(1.0))
+            message_pump.forward(_data_stream_id(key), sc.DataArray(sc.scalar(1.0)))
 
         subscriber = _KeysSubscriber(_data_keys(workflow_spec))
         data_service.register_subscriber(subscriber)
@@ -188,7 +188,7 @@ class TestRestartCleanup:
         key = _make_result_key(
             workflow_id, workflow_spec.source_names[0], job_ids[0].job_number
         )
-        message_pump.forward(_data_stream_id(key), sc.scalar(1.0))
+        message_pump.forward(_data_stream_id(key), sc.DataArray(sc.scalar(1.0)))
         assert key.data_key in data_service
 
         # No staging between commits: byte-identical config.
@@ -277,7 +277,7 @@ class TestRestartCleanup:
         job_ids = job_orchestrator.commit_workflow(workflow_id)
         for sn in workflow_spec.source_names:
             key = _make_result_key(workflow_id, sn, job_ids[0].job_number)
-            message_pump.forward(_data_stream_id(key), sc.scalar(1.0))
+            message_pump.forward(_data_stream_id(key), sc.DataArray(sc.scalar(1.0)))
 
         job_orchestrator.stop_workflow(workflow_id)
 
@@ -297,7 +297,7 @@ class TestRestartCleanup:
         job_orchestrator.commit_workflow(workflow_id)
 
         key = _make_result_key(workflow_id, workflow_spec.source_names[0], old_number)
-        message_pump.forward(_data_stream_id(key), sc.scalar(42.0))
+        message_pump.forward(_data_stream_id(key), sc.DataArray(sc.scalar(42.0)))
 
         assert len(data_service) == 0
 
@@ -309,14 +309,14 @@ class TestRestartCleanup:
         job_ids_1 = job_orchestrator.commit_workflow(workflow_id)
         for sn in workflow_spec.source_names:
             key = _make_result_key(workflow_id, sn, job_ids_1[0].job_number)
-            message_pump.forward(_data_stream_id(key), sc.scalar(1.0))
+            message_pump.forward(_data_stream_id(key), sc.DataArray(sc.scalar(1.0)))
 
         job_ids_2 = job_orchestrator.commit_workflow(workflow_id)
         new_number = job_ids_2[0].job_number
 
         for sn in workflow_spec.source_names:
             key = _make_result_key(workflow_id, sn, new_number)
-            message_pump.forward(_data_stream_id(key), sc.scalar(99.0))
+            message_pump.forward(_data_stream_id(key), sc.DataArray(sc.scalar(99.0)))
 
         for data_key in _data_keys(workflow_spec):
             assert data_key in data_service
@@ -408,8 +408,8 @@ class TestRestartCleanup:
         key_2 = _make_result_key(
             wf_id_2, workflow_spec_2.source_names[0], jobs_2[0].job_number
         )
-        message_pump.forward(_data_stream_id(key_1), sc.scalar(1.0))
-        message_pump.forward(_data_stream_id(key_2), sc.scalar(2.0))
+        message_pump.forward(_data_stream_id(key_1), sc.DataArray(sc.scalar(1.0)))
+        message_pump.forward(_data_stream_id(key_2), sc.DataArray(sc.scalar(2.0)))
 
         job_orchestrator.commit_workflow(wf_id_1)
         job_orchestrator.commit_workflow(wf_id_1)
@@ -451,7 +451,7 @@ class TestConcurrentForwardAndCommit:
                     try:
                         with registry.ingestion_guard():
                             message_pump.forward(
-                                _data_stream_id(key), sc.scalar(float(i))
+                                _data_stream_id(key), sc.DataArray(sc.scalar(float(i)))
                             )
                     except Exception as exc:
                         errors.append(exc)
@@ -509,7 +509,9 @@ class TestConcurrentForwardAndCommit:
             with registry.ingestion_guard():
                 for sn in workflow_spec.source_names:
                     key = _make_result_key(workflow_id, sn, job_ids[0].job_number)
-                    message_pump.forward(_data_stream_id(key), sc.scalar(value))
+                    message_pump.forward(
+                        _data_stream_id(key), sc.DataArray(sc.scalar(value))
+                    )
 
         def ingest_loop():
             try:

--- a/tests/dashboard/restart_cleanup_test.py
+++ b/tests/dashboard/restart_cleanup_test.py
@@ -28,7 +28,10 @@ from ess.livedata.core.message import STATUS_STREAM_ID, StreamId, StreamKind
 from ess.livedata.dashboard.active_job_registry import ActiveJobRegistry
 from ess.livedata.dashboard.command_service import CommandService
 from ess.livedata.dashboard.data_service import DataService, DataServiceSubscriber
-from ess.livedata.dashboard.extractors import LatestValueExtractor
+from ess.livedata.dashboard.extractors import (
+    FullHistoryExtractor,
+    LatestValueExtractor,
+)
 from ess.livedata.dashboard.job_orchestrator import JobOrchestrator
 from ess.livedata.dashboard.job_service import JobService
 from ess.livedata.dashboard.message_pump import MessagePump
@@ -62,11 +65,51 @@ def _data_keys(workflow_spec) -> list[DataKey]:
     ]
 
 
-class _KeysSubscriber(DataServiceSubscriber):
-    """Subscriber over a fixed set of keys, for pulling data with stamps."""
+def _publish_cumulative(
+    message_pump,
+    workflow_spec,
+    job_number,
+    start_ns: int,
+    times_ns: list[int],
+) -> None:
+    """Publish one cumulative message per timestamp, for every source.
 
-    def __init__(self, keys: list[DataKey]) -> None:
-        self._extractors = {key: LatestValueExtractor() for key in keys}
+    ``start_ns`` is pinned across the batch, as a generation's ``start_time`` is,
+    and the value restarts from zero each call, as a restarted accumulation does.
+    """
+    for source_name in workflow_spec.source_names:
+        key = _make_result_key(workflow_spec.get_id(), source_name, job_number)
+        for i, time_ns in enumerate(times_ns):
+            message_pump.forward(
+                _data_stream_id(key),
+                sc.DataArray(
+                    sc.scalar(float(i), unit='counts'),
+                    coords={
+                        'start_time': sc.scalar(start_ns, unit='ns'),
+                        'time': sc.scalar(time_ns, unit='ns'),
+                    },
+                ),
+            )
+
+
+def _history_sizes(data_service, subscriber) -> list[int]:
+    """Buffered history length per subscribed key, in a stable order."""
+    snapshot = data_service.snapshot(subscriber)
+    return [snapshot[key].sizes['time'] for key in sorted(snapshot, key=str)]
+
+
+class _KeysSubscriber(DataServiceSubscriber):
+    """Subscriber over a fixed set of keys, for pulling data with stamps.
+
+    The extractor type also decides the buffer backing each key, so pass
+    ``FullHistoryExtractor`` to exercise a ``TemporalBuffer`` rather than a
+    ``SingleValueBuffer``.
+    """
+
+    def __init__(
+        self, keys: list[DataKey], extractor: type = LatestValueExtractor
+    ) -> None:
+        self._extractors = {key: extractor() for key in keys}
         super().__init__()
 
     @property
@@ -154,6 +197,76 @@ class TestRestartCleanup:
         subscriber = _KeysSubscriber(_data_keys(workflow_spec))
         data_service.register_subscriber(subscriber)
         assert data_service.snapshot(subscriber) == {}
+
+    def test_accumulated_cumulative_history_cleared_on_recommit(self, workflow_spec):
+        """A cumulative growth curve must not survive its generation.
+
+        A recommit may carry a changed config, so the curve either side of it is
+        not necessarily the same quantity. A *reset* is the opposite case: the
+        same accumulation restarting, whose history is worth keeping — NICOS
+        resets once per scan point, and the resulting sawtooth is how that scan
+        reads on a wall-clock plot.
+
+        Nothing on the data path tells the two apart. DataKey strips the
+        job_number, so the buffer is reused, and TemporalBuffer drops the
+        accumulated coords before comparing metadata, so the changed start_time
+        triggers nothing either. The generation flip's clear_keys is the only
+        thing separating them, hence this guard.
+        """
+        message_pump, job_orchestrator, data_service, _ = _make_system(workflow_spec)
+        workflow_id = workflow_spec.get_id()
+        subscriber = _KeysSubscriber(_data_keys(workflow_spec), FullHistoryExtractor)
+        data_service.register_subscriber(subscriber)
+
+        job_ids = job_orchestrator.commit_workflow(workflow_id)
+        _publish_cumulative(
+            message_pump, workflow_spec, job_ids[0].job_number, 0, [0, 100, 200]
+        )
+        assert _history_sizes(data_service, subscriber) == [3, 3]
+
+        job_ids = job_orchestrator.commit_workflow(workflow_id)
+
+        assert data_service.snapshot(subscriber) == {}
+
+        # The next generation starts its own curve rather than extending the old.
+        _publish_cumulative(
+            message_pump, workflow_spec, job_ids[0].job_number, 1000, [1000]
+        )
+        assert _history_sizes(data_service, subscriber) == [1, 1]
+
+    def test_cumulative_history_survives_a_reset(self, workflow_spec):
+        """A reset restarts the accumulation without discarding its history.
+
+        NICOS resets once per scan point (ADR 0006: move motor, reset, count,
+        repeat), so the sawtooth this leaves on a wall-clock plot *is* how a scan
+        reads: one tooth per point, its height the counts collected there.
+        Unlike a recommit, a reset cannot have changed the config, so the curve
+        either side of it is the same quantity.
+
+        The dashboard is not told about the reset at all — the job number is
+        unchanged, so the restarted values simply append. This pins that, since
+        it is the behavior a reader would otherwise mistake for the missing
+        clear that :meth:`test_accumulated_cumulative_history_cleared_on_recommit`
+        guards.
+        """
+        message_pump, job_orchestrator, data_service, _ = _make_system(workflow_spec)
+        workflow_id = workflow_spec.get_id()
+        subscriber = _KeysSubscriber(_data_keys(workflow_spec), FullHistoryExtractor)
+        data_service.register_subscriber(subscriber)
+
+        job_ids = job_orchestrator.commit_workflow(workflow_id)
+        job_number = job_ids[0].job_number
+        _publish_cumulative(message_pump, workflow_spec, job_number, 0, [0, 100, 200])
+
+        # Guards against the assertion below passing vacuously: the reset must
+        # actually have been dispatched to the running jobs.
+        assert job_orchestrator.reset_workflow(workflow_id) is True
+
+        # The backend re-latches start_time and the total restarts from zero, but
+        # the generation — and so the buffer — is the same one.
+        _publish_cumulative(message_pump, workflow_spec, job_number, 300, [300, 400])
+
+        assert _history_sizes(data_service, subscriber) == [5, 5]
 
     def test_data_retained_after_stop(self, workflow_spec):
         """Stopping does not evict: the stopped generation's data stays

--- a/tests/dashboard/temporal_buffer_manager_test.py
+++ b/tests/dashboard/temporal_buffer_manager_test.py
@@ -83,6 +83,36 @@ class TestTemporalBufferManager:
         result = manager.get_buffered_data('test')
         assert sc.identical(result, data)
 
+    def test_history_of_cumulative_output_yields_growth_curve(self):
+        """The whole point of #1058: a cumulative total plots as history.
+
+        Its `time` is the instant it was observed rather than a window's close,
+        but the buffer and extractor need not know the difference.
+        """
+        manager = TemporalBufferManager()
+        manager.create_buffer('test', [FullHistoryExtractor()])
+
+        for i in range(3):
+            manager.update_buffer(
+                'test',
+                sc.DataArray(
+                    sc.scalar(10.0 * i, unit='counts'),
+                    coords={
+                        'start_time': sc.scalar(0, unit='ns'),
+                        'time': sc.scalar(i, unit='ns'),
+                    },
+                ),
+            )
+
+        result = FullHistoryExtractor().extract(manager.get_buffered_data('test'))
+        assert sc.identical(
+            result.data,
+            sc.array(dims=['time'], values=[0.0, 10.0, 20.0], unit='counts'),
+        )
+        # Pinned since the generation started, observed at the latest update.
+        assert sc.identical(result.coords['start_time'], sc.scalar(0, unit='ns'))
+        assert sc.identical(result.coords['end_time'], sc.scalar(2, unit='ns'))
+
     def test_update_buffer_raises_error_for_missing_key(self):
         """Test that updating non-existent buffer raises KeyError."""
         manager = TemporalBufferManager()

--- a/tests/dashboard/temporal_buffers_test.py
+++ b/tests/dashboard/temporal_buffers_test.py
@@ -81,6 +81,22 @@ def make_thick_slice(x_size, time_values, time_unit='s'):
     )
 
 
+def make_cumulative_slice(value, start_time, time, time_unit='s'):
+    """Create a cumulative output message: the value as of ``time``.
+
+    Mirrors what a ``Job`` publishes for a cumulative output: accumulated since
+    the generation's ``start_time``, which does not advance, and observed at
+    ``time``, which does.
+    """
+    return sc.DataArray(
+        sc.scalar(value, unit='counts'),
+        coords={
+            'start_time': sc.scalar(start_time, unit=time_unit),
+            'time': sc.scalar(time, unit=time_unit),
+        },
+    )
+
+
 def assert_buffer_has_time_data(buffer, expected_size):
     """Assert buffer contains time-dimensioned data of expected size."""
     result = buffer.get()
@@ -209,6 +225,49 @@ class TestTemporalBuffer:
         """Test that get returns None for empty buffer."""
         buffer = TemporalBuffer()
         assert buffer.get() is None
+
+    def test_cumulative_slices_accumulate_into_growth_curve(self):
+        """A cumulative output buffers because it carries `time` like any other."""
+        buffer = TemporalBuffer()
+
+        for i in range(3):
+            buffer.add(make_cumulative_slice(10.0 * i, 0.0, float(i)))
+
+        result = buffer.get()
+        assert sc.identical(
+            result.data,
+            sc.array(dims=['time'], values=[0.0, 10.0, 20.0], unit='counts'),
+        )
+        assert sc.identical(
+            result.coords['time'],
+            sc.array(dims=['time'], values=[0.0, 1.0, 2.0], unit='s'),
+        )
+
+    def test_pinned_start_time_does_not_collapse_cumulative_curve(self):
+        """A constant start_time is buffered per slice, not folded into metadata."""
+        buffer = TemporalBuffer()
+
+        for i in range(3):
+            buffer.add(make_cumulative_slice(float(i), 0.0, float(i)))
+
+        result = buffer.get()
+        assert sc.identical(
+            result.coords['start_time'], sc.zeros(dims=['time'], shape=[3], unit='s')
+        )
+
+    def test_cumulative_trimming_ages_by_time(self):
+        """Retention follows `time`; the pinned start_time must not age data out."""
+        buffer = TemporalBuffer()
+        buffer.set_required_timespan(2.0)
+        buffer.set_max_memory(100)  # Small limit so the buffer fills and trims
+
+        buffer.add(make_cumulative_slice(0.0, 0.0, 0.0))
+        for i in range(1, buffer._data_buffer.max_capacity):
+            buffer.add(make_cumulative_slice(float(i), 0.0, float(i)))
+        buffer.add(make_cumulative_slice(99.0, 0.0, 99.0))
+
+        result = buffer.get()
+        assert result.coords['time'].values[0] >= 97.0
 
     def test_clear_removes_all_data(self):
         """Test that clear removes all buffered data."""

--- a/tests/dashboard/widgets/plot_config_modal_test.py
+++ b/tests/dashboard/widgets/plot_config_modal_test.py
@@ -5,12 +5,14 @@ import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
     REDUCTION,
+    WindowOutput,
     WorkflowId,
     WorkflowOutputsBase,
     WorkflowSpec,
 )
 from ess.livedata.dashboard.data_roles import X_AXIS, Y_AXIS
 from ess.livedata.dashboard.plot_orchestrator import DataSourceConfig
+from ess.livedata.dashboard.plot_params import PlotParams1d, PlotParamsTimeseries
 from ess.livedata.dashboard.widgets.plot_config_modal import (
     _build_timeseries_options,
     _inject_axis_source_titles,
@@ -281,7 +283,10 @@ class TestBuildTimeseriesOptions:
 class TestResolveOutputDisplayHints:
     def test_static_overlay_preselects_all_and_no_hidden_fields(self):
         hints = _resolve_output_display_hints(
-            is_static=True, workflow_spec=None, view_name="any"
+            is_static=True,
+            workflow_spec=None,
+            params_class=PlotParams1d,
+            view_name="any",
         )
         assert hints.preselect_all_sources is True
         assert hints.hidden_fields == frozenset()
@@ -294,7 +299,10 @@ class TestResolveOutputDisplayHints:
 
         spec = _make_workflow_spec("Scalar output", Outputs)
         hints = _resolve_output_display_hints(
-            is_static=False, workflow_spec=spec, view_name="counts"
+            is_static=False,
+            workflow_spec=spec,
+            params_class=PlotParams1d,
+            view_name="counts",
         )
         assert hints.preselect_all_sources is True
 
@@ -306,7 +314,10 @@ class TestResolveOutputDisplayHints:
 
         spec = _make_workflow_spec("1D output", Outputs)
         hints = _resolve_output_display_hints(
-            is_static=False, workflow_spec=spec, view_name="spectrum"
+            is_static=False,
+            workflow_spec=spec,
+            params_class=PlotParams1d,
+            view_name="spectrum",
         )
         assert hints.preselect_all_sources is True
 
@@ -318,7 +329,10 @@ class TestResolveOutputDisplayHints:
 
         spec = _make_workflow_spec("2D output", Outputs)
         hints = _resolve_output_display_hints(
-            is_static=False, workflow_spec=spec, view_name="image"
+            is_static=False,
+            workflow_spec=spec,
+            params_class=PlotParams1d,
+            view_name="image",
         )
         assert hints.preselect_all_sources is False
 
@@ -332,36 +346,34 @@ class TestResolveOutputDisplayHints:
 
         spec = _make_workflow_spec("3D output", Outputs)
         hints = _resolve_output_display_hints(
-            is_static=False, workflow_spec=spec, view_name="volume"
+            is_static=False,
+            workflow_spec=spec,
+            params_class=PlotParams1d,
+            view_name="volume",
         )
         assert hints.preselect_all_sources is False
 
-    def test_output_with_time_coord_does_not_hide_window(self):
+    def test_window_control_visibility_follows_the_plotter_params(self):
+        # Which window-mode control a params class carries decides what the view
+        # must back for it: a per-update-only view backs the duration control but
+        # not the timeseries cumulative toggle.
         class Outputs(WorkflowOutputsBase):
-            spectrum: sc.DataArray = pydantic.Field(
-                default_factory=lambda: sc.DataArray(
-                    sc.zeros(sizes={'time': 0, 'wavelength': 0}),
-                    coords={'time': sc.zeros(sizes={'time': 0})},
-                ),
-            )
-
-        spec = _make_workflow_spec("Windowed output", Outputs)
-        hints = _resolve_output_display_hints(
-            is_static=False, workflow_spec=spec, view_name="spectrum"
-        )
-        assert 'time_window' in hints.hidden_fields
-
-    def test_output_without_time_coord_hides_window(self):
-        class Outputs(WorkflowOutputsBase):
-            total: sc.DataArray = pydantic.Field(
+            spectrum: WindowOutput = pydantic.Field(
                 default_factory=lambda: sc.DataArray(sc.zeros(sizes={'wavelength': 0})),
             )
 
-        spec = _make_workflow_spec("Cumulative output", Outputs)
-        hints = _resolve_output_display_hints(
-            is_static=False, workflow_spec=spec, view_name="total"
-        )
-        assert 'time_window' in hints.hidden_fields
+        spec = _make_workflow_spec("Windowed output", Outputs)
+
+        def hidden(params_class: type[pydantic.BaseModel]) -> frozenset[str]:
+            return _resolve_output_display_hints(
+                is_static=False,
+                workflow_spec=spec,
+                params_class=params_class,
+                view_name="spectrum",
+            ).hidden_fields
+
+        assert 'time_window' not in hidden(PlotParams1d)
+        assert 'accumulation' in hidden(PlotParamsTimeseries)
 
     def test_unknown_output_preselects_all(self):
         class Outputs(WorkflowOutputsBase):
@@ -371,6 +383,9 @@ class TestResolveOutputDisplayHints:
 
         spec = _make_workflow_spec("Some workflow", Outputs)
         hints = _resolve_output_display_hints(
-            is_static=False, workflow_spec=spec, view_name="nonexistent"
+            is_static=False,
+            workflow_spec=spec,
+            params_class=PlotParams1d,
+            view_name="nonexistent",
         )
         assert hints.preselect_all_sources is True

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -20,7 +20,8 @@ from ess.livedata.dashboard.plot_orchestrator import (
     PlotConfig,
 )
 from ess.livedata.dashboard.plot_params import (
-    TimeWindowMixin,
+    PlotParams1d,
+    PlotParamsTimeseries,
     TimeWindowMode,
     TimeWindowParams,
 )
@@ -88,20 +89,23 @@ class TestPerPanelToolHooks:
             assert 'lt-cell-r0c0' in matches[0].css_classes, tool
 
 
-class _FakeParams(TimeWindowMixin):
-    pass
-
-
 class TestFormatWindowInfo:
     def test_returns_since_run_start_for_since_start_mode(self) -> None:
-        params = _FakeParams(
+        params = PlotParams1d(
             time_window=TimeWindowParams(mode=TimeWindowMode.since_start)
+        )
+        assert _format_window_info(params) == 'since run start'
+
+    def test_returns_since_run_start_for_cumulative_timeseries(self) -> None:
+        """The timeseries plotter spells the same choice as a checkbox."""
+        params = PlotParamsTimeseries.model_validate(
+            {'accumulation': {'cumulative': True}}
         )
         assert _format_window_info(params) == 'since run start'
 
     def test_returns_empty_for_window_mode(self) -> None:
         """Window mode shows no static label; data range comes from the plot."""
-        params = _FakeParams(
+        params = PlotParams1d(
             time_window=TimeWindowParams(
                 mode=TimeWindowMode.window, window_duration_seconds=10
             )
@@ -109,12 +113,15 @@ class TestFormatWindowInfo:
         assert _format_window_info(params) == ''
 
     def test_returns_empty_for_window_mode_zero_duration(self) -> None:
-        params = _FakeParams(
+        params = PlotParams1d(
             time_window=TimeWindowParams(
                 mode=TimeWindowMode.window, window_duration_seconds=0
             )
         )
         assert _format_window_info(params) == ''
+
+    def test_returns_empty_for_per_update_timeseries(self) -> None:
+        assert _format_window_info(PlotParamsTimeseries()) == ''
 
     def test_returns_empty_when_no_window_attr(self) -> None:
         class NoWindowParams(pydantic.BaseModel):
@@ -159,8 +166,7 @@ class TestGetPlotCellDisplayInfo:
                 )
             },
             plot_name='lines',
-            params=_FakeParams(),
-            supports_windowing=False,
+            params=PlotParams1d(),
         )
 
         title, _ = get_plot_cell_display_info(config, registry)
@@ -205,7 +211,7 @@ class TestGetPlotCellDisplayInfo:
                 )
             },
             plot_name='lines',
-            params=_FakeParams(
+            params=PlotParams1d(
                 time_window=TimeWindowParams(mode=TimeWindowMode.since_start)
             ),
         )
@@ -247,7 +253,7 @@ class TestPlotterTitleInDisplayInfo:
                 )
             },
             plot_name=plot_name,
-            params=_FakeParams(),
+            params=PlotParams1d(),
         )
 
     def test_title_includes_plotter_title(self) -> None:
@@ -301,7 +307,7 @@ def _make_layer(
             )
         },
         plot_name=plot_name,
-        params=params if params is not None else _FakeParams(),
+        params=params if params is not None else PlotParams1d(),
     )
     return Layer(layer_id=LayerId(uuid4()), config=config)
 
@@ -319,7 +325,7 @@ def _make_static_layer(name, plot_name='rectangle'):
             )
         },
         plot_name=plot_name,
-        params=_FakeParams(),
+        params=PlotParams1d(),
     )
     return Layer(layer_id=LayerId(uuid4()), config=config)
 

--- a/tests/workflows/area_detector_view_test.py
+++ b/tests/workflows/area_detector_view_test.py
@@ -167,14 +167,14 @@ class TestAreaDetectorView:
 
 
 def _bounds(da: sc.DataArray) -> tuple[int, int]:
-    return da.coords['start_time'].value, da.coords['end_time'].value
+    return da.coords['start_time'].value, da.coords['time'].value
 
 
 class TestAreaDetectorViewWindowBounds:
     """The 'current' output must carry the bounds of the window it covers.
 
     The dashboard derives freshness/lag and counts-per-second normalization from
-    start_time/end_time, and Job._add_time_coords deliberately leaves outputs that
+    start_time/time, and Job._add_time_coords deliberately leaves outputs that
     set their own time coords alone.
     """
 
@@ -198,8 +198,6 @@ class TestAreaDetectorViewWindowBounds:
         current = workflow.finalize()['current']
 
         assert _bounds(current) == (1000, 2000)
-        # 'time' duplicates start_time until issue #1058 drops it everywhere.
-        assert sc.identical(current.coords['time'], current.coords['start_time'])
 
     def test_bounds_span_all_accumulates_of_the_window(self, workflow, frame):
         workflow.accumulate(
@@ -286,6 +284,5 @@ class TestAreaDetectorViewWindowBounds:
 
         cumulative = workflow.finalize()['cumulative']
 
-        assert 'time' not in cumulative.coords
         assert 'start_time' not in cumulative.coords
-        assert 'end_time' not in cumulative.coords
+        assert 'time' not in cumulative.coords

--- a/tests/workflows/detector_view/integration_test.py
+++ b/tests/workflows/detector_view/integration_test.py
@@ -26,7 +26,7 @@ class TestIntegrationWithStreamProcessor:
     """Integration tests using the full StreamProcessorWorkflow via factory."""
 
     def test_window_outputs_have_time_coords(self):
-        """Test that window outputs have time, start_time, end_time coords.
+        """Test that window outputs have start_time and time coords.
 
         The factory configures current, counts_total, counts_in_toa_range, and
         roi_spectra_current as window outputs. These should have time coords;
@@ -59,29 +59,29 @@ class TestIntegrationWithStreamProcessor:
         result = workflow.finalize()
 
         # Window outputs should have time coords
-        for key in ('current', 'counts_total', 'counts_in_toa_range'):
-            assert 'time' in result[key].coords, f"{key} missing 'time' coord"
-            assert 'start_time' in result[key].coords, f"{key} missing 'start_time'"
-            assert 'end_time' in result[key].coords, f"{key} missing 'end_time'"
-            assert result[key].coords['time'].value == 1000
-            assert result[key].coords['start_time'].value == 1000
-            assert result[key].coords['end_time'].value == 2000
-            assert result[key].coords['time'].unit == 'ns'
-
-        # ROI spectra current should also have time coords
-        assert 'time' in result['roi_spectra_current'].coords
-        assert result['roi_spectra_current'].coords['time'].value == 1000
+        for key in (
+            'current',
+            'counts_total',
+            'counts_in_toa_range',
+            'roi_spectra_current',
+        ):
+            coords = result[key].coords
+            assert coords['start_time'].value == 1000, key
+            assert coords['time'].value == 2000, key
+            assert coords['time'].unit == 'ns', key
 
         # Cumulative outputs should NOT have time coords at this level.
-        # The Job layer (not tested here) adds start_time/end_time spanning
+        # The Job layer (not tested here) adds start_time/time spanning
         # the full job duration to any output that doesn't already have them.
-        assert 'time' not in result['cumulative'].coords
-        assert 'start_time' not in result['cumulative'].coords
-        assert 'time' not in result['roi_spectra_cumulative'].coords
-        assert 'time' not in result['counts_total_cumulative'].coords
-        assert 'start_time' not in result['counts_total_cumulative'].coords
-        assert 'time' not in result['counts_in_toa_range_cumulative'].coords
-        assert 'start_time' not in result['counts_in_toa_range_cumulative'].coords
+        for key in (
+            'cumulative',
+            'roi_spectra_cumulative',
+            'counts_total_cumulative',
+            'counts_in_toa_range_cumulative',
+        ):
+            coords = result[key].coords
+            assert 'start_time' not in coords, key
+            assert 'time' not in coords, key
 
     def test_full_workflow_accumulate_and_finalize(self):
         """Test the full workflow with accumulate and finalize."""

--- a/tests/workflows/monitor_workflow_test.py
+++ b/tests/workflows/monitor_workflow_test.py
@@ -391,7 +391,7 @@ class TestMonitorWorkflowIntegration:
         assert results['counts_in_toa_range_cumulative'].value == 5.0
 
     def test_time_coords_on_delta_outputs(self, toa_edges, sample_binned_events):
-        """Delta outputs get time, start_time, end_time coords."""
+        """Delta outputs get start_time and time coords bounding the window."""
         workflow = create_monitor_workflow('monitor_1', toa_edges)
         workflow.build()
         workflow.accumulate(
@@ -401,29 +401,10 @@ class TestMonitorWorkflowIntegration:
         )
         results = workflow.finalize()
 
-        # Current (window histogram) should have time coords
-        assert 'time' in results['current'].coords
-        assert 'start_time' in results['current'].coords
-        assert 'end_time' in results['current'].coords
-        assert results['current'].coords['time'].value == 1000
-        assert results['current'].coords['start_time'].value == 1000
-        assert results['current'].coords['end_time'].value == 2000
-
-        # counts_total should have time coords
-        assert 'time' in results['counts_total'].coords
-        assert 'start_time' in results['counts_total'].coords
-        assert 'end_time' in results['counts_total'].coords
-        assert results['counts_total'].coords['time'].value == 1000
-        assert results['counts_total'].coords['start_time'].value == 1000
-        assert results['counts_total'].coords['end_time'].value == 2000
-
-        # counts_in_toa_range should have time coords
-        assert 'time' in results['counts_in_toa_range'].coords
-        assert 'start_time' in results['counts_in_toa_range'].coords
-        assert 'end_time' in results['counts_in_toa_range'].coords
-        assert results['counts_in_toa_range'].coords['time'].value == 1000
-        assert results['counts_in_toa_range'].coords['start_time'].value == 1000
-        assert results['counts_in_toa_range'].coords['end_time'].value == 2000
+        for name in ('current', 'counts_total', 'counts_in_toa_range'):
+            coords = results[name].coords
+            assert coords['start_time'].value == 1000, name
+            assert coords['time'].value == 2000, name
 
     def test_cumulative_output_has_no_time_coords(
         self, toa_edges, sample_binned_events
@@ -438,17 +419,20 @@ class TestMonitorWorkflowIntegration:
         )
         results = workflow.finalize()
 
-        assert 'time' not in results['cumulative'].coords
-        assert 'start_time' not in results['cumulative'].coords
-        assert 'end_time' not in results['cumulative'].coords
-        # Cumulative scalar totals also span all time, so no time coords.
-        assert 'time' not in results['counts_total_cumulative'].coords
-        assert 'time' not in results['counts_in_toa_range_cumulative'].coords
+        # Scalar totals span all time as well.
+        for name in (
+            'cumulative',
+            'counts_total_cumulative',
+            'counts_in_toa_range_cumulative',
+        ):
+            coords = results[name].coords
+            assert 'start_time' not in coords, name
+            assert 'time' not in coords, name
 
     def test_time_coords_track_first_start_last_end(
         self, toa_edges, sample_binned_events
     ):
-        """Time coords should track first start_time and last end_time."""
+        """start_time tracks the first accumulate, time the last."""
         workflow = create_monitor_workflow('monitor_1', toa_edges)
         workflow.build()
         # Multiple accumulate calls before finalize
@@ -469,10 +453,8 @@ class TestMonitorWorkflowIntegration:
         )
         results = workflow.finalize()
 
-        # start_time should be from first accumulate, end_time from last
-        assert results['current'].coords['time'].value == 1000
         assert results['current'].coords['start_time'].value == 1000
-        assert results['current'].coords['end_time'].value == 4000
+        assert results['current'].coords['time'].value == 4000
 
     def test_time_coords_reset_after_finalize(self, toa_edges, sample_binned_events):
         """Time coords should reset between finalize cycles."""
@@ -487,7 +469,7 @@ class TestMonitorWorkflowIntegration:
         )
         results1 = workflow.finalize()
         assert results1['current'].coords['start_time'].value == 1000
-        assert results1['current'].coords['end_time'].value == 2000
+        assert results1['current'].coords['time'].value == 2000
 
         # Second cycle should have fresh time tracking
         workflow.accumulate(
@@ -497,7 +479,7 @@ class TestMonitorWorkflowIntegration:
         )
         results2 = workflow.finalize()
         assert results2['current'].coords['start_time'].value == 5000
-        assert results2['current'].coords['end_time'].value == 6000
+        assert results2['current'].coords['time'].value == 6000
 
     def test_cumulative_accumulates_window_clears(
         self, toa_edges, sample_binned_events

--- a/tests/workflows/stream_processor_workflow_test.py
+++ b/tests/workflows/stream_processor_workflow_test.py
@@ -430,16 +430,16 @@ class TestWindowOutputs:
         result = workflow.finalize()
 
         # Window output should have time coords with correct values
-        assert result['current'].coords['time'].value == 1000
         assert result['current'].coords['start_time'].value == 1000
-        assert result['current'].coords['end_time'].value == 2000
+        assert result['current'].coords['time'].value == 2000
         assert result['current'].coords['time'].unit == 'ns'
 
         # Non-window output should not have time coords
+        assert 'start_time' not in result['cumulative'].coords
         assert 'time' not in result['cumulative'].coords
 
     def test_time_coord_tracks_first_accumulate(self, dataarray_workflow):
-        """Test that start_time uses first accumulate, end_time uses last."""
+        """Test that start_time uses first accumulate, time uses last."""
         from ess.reduce.streaming import EternalAccumulator
 
         workflow = StreamProcessorWorkflow(
@@ -465,9 +465,9 @@ class TestWindowOutputs:
         )
         result = workflow.finalize()
 
-        # start_time from first accumulate, end_time from last
+        # start_time from first accumulate, time from last
         assert result['current'].coords['start_time'].value == 1000
-        assert result['current'].coords['end_time'].value == 4000
+        assert result['current'].coords['time'].value == 4000
 
     def test_time_tracking_resets_after_finalize_and_clear(self, dataarray_workflow):
         """Test that time tracking resets after finalize() and clear()."""


### PR DESCRIPTION
## User-facing changes

As a nice side-benefit, this enables plotting cumulative timeseries, showing how counts accumulate over time, and how/when resets affect this:

<img width="448" height="224" alt="image" src="https://github.com/user-attachments/assets/27a85581-e02c-4ce1-819c-41d66d24da8b" />

## Details

Closes #1058. Builds on #1132, which landed the `Temporality` declaration this relies on.

Four commits, best reviewed in order. The first makes a cumulative output plottable as history, the third lets a user ask for it, and the fourth is review follow-up.

## Stamp the instant a value refers to as `time`

A non-series output carried scalar `start_time` + `end_time`. That name is accurate for a window output, whose interval genuinely closed, but a lie for a cumulative one: the job is still running, and the bound really means "as of" — the observation watermark. The concept common to all three temporalities is *the instant the value refers to*, which is exactly what `time` already means for a series output. So the upper bound is now `time` everywhere, `start_time` keeps its name and its "since when" meaning, and `Temporality` says what the pair means per flavor rather than which coords each flavor happens to carry.

Every output now carries `time`, at unchanged wire cost — two timestamps either way, since window outputs no longer pay for a third that only duplicated `start_time`. A cumulative output becomes plottable as a history purely because it now carries the coord `TemporalBuffer` has always keyed on, so the buffer itself is untouched. `start_time` stays pinned for the lifetime of a generation, which NICOS depends on.

The dashboard keeps spelling the pair `(start_time, end_time)`: there it is provenance for the freshness/lag readout and rate normalization, not an axis. The extractors are the naming boundary, and all three now mint that pair uniformly — including `LatestValueExtractor`, which also fixes a pre-existing inconsistency where a window output reaching the plotters through a `SingleValueBuffer` was structurally different from the same output through a `TemporalBuffer`. `FullHistoryExtractor` captures the bounds before its timezone shift rewrites `time`, or they would misreport wall-clock time by the UTC offset. Nothing in `plots.py` changes.

`DeviceExtractor` adds `end_time` alongside `time` on the echoed device output. NICOS's consumer expects that name; adding rather than renaming decouples the published contract from our internal naming, so NICOS can migrate when it suits.

Three robustness fixes the rename makes reachable or worth pinning. `_add_time_coords` returned early when the job had no bounds, emitting outputs with no time coords at all — harmless while cumulative outputs were unbufferable, a `TemporalBuffer` rejection once they are not. The JobManager only finalizes jobs that accumulated primary data, so this is a scheduling fault, and it now raises rather than publishing untimestamped data for the dashboard to trip over far from the cause. A generation flip must clear an accumulated cumulative buffer, because a recommit may carry a changed config and the curve either side of it need not be the same quantity. A reset is the opposite case — the same accumulation restarting, whose history is worth keeping, since NICOS resets once per scan point and the resulting sawtooth is how that scan reads against wall-clock time. Nothing on the data path tells the two apart: `DataKey` strips the job number so the buffer is reused, and `TemporalBuffer` drops the accumulated coords before comparing metadata, so the changed `start_time` triggers nothing either. `clear_keys` on the generation flip is the only thing separating them. Both halves are pinned: the recommit clears, the reset does not. And the wall-clock x of a window output is now its `time`, the interval's right edge, where it used to be its left, so every existing window timeseries and correlation join shifts by one update interval — pinned as a convention rather than left incidental.

## Refuse to aggregate a time window over a cumulative field

Every message of a cumulative field holds the total accumulated since the run started, so summing consecutive ones counts the same events repeatedly. Fresh configs cannot reach this — the window controls are hidden for views without a per-update field — but `WorkflowSpec.field_for` falls back to the cumulative field, so a persisted config carrying a nonzero window duration, from a view that has since lost its per-update field, resolves to one. While a cumulative field carried no `time` coord this combination died in `TemporalBuffer.add`; now it buffers happily and returns a wrong number, which is worse, hence the guard.

Aggregating a `series` field is deliberately untouched: `nanmean` over non-uniformly spaced samples is #843's problem, not a temporality question, and blocking it would remove something users have today.

## Offer the cumulative flavor to the timeseries plotter

Until here, the growth curve was only reachable where a view has no per-update field for `field_for` to prefer. For the 53 zero-dim views backing both flavors — every `total_counts` and `total_in_range` across the instruments — a timeseries plot stayed pinned to the per-update field, with no control to say otherwise. The general plots' window controls do not transfer: a `FullHistoryExtractor` collapses the window bounds to the whole buffer, so duration and aggregation mean nothing on this plotter. It gets a single `Cumulative` checkbox instead.

Two spellings of one choice, so `WindowModeMixin` names what consumers actually want — the resulting `Windowing` — and the field-resolving, mode-validating and title-formatting sites read it through that one method rather than reaching for `time_window.mode`. What a view must back for a control to apply differs per spelling and is declared per params class: the duration control needs only a per-update field, the checkbox needs both, since with one missing one of its two states would either lie about the data shown or be rejected on submit. `PlotConfig.supports_windowing` is removed — written in three places, read in none, and unable to express that per-class rule anyway.

## Leave a series output's time axis alone at the extractor boundary

Review follow-up, correcting the first commit. Minting the pair from whatever coords the data happened to carry gave a series output an `end_time` taken from its last sample, and with it a freshness pill and a lag readout it did not have before. Both would then track the device's own sampling rate rather than the pipeline's latency, so a temperature logged every few minutes reads as permanently stale, and the "Lag" label would no longer mean what its docstring promises. Its age is already legible on the plot's x axis, which *is* that coord.

The pair is therefore minted whole or not at all, keyed on `start_time` — the coord only a bounded output carries. Every assertion the first commit had added to `extractors_test.py` was a series-shaped fixture, so that file is byte-identical to `main` again; the rule is pinned for both extractors instead.

Two smaller points from the same review. `LatestValueExtractor` drops its non-`DataArray` escape hatch and takes the `DataArray` the `DataService` is declared to hold — the branch was reachable only from tests publishing bare `Variable`s, i.e. it was absorbing a type violation rather than a real wire shape, and those tests now publish `DataArray`s. And `_build_subscription_keys` mints the `DataKey`s and their temporality in one pass, so `setup_pipeline` takes a single per-key mapping rather than a role-keyed one it had to re-zip against the keys.

## Deviations from the issue

#1058 is wrong in three places; a correction block is on the issue. The two that change the design:

- It proposes keying the buffer on `start_time` (or the window midpoint). Both are wrong for cumulative outputs: `start_time` stays pinned for the lifetime of a generation, which would stack every point of the growth curve on one x. The rename makes the question moot — the buffer keys on `time` as it always did.
- It proposes gating rate normalization on temporality. That would remove a working feature: on a cumulative field `_normalize_to_rate` divides by the run duration, giving the mean rate since the run started, which BIFROST's `detector_region_counts` view description already tells users to ask for. The genuinely wrong case — rate over a `FullHistoryExtractor`'s whole-buffer bounds — is unreachable, since the plotters requiring that extractor expose no rate control.

## Verification

Compatible plotters per output view are byte-identical before and after the template changes, dumped across all 157 views of all instruments.

Every output of every `dummy` workflow was driven through the real fake backend into a real `TemporalBuffer` and out through the extractors: 33 window, 48 cumulative and 3 series messages into 28 buffers, no rejections, every window and cumulative buffer yielding time bounds after extraction (series buffers deliberately yield none — see the fourth commit), and all 23 counts outputs normalizing to counts/s.

Driven in a fake-backend dashboard with a config covering all three temporalities through `TemporalBuffer`: a cumulative-only 0-D view (`dummy/total_counts/1`, the case that used to raise), the same plotter over a view that does have a window field, a 5 s window aggregation, and a series output.

The `Accumulation` group is present on a both-flavors view (`monitor_histogram/total_counts`) and absent on a cumulative-only one (`dummy/total_counts`), checked in the same fake-backend dashboard. That check cannot show the two subscriptions differing, since the fake backend synthesizes every 0-D field from the same wiggle regardless of temporality; the resolved field name is asserted in `plot_orchestrator_test.py` instead.

## Test plan

- [x] History plot of a cumulative 0-D output renders a growth curve against wall-clock time
- [x] The timeseries `Cumulative` checkbox switches a `total_counts` plot between the fluctuating per-update value and the monotonic total
- [x] Existing window-output plots (detector image, monitor histogram, totals) still show lag/freshness and rate normalization — worth re-running, since the bounds these read are now minted at the extractor boundary rather than carried on the wire
- [x] Timeseries plots of device readings are unaffected
- [x] Correlation plots still align sensibly — their wall-clock axis for a window output is now its `time` (the old `end_time`) rather than its `start_time`

