### PR TITLE
Add --collapsed-sidebar, used by the automation launcher

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -87,7 +87,7 @@ it, on a port other than 5009 (interactive dev uses 5009):
 ```sh
 cp -r tests/dashboard/ui_config_fixtures/dummy "$TMP/cfg/dummy"
 python -m ess.livedata.dashboard.reduction --instrument dummy --transport fake \
-    --port 5011 --config-dir "$TMP/cfg" --no-fetch-announcements
+    --port 5011 --config-dir "$TMP/cfg" --no-fetch-announcements --collapsed-sidebar
 ```
 
 Add `--auto-start` (requires `--transport fake`) to commit every staged workflow on
@@ -104,6 +104,12 @@ button with a *compound* selector on one element:
 - ✅ `.lt-wf-total_counts.lt-tool-player-stop` (both classes on the same button)
 - ❌ `.lt-wf-total_counts .lt-tool-player-stop` (matches nothing — the descendant
   crosses a shadow boundary)
+
+**Sidebar.** `--launch` passes `--collapsed-sidebar`, so the main content gets the full
+window width: the sidebar is static in automation runs (announcements are off) and an
+open drawer only narrows the plots under test and their screenshots. Pass the flag when
+running a server by hand too. It sets `MaterialTemplate.collapsed_sidebar`, so the page
+arrives collapsed — no clicking the hamburger, and it survives `page.reload()`.
 
 **Tabs.** The top-level tabs are Bokeh-owned `.bk-tab` divs with no `lt-*` hooks, so
 navigate by visible text (`page.get_by_text("Detectors", exact=True)`). Static tab

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -210,6 +210,8 @@ def _fake_dashboard(instrument: str, port: int):
 
     Copies the committed fixture to a writable scratch dir (the dashboard writes
     to its config dir), waits for readiness, and tears the server down on exit.
+    The sidebar starts collapsed: it is static here (announcements are off), so
+    an open drawer would only narrow the plots under test and their screenshots.
     """
     fixture = REPO_ROOT / "tests/dashboard/ui_config_fixtures" / instrument
     if not fixture.is_dir():
@@ -238,6 +240,7 @@ def _fake_dashboard(instrument: str, port: int):
                     "--config-dir",
                     str(cfg),
                     "--auto-start",
+                    "--collapsed-sidebar",
                     "--no-fetch-announcements",
                 ],
                 cwd=REPO_ROOT,

--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -42,6 +42,7 @@ class DashboardBase(ServiceBase, ABC):
         transport: str = 'kafka',
         config_dir: str | None = None,
         auto_start: bool = False,
+        collapsed_sidebar: bool = False,
         basic_auth_password: str | None = None,
         basic_auth_cookie_secret: str | None = None,
     ):
@@ -56,6 +57,7 @@ class DashboardBase(ServiceBase, ABC):
         self._port = port
         self._dev = dev
         self._auto_start = auto_start
+        self._collapsed_sidebar = collapsed_sidebar
         self._basic_auth_password = basic_auth_password
         self._basic_auth_cookie_secret = basic_auth_cookie_secret
 
@@ -252,6 +254,7 @@ class DashboardBase(ServiceBase, ABC):
         template = pn.template.MaterialTemplate(
             title=self.get_dashboard_title(),
             sidebar=sidebar_with_heartbeat,
+            collapsed_sidebar=self._collapsed_sidebar,
             main=main_content,
             header_background=self.get_header_background(),
             header=header,

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -80,6 +80,7 @@ class ReductionApp(DashboardBase):
         transport: str = 'kafka',
         config_dir: str | None = None,
         auto_start: bool = False,
+        collapsed_sidebar: bool = False,
         fetch_announcements: bool = True,
         basic_auth_password: str | None = None,
         basic_auth_cookie_secret: str | None = None,
@@ -93,6 +94,7 @@ class ReductionApp(DashboardBase):
             transport=transport,
             config_dir=config_dir,
             auto_start=auto_start,
+            collapsed_sidebar=collapsed_sidebar,
             basic_auth_password=basic_auth_password,
             basic_auth_cookie_secret=basic_auth_cookie_secret,
         )
@@ -230,6 +232,14 @@ def get_arg_parser() -> argparse.ArgumentParser:
         help='Commit every workflow that has staged config on startup. Requires '
         '--transport fake; combine with --config-dir to launch a fully live '
         'dashboard with no UI interaction (e.g. for screenshots).',
+    )
+    parser.add_argument(
+        '--collapsed-sidebar',
+        action='store_true',
+        default=False,
+        help='Start with the sidebar collapsed. The sidebar holds announcements '
+        'and the version label, so collapsing it gives plots the full window '
+        'width -- useful on small screens and for automation/screenshots.',
     )
     parser.add_argument(
         '--no-fetch-announcements',


### PR DESCRIPTION
Adds a `--collapsed-sidebar` flag to the dashboard and passes it from the Playwright driving kit's `--launch`.

The sidebar carries announcements and the version label. Automation runs disable announcements, so the drawer is static there — it only narrows the plots under test and the screenshots taken of them, and eats a chunk of every image handed to a reviewer or a model. The flag sets `MaterialTemplate.collapsed_sidebar`, so the page arrives collapsed on the first frame: no hamburger click, no resize while Bokeh models are still settling, and it survives a page reload. Plots go from 1230 px to the full 1600 px of the automation viewport.

Not automation-only: a small screen is as good a reason to want the extra plot width, hence a plain flag rather than something coupled to `--transport fake`.

The alternative was collapsing browser-side by clicking the hamburger, which also covers dashboards the kit did not launch itself. Rejected: it hangs the automation off Panel's Material markup (`#sidebar.mdc-drawer--open`, `button.mdc-top-app-bar__navigation-icon`), which is exactly the kind of selector that breaks on a Panel upgrade, and there is no current need to drive a hand-run server this way.

## Test plan

- `pytest -m browser tests/dashboard/` — 5 passed.
- `pytest tests/dashboard` — 1784 passed.
- `python scripts/drive_dashboard.py --launch --tab Detectors --screenshot out.png` — sidebar absent, grid spans the full width.
- `--check --collapsed-sidebar` constructs the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
