### PR TITLE
Guard grid-edit Save against a concurrently vanished grid

### DIFF
--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -48,6 +48,7 @@ import tempfile
 import time
 import urllib.request
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.error import URLError
 
@@ -204,6 +205,23 @@ def _wait_until_ready(url: str, log: Path, *, timeout_s: float = 60.0) -> None:
     raise TimeoutError(f"Dashboard at {url} not ready within {timeout_s}s.\n{tail}")
 
 
+@dataclass
+class FakeDashboard:
+    """A launched fake-backend dashboard: its URL plus its server log.
+
+    ``log`` is the path to the server's merged stdout/stderr (still being
+    appended to while the dashboard runs), for tests that need to assert on
+    server-side behavior a browser can't observe directly -- e.g. that an
+    action didn't raise an unhandled exception. Read only the tail written
+    after your action (``log.read_text()[offset:]``, with ``offset`` taken
+    from ``log.stat().st_size`` beforehand) so unrelated startup log lines
+    can't produce a false positive.
+    """
+
+    url: str
+    log: Path
+
+
 @contextmanager
 def _fake_dashboard(instrument: str, port: int):
     """Launch a Kafka-free fake-backend dashboard seeded from the fixture.
@@ -212,6 +230,7 @@ def _fake_dashboard(instrument: str, port: int):
     to its config dir), waits for readiness, and tears the server down on exit.
     The sidebar starts collapsed: it is static here (announcements are off), so
     an open drawer would only narrow the plots under test and their screenshots.
+    Yields a :class:`FakeDashboard`.
     """
     fixture = REPO_ROOT / "tests/dashboard/ui_config_fixtures" / instrument
     if not fixture.is_dir():
@@ -249,7 +268,7 @@ def _fake_dashboard(instrument: str, port: int):
             )
             try:
                 _wait_until_ready(f"http://localhost:{port}", log)
-                yield f"http://localhost:{port}"
+                yield FakeDashboard(url=f"http://localhost:{port}", log=log)
             finally:
                 proc.terminate()
                 try:
@@ -284,8 +303,8 @@ def main() -> None:
     @contextmanager
     def target_url():
         if args.launch:
-            with _fake_dashboard(args.instrument, args.port) as url:
-                yield url
+            with _fake_dashboard(args.instrument, args.port) as fake:
+                yield fake.url
         else:
             yield args.url
 

--- a/src/ess/livedata/dashboard/widgets/plot_grid_manager.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_manager.py
@@ -941,13 +941,26 @@ class PlotGridManager:
             self._update_preview()
 
     def _on_save_changes(self, event) -> None:
-        """Handle Save Changes button click in edit mode."""
+        """Handle Save Changes button click in edit mode.
+
+        The click is queued client-side before this session's next topology
+        poll, so it can arrive after another session already replaced or
+        removed this grid: ``_editing_grid_id`` is then stale (or, if our own
+        poll ran first, already ``None`` from :meth:`on_topology_changed`).
+        Re-check existence the same way that poll does before touching the
+        orchestrator, and drop the edit instead of saving over a grid that no
+        longer exists.
+        """
         grid_id = self._editing_grid_id
         cells_to_add = self._editing_cells or ()
         title = self._title_input.value
         nrows = self._nrows_input.value
         ncols = self._ncols_input.value
         self._exit_edit_mode()
