### PR TITLE
Fix plot axes that collapse on a degenerate data range

### DIFF
--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -29,7 +29,15 @@ from .plot_params import (
     PlotDisplayParams1d,
     PlotDisplayParams2d,
 )
-from .plots import ImagePlotter, LinePlotter, PresenterBase, TimeBounds, TitleResolver
+from .plots import (
+    ImagePlotter,
+    LinePlotter,
+    PresenterBase,
+    TimeBounds,
+    TitleResolver,
+    ensure_span,
+    is_degenerate_span,
+)
 from .range_hook import Axis, RangeTargets
 
 
@@ -169,32 +177,22 @@ class AxisSpec:
     """Number of bins for this axis."""
 
 
-_CONSTANT_AXIS_REL_TOL = 1e-9
-"""Relative span below which correlation axis values count as constant.
-
-The axis carries device readings such as a temperature or a motor position,
-never epoch timestamps, so a span this small next to the magnitude is jitter in
-the last bits rather than a range worth binning over.
-"""
-
-
 def _axis_bins(values: sc.Variable, axis: AxisSpec) -> sc.Variable | int:
-    """Binning for ``values``: a bin count, or explicit edges if constant.
+    """Binning for ``values``: a bin count, or explicit edges if degenerate.
 
     ``hist`` derives edges from the value range and does not guard a degenerate
     one. A stationary device, or a single axis reading correlated with every
     data point, yields bins of zero width: nothing is drawn, and the axis range
-    derived from the edges collapses to a point. Spread the edges over a visible
-    interval around the value instead, widening as ``plots._ensure_span`` does
-    for degenerate view ranges.
+    derived from those edges collapses to a point. Bin over the interval such a
+    range is widened to instead -- fixing the edges rather than the view,
+    because zero-width bars stay invisible however wide the axis around them.
     """
     lo = sc.nanmin(values).value
     hi = sc.nanmax(values).value
-    if abs(hi - lo) > _CONSTANT_AXIS_REL_TOL * max(abs(lo), abs(hi)):
+    if not is_degenerate_span(lo, hi):
         return axis.bins
-    offset = max(abs(lo) * 0.05, 0.5)
     return sc.linspace(
-        axis.name, lo - offset, hi + offset, axis.bins + 1, unit=values.unit
+        axis.name, *ensure_span(lo, hi, log=False), axis.bins + 1, unit=values.unit
     )
 
 

--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -181,11 +181,12 @@ def _axis_bins(values: sc.Variable, axis: AxisSpec) -> sc.Variable | int:
     """Binning for ``values``: a bin count, or explicit edges if degenerate.
 
     ``hist`` derives edges from the value range and does not guard a degenerate
