### PR TITLE
Re-latch a job start time contradicted by its own data

### DIFF
--- a/src/ess/livedata/core/job.py
+++ b/src/ess/livedata/core/job.py
@@ -9,11 +9,14 @@ from enum import StrEnum, auto
 from typing import Any, Protocol, runtime_checkable
 
 import scipp as sc
+import structlog
 
 from ess.livedata.workflows.workflow_factory import Workflow
 
 from ..config.workflow_spec import JobId, ResultKey, WorkflowId
 from .timestamp import Timestamp
+
+logger = structlog.get_logger(__name__)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -377,6 +380,22 @@ class Job:
             )
             if data.is_active():
                 if self._start_time is None:
+                    self._start_time = data.start_time
+                elif data.end_time < self._start_time:
+                    # A job cannot begin after its accumulation ends, so the
+                    # latched start is provably wrong: it came from a batch
+                    # anchored on a timestamp outside this stream's timeline
+                    # (plausible_anchor has nothing to weigh a lone message
+                    # against). The start is sticky, so without this it would
+                    # pin that value -- and an inconsistent time pair on every
+                    # result -- for the job's lifetime.
+                    logger.warning(
+                        'job_start_time_relatched',
+                        job_id=str(self._job_id),
+                        previous_start_time=str(self._start_time),
+                        start_time=str(data.start_time),
+                        end_time=str(data.end_time),
+                    )
                     self._start_time = data.start_time
                 self._end_time = data.end_time
             return JobReply(job_id=self._job_id)

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -238,6 +238,57 @@ class TestJob:
         assert sample_job.start_time == Timestamp.from_ns(100)  # Should not change
         assert sample_job.end_time == Timestamp.from_ns(250)  # Should update
 
