### PR TITLE
Add integration test for the stop path halting backend publishing

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -114,6 +114,41 @@ def wait_for_watermark_stall(
         previous = current
 
 
+def wait_for_watermark_advance(topic: str, *, since: int, timeout: float = 30.0) -> int:
+    """Wait until a topic's high watermark exceeds ``since``, then return it.
+
+    Complements :func:`wait_for_watermark_stall`: proves a producer is live
+    (e.g. before asserting a later stop makes it go quiet) without a fixed
+    sleep, which would either be too short in a slow CI run or waste time
+    otherwise.
+
+    Parameters
+    ----------
+    topic:
+        Topic whose single-partition high watermark to observe.
+    since:
+        Watermark value that must be exceeded for the wait to succeed.
+    timeout:
+        Maximum time to wait in seconds.
+
+    Raises
+    ------
+    WaitTimeout:
+        If the watermark has not advanced past ``since`` within the timeout.
+    """
+    deadline = time.time() + timeout
+    while True:
+        current = topic_high_watermark(topic)
+        if current > since:
+            return current
+        if time.time() > deadline:
+            raise WaitTimeout(
+                f"Watermark of {topic} did not advance past {since} "
+                f"after {timeout} seconds"
+            )
+        time.sleep(0.2)
+
+
 def wait_for_condition(
     condition: Callable[[], bool], timeout: float = 5.0, poll_interval: float = 0.1
 ) -> None:

--- a/tests/integration/stop_path_test.py
+++ b/tests/integration/stop_path_test.py
@@ -12,8 +12,13 @@ from tests.integration.conftest import IntegrationEnv
 from tests.integration.helpers import (
     topic_high_watermark,
     wait_for_job_data,
+    wait_for_watermark_advance,
     wait_for_watermark_stall,
 )
+
+# Gap between detecting the stall and reconfirming it, so the reconfirmation
+# is not just re-reading the sample that triggered the stall detection.
+STALL_RECHECK_GAP = 8.0
 
 # fake_monitors keeps publishing raw ev44 data on this topic regardless of
 # whether any workflow is running, so it must not be used for the stall
@@ -54,13 +59,14 @@ def test_stop_workflow_halts_backend_publishing(
     # a later stall assertion would be vacuous (e.g. if the topic name were
     # wrong, or the pipeline had already stalled for an unrelated reason).
     first = topic_high_watermark(DATA_TOPIC)
-    time.sleep(4.0)
-    second = topic_high_watermark(DATA_TOPIC)
-    assert second > first, "Data topic watermark must be advancing before stop"
+    wait_for_watermark_advance(DATA_TOPIC, since=first, timeout=30.0)
 
     assert backend.job_orchestrator.stop_workflow(WORKFLOW_ID)
 
     # Watermark stalls once the worker consumes the stop command...
     stalled_watermark = wait_for_watermark_stall(DATA_TOPIC)
-    # ...and stays stalled -- no further messages trickle in afterwards.
+    # ...and stays stalled: a real gap separates detection from
+    # reconfirmation, so this rules out a late trickle rather than
+    # re-reading the sample that triggered the stall detection.
+    time.sleep(STALL_RECHECK_GAP)
     assert topic_high_watermark(DATA_TOPIC) == stalled_watermark

--- a/tests/integration/stop_path_test.py
+++ b/tests/integration/stop_path_test.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration test for the stop path: a commanded stop halts backend work."""
+
+import time
+
+import pytest
+
+from ess.livedata.config.workflow_spec import WorkflowId
+from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
+from tests.integration.conftest import IntegrationEnv
+from tests.integration.helpers import (
+    topic_high_watermark,
+    wait_for_job_data,
+    wait_for_watermark_stall,
+)
+
+# fake_monitors keeps publishing raw ev44 data on this topic regardless of
+# whether any workflow is running, so it must not be used for the stall
+# assertions -- only the results topic (livedata_data) goes quiet on stop.
+DATA_TOPIC = 'dummy_livedata_data'
+
+WORKFLOW_ID = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
+
+
+@pytest.mark.integration
+@pytest.mark.services('monitor')
+def test_stop_workflow_halts_backend_publishing(
+    integration_env: IntegrationEnv,
+) -> None:
+    """
+    A commanded stop actually stops backend work, not just the dashboard status.
+
+    JobOrchestrator.stop_workflow also deactivates the workflow dashboard-side,
+    so DataService would filter out late results even if the backend kept
+    churning -- a dashboard-only assertion (e.g. on job status) would pass
+    vacuously whether or not the worker process actually stopped consuming
+    and producing. The only assertion that proves the backend itself halted
+    is on Kafka: the results topic's high watermark must stop advancing, and
+    stay stopped, after the stop command is issued.
+
+    Uses ``job_orchestrator.stop_workflow`` directly, the same call the
+    dashboard's stop button makes (``WorkflowStatusWidget._on_stop_click``).
+    """
+    backend = integration_env.backend
+    job_ids = backend.workflow_controller.start_workflow(
+        workflow_id=WORKFLOW_ID,
+        source_names=['monitor1'],
+        config=MonitorDataParams(),
+    )
+    wait_for_job_data(backend, WORKFLOW_ID, job_ids, timeout=30.0)
+
+    # Prove the watermark is actually advancing before stopping -- otherwise
+    # a later stall assertion would be vacuous (e.g. if the topic name were
+    # wrong, or the pipeline had already stalled for an unrelated reason).
+    first = topic_high_watermark(DATA_TOPIC)
+    time.sleep(4.0)
+    second = topic_high_watermark(DATA_TOPIC)
+    assert second > first, "Data topic watermark must be advancing before stop"
+
+    assert backend.job_orchestrator.stop_workflow(WORKFLOW_ID)
+
+    # Watermark stalls once the worker consumes the stop command...
+    stalled_watermark = wait_for_watermark_stall(DATA_TOPIC)
+    # ...and stays stalled -- no further messages trickle in afterwards.
+    assert topic_high_watermark(DATA_TOPIC) == stalled_watermark


### PR DESCRIPTION
## Summary

Adds an integration test for the "stop path" checkbox in issue #1116: a commanded stop must actually halt backend work, not just flip the status shown in the dashboard.

`JobOrchestrator.stop_workflow` also deactivates the workflow on the dashboard side, so `DataService` would filter out late results even if the backend worker kept churning after the stop. A dashboard-only assertion (e.g. on job status) would therefore pass vacuously whether or not the backend actually stopped. The test instead asserts directly on Kafka: after starting a monitor workflow it confirms the results topic's (`livedata_data`) high watermark is genuinely advancing, issues the stop via `job_orchestrator.stop_workflow` (the same call the dashboard's stop button makes), and then asserts the watermark stalls and stays stalled. The raw monitor topic keeps advancing throughout since `fake_monitors` publishes independently of any workflow, so the test is careful to only assert on the results topic.

Refs #1116.