-    one. A stationary device, or a single axis reading correlated with every
-    data point, yields bins of zero width: nothing is drawn, and the axis range
-    derived from those edges collapses to a point. Bin over the interval such a
-    range is widened to instead -- fixing the edges rather than the view,
-    because zero-width bars stay invisible however wide the axis around them.
+    one (scipp/scipp#3935). A stationary device, or a single axis reading
+    correlated with every data point, yields bins of zero width: nothing is
+    drawn, and the axis range derived from those edges collapses to a point.
+    Bin over the interval such a range is widened to instead -- fixing the edges
+    rather than the view, because zero-width bars stay invisible however wide
+    the axis around them.
     """
     lo = sc.nanmin(values).value
     hi = sc.nanmax(values).value

--- a/src/ess/livedata/dashboard/correlation_plotter.py
+++ b/src/ess/livedata/dashboard/correlation_plotter.py
@@ -169,6 +169,35 @@ class AxisSpec:
     """Number of bins for this axis."""
 
 
+_CONSTANT_AXIS_REL_TOL = 1e-9
+"""Relative span below which correlation axis values count as constant.
+
+The axis carries device readings such as a temperature or a motor position,
+never epoch timestamps, so a span this small next to the magnitude is jitter in
+the last bits rather than a range worth binning over.
+"""
+
+
+def _axis_bins(values: sc.Variable, axis: AxisSpec) -> sc.Variable | int:
+    """Binning for ``values``: a bin count, or explicit edges if constant.
+
+    ``hist`` derives edges from the value range and does not guard a degenerate
+    one. A stationary device, or a single axis reading correlated with every
+    data point, yields bins of zero width: nothing is drawn, and the axis range
+    derived from the edges collapses to a point. Spread the edges over a visible
+    interval around the value instead, widening as ``plots._ensure_span`` does
+    for degenerate view ranges.
+    """
+    lo = sc.nanmin(values).value
+    hi = sc.nanmax(values).value
+    if abs(hi - lo) > _CONSTANT_AXIS_REL_TOL * max(abs(lo), abs(hi)):
+        return axis.bins
+    offset = max(abs(lo) * 0.05, 0.5)
+    return sc.linspace(
+        axis.name, lo - offset, hi + offset, axis.bins + 1, unit=values.unit
+    )
+
+
 class CorrelationHistogramPlotter:
     """Base plotter for correlation histograms with arbitrary number of axes.
 
@@ -228,9 +257,6 @@ class CorrelationHistogramPlotter:
                 )
             axis_data[axis.name] = ax
 
-        # Build bin spec
-        bin_spec = {axis.name: axis.bins for axis in self._axes}
-
         histograms: dict[DataKey, sc.DataArray] = {}
         for key, source_data in histogram_data.items():
             dependent = source_data.copy(deep=False)
@@ -240,6 +266,11 @@ class CorrelationHistogramPlotter:
             for axis in self._axes:
                 lut = _make_lookup(axis_data[axis.name], data_max_time)
                 dependent.coords[axis.name] = lut[dependent.coords['time']]
+
+            bin_spec = {
+                axis.name: _axis_bins(dependent.coords[axis.name], axis)
+                for axis in self._axes
+            }
 
             # Bin data with optional normalization by time width
             if self._normalize:

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -57,11 +57,13 @@ def _latest_time_ns(primary: dict[DataKey, sc.DataArray]) -> int | None:
     )
 
 
-# Used only to widen a zero-width range (see _ensure_span); the per-axis
+# Used only to widen a degenerate range (see ensure_span); the per-axis
 # padding fraction itself comes from HoloViews (see _hv_axis_padding).
 _DEGENERATE_PAD = 0.05
 _DEGENERATE_PAD_MIN = 0.5
 _DEGENERATE_LOG_FACTOR = 1.1
+_DEGENERATE_PAD_NS = 1e9  # one second, for epoch-nanosecond axes
+_DEGENERATE_ULPS = 4
 
 
 def _hv_axis_padding(element_type: type) -> tuple[float, float, float]:
@@ -76,31 +78,56 @@ def _hv_axis_padding(element_type: type) -> tuple[float, float, float]:
     return get_axis_padding(plot_cls.param.padding.default)
 
 
-def _ensure_span(lo: float, hi: float, *, log: bool) -> tuple[float, float]:
-    """Widen a zero-width range so Bokeh has something to render.
+def is_degenerate_span(lo: float, hi: float) -> bool:
+    """Whether ``(lo, hi)`` is too narrow for float64 to resolve.
+
+    Measured in units of the float64 spacing at the range's own magnitude, so
+    one test serves data axes and epoch-nanosecond datetime axes alike: a
+    float64 step is ~1e-16 next to a temperature in kelvin but a few hundred
+    nanoseconds next to a 2020s epoch, which is precisely the resolution below
+    which each range stops carrying information. A few ULP of slack admits
+    ranges that are nominally non-empty yet still unrenderable, such as the
+    one-ULP upper bound ``scipp.hist`` derives from a constant coord.
+    """
+    return hi - lo <= _DEGENERATE_ULPS * np.spacing(max(abs(lo), abs(hi)))
+
+
+def ensure_span(
+    lo: float, hi: float, *, log: bool, datetime: bool = False
+) -> tuple[float, float]:
+    """Widen a degenerate range so Bokeh has something to render.
 
     ``range_pad`` derives padding from the span, so it leaves a single-valued
     range (constant image, single point or bin) untouched; HoloViews handles
     this separately via ``default_span``. Bump multiplicatively on log axes to
     keep the lower bound positive, additively on linear axes.