+    def test_start_time_relatches_when_data_ends_before_it(self, sample_job):
+        """A start time later than the newest data is contradicted by the data.
+
+        A batch built from a single far-future message anchors on that message,
+        so the job's first start time can land outside its stream's timeline.
+        Keeping it would leave every later result with start_time > end_time.
+        """
+        poisoned = JobData(
+            start_time=Timestamp.from_ns(10**18),
+            end_time=Timestamp.from_ns(10**18),
+            primary_data={"test_source": sc.scalar(10.0)},
+            aux_data={},
+        )
+        real = JobData(
+            start_time=Timestamp.from_ns(100),
+            end_time=Timestamp.from_ns(200),
+            primary_data={"test_source": sc.scalar(20.0)},
+            aux_data={},
+        )
+
+        sample_job.add(poisoned)
+        assert sample_job.start_time == Timestamp.from_ns(10**18)
+
+        sample_job.add(real)
+        assert sample_job.start_time == Timestamp.from_ns(100)
+        assert sample_job.end_time == Timestamp.from_ns(200)
+
+    def test_start_time_survives_end_time_moving_backwards_within_the_job(
+        self, sample_job
+    ):
+        """Only a contradiction re-latches: the batchers legitimately move
+        ``end_time`` backwards when recovering a misplaced window, and the job
+        start must survive that."""
+        first = JobData(
+            start_time=Timestamp.from_ns(100),
+            end_time=Timestamp.from_ns(500),
+            primary_data={"test_source": sc.scalar(10.0)},
+            aux_data={},
+        )
+        rewound = JobData(
+            start_time=Timestamp.from_ns(300),
+            end_time=Timestamp.from_ns(400),
+            primary_data={"test_source": sc.scalar(20.0)},
+            aux_data={},
+        )
+
+        sample_job.add(first)
+        sample_job.add(rewound)
+        assert sample_job.start_time == Timestamp.from_ns(100)
+        assert sample_job.end_time == Timestamp.from_ns(400)
+
     def test_add_data_processes_all_provided_data(self, sample_job, fake_processor):
         """Test that add() processes all provided data."""
         data = JobData(

--- a/tests/kafka/adapter_robustness_test.py
+++ b/tests/kafka/adapter_robustness_test.py
@@ -158,9 +158,12 @@ def _far_future_cases() -> list[tuple[str, KafkaAdapter, bytes]]:
 )
 @pytest.mark.xfail(
     strict=True,
-    reason='#1038 finding 1 / #1047: data-derived timestamps cross the '
-    'adapter boundary unvalidated; a single far-future value wedges the '
-    'batcher service-wide',
+    reason='#1038 finding 1: data-derived timestamps cross the adapter '
+    'boundary unvalidated, so the boundary sees no evidence of a producer '
+    'whose clock is wrong. It no longer wedges the batchers (#1122 bounds '
+    'window placement and adds a liveness backstop); what the boundary is '
+    'still wanted for is per-source clock-offset detection, tracked by '
+    '#1133.',
 )
 def test_far_future_data_timestamp_does_not_cross_adapter_boundary(
     adapter: KafkaAdapter, payload: bytes

--- a/tests/kafka/adapter_robustness_test.py
+++ b/tests/kafka/adapter_robustness_test.py
@@ -4,23 +4,21 @@
 
 Two invariants, driven by the corpus in ``tests/helpers/hostile_wire``:
 
-1. **Containment** (holds today, guarded here against regression): a payload
-   that cannot be adapted is dropped by ``AdaptingMessageSource`` without the
-   exception escaping and without affecting subsequent messages.
-2. **Timestamp sanity** (does not hold today — strict xfail): data-derived
-   timestamps should be bounded against the wall clock before crossing the
-   adapter boundary, because the batcher uses them as its only clock and a
-   single far-future value wedges the whole service (#1038 finding 1). These
-   tests are the acceptance criterion for the boundary-validation layer
-   proposed in #1047: when it lands, the xfails flip to XPASS (strict, so
-   pytest will insist the markers are removed). Any resolution — dropping,
-   clamping, or falling back to the Kafka broker timestamp — satisfies the
-   assertion as written.
+1. **Containment**: a payload that cannot be adapted is dropped by
+   ``AdaptingMessageSource`` without the exception escaping and without
+   affecting subsequent messages.
+2. **Verbatim timestamps**: a data-derived timestamp crosses the boundary
+   unmodified, however insane it looks. It is the producer's claim about when
+   the data was taken, and the lag reporter judges the producer by subtracting
+   it from the broker's create time; clamping or dropping it here would erase
+   the only evidence that a device's clock is wrong (#1133). Consumers that
+   cannot use an insane time defend themselves instead: the batchers bound
+   window placement, and a job re-latches a start time its own data
+   contradicts.
 """
 
 from __future__ import annotations
 
-import time
 from collections.abc import Sequence
 
 import pytest
@@ -44,10 +42,6 @@ from tests.helpers import hostile_wire
 TOPIC = 'dummy_beam_monitor'
 SOURCE = 'monitor1'
 GOOD_TIME_NS = hostile_wire.REALISTIC_EPOCH_NS
-
-# Data-derived timestamps further than this ahead of the wall clock have no
-# legitimate producer; they must not cross the adapter boundary unmodified.
-FUTURE_TOLERANCE_NS = 24 * 3600 * 1_000_000_000
 
 
 class ListSource:
@@ -156,24 +150,21 @@ def _far_future_cases() -> list[tuple[str, KafkaAdapter, bytes]]:
     ('adapter', 'payload'),
     [pytest.param(a, p, id=name) for name, a, p in _far_future_cases()],
 )
-@pytest.mark.xfail(
-    strict=True,
-    reason='#1038 finding 1: data-derived timestamps cross the adapter '
-    'boundary unvalidated, so the boundary sees no evidence of a producer '
-    'whose clock is wrong. It no longer wedges the batchers (#1122 bounds '
-    'window placement and adds a liveness backstop); what the boundary is '
-    'still wanted for is per-source clock-offset detection, tracked by '
-    '#1133.',
-)
-def test_far_future_data_timestamp_does_not_cross_adapter_boundary(
+def test_far_future_data_timestamp_crosses_adapter_boundary_verbatim(
     adapter: KafkaAdapter, payload: bytes
 ) -> None:
+    """A timestamp no producer can legitimately claim is still passed on as-is.
+
+    The lag reporter measures a producer by the distance between this value
+    and the broker's create time, so bounding it here would report a device
+    with a badly wrong clock as perfectly punctual (#1133).
+    """
     source = AdaptingMessageSource(
         source=ListSource([_kafka_message(payload)]), adapter=adapter
     )
-    bound = time.time_ns() + FUTURE_TOLERANCE_NS
-    for message in source.get_messages():
-        assert message.timestamp.to_ns() <= bound
+    assert [m.timestamp.to_ns() for m in source.get_messages()] == [
+        hostile_wire.FAR_FUTURE_NS
+    ]
 
 
 def test_da00_non_int64_reference_time_falls_back_to_timestamp_ns() -> None:

--- a/tests/services/hostile_input_liveness_test.py
+++ b/tests/services/hostile_input_liveness_test.py
@@ -295,3 +295,49 @@ def test_far_future_timestamp_in_first_batch_does_not_stall_service(
     harness.publish_good()
     harness.app.step()
     assert_service_live(harness, cycles=60)
+
+
+@pytest.mark.parametrize(
+    'harness',
+    [
+        pytest.param(
+            _simple_inner,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason='#1038 finding 1 / #1047: the simple batcher wedges on '
+                'this input (see the xfail above), so no later batch ever '
+                'reaches the job and nothing can contradict the poisoned start '
+                'time. Recovering the times requires recovering delivery first.',
+            ),
+        ),
+        pytest.param(_rate_aware_inner),
+    ],
+    indirect=True,
+    ids=['simple', 'rate_aware'],
+)
+def test_far_future_timestamp_does_not_permanently_poison_result_times(
+    harness: MonitorServiceHarness,
+) -> None:
+    """Liveness is not enough: the results must come back to the real timeline.
+
+    A batch built from a lone far-future message anchors on it, so the job's
+    first result legitimately carries that time. If the job kept it as its
+    start time, every later result would report ``start_time > end_time`` for
+    the life of the job -- silently disabling rate normalization in the
+    dashboard and outranking every newer job in adoption. Results are stamped
+    with the job's start time, so the published timestamps show whether it
+    recovered.
+    """
+    harness.publish_payload(
+        hostile_wire.ev44_events(SOURCE, reference_time_ns=hostile_wire.FAR_FUTURE_NS)
+    )
+    harness.app.step()
+    harness.run_good_cycles(40)
+
+    stamps = [
+        m.timestamp.to_ns()
+        for m in harness.app.sink.messages
+        if m.stream.kind == StreamKind.LIVEDATA_DATA
+    ]
+    assert stamps, 'no results published'
+    assert stamps[-1] < hostile_wire.FAR_FUTURE_NS


### PR DESCRIPTION
## Why

`Job._start_time` is sticky by design: it records when the job began accumulating and is never lowered. That makes it a permanent amplifier for a transient bad timestamp. A batch built from a single far-future message anchors on that message (`plausible_anchor` has nothing to weigh a lone timestamp against), so a job whose first active batch is such a batch keeps that start time for its lifetime.

Every later result then carries `start_time > end_time`, with two consequences that are silent in operation: the dashboard's rate normalization treats a non-positive duration as "cannot normalize" and returns raw counts instead of counts/s with no warning, and job adoption ranks record-less observed jobs by start time, so the poisoned job outranks every legitimately newer one.

## What changed

A start time later than the newest accumulated data is contradicted by the data itself — a job cannot begin after its accumulation ends. That is sufficient evidence to correct the latch in band: no wall clock, no plausibility bound, no new layer. The job re-latches on the current batch and logs it.

The condition is conservative on purpose. Batch end times legitimately move backwards within a job whenever a batcher recovers a misplaced window, but they do not drop below the job's own start unless that start is wrong.

Bad timestamps still produce wrong times on the batches that carry them. What changes is that the damage no longer outlives them.

## Relation to #1059

#1059 attacked the same class of failure from the other end, by clamping far-future data-derived timestamps at the Kafka adapter boundary. It was written against an earlier revision of #1122; re-examined against `main` now that #1122 has landed with a wall-clock liveness backstop and the rate-aware batcher as the default, most of its motivation is gone:

- Liveness no longer depends on it. The backstop bounds a poisoned window at roughly ten batch lengths and costs one stall per poison message; the remaining hole is specific to `SimpleMessageBatcher`, which is now opt-in.
- The data-clock damage it was sized against is currently unreachable. `_fire_pending_resets` only ever sees an empty list, because `with_run_control_route` is disabled for #795, and no `JobSchedule` carrying an `end_time` is constructed anywhere in `src/`.
- Clamping in the dashboard-side adapters cannot do anything: `MessagePump` forwards only `stream` and `value` and discards the message timestamp.

What remained live was this latch, which is in-band and needs no arrival-time evidence. #1059 is closed in favour of it. The parts of #1059 that stand on their own merits are separable and unaffected: per-source clock-offset telemetry belongs with #1133 (and should extend the existing lag reporting rather than add a parallel counter), and the ev44 absent-event-vector handling is #1124.

Note this does not address `ToNXlog._last_time`, which latches on the *payload* timestamp and rejects every later sample for the process lifetime. That is a separate defect on the payload side and no envelope-level fix reaches it.

Also here: the six adapter-boundary far-future cases were strict xfails asserting that such a timestamp must be clamped, dropped or replaced before crossing the boundary — #1059's acceptance criterion. That remedy is now rejected rather than merely unimplemented, and a strict xfail encoding a rejected design is a standing invitation to implement it. `_record_lag` measures a producer by the gap between the payload's claimed time and the broker's create time, so a clamp upstream of it would report a device with a badly wrong clock as perfectly punctual — erasing exactly the evidence #1133 needs. The assertion is inverted to pin the pass-through instead, keeping all six timestamp entry points covered.

## Test plan

Unit tests for both directions of the re-latch condition, and a service-level test on the hostile-input harness asserting that published result timestamps return to the real timeline after a lone far-future message. `SimpleMessageBatcher` wedges outright on that input, so no later batch can contradict the poisoned start; that case is pinned as a strict xfail beside the existing one for the same hole.

