### PR TITLE
Integration test: rapid recommit under a live producer

### DIFF
--- a/src/ess/livedata/dashboard/active_job_registry.py
+++ b/src/ess/livedata/dashboard/active_job_registry.py
@@ -194,6 +194,18 @@ class ActiveJobRegistry:
                     return gen.config
             return None
 
+    def stale_count(self, workflow_id: WorkflowId) -> int:
+        """Number of data messages dropped since the current generation began.
+
+        Every :py:meth:`begin_generation` resets the counter, so the value is
+        scoped to the workflow's current generation: it measures how much
+        in-flight data the latest commit superseded. Zero for a workflow with
+        no generation record.
+        """
+        with self._lock:
+            record = self._generations.get(workflow_id)
+            return 0 if record is None else record.stale_count
+
     def record_stale(self, workflow_id: WorkflowId, job_number: JobNumber) -> None:
         """Count a dropped data message from a non-current generation.
 

--- a/tests/dashboard/active_job_registry_test.py
+++ b/tests/dashboard/active_job_registry_test.py
@@ -212,6 +212,11 @@ class TestUnobservedWorkflow:
 
         assert not registry.is_current(_workflow_id, uuid.uuid4())
 
+    def test_has_no_stale_drops(self):
+        registry, _ds, _js = _make_registry()
+
+        assert registry.stale_count(_workflow_id) == 0
+
 
 class TestRecordStale:
     def test_counts_without_side_effects(self):
@@ -224,5 +229,22 @@ class TestRecordStale:
         for _ in range(3):
             registry.record_stale(_workflow_id, uuid.uuid4())
 
+        assert registry.stale_count(_workflow_id) == 3
         assert registry.is_current(_workflow_id, current)
         assert key in ds
+
+    def test_counts_per_workflow(self):
+        registry, _ds, _js = _make_registry()
+
+        registry.record_stale(_workflow_id, uuid.uuid4())
+
+        assert registry.stale_count(_workflow_id) == 1
+        assert registry.stale_count(_other_workflow_id) == 0
+
+    def test_count_is_scoped_to_the_current_generation(self):
+        registry, _ds, _js = _make_registry()
+        registry.record_stale(_workflow_id, uuid.uuid4())
+
+        registry.begin_generation(_workflow_id, uuid.uuid4(), config={})
+
+        assert registry.stale_count(_workflow_id) == 0

--- a/tests/dashboard/message_pump_test.py
+++ b/tests/dashboard/message_pump_test.py
@@ -639,6 +639,7 @@ class TestMessagePumpGenerationFiltering:
         result_key = self._forward_data(message_pump, old_number)
 
         assert result_key.data_key not in data_service
+        assert registry.stale_count(self._workflow_id) == 1
 
     def test_discards_data_for_unknown_generation(self) -> None:
         message_pump, data_service, _, _ = self._make_message_pump(

--- a/tests/integration/rapid_recommit_test.py
+++ b/tests/integration/rapid_recommit_test.py
@@ -6,25 +6,19 @@ from collections.abc import Iterable, Mapping
 
 import pytest
 
-from ess.livedata.config.streams import get_stream_mapping
 from ess.livedata.config.workflow_spec import DataKey, JobId, JobNumber, WorkflowId
 from ess.livedata.dashboard.data_service import DataServiceSubscriber
 from ess.livedata.dashboard.extractors import LatestValueExtractor, UpdateExtractor
 from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
 from tests.integration.conftest import IntegrationEnv
-from tests.integration.helpers import (
-    topic_high_watermark,
-    wait_for_backend_condition,
-    wait_for_condition,
-    wait_for_job_data,
-)
+from tests.integration.helpers import wait_for_backend_condition, wait_for_job_data
 
-#: Recommits issued back-to-back, with no backend update in between, so several
-#: generations are in flight at once while the producer keeps running.
+#: Recommits issued back-to-back, so later flips land while the backend is
+#: still working through the earlier ones.
 _BURST_RECOMMITS = 3
 
 #: Backend updates to keep watching after the final generation's data arrived,
-#: to catch a late-arriving stale message being admitted.
+#: to catch a late-arriving superseded result being admitted.
 _CONFIRM_POLLS = 25
 
 
@@ -57,16 +51,25 @@ def test_rapid_recommit_admits_only_latest_generation(
     """
     Recommitting repeatedly under a live producer admits only the last commit.
 