+
+    The additive offset is a fraction of the magnitude, which presumes the axis
+    is measured from its zero. A datetime axis is measured from the epoch, where
+    5% of the magnitude is decades, so widen it by a fixed interval instead.
     """
-    if hi != lo:
+    if not is_degenerate_span(lo, hi):
         return lo, hi
     if log:
         return lo / _DEGENERATE_LOG_FACTOR, hi * _DEGENERATE_LOG_FACTOR
-    offset = max(abs(lo) * _DEGENERATE_PAD, _DEGENERATE_PAD_MIN)
+    if datetime:
+        offset = _DEGENERATE_PAD_NS
+    else:
+        offset = max(abs(lo) * _DEGENERATE_PAD, _DEGENERATE_PAD_MIN)
     return lo - offset, hi + offset
 
 
-def _pad_range(lo: float, hi: float, *, pad: float, log: bool) -> tuple[float, float]:
+def _pad_range(
+    lo: float, hi: float, *, pad: float, log: bool, datetime: bool = False
+) -> tuple[float, float]:
     """Pad ``(lo, hi)`` by fraction ``pad`` using HoloViews' range padding.
 
     ``pad`` is the per-axis fraction HoloViews assigns to the element type (see
     :func:`_hv_axis_padding`); :func:`range_pad` applies it in data space, or in
     log space when ``log=True``. ``pad=0`` (e.g. every image axis) is a no-op
