### PR TITLE
Poison-message liveness over real Kafka

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -6,7 +6,7 @@ Integration tests verify end-to-end behavior of ESSlivedata by running actual se
 
 - **`@pytest.mark.integration`**: Marks a test as an integration test
 - **`@pytest.mark.instrument('name')`**: Runs test with specified instrument (default: 'dummy')
-- **`@pytest.mark.services('name')`**: **Required** when using `integration_env` fixture. Valid values: `'monitor'`, `'detector'`, or `'reduction'` (specifies which services to run)
+- **`@pytest.mark.services('name')`**: **Required** when using `integration_env` fixture. Selects the `<name>_services` fixture. `'monitor'`, `'detector'` and `'reduction'` come from `conftest.py`; a test module can define its own group via `create_service_group()`
 
 ## Available Fixtures
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -85,10 +85,13 @@ def _get_instrument_and_log_level(request):
     return instrument, log_level_name
 
 
-def _create_service_group(
+def create_service_group(
     request, services_config: dict[str, tuple[str, dict]]
 ) -> Generator[ServiceGroup, None, None]:
     """Common service group creation and lifecycle management.
+
+    Public so that a test module can define its own ``<name>_services`` fixture
+    for a service combination the shared fixtures do not offer.
 
     Parameters
     ----------
@@ -242,7 +245,7 @@ def monitor_services(request) -> Generator[ServiceGroup, None, None]:
     :
         ServiceGroup containing fake_monitors and monitor_data
     """
-    yield from _create_service_group(
+    yield from create_service_group(
         request,
         {
             'fake_monitors': (
@@ -276,7 +279,7 @@ def detector_services(request) -> Generator[ServiceGroup, None, None]:
     :
         ServiceGroup containing fake_detectors and detector_data
     """
-    yield from _create_service_group(
+    yield from create_service_group(
         request,
         {
             'fake_detectors': ('ess.livedata.services.fake_detectors', {}),
@@ -307,7 +310,7 @@ def reduction_services(request) -> Generator[ServiceGroup, None, None]:
     :
         ServiceGroup containing all reduction pipeline services
     """
-    yield from _create_service_group(
+    yield from create_service_group(
         request,
         {
             'fake_detectors': ('ess.livedata.services.fake_detectors', {}),

--- a/tests/integration/poison_message_liveness_test.py
+++ b/tests/integration/poison_message_liveness_test.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Integration test for service liveness after malformed data on a real topic.
+
+``tests/services/hostile_input_liveness_test.py`` establishes the same
+invariant in-process, handing payloads straight to the service loop. What it
+cannot cover is everything between broker and loop: a real consumer, schema
+routing off a topic shared by many sources, and a service that takes its whole
+process down if containment fails.
+
+Liveness here is proven by ordering, not by timing. The fake producer is
+restricted to ``monitor1``, which leaves ``monitor2`` -- a configured monitor
+source of the dummy instrument -- with no producer other than this test. Poison
+and probe messages are published to the same single-partition topic in that
+order, so a workflow result for ``monitor2`` can only exist if the service
+consumed past the poison. Observing continued output for ``monitor1`` instead
+would prove nothing: it cannot tell "survived the poison" from "has not reached
+the poison yet".
+
+Only the malformed family of the corpus is injected. The well-formed-but-insane
+timestamps are a batcher concern, covered in-process where the clock can be
+controlled; over real Kafka they would only add wall-clock-dependent silence
+windows to wait out.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Generator
+
+import pytest
+from confluent_kafka import Producer
+
+from ess.livedata.config import config_names
+from ess.livedata.config.config_loader import load_config
+from ess.livedata.config.streams import stream_kind_to_topic
+from ess.livedata.config.workflow_spec import DataKey, WorkflowId
+from ess.livedata.core.message import StreamKind
+from ess.livedata.workflows.monitor_workflow_specs import MonitorDataParams
+from tests.helpers import hostile_wire
+from tests.integration.conftest import IntegrationEnv, create_service_group
+from tests.integration.helpers import wait_for_backend_condition, wait_for_job_data
+from tests.integration.service_process import ServiceGroup
+
+WORKFLOW_ID = WorkflowId(instrument='dummy', name='monitor_histogram', version=1)
+MONITOR_TOPIC = stream_kind_to_topic('dummy', StreamKind.MONITOR_EVENTS)
+
+#: Source the fake producer keeps feeding, so the poison arrives mid-stream.
+LIVE_SOURCE = 'monitor1'
+#: Source only this test produces for, carrying the proof of progress.
+PROBE_SOURCE = 'monitor2'
+
+
+@pytest.fixture
+def probe_monitor_services(request) -> Generator[ServiceGroup, None, None]:
+    """Monitor services whose fake producer is restricted to ``monitor1``.
+
+    ``monitor2`` remains a configured source of the workflow, but nothing
+    produces for it, which reserves it as this test's private channel.
+    """
+    yield from create_service_group(
+        request,
+        {
+            'fake_monitors': (
+                'ess.livedata.services.fake_monitors',
+                {'mode': 'ev44', 'num_monitors': 1},
+            ),
+            'monitor_data': (
+                'ess.livedata.services.monitor_data',
+                {
+                    'dev': True,
+                    'readiness_messages': ['Service started', 'kafka_consumer_ready'],
+                },
+            ),
+        },
+    )
+
+
+def _probe_outputs(backend) -> list[DataKey]:
+    """Data keys the dashboard holds for the probe source."""
+    return [
+        key
+        for key in backend.data_service
+        if key.workflow_id == WORKFLOW_ID and key.source_name == PROBE_SOURCE
+    ]
+
+
+def _publish_probe(producer: Producer) -> None:
+    """Publish one well-formed event message for the probe source."""
+    producer.produce(
+        MONITOR_TOPIC,
+        value=hostile_wire.ev44_events(PROBE_SOURCE, reference_time_ns=time.time_ns()),
+    )
+    producer.flush(timeout=10.0)
+
+
+@pytest.mark.integration
+@pytest.mark.services('probe_monitor')
+def test_malformed_payloads_do_not_stall_service(
+    integration_env: IntegrationEnv,
+) -> None:
+    """Malformed payloads on the input topic do not stop a running pipeline."""
+    backend = integration_env.backend
+    job_ids = backend.workflow_controller.start_workflow(
+        workflow_id=WORKFLOW_ID,
+        source_names=[LIVE_SOURCE, PROBE_SOURCE],
+        config=MonitorDataParams(),
+    )
+    jobs = {job_id.source_name: job_id for job_id in job_ids}
+    wait_for_job_data(backend, WORKFLOW_ID, [jobs[LIVE_SOURCE]], timeout=30.0)
+    # Precondition of the proof below: the probe source is silent until we
+    # produce for it ourselves.
+    assert not _probe_outputs(backend)
+
+    producer = Producer(load_config(namespace=config_names.kafka, env='dev'))
+    for payload in hostile_wire.malformed_corpus(LIVE_SOURCE).values():
+        producer.produce(MONITOR_TOPIC, value=payload)
+    # Flush before the first probe: only delivered messages have an offset, and
+    # the proof rests on every probe sitting behind the poison in the partition.
+    producer.flush(timeout=30.0)
+
+    def probe_output_arrived() -> bool:
+        """Keep the probe source fed until its first result comes back."""
+        _publish_probe(producer)
+        return bool(_probe_outputs(backend))
+
+    wait_for_backend_condition(
+        backend, probe_output_arrived, timeout=60.0, poll_interval=1.0
+    )
+    assert integration_env.services['monitor_data'].is_running()

--- a/tests/integration/poison_message_liveness_test.py
+++ b/tests/integration/poison_message_liveness_test.py
@@ -119,12 +119,19 @@ def test_malformed_payloads_do_not_stall_service(
     # the proof rests on every probe sitting behind the poison in the partition.
     producer.flush(timeout=30.0)
 
-    def probe_output_arrived() -> bool:
-        """Keep the probe source fed until its first result comes back."""
+    def feed_probe_and_check_for_output() -> bool:
+        """Publish one probe message, then report whether a result came back.
+
+        The probe source is fed on every poll rather than in one burst up
+        front: a batcher completes a stream's slot on the *next* message of
+        that stream, so a burst can leave its own tail unclosed until some
+        later probe message arrives. A steady feed keeps that from being
+        mistaken for a stalled service.
+        """
         _publish_probe(producer)
         return bool(_probe_outputs(backend))
 
     wait_for_backend_condition(
-        backend, probe_output_arrived, timeout=60.0, poll_interval=1.0
+        backend, feed_probe_and_check_for_output, timeout=60.0, poll_interval=1.0
     )
     assert integration_env.services['monitor_data'].is_running()


### PR DESCRIPTION
Adds the end-to-end poison-message liveness test from #1116 (third integration checkbox: "publish a malformed `ev44` into the detector/monitor topic mid-job; the service keeps processing subsequent good data").

The claim that a malformed payload is contained per-message is currently tested at the adapter level and at the service level in-process, where payloads are handed straight to the service loop. Over real Kafka the path also contains a real consumer, schema routing off a topic shared by many sources, and process-level containment — none of which the in-process harness can exercise.

Liveness is asserted by ordering rather than by timing. The fake producer is restricted to `monitor1`, which leaves `monitor2` — a configured monitor source of the dummy instrument — with no producer other than the test. Poison and probe messages reach the same single-partition topic in that order, so a workflow result for `monitor2` can only exist if the service consumed past the poison. Watching `monitor1` keep producing instead would not distinguish "survived the poison" from "has not reached the poison yet", which is the failure mode that makes this kind of test rot into a vacuous pass.

Injected are the malformed entries of the shared corpus in `tests/helpers/hostile_wire.py` (garbage bytes, empty payload, truncated `ev44`, `ev44` without event vectors, wrong schema on the monitor topic, unmapped source name). The well-formed-but-insane timestamps stay out: they are a batcher concern, covered in-process where the clock is controllable, and over real Kafka they would only add wall-clock-dependent silence windows to wait out.

The service combination needed here (fake producer restricted to one monitor) does not exist among the shared fixtures, so the group-creation helper in the integration `conftest.py` is now public and the `services` marker's extension point is documented.

## Test plan

- [ ] `tox -e integration` against a local Kafka