-    Each commit flips the dashboard's generation before its commands even reach
-    the backend, so results computed for the superseded generations keep
-    arriving afterwards. They must be dropped and counted, and the data that
-    does reach DataService must carry the final generation's job_number only.
+    Each commit flips the dashboard's generation and clears the workflow's
+    buffers before its commands reach the backend, so results computed for a
+    superseded generation can still arrive afterwards. None of them may reach
+    DataService: what is buffered must carry the final generation's job_number
+    alone.
+
+    Scope: this asserts the admission property, not the drop *count*
+    (``ActiveJobRegistry.stale_count``). Counting is not reliably observable at
+    this layer, because a superseded result usually does not exist to be
+    dropped. The dashboard's stop reaches the backend within about 100 ms while
+    a monitor workflow publishes roughly once a second, so a flip typically
+    finds nothing of the old generation in flight; and a generation superseded
+    before the backend ever starts it publishes nothing at all, which is what a
+    burst produces. Every flip also resets the counter, leaving only the final
+    commit's window assertable. ``tests/dashboard/message_pump_test.py`` covers
+    the counting deterministically instead, forwarding a superseded result
+    directly.
     """
     backend = integration_env.backend
-    registry = backend.job_orchestrator.active_job_registry
-    data_topic = get_stream_mapping(
-        instrument=integration_env.instrument, dev=True
-    ).topics.livedata_data
     workflow_id = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
     source_name = 'monitor1'
 
@@ -86,33 +89,13 @@ def test_rapid_recommit_admits_only_latest_generation(
     first_job = commit()
     wait_for_job_data(backend, workflow_id, [first_job], timeout=30.0)
 
-    # Burst of recommits, each superseding a generation the backend may not
-    # even have started yet. No backend.update() in between: the messages the
-    # producer emits meanwhile stay unforwarded, so they meet the generation
-    # filter only after the burst.
+    # Burst of recommits with nothing awaited in between, so the flips land
+    # while the backend is still producing for the generation established above
+    # and still working through the queued commands. This is the race: results
+    # of superseded generations are in flight exactly here.
     job_numbers = {first_job.job_number}
     for _ in range(_BURST_RECOMMITS):
         job_numbers.add(commit().job_number)
-
-    # Wait for the producer to publish at least once more, reading the broker's
-    # watermark rather than consuming. This makes the assertion on stale drops
-    # deterministic instead of a race: the observed message predates the flip
-    # below, so whichever generation stamped it is superseded by the time the
-    # dashboard forwards it.
-    #
-    # The helper choice is load-bearing. wait_for_condition only polls;
-    # wait_for_backend_condition calls backend.update() before every check and
-    # would forward the very message this waits for, letting it meet the filter
-    # while its generation is still current. The stale drop then depends on
-    # winning the race this construction exists to avoid — and the test would
-    # most often still pass, hiding the loss.
-    watermark = topic_high_watermark(data_topic)
-    wait_for_condition(
-        lambda: topic_high_watermark(data_topic) > watermark,
-        timeout=60.0,
-        poll_interval=1.0,
-    )
-
     final_job = commit()
     job_numbers.add(final_job.job_number)
     assert len(job_numbers) == _BURST_RECOMMITS + 2, "commits reused a job_number"
@@ -121,17 +104,6 @@ def test_rapid_recommit_admits_only_latest_generation(
     # backend runs the final generation.
     wait_for_backend_condition(
         backend, lambda: bool(stamps()), timeout=90.0, poll_interval=0.1
-    )
-
-    # The topic has a single partition and is therefore forwarded in offset
-    # order: the pre-flip message observed above met the generation filter
-    # before the final generation's first result did. Its count survives, the
-    # counter being reset only by a generation flip and none following — a
-    # superseded generation's heartbeat is recognized as such rather than
-    # adopted.
-    assert registry.stale_count(workflow_id) > 0, (
-        "no stale-generation drop was counted, although data published before "
-        "the final commit was still unforwarded when it happened"
     )
 
     polls: list[dict[DataKey, JobNumber]] = []

--- a/tests/integration/rapid_recommit_test.py
+++ b/tests/integration/rapid_recommit_test.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration test: rapid recommits admit only the latest generation's data."""
+
+from collections.abc import Iterable, Mapping
+
+import pytest
+
+from ess.livedata.config.streams import get_stream_mapping
+from ess.livedata.config.workflow_spec import DataKey, JobId, JobNumber, WorkflowId
+from ess.livedata.dashboard.data_service import DataServiceSubscriber
+from ess.livedata.dashboard.extractors import LatestValueExtractor, UpdateExtractor
+from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
+from tests.integration.conftest import IntegrationEnv
+from tests.integration.helpers import (
+    topic_high_watermark,
+    wait_for_backend_condition,
+    wait_for_condition,
+    wait_for_job_data,
+)
+
+#: Recommits issued back-to-back, with no backend update in between, so several
+#: generations are in flight at once while the producer keeps running.
+_BURST_RECOMMITS = 3
+
+#: Backend updates to keep watching after the final generation's data arrived,
+#: to catch a late-arriving stale message being admitted.
+_CONFIRM_POLLS = 25
+
+
+class _StampReader(DataServiceSubscriber[DataKey]):
+    """Throwaway view reading the generation stamps of a set of keys.
+
+    ``snapshot_with_stamps`` is the only public read of the provenance stamps
+    recorded at ingest, and it is subscriber-shaped. Registration is not needed
+    for a read: extraction of the latest value neither requires history
+    retention nor notifications.
+    """
+
+    def __init__(self, keys: Iterable[DataKey]) -> None:
+        self._extractors = {key: LatestValueExtractor() for key in keys}
+        super().__init__()
+
+    @property
+    def extractors(self) -> Mapping[DataKey, UpdateExtractor]:
+        return self._extractors
+
+    def on_updated(self, updated_keys: set[DataKey]) -> None:
+        pass
+
+
+@pytest.mark.integration
+@pytest.mark.services('monitor')
+def test_rapid_recommit_admits_only_latest_generation(
+    integration_env: IntegrationEnv,
+) -> None:
+    """
+    Recommitting repeatedly under a live producer admits only the last commit.
+
+    Each commit flips the dashboard's generation before its commands even reach
+    the backend, so results computed for the superseded generations keep
+    arriving afterwards. They must be dropped and counted, and the data that
+    does reach DataService must carry the final generation's job_number only.
+    """
+    backend = integration_env.backend
+    registry = backend.job_orchestrator.active_job_registry
+    data_topic = get_stream_mapping(
+        instrument=integration_env.instrument, dev=True
+    ).topics.livedata_data
+    workflow_id = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
+    source_name = 'monitor1'
+
+    def commit() -> JobId:
+        job_ids = backend.workflow_controller.start_workflow(
+            workflow_id=workflow_id,
+            source_names=[source_name],
+            config=MonitorDataParams(),
+        )
+        return job_ids[0]
+
+    def stamps() -> dict[DataKey, JobNumber]:
+        keys = [key for key in backend.data_service if key.workflow_id == workflow_id]
+        _data, stamps = backend.data_service.snapshot_with_stamps(_StampReader(keys))
+        return stamps
+
+    first_job = commit()
+    wait_for_job_data(backend, workflow_id, [first_job], timeout=30.0)
+
+    # Burst of recommits, each superseding a generation the backend may not
+    # even have started yet. No backend.update() in between: the messages the
+    # producer emits meanwhile stay unforwarded, so they meet the generation
+    # filter only after the burst.
+    job_numbers = {first_job.job_number}
+    for _ in range(_BURST_RECOMMITS):
+        job_numbers.add(commit().job_number)
+
+    # Wait for the producer to publish at least once more, reading the broker's
+    # watermark rather than consuming. This makes the assertion on stale drops
+    # deterministic instead of a race: the observed message predates the flip
+    # below, so whichever generation stamped it is superseded by the time the
+    # dashboard forwards it.
+    watermark = topic_high_watermark(data_topic)
+    wait_for_condition(
+        lambda: topic_high_watermark(data_topic) > watermark,
+        timeout=60.0,
+        poll_interval=1.0,
+    )
+
+    final_job = commit()
+    job_numbers.add(final_job.job_number)
+    assert len(job_numbers) == _BURST_RECOMMITS + 2, "commits reused a job_number"
+
+    # The final commit cleared the buffers, so data reappears only once the
+    # backend runs the final generation. Stale drops are counted against the
+    # same generation record and are not reset again: no further commit
+    # follows, and a heartbeat of a superseded generation is recognized as such
+    # instead of being adopted.
+    def settled() -> bool:
+        return bool(stamps()) and registry.stale_count(workflow_id) > 0
+
+    wait_for_backend_condition(backend, settled, timeout=90.0, poll_interval=0.1)
+
+    polls: list[dict[DataKey, JobNumber]] = []
+
+    def watched_enough() -> bool:
+        polls.append(stamps())
+        return len(polls) >= _CONFIRM_POLLS
+
+    wait_for_backend_condition(backend, watched_enough, timeout=60.0, poll_interval=0.2)
+
+    admitted = {stamp for poll in polls for stamp in poll.values()}
+    assert admitted == {final_job.job_number}, (
+        f"data from superseded generations reached DataService: "
+        f"{admitted - {final_job.job_number}}"
+    )
+    assert registry.stale_count(workflow_id) > 0, (
+        "no stale-generation drop was counted, although data published before "
+        "the final commit was still unforwarded when it happened"
+    )