-    beyond the zero-width guard.
+    beyond the degenerate-range guard.
     """
-    lo, hi = _ensure_span(lo, hi, log=log)
+    lo, hi = ensure_span(lo, hi, log=log, datetime=datetime)
     return range_pad(lo, hi, pad, log)
 
 
@@ -1083,10 +1110,15 @@ class LinePlotter(Plotter):
         targets: RangeTargets = {}
         dim = data.dim
         if dim in data.coords:
-            coord_values = data.coords[dim].values
-            coord_extent = _finite_min_max(coord_values, log=self._logx)
+            coord = data.coords[dim]
+            coord_extent = _finite_min_max(coord.values, log=self._logx)
             if coord_extent is not None:
-                targets['x'] = _pad_range(*coord_extent, pad=xpad, log=self._logx)
+                targets['x'] = _pad_range(
+                    *coord_extent,
+                    pad=xpad,
+                    log=self._logx,
+                    datetime=coord.dtype == sc.DType.datetime64,
+                )
         value_extent = _value_extent_with_errors(
             data, show_errors=self._errors != 'none', log=self._logy
         )
@@ -1416,10 +1448,15 @@ class Overlay1DPlotter(Plotter):
         targets: RangeTargets = {}
         plot_dim = data.dims[1]
         if plot_dim in data.coords:
-            coord_values = data.coords[plot_dim].values
-            coord_extent = _finite_min_max(coord_values, log=self._logx)
+            coord = data.coords[plot_dim]
+            coord_extent = _finite_min_max(coord.values, log=self._logx)
             if coord_extent is not None:
-                targets['x'] = _pad_range(*coord_extent, pad=xpad, log=self._logx)
+                targets['x'] = _pad_range(
+                    *coord_extent,
+                    pad=xpad,
+                    log=self._logx,
+                    datetime=coord.dtype == sc.DType.datetime64,
+                )
         value_extent = _value_extent_with_errors(
             data, show_errors=self._errors != 'none', log=self._logy
         )

--- a/tests/dashboard/correlation_plotter_test.py
+++ b/tests/dashboard/correlation_plotter_test.py
@@ -3,6 +3,7 @@
 """Tests for correlation histogram plotters."""
 
 import holoviews as hv
+import numpy as np
 import pytest
 import scipp as sc
 
@@ -265,6 +266,62 @@ class TestCorrelationHistogramPlotter:
         plotter.compute(data)
         result = plotter.get_cached_state()
         assert result is not None
+
+
+class TestConstantAxisValues:
+    """A correlation axis that does not vary must still produce a usable plot."""
+
+    def _histogram(self, axis_values: list[float]) -> dict[str, np.ndarray]:
+        """Correlate three data points against one axis reading per point."""
+        plotter = CorrelationHistogramPlotter(
+            axes=[AxisSpec(role=X_AXIS, name='position', bins=4)],
+            normalize=False,
+            renderer=_make_line_renderer(),
+        )
+        times = [100 * (i + 1) for i in range(len(axis_values))]
+        plotter.compute(
+            {
+                PRIMARY: {
+                    _make_result_key('detector'): make_source_data(
+                        [t + 50 for t in times], [10.0] * len(times)
+                    )
+                },
+                X_AXIS: {
+                    _make_result_key('position'): make_axis_data(times, axis_values)
+                },
+            }
+        )
+        state = plotter.get_cached_state()
+        assert state is not None
+        return next(iter(state.values())).data
+
+    def test_constant_axis_spans_a_visible_range(self):
+        """Identical values must not collapse the bins and the axis to a point.
+
+        ``hist`` derives edges from the value range and leaves a degenerate one
+        degenerate, giving zero-width bars on a zero-width axis.
+        """
+        edges = self._histogram([5.0, 5.0, 5.0])['position']
+
+        assert edges[0] < edges[-1]
+        assert np.all(np.diff(edges) > 0.0)
+
+    def test_constant_axis_keeps_all_counts(self):
+        """Widening the bins must not push data outside the histogram."""
+        assert self._histogram([5.0, 5.0, 5.0])['values'].sum() == 30.0
+
+    def test_constant_axis_at_zero_spans_a_visible_range(self):
+        """A value of zero has no magnitude to widen relative to."""
+        edges = self._histogram([0.0, 0.0, 0.0])['position']
+
+        assert edges[0] < 0.0 < edges[-1]
+
+    def test_varying_axis_bins_over_the_data_range(self):
+        """Edges follow the values whenever they actually span a range."""
+        edges = self._histogram([1.0, 2.0, 3.0])['position']
+
+        assert edges[0] == pytest.approx(1.0)
+        assert edges[-1] == pytest.approx(3.0)
 
 
 class TestCorrelationHistogramPlotterOwnership:

--- a/tests/dashboard/plotter_range_targets_test.py
+++ b/tests/dashboard/plotter_range_targets_test.py
@@ -120,6 +120,48 @@ class TestLinePlotterRangeTargets:
         targets = plotter.get_range_targets(key)
         assert targets['y'][0] > 0.0
 
+    def test_constant_axis_is_widened(self):
+        plotter = LinePlotter.from_params(PlotParams1d())
+        key = _key()
+        data = sc.DataArray(
+            sc.array(dims=['x'], values=[2.0, 5.0], unit='counts'),
+            coords={'x': sc.array(dims=['x'], values=[3.0, 3.0], unit='m')},
+        )
+        plotter.compute({PRIMARY: {key: data}})
+
+        lo, hi = plotter.get_range_targets(key)['x']
+        assert lo < 3.0 < hi
+
+    def test_axis_spanning_a_single_ulp_is_widened(self):
+        """A range Bokeh cannot resolve is degenerate even if nominally non-empty."""
+        plotter = LinePlotter.from_params(PlotParams1d())
+        key = _key()
+        values = [3.0, np.nextafter(3.0, 4.0)]
+        data = sc.DataArray(
+            sc.array(dims=['x'], values=[2.0, 5.0], unit='counts'),
+            coords={'x': sc.array(dims=['x'], values=values, unit='m')},
+        )
+        plotter.compute({PRIMARY: {key: data}})
+
+        lo, hi = plotter.get_range_targets(key)['x']
+        assert hi - lo > 0.1
+
+    def test_single_sample_datetime_axis_is_widened_by_seconds(self):
+        """Widening a datetime axis relative to the epoch would span decades."""
+        plotter = LinePlotter.from_params(PlotParams1d())
+        key = _key()
+        sample = np.datetime64('2026-07-28T12:00:00', 'ns')
+        data = sc.DataArray(
+            sc.array(dims=['time'], values=[2.0], unit='counts'),
+            coords={'time': sc.array(dims=['time'], values=[sample], unit='ns')},
+        )
+        plotter.compute({PRIMARY: {key: data}})
+
+        lo, hi = plotter.get_range_targets(key)['x']
+        epoch_ns = float(sample.astype('int64'))
+        assert lo < epoch_ns < hi
+        assert (hi - lo) / 1e9 == pytest.approx(2.0)
+
     def test_y_extent_includes_error_whiskers(self):
         plotter = LinePlotter.from_params(PlotParams1d())  # errors='bars' default
         key = _key()


### PR DESCRIPTION
A 1D correlation histogram whose axis values are all identical renders with its x axis collapsed to a point — every tick label stacked on the same pixel — and no visible bars. Found while manually testing #1134; it reproduces unchanged on `main`. The trigger is not exotic: a device parked at a setpoint, or an axis timeseries that has produced a single reading so far while the data updates faster, both correlate every point onto one value.

Two faults meet there, and only one of them is specific to correlation histograms.

`hist` derives bin edges from the value range and does not guard a degenerate one: for a constant axis it emits N bins of zero width, bumping only the top edge by one ULP to keep the range technically valid (reported upstream as scipp/scipp#3935). Zero-width bars stay invisible however wide the axis around them, so this has to be fixed where the edges are made, and the correlation plotter is the only place in the dashboard that derives edges from data rather than from workflow config. Patching the edges after binning would not work: scipp puts the counts in bin index 1 whatever the bin count, so relabelling the edges over a wider interval would leave the bar 1% from the left of an axis centred on the value.

The zero-width guard behind every plotter's autoscale range then has two holes of its own, neither of which needs a correlation histogram to reach. It tests for an exactly zero span, which the ULP bump defeats. And it widens a degenerate range by 5% of its magnitude, which presumes the axis is measured from its zero — a datetime axis is measured from the epoch, so a timeseries plot showing a single sample was framed by an x axis spanning roughly 2000 days. A single sample is a normal state at startup, and it is also what any set of samples within ~256 ns collapses to, that being the float64 spacing at a 2020s epoch. Degeneracy is now measured against the float64 spacing at the range's own magnitude, which is the right resolution both for a temperature in kelvin and for an epoch in nanoseconds, and datetime axes are widened by a fixed interval of one second.

The correlation plotter takes both the test and the widening from that shared guard rather than restating them.

One deliberate narrowing: the constant-axis test is a few ULP rather than a relative tolerance, so an axis jittering in its last few digits now gets genuine narrow bins instead of a widened range. Whether jitter that small is worth binning over is a display policy, and it belongs in the range layer if we want it, not in the binning.

## Test plan

Regression tests assert that a constant correlation axis produces strictly increasing edges and retains all counts, that an axis constant at zero (no magnitude to widen relative to) also spans a visible range, and that a varying axis still takes its edges from the data. On the shared guard, a line plot gets a visible x range for a constant axis and for one spanning a single ULP, and a single-sample datetime axis is widened by seconds rather than years. The constant correlation axis, the ULP case and the datetime case all fail on `main`.

- [x] A correlation histogram against a parked device shows a bar and a readable x axis.
- [x] A timeseries plot showing its first sample has a readable x axis.
