### PR TITLE
Loop ROI requests back into the fake backend

### DIFF
--- a/src/ess/livedata/dashboard/fake_backend.py
+++ b/src/ess/livedata/dashboard/fake_backend.py
@@ -13,6 +13,10 @@ Result data is synthesized from each workflow's output templates (the
 the dashboard selects plotters from these same templates, generated data is
 guaranteed to match what the plotter expects, so plots render correctly.
 
+ROI requests the dashboard publishes are looped back in the same way: the
+backend stores the latest request per job and geometry, echoes it as the
+geometry readback, and synthesizes one spectrum per drawn ROI.
+
 The whole flow is driven by the normal UI: start a workflow and plots come to
 life. No fixtures, no external injection, no Kafka.
 """
@@ -31,6 +35,7 @@ import structlog
 
 from ..config.acknowledgement import AcknowledgementResponse, CommandAcknowledgement
 from ..config.instruments import get_config
+from ..config.roi_names import get_roi_mapper
 from ..config.workflow_spec import (
     JobId,
     ResultKey,
@@ -48,7 +53,7 @@ from ..core.message import (
     StreamKind,
 )
 from ..core.timestamp import Timestamp
-from .transport import DashboardResources, NullMessageSink, Transport
+from .transport import DashboardResources, Transport
 
 logger = structlog.get_logger(__name__)
 
@@ -56,6 +61,8 @@ logger = structlog.get_logger(__name__)
 _DEFAULT_DIM_SIZE = 64
 # Wall-clock interval between synthesized data updates per job.
 _UPDATE_PERIOD_SECONDS = 1.0
+# Output fields echoing ROI geometry; named after the ROI stream readback keys.
+_ROI_READBACK_KEYS = frozenset(get_roi_mapper().readback_keys)
 
 
 def _expand_coord(coord: sc.Variable, dim: str, size: int) -> sc.Variable:
@@ -151,6 +158,71 @@ def expand_template(
     return sc.DataArray(data=data, coords=coords)
 
 
+def roi_variants(rois: Mapping[str, sc.DataArray]) -> dict[int, float]:
+    """Map each drawn ROI's index to a stable phase in ``[0, 1)``.
+
+    The phase is derived from the ROI's own vertex coordinates, so moving or
+    resizing an ROI changes its synthesized spectrum while an untouched ROI
+    keeps its curve. Indices are unique across geometries (each geometry owns a
+    disjoint index range) and sorted, giving a stable row order.
+
+    Parameters
+    ----------
+    rois:
+        Concatenated ROI request per geometry readback key, as published by the
+        dashboard.
+    """
+    variants: dict[int, float] = {}
+    for geometry in rois.values():
+        indices = geometry.coords['roi_index'].values
+        for roi_index in np.unique(indices):
+            vertices = np.concatenate(
+                [
+                    geometry.coords[dim].values[indices == roi_index]
+                    for dim in ('x', 'y')
+                ]
+            )
+            variants[int(roi_index)] = (zlib.crc32(vertices.tobytes()) % 1000) / 1000.0
+    return dict(sorted(variants.items()))
+
+
+def expand_roi_spectra(
+    template: sc.DataArray,
+    variants: Mapping[int, float],
+    update: int,
+    timestamp_ns: int,
+) -> sc.DataArray:
+    """Build one synthetic spectrum per currently drawn ROI.
+
+    The length of the ``roi`` dimension follows the ROI set the dashboard
+    published, down to zero rows while no ROI is drawn. This mirrors the real
+    backend, which computes ROI spectra from the start and yields an empty
+    result until an ROI request arrives.
+
+    Parameters
+    ----------
+    template:
+        Empty ROI spectra template, with dims ``(roi, <spectral>)``.
+    variants:
+        Phase per ROI index, see :func:`roi_variants`.
+    update:
+        Monotonic update counter; varies the data so plots appear live.
+    timestamp_ns:
+        Wall-clock time of this update, used for the ``time`` coordinate.
+    """
+    spectral_size = template.sizes[template.dims[-1]] or _DEFAULT_DIM_SIZE
+    spectra = [
+        _synthesize_values([spectral_size], update, variant)
+        for variant in variants.values()
+    ]
+    values = np.stack(spectra) if spectra else np.zeros((0, spectral_size))
+    coords = {'roi': sc.array(dims=['roi'], values=list(variants), dtype='int32')}
+    if (time := template.coords.get('time')) is not None and time.ndim == 0:
+        coords['time'] = sc.scalar(timestamp_ns, unit=time.unit, dtype=time.dtype)
+    data = sc.array(dims=template.dims, values=values, unit=template.unit)
+    return sc.DataArray(data=data, coords=coords)
+
+
 class _Job:
     """A running fake job and its synthesized output state."""
 
@@ -161,6 +233,7 @@ class _Job:
         self.next_emit = 0.0  # monotonic deadline; 0 => emit immediately
         self.variant = source_variant(config.job_id.source_name)
         self.start_time = Timestamp.now()
+        self.rois: dict[str, sc.DataArray] = {}
 
     def output_templates(self) -> Mapping[str, sc.DataArray]:
         """Templates for every output field that declares one."""
@@ -200,6 +273,26 @@ class FakeBackend:
         self._jobs[config.job_id] = _Job(config=config, spec=spec)
         self._ack(config.message_id, config.job_id.source_name)
         logger.info("fake_backend_started", job_id=str(config.job_id))
+
+    def set_roi(self, stream_name: str, rois: sc.DataArray) -> None:
+        """Store an ROI request, replacing the previous one for its geometry.
+
+        Latest-value semantics match the backend, which accumulates ROI streams
+        with a ``LatestValueAccumulator``. Requests for jobs that are not
+        running are dropped, as they would be by a backend that has no such job.
+
+        Parameters
+        ----------
+        stream_name:
+            ROI stream name, ``f"{job_id}/{readback_key}"``.
+        rois:
+            Concatenated ROI geometries for that readback key.
+        """
+        job_key, _, readback_key = stream_name.rpartition('/')
+        with self._lock:
+            for job_id, job in self._jobs.items():
+                if str(job_id) == job_key:
+                    job.rois[readback_key] = rois
 
     def _control_job(self, command: JobCommand) -> None:
         if command.action is JobAction.stop and command.job_id is not None:
@@ -241,6 +334,7 @@ class FakeBackend:
 
     def _emit_data(self, job: _Job) -> list[Message]:
         timestamp_ns = time.time_ns()
+        variants = roi_variants(job.rois)
         messages = []
         for output_name, template in job.output_templates().items():
             key = ResultKey(
@@ -249,7 +343,14 @@ class FakeBackend:
                 output_name=output_name,
             )
             stream = StreamId(kind=StreamKind.LIVEDATA_DATA, name=key.model_dump_json())
-            value = expand_template(template, job.update, timestamp_ns, job.variant)
+            if output_name in _ROI_READBACK_KEYS:
+                # The backend echoes the request as readback; the template is
+                # its empty-request equivalent.
+                value = job.rois.get(output_name, template)
+            elif 'roi' in template.dims:
+                value = expand_roi_spectra(template, variants, job.update, timestamp_ns)
+            else:
+                value = expand_template(template, job.update, timestamp_ns, job.variant)
             messages.append(Message(stream=stream, value=value))
         job.update += 1
         return messages
@@ -276,6 +377,17 @@ class _FakeCommandSink:
             self._backend.submit(message.value)
 
 
+class _FakeROISink:
+    """Feeds dashboard ROI requests into the backend."""
+
+    def __init__(self, backend: FakeBackend) -> None:
+        self._backend = backend
+
+    def publish_messages(self, messages: list[Message[sc.DataArray]]) -> None:
+        for message in messages:
+            self._backend.set_roi(message.stream.name, message.value)
+
+
 class FakeBackendTransport(Transport[DashboardResources]):
     """Transport with an in-process fake backend instead of Kafka.
 