--- a/tests/integration/rapid_recommit_test.py
+++ b/tests/integration/rapid_recommit_test.py
@@ -99,6 +99,13 @@ def test_rapid_recommit_admits_only_latest_generation(
     # deterministic instead of a race: the observed message predates the flip
     # below, so whichever generation stamped it is superseded by the time the
     # dashboard forwards it.
+    #
+    # The helper choice is load-bearing. wait_for_condition only polls;
+    # wait_for_backend_condition calls backend.update() before every check and
+    # would forward the very message this waits for, letting it meet the filter
+    # while its generation is still current. The stale drop then depends on
+    # winning the race this construction exists to avoid — and the test would
+    # most often still pass, hiding the loss.
     watermark = topic_high_watermark(data_topic)
     wait_for_condition(
         lambda: topic_high_watermark(data_topic) > watermark,
@@ -111,14 +118,21 @@ def test_rapid_recommit_admits_only_latest_generation(
     assert len(job_numbers) == _BURST_RECOMMITS + 2, "commits reused a job_number"
 
     # The final commit cleared the buffers, so data reappears only once the
-    # backend runs the final generation. Stale drops are counted against the
-    # same generation record and are not reset again: no further commit
-    # follows, and a heartbeat of a superseded generation is recognized as such
-    # instead of being adopted.
-    def settled() -> bool:
-        return bool(stamps()) and registry.stale_count(workflow_id) > 0
+    # backend runs the final generation.
+    wait_for_backend_condition(
+        backend, lambda: bool(stamps()), timeout=90.0, poll_interval=0.1
+    )
 
-    wait_for_backend_condition(backend, settled, timeout=90.0, poll_interval=0.1)
+    # The topic has a single partition and is therefore forwarded in offset
+    # order: the pre-flip message observed above met the generation filter
+    # before the final generation's first result did. Its count survives, the
+    # counter being reset only by a generation flip and none following — a
+    # superseded generation's heartbeat is recognized as such rather than
+    # adopted.
+    assert registry.stale_count(workflow_id) > 0, (
+        "no stale-generation drop was counted, although data published before "
+        "the final commit was still unforwarded when it happened"
+    )
 
     polls: list[dict[DataKey, JobNumber]] = []
 
@@ -132,8 +146,4 @@ def test_rapid_recommit_admits_only_latest_generation(
     assert admitted == {final_job.job_number}, (
         f"data from superseded generations reached DataService: "
         f"{admitted - {final_job.job_number}}"
-    )
-    assert registry.stale_count(workflow_id) > 0, (
-        "no stale-generation drop was counted, although data published before "
-        "the final commit was still unforwarded when it happened"
     )


### PR DESCRIPTION
Covers the "Rapid recommit under a live producer" integration checkbox of #1116, with one deliberate reduction in scope explained below.

A commit flips the dashboard's generation and clears the workflow's buffers before its commands reach the backend, so results computed for a superseded generation can still arrive afterwards. The test recommits a running workflow several times back-to-back against a live producer and asserts that the data reaching `DataService` carries the final commit's `job_number` alone.

## Why drop counting is not asserted here

The checkbox also asks that stale-generation drops be counted. That half is not assertable at this layer, and the investigation is the more useful outcome of this PR.

Message forwarding is driven by a background thread pumping every 50 ms, independently of the explicit `update()` calls the integration wait helpers make. A message therefore cannot be held unforwarded until a chosen moment, which rules out making the assertion deterministic by controlling when forwarding happens.

The drops are also systematically absent in this scenario rather than merely hard to catch. A stop reaches the backend in roughly 100 ms while a monitor workflow publishes about once a second, so a flip usually finds nothing of the old generation in flight. A generation superseded before the backend ever starts it publishes nothing at all — which is precisely what a rapid burst produces. And every flip resets the counter, so only the final commit's window could ever be asserted. Two CI runs counted zero drops, matching `begin_generation`'s own independently logged tally.

Worth recording against #1116: the checkbox's wording assumes in-flight superseded results that this pipeline does not normally produce. Counting is covered deterministically by the `message_pump` unit test instead, which constructs the superseded result directly and now asserts the count rather than only the discard.

To head off a plausible-sounding wrong explanation: data admission consults `is_current`, a single-entry check, so the immediately preceding generation is dropped like any other. The two-entry window governs heartbeat adoption only, and is not what absorbs these messages.

## Production change

`ActiveJobRegistry.stale_count` is added as a public read of the drop counter, which previously had no read path outside its log line. That left the counting behaviour unassertable — the existing unit test could only check that recording a drop has no side effects. It is now covered directly.

## Test plan

- [x] Unit coverage for the accessor (per-workflow scoping, reset at generation flip, unobserved workflow) and for the drop being counted.
- [ ] Integration test passes against real Kafka.