+
+        if grid_id is None or self._orchestrator.peek_grid(grid_id) is None:
+            show_error('Cannot save changes: the grid was removed.')
+            return
 
         new_grid_id = self._orchestrator.replace_grid(
             grid_id, title=title, nrows=nrows, ncols=ncols

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -10,7 +10,9 @@ through the stable ``lt-*`` automation hooks:
 - a grid created in one session appears in others without stealing focus;
 - a cell title survives a no-op Save of the cell-properties modal;
 - disabling or removing a grid keeps the remaining tabs resolving and
-  updating.
+  updating;
+- two sessions racing to save edits on the same grid converge on one title,
+  without a server-side exception or a duplicated/lost tab.
 
 Each test launches its own dashboard on a dedicated port for isolation, since
 grid topology changes are process-global. Runs via ``pytest -m browser``
@@ -55,7 +57,7 @@ def _add_grid(dash: Dashboard, title: str) -> None:
 
 @pytest.mark.browser
 def test_session_reload_restores_tabs_and_live_updates():
-    with fake_dashboard("dummy", 5033) as url, Dashboard.connect(url) as dash:
+    with fake_dashboard("dummy", 5033) as fake, Dashboard.connect(fake.url) as dash:
         dash.goto_tab("Detectors")
         assert_updating(dash, "session before reload")
 
@@ -72,8 +74,8 @@ def test_session_reload_restores_tabs_and_live_updates():
 @pytest.mark.browser
 def test_grid_created_in_one_session_appears_in_other_without_stealing_focus():
     with (
-        fake_dashboard("dummy", 5034) as url,
-        Dashboard.connect_many(2, url) as (creator, observer),
+        fake_dashboard("dummy", 5034) as fake,
+        Dashboard.connect_many(2, fake.url) as (creator, observer),
     ):
         observer_tab = _active_tab(observer)
         creator.goto_tab("Manage Plots")
@@ -101,7 +103,7 @@ def test_cell_title_survives_noop_save_of_cell_properties_modal():
     # The per-cell hook (not DOM order) addresses the cell: a rebuilt cell --
     # e.g. after the rename below -- moves to the end of the document.
     pencil = ".lt-cell-r0c0.lt-tool-pencil"
-    with fake_dashboard("dummy", 5035) as url, Dashboard.connect(url) as dash:
+    with fake_dashboard("dummy", 5035) as fake, Dashboard.connect(fake.url) as dash:
         page = dash.page
         dash.goto_tab("Detectors")
 
@@ -131,7 +133,7 @@ def test_cell_title_survives_noop_save_of_cell_properties_modal():
 
 @pytest.mark.browser
 def test_remaining_tabs_keep_updating_after_disabling_and_removing_grids():
-    with fake_dashboard("dummy", 5036) as url, Dashboard.connect(url) as dash:
+    with fake_dashboard("dummy", 5036) as fake, Dashboard.connect(fake.url) as dash:
         # Arrange three grids ordered [Bravo, Charlie, Detectors]: two empty
         # grids ahead of the fixture's populated one, so disabling the first
         # and removing the middle both shift the Detectors tab position --
@@ -182,7 +184,7 @@ def test_multi_layer_cell_gear_picks_the_layer_to_configure():
     # gear and the entry it routes to are addressed per cell, since DOM order
     # across cells is not stable.
     gear = ".lt-cell-r2c0.lt-tool-settings"
-    with fake_dashboard("dummy", 5038) as url, Dashboard.connect(url) as dash:
+    with fake_dashboard("dummy", 5038) as fake, Dashboard.connect(fake.url) as dash:
         page = dash.page
         dash.goto_tab("Detectors")
 
@@ -204,3 +206,99 @@ def test_multi_layer_cell_gear_picks_the_layer_to_configure():
         chip = page.locator(".choices__list--multiple .choices__item").first
         chip.wait_for(state="visible", timeout=10000)
         assert chip.inner_text().startswith("monitor2")
+
+
+@pytest.mark.browser
+def test_concurrent_grid_property_edits_resolve_to_one_title_without_crash():
+    """Two sessions racing to save edits on the same grid's properties.
+
+    Grid edit is inline (a Manage Plots form switching into an edit state),
+    not a modal, despite the wording in
+    ``.claude/rules/dashboard-widgets.md``.
+
+    There is no true last-writer-wins conflict resolution here: each
+    session's Save Changes targets the grid it started editing, captured by
+    id when the edit form opened. Whichever save reaches the orchestrator
+    while that grid still exists commits; a save that arrives once the grid
+    is already gone (replaced by the other session) is dropped -- with an
+    error notification, not an unhandled exception (the bug this test
+    guards: it used to be an unhandled ``KeyError``). In a tight race,
+    which of the two saves actually lands first is not something this test
+    controls or asserts on -- only the invariants that must hold regardless:
+    exactly one of the two submitted titles survives, the losing session is
+    told its edit did not apply, no server-side exception is logged, and the
+    tab set stays intact and live.
+    """
+    pencil = ".lt-grid-detectors.lt-tool-pencil"
+    first_title = "First Session Title"
+    second_title = "Second Session Title"
+    with (
+        fake_dashboard("dummy", 5037) as fake,
+        Dashboard.connect_many(2, fake.url) as (first, second),
+    ):
+        for dash in (first, second):
+            dash.goto_tab("Manage Plots")
+
+        # Both sessions open the same grid's edit form and type a different
+        # title before either saves.
+        first.click(pencil)
+        first.page.locator(_GRID_TITLE_INPUT).fill(first_title)
+        first.page.keyboard.press("Enter")
+
+        second.click(pencil)
+        second.page.locator(_GRID_TITLE_INPUT).fill(second_title)
+        second.page.keyboard.press("Enter")
+
+        log_offset = fake.log.stat().st_size
+
+        # Fire both saves back-to-back, no wait in between, to race each
+        # click against the other session's own topology poll.
+        first.page.get_by_role("button", name="Save Changes", exact=True).click()
+        second.page.get_by_role("button", name="Save Changes", exact=True).click()
+
+        wait_until(
+            first,
+            lambda: (
+                first_title in first.tab_names() or second_title in first.tab_names()
+            ),
+            label="one of the two submitted titles to win the race",
+        )
+        winning_title, losing_title = (
+            (first_title, second_title)
+            if first_title in first.tab_names()
+            else (second_title, first_title)
+        )
+        winner, loser = (
+            (first, second) if winning_title == first_title else (second, first)
+        )
+
+        for dash in (first, second):
+            wait_until(
+                dash,
+                lambda dash=dash: winning_title in dash.tab_names(),
+                label="both sessions to converge on the same grid title",
+            )
+            tabs = dash.tab_names()
+            assert tabs.count(winning_title) == 1, tabs
+            assert losing_title not in tabs
+            assert "Detectors" not in tabs
+
+        # The losing session is told its edit did not apply -- a dropped
+        # save is a deliberate, user-visible outcome, not silent data loss.
+        wait_until(
+            loser,
+            lambda: loser.page.locator('.notyf__message').count() > 0,
+            label="the losing session's error notification",
+        )
+        assert (
+            'grid was removed'
+            in loser.page.locator('.notyf__message').first.inner_text()
+        )
+
+        new_log = fake.log.read_text()[log_offset:]
+        assert "Traceback" not in new_log, (
+            f"server logged an exception while saving concurrent grid edits:\n{new_log}"
+        )
+
+        winner.goto_tab(winning_title)
+        assert_updating(winner, "surviving grid after concurrent edit race")

--- a/tests/dashboard/multisession_smoke_test.py
+++ b/tests/dashboard/multisession_smoke_test.py
@@ -38,8 +38,8 @@ from tests.helpers.browser import (
 @pytest.mark.browser
 def test_two_sessions_see_plots_and_keep_receiving_updates():
     with (
-        fake_dashboard("dummy", 5032) as url,
-        Dashboard.connect_many(2, url) as (
+        fake_dashboard("dummy", 5032) as fake,
+        Dashboard.connect_many(2, fake.url) as (
             first,
             second,
         ),

--- a/tests/dashboard/widgets/plot_grid_manager_test.py
+++ b/tests/dashboard/widgets/plot_grid_manager_test.py
@@ -975,6 +975,46 @@ class TestEditMode:
         assert grid_manager._editing_grid_id is None
         assert grid_manager._editing_cells is None
 
+    def test_save_changes_on_grid_removed_by_another_session_is_a_noop(
+        self, grid_manager, plot_orchestrator, workflow_id
+    ):
+        """Saving over a grid already removed elsewhere does not raise.
+
+        The removal landed in the orchestrator, but this session's topology
+        poll (``on_topology_changed``) has not run yet, so ``_editing_grid_id``
+        is still the stale id when Save Changes fires.
+        """
+        grid_id = self._add_grid_with_cell(plot_orchestrator, workflow_id)
+        grid_manager._enter_edit_mode(grid_id)
+
+        plot_orchestrator.remove_grid(grid_id)
+
+        grid_manager._on_save_changes(None)
+
+        assert grid_manager._editing_grid_id is None
+        assert plot_orchestrator.get_all_grids() == {}
+
+    def test_save_changes_after_own_poll_cleared_editing_state_is_a_noop(
+        self, grid_manager, plot_orchestrator, workflow_id
+    ):
+        """Saving with an already-cleared edit state does not raise.
+
+        Reproduces the two-session race: this session's own topology poll
+        notices the grid is gone and clears ``_editing_grid_id`` to ``None``
+        first, but a Save Changes click already queued client-side still
+        arrives and invokes the handler with nothing left to save.
+        """
+        grid_id = self._add_grid_with_cell(plot_orchestrator, workflow_id)
+        grid_manager._enter_edit_mode(grid_id)
+
+        plot_orchestrator.remove_grid(grid_id)
+        grid_manager.on_topology_changed()
+        assert grid_manager._editing_grid_id is None
+
+        grid_manager._on_save_changes(None)
+
+        assert plot_orchestrator.get_all_grids() == {}
+
     def test_exit_edit_mode_restores_ui(
         self, grid_manager, plot_orchestrator, workflow_id
     ):


### PR DESCRIPTION
Implements the concurrent-edits browser check from #1116, and fixes the crash it uncovered.

Probing the scenario before writing the test showed it did not behave as the issue assumed. Two sessions editing the same grid's properties and saving back-to-back raised an unhandled `KeyError` server-side, reproducibly: the Save Changes click is queued client-side before the losing session's next topology poll, so its handler read a grid id that had already been invalidated and passed it into an unguarded orchestrator lookup. The losing edit vanished with a traceback in the server log and no feedback in the browser. The fix re-checks that the grid still exists immediately before applying the change — the same check the topology poll already performs — and surfaces a notification instead of crashing, matching the wording this codebase already uses for other "removed mid-action" cases.

Worth recording for the issue: the resulting behaviour is not last-writer-wins as #1116 describes it. Whichever save commits while the grid still exists wins, and in a tight race that is closer to first-commit-wins, because the first save landing is precisely what makes the second session's target disappear. The test therefore asserts the invariants that always hold — exactly one of the two submitted titles survives, no duplicate or lost tab, the losing session is told why, no server-side exception, plots still updating — rather than pinning which session wins.

Coverage is deliberately split across two layers. The browser test drives the real race through two sessions, which is the only place the client-side click ordering exists at all; two fast unit tests pin the guard directly so the stale and `None` grid-id paths do not depend on a slow browser run to stay fixed. Both were confirmed to fail with the exact `KeyError` when the guard is reverted.

Asserting that no exception reached the server required the browser harness to expose its log alongside its URL, so its callers now unpack the URL from the returned value. The interactive `--map` and `--screenshot` paths were verified unaffected.

## Test plan

- [x] New browser test run repeatedly to check for flake
- [x] Full browser suite
- [x] Fast suite