@@ -299,7 +411,7 @@ class FakeBackendTransport(Transport[DashboardResources]):
         return DashboardResources(
             message_source=_FakeMessageSource(self._backend),
             command_sink=_FakeCommandSink(self._backend),
-            roi_sink=NullMessageSink(),
+            roi_sink=_FakeROISink(self._backend),
         )
 
     def __exit__(

--- a/tests/dashboard/fake_backend_test.py
+++ b/tests/dashboard/fake_backend_test.py
@@ -1,15 +1,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import uuid
+from collections.abc import Iterator
 
 import pytest
 import scipp as sc
 from pydantic import Field
 
+from ess.livedata.config import instrument_registry
 from ess.livedata.config.acknowledgement import (
     AcknowledgementResponse,
     CommandAcknowledgement,
 )
+from ess.livedata.config.models import Interval, PolygonROI, RectangleROI
+from ess.livedata.config.roi_names import ROIGeometryType, get_roi_mapper
 from ess.livedata.config.workflow_spec import (
     REDUCTION,
     JobId,
@@ -26,7 +30,14 @@ from ess.livedata.core.message import (
     STATUS_STREAM_ID,
     StreamKind,
 )
-from ess.livedata.dashboard.fake_backend import FakeBackend, expand_template
+from ess.livedata.dashboard.command_service import CommandService
+from ess.livedata.dashboard.fake_backend import (
+    FakeBackend,
+    FakeBackendTransport,
+    expand_template,
+)
+from ess.livedata.dashboard.roi_publisher import ROIPublisher
+from ess.livedata.dashboard.transport import DashboardResources
 
 
 class Outputs1D(WorkflowOutputsBase):
@@ -270,6 +281,134 @@ class TestFakeBackend:
     def test_poll_is_empty_without_active_jobs(self) -> None:
         backend = FakeBackend({})
         assert backend.poll() == []
+
+
+_DETECTOR_SOURCE = 'panel_0'
+
+
+def _rectangle(x: float, y: float) -> RectangleROI:
+    return RectangleROI(
+        x=Interval(min=x, max=x + 10.0), y=Interval(min=y, max=y + 10.0)
+    )
+
+
+def _polygon(x: float) -> PolygonROI:
+    return PolygonROI(x=[x, x + 5.0, x], y=[0.0, 5.0, 10.0], x_unit=None, y_unit=None)
+
+
+class _DetectorSession:
+    """A started detector-view job, driven through the fake transport.
+
+    Uses the real :class:`CommandService` and :class:`ROIPublisher` so the ROIs
+    take the same route as those drawn in the UI.
+    """
+
+    def __init__(self, resources: DashboardResources) -> None:
+        self._source = resources.message_source
+        self.workflow_id = next(
+            workflow_id
+            for workflow_id in instrument_registry['dummy'].workflow_factory
+            if workflow_id.name == 'panel_0_xy'
+        )
+        job_id = JobId(source_name=_DETECTOR_SOURCE, job_number=uuid.uuid4())
+        self.publisher = ROIPublisher(sink=resources.roi_sink)
+        self.publisher.set_job_number_resolver(lambda _: job_id.job_number)
+        CommandService(sink=resources.command_sink).send(
+            WorkflowConfig.from_params(workflow_id=self.workflow_id, job_id=job_id)
+        )
+
+    def publish(self, rois: dict, geometry_type: ROIGeometryType = 'rectangle') -> None:
+        """Publish the full ROI set for one geometry, as the UI does."""
+        self.publisher.publish(
+            self.workflow_id,
+            _DETECTOR_SOURCE,
+            rois,
+            get_roi_mapper().geometry_for_type(geometry_type),
+        )
+
+    def results(self) -> dict[str, sc.DataArray]:
+        """Poll the backend, returning the freshest result per output name."""
+        return {
+            ResultKey.model_validate_json(m.stream.name).output_name: m.value
+            for m in self._source.get_messages()
+            if m.stream.kind is StreamKind.LIVEDATA_DATA
+        }
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> Iterator[_DetectorSession]:
+    # Zero update period makes every poll due, so each poll yields fresh results.
+    monkeypatch.setattr(
+        'ess.livedata.dashboard.fake_backend._UPDATE_PERIOD_SECONDS', 0.0
+    )
+    with FakeBackendTransport(instrument='dummy') as resources:
+        yield _DetectorSession(resources)
+
+
+class TestROILoopback:
+    def test_spectra_are_empty_until_an_roi_is_drawn(
+        self, session: _DetectorSession
+    ) -> None:
+        results = session.results()
+        spectra = results['roi_spectra_cumulative']
+        assert spectra.sizes['roi'] == 0
+        assert spectra.sizes['time_of_arrival'] == 64
+        assert len(results['roi_rectangle']) == 0
+
+    def test_roi_dim_follows_published_rois(self, session: _DetectorSession) -> None:
+        session.publish({0: _rectangle(0.0, 0.0), 1: _rectangle(20.0, 20.0)})
+        assert session.results()['roi_spectra_cumulative'].sizes['roi'] == 2
+
+        session.publish({0: _rectangle(0.0, 0.0)})
+        spectra = session.results()['roi_spectra_cumulative']
+        assert spectra.sizes['roi'] == 1
+        assert spectra.coords['roi'].values.tolist() == [0]
+
+        session.publish({})
+        assert session.results()['roi_spectra_cumulative'].sizes['roi'] == 0
+
+    def test_roi_coord_carries_published_indices(
+        self, session: _DetectorSession
+    ) -> None:
+        session.publish({1: _rectangle(0.0, 0.0), 3: _rectangle(20.0, 20.0)})
+        spectra = session.results()['roi_spectra_cumulative']
+        assert spectra.coords['roi'].values.tolist() == [1, 3]
+
+    def test_geometries_share_the_roi_dim(self, session: _DetectorSession) -> None:
+        session.publish({0: _rectangle(0.0, 0.0)})
+        session.publish({4: _polygon(0.0)}, geometry_type='polygon')
+        spectra = session.results()['roi_spectra_cumulative']
+        assert spectra.coords['roi'].values.tolist() == [0, 4]
+
+    def test_spectra_follow_roi_geometry(self, session: _DetectorSession) -> None:
+        # Comparing rows within one update isolates the ROI dependence from the
+        # update counter, which also varies the data.
+        session.publish({0: _rectangle(0.0, 0.0), 1: _rectangle(0.0, 0.0)})
+        spectra = session.results()['roi_spectra_cumulative']
+        assert sc.identical(spectra['roi', 0].data, spectra['roi', 1].data)
+
+        session.publish({0: _rectangle(0.0, 0.0), 1: _rectangle(20.0, 20.0)})
+        spectra = session.results()['roi_spectra_cumulative']
+        assert not sc.allclose(spectra['roi', 0].data, spectra['roi', 1].data)
+
+    def test_current_spectra_are_stamped_with_time(
+        self, session: _DetectorSession
+    ) -> None:
+        session.publish({0: _rectangle(0.0, 0.0)})
+        spectra = session.results()['roi_spectra_current']
+        assert spectra.sizes['roi'] == 1
+        assert spectra.coords['time'].ndim == 0
+
+    def test_readback_echoes_published_rois(self, session: _DetectorSession) -> None:
+        rois = {0: _rectangle(0.0, 0.0), 2: _rectangle(20.0, 20.0)}
+        session.publish(rois)
+        readback = session.results()['roi_rectangle']
+        assert RectangleROI.from_concatenated_data_array(readback) == rois
+
+    def test_rois_of_other_jobs_are_ignored(self, session: _DetectorSession) -> None:
+        session.publisher.set_job_number_resolver(lambda _: uuid.uuid4())
+        session.publish({0: _rectangle(0.0, 0.0)})
+        assert session.results()['roi_spectra_cumulative'].sizes['roi'] == 0
 
 
 @pytest.mark.parametrize('update', [0, 1, 7])


### PR DESCRIPTION
Implements the infrastructure enabler from #1116.

`FakeBackendTransport` wired its `roi_sink` to a null sink, so ROIs drawn in the UI were discarded. Nothing downstream could respond: `roi_spectra` outputs were synthesized by the generic template expansion, which treats the empty `roi` dimension as unsized and stretched it to a fixed 64 rows of data unrelated to any ROI the user had drawn. The geometry readbacks were worse off — the same expansion stretched their `bounds`/`vertex` dimension and dropped the coordinates the readback plotter requires, so the ROI overlay could not render at all. Both are the same bug, and both are fixed here: ROI requests now loop back into the fake backend, which stores the latest request per job and geometry, echoes it as the readback, and synthesizes one spectrum per drawn ROI whose values depend on that ROI's own coordinates.

The synthesized row count follows the published ROI set, down to zero rows while nothing is drawn. That matches production rather than special-casing it: ROI requests are context keys seeded to `None`, the providers tolerate `None`, and the real `roi_spectra` returns an empty result from the first batch onward. Detection of ROI-shaped outputs is structural rather than name-based, so it does not need a list of output names kept in sync.

Tests drive the real `ROIPublisher` through the real transport and command service rather than stubbing the path, covering the ROI dimension tracking additions, removals and clears, index preservation, rectangles and polygons sharing the dimension, geometry-dependent values, readback round-tripping, and requests addressed to a job that is not running.

No browser-level ROI test is included. Driving the box-edit tool would be the first canvas interaction in the suite, and it is not committable as non-flaky: there is no automation hook on the figure or toolbar, tool activation is client-side so there is nothing server-side to await, and pixel targets depend on axis ranges that autoscale can move mid-gesture. A deterministic widget-driven alternative exists — the ROI-request plotter publishes its initial set from a text parameter — but it needs an ROI layer added to the shared, drift-guarded dummy UI fixture, which is regression risk disproportionate to this change. The loopback is what unblocks that work either way.

## Test plan

- [x] Fast suite
- [x] Existing browser suite, to confirm the changed synthesis does not disturb rendering
