### PR TITLE
Address every cell titlebar tool per cell, not just the pencil

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -60,10 +60,11 @@ no text, `title`, or `aria-label` — leaving nothing semantic for browser autom
 *name* identity to slug (`workflow_status_widget.py`'s `_tool_css_class`), but a grid has
 none, so `lt-grid-*` slugs the grid *title* instead (`plot_grid_manager.py`) — the same
 title that also drives the grid's download filename. Plot cells have neither a name nor
-a stable title, so their titlebar pencil carries the grid position as
-`lt-cell-r{row}c{col}` (`cell.py`) — unique per grid, and only the active tab's grid is
-rendered. Do not rely on DOM order for cells: a rebuilt cell (e.g. after a rename) moves
-to the end of the document.
+a stable title, so every button in their titlebar — gear (or layer menu), pencil, and
+layer-details toggle — carries the grid position as `lt-cell-r{row}c{col}` (`cell.py`),
+unique per grid, and only the active tab's grid is rendered. Address one with a compound
+selector: `.lt-cell-r0c1.lt-tool-settings`. Do not rely on DOM order for cells: a rebuilt
+cell (e.g. after a rename) moves to the end of the document.
 
 These classes have no associated style rules — adding/removing them is visually inert.
 Treat them as a stable contract: do not drop them in refactors (a test in

--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -119,12 +119,15 @@ tabs are user/fixture plot-grid titles (the dummy fixture adds **Detectors**). W
 `dynamic=True` only the active tab's models exist, so a DOM/`lt-*` inventory reflects the
 *current* tab only — switch tabs before querying that tab's hooks.
 
-**Modals.** Settings (gear), edit (pencil), and grid/workflow config open a `pn.Modal`
+**Modals.** Settings (gear), cell edit (pencil), and workflow config open a `pn.Modal`
 rendered as `[role=dialog]` — use that as the open/visible signal (`Dashboard.open_modal`
 waits on it). Footer buttons are reachable by text (`Cancel`, `Update Plot`, `Back`). To
 dismiss, press **Escape** (a `ModalEscapeCloser` widget makes this work from initial
 focus) or click `.pnx-dialog-close`. Per-grid rows in **Manage Plots** carry
-`lt-grid-{title-slug}` (e.g. `.lt-grid-detectors.lt-tool-pencil`).
+`lt-grid-{title-slug}` (e.g. `.lt-grid-detectors.lt-tool-pencil`) — that pencil is the
+exception: it opens edit mode *inline* in the row, not a dialog, so `Dashboard.open_modal`
+times out on it. Wait on its fields instead (`input[placeholder="Enter grid title"]`) and
+commit with the `Save Changes` button.
 
 ### Driving workflow config flows
 

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -252,6 +252,7 @@ def _create_toolbar_visibility_button(
     *,
     visible: bool,
     on_toggle: Callable[[bool], None],
+    css_classes: list[str] | None = None,
 ) -> pn.widgets.Button:
     """Adjustments button toggling per-layer info-row visibility for a cell."""
 
@@ -274,7 +275,7 @@ def _create_toolbar_visibility_button(
         # Hand-rolled (toggling icon) so it bypasses create_tool_button; tag it
         # with the stable automation hooks by hand. Icon name varies, so use a
         # semantic suffix rather than lt-tool-{icon_name}.
-        css_classes=['lt-tool', 'lt-tool-layer-details'],
+        css_classes=['lt-tool', 'lt-tool-layer-details', *(css_classes or [])],
         stylesheets=create_tool_button_stylesheet(Colors.TEXT_MUTED, HoverColors.MUTED),
     )
     state = {'visible': visible}
@@ -293,6 +294,7 @@ def _create_configure_button_or_menu(
     *,
     layers: list[tuple[LayerId, str]],
     on_configure: Callable[[LayerId], None],
+    css_classes: list[str] | None = None,
 ) -> pn.widgets.Button | pn.widgets.MenuButton:
     """
     Gear button (single layer) or menu picking which layer to configure.
@@ -307,6 +309,8 @@ def _create_configure_button_or_menu(
         ``(layer_id, title)`` pairs for the cell's layers, in display order.
     on_configure:
         Callback invoked with the layer ID to configure.
+    css_classes:
+        Extra context classes, so the button is addressable per cell.
     """
     button_color = Colors.TEXT_MUTED
     hover_color = HoverColors.MUTED
@@ -318,6 +322,7 @@ def _create_configure_button_or_menu(
             button_color=button_color,
             hover_color=hover_color,
             on_click_callback=lambda: on_configure(layer_id),
+            css_classes=css_classes,
         )
 
     # Titles carry HTML entities (e.g. '&rarr;'); unescape for plain menu
@@ -356,7 +361,7 @@ def _create_configure_button_or_menu(
         margin=0,
         # MenuButton (dropdown), so it bypasses create_tool_button; tag it with
         # the same hooks as the single-layer gear for consistent automation.
-        css_classes=['lt-tool', 'lt-tool-settings'],
+        css_classes=['lt-tool', 'lt-tool-settings', *(css_classes or [])],
         stylesheets=stylesheets,
     )
 
@@ -412,9 +417,10 @@ def create_cell_titlebar(
         Optional pane showing the data freshness/lag indicator, placed between
         the title and the action buttons. Updated in place by the caller.
     css_classes:
-        Extra context classes for the edit (pencil) button so repeated cell
-        instances are uniquely addressable in automation (e.g.
-        ``lt-cell-r0c0``); a rebuilt cell's DOM position is not stable.
+        Extra context classes for every button in the titlebar, so repeated
+        cell instances are uniquely addressable in automation (e.g.
+        ``lt-cell-r0c0``); a rebuilt cell's DOM position is not stable, and
+        the three buttons are distinguished by their ``lt-tool-*`` class.
 
     Returns
     -------
@@ -432,6 +438,7 @@ def create_cell_titlebar(
     gear_button = _create_configure_button_or_menu(
         layers=configure_layers,
         on_configure=on_configure_layer,
+        css_classes=css_classes,
     )
     edit_button = create_tool_button(
         icon_name='pencil',
@@ -443,6 +450,7 @@ def create_cell_titlebar(
     toggle_button = _create_toolbar_visibility_button(
         visible=toolbars_visible,
         on_toggle=on_toggle_toolbars_callback,
+        css_classes=css_classes,
     )
 
     right_buttons: list = [gear_button, edit_button, toggle_button]

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -174,3 +174,33 @@ def test_remaining_tabs_keep_updating_after_disabling_and_removing_grids():
         )
         dash.goto_tab("Detectors")
         assert_updating(dash, "Detectors tab after removing middle grid")
+
+
+@pytest.mark.browser
+def test_multi_layer_cell_gear_picks_the_layer_to_configure():
+    # A cell with several layers turns its gear into a layer picker. Both the
+    # gear and the entry it routes to are addressed per cell, since DOM order
+    # across cells is not stable.
+    gear = ".lt-cell-r2c0.lt-tool-settings"
+    with fake_dashboard("dummy", 5038) as url, Dashboard.connect(url) as dash:
+        page = dash.page
+        dash.goto_tab("Detectors")
+
+        # The picker lists one entry per layer, named after it.
+        dash.click(gear)
+        entries = [
+            page.get_by_text(f"Beam monitor → Histogram → Lines ({source})").first
+            for source in ("monitor1", "monitor2")
+        ]
+        for entry in entries:
+            wait_until(dash, entry.is_visible, label="layer menu entry")
+
+        # Choosing one opens the config modal for that layer, not the cell's
+        # first: the source selector is pre-filled with the chosen layer's
+        # source. (The dialog's own inner_text is empty -- Panel renders each
+        # widget into its own shadow root -- so assert on the chip itself.)
+        entries[1].click()
+        page.locator("[role=dialog]").first.wait_for(state="visible", timeout=10000)
+        chip = page.locator(".choices__list--multiple .choices__item").first
+        chip.wait_for(state="visible", timeout=10000)
+        assert chip.inner_text().startswith("monitor2")

--- a/tests/dashboard/ui_config_fixtures/dummy/plot_configs.yaml
+++ b/tests/dashboard/ui_config_fixtures/dummy/plot_configs.yaml
@@ -1,7 +1,7 @@
 plot_grids:
   grids:
   - title: Detectors
-    nrows: 2
+    nrows: 3
     ncols: 2
     cells:
     - geometry:
@@ -76,3 +76,27 @@ plot_grids:
             aggregation: auto
           rate:
             normalize_to_rate: false
+    # Two layers in one cell, so the titlebar gear is a layer-picker menu rather
+    # than a direct button. Omitted params take their model defaults.
+    - geometry:
+        row: 2
+        col: 0
+        row_span: 1
+        col_span: 2
+      layers:
+      - data_sources:
+          primary:
+            workflow_id: dummy/monitor_histogram/1
+            source_names:
+            - monitor1
+            view_name: histogram
+        plot_name: lines
+        params: {}
+      - data_sources:
+          primary:
+            workflow_id: dummy/monitor_histogram/1
+            source_names:
+            - monitor2
+            view_name: histogram
+        plot_name: lines
+        params: {}

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import pydantic
+import pytest
 import scipp as sc
 
 from ess.livedata.config.workflow_spec import (
@@ -56,30 +57,35 @@ class TestPerPanelToolHooks:
         assert 'lt-tool' in menu.css_classes
         assert 'lt-tool-settings' in menu.css_classes
 
-    def test_titlebar_pencil_carries_per_cell_context_hook(self) -> None:
-        """The edit pencil must carry the caller's per-cell context class.
+    @pytest.mark.parametrize('n_layers', [1, 2], ids=['gear', 'layer_menu'])
+    def test_titlebar_tools_carry_per_cell_context_hook(self, n_layers: int) -> None:
+        """Every titlebar tool must carry the caller's per-cell context class.
 
-        A rebuilt cell's DOM position is not stable, so automation addresses
-        the pencil via the cell-position context (e.g. lt-cell-r0c0) instead
-        of DOM order.
+        A rebuilt cell's DOM position is not stable, so automation addresses a
+        cell's tools by a compound selector combining the cell-position context
+        with the tool (e.g. ``.lt-cell-r0c0.lt-tool-settings``). A descendant
+        selector cannot serve: each button lives in its own shadow root.
         """
         titlebar = create_cell_titlebar(
             title='T',
             has_user_title=False,
             on_edit_title_callback=lambda: None,
-            configure_layers=[(LayerId('a'), 'A')],
+            configure_layers=[
+                (LayerId(name), name.upper()) for name in 'ab'[:n_layers]
+            ],
             on_configure_layer=lambda _: None,
             toolbars_visible=True,
             on_toggle_toolbars_callback=lambda _: None,
             css_classes=['lt-cell-r0c0'],
         )
-        pencils = [
-            obj
-            for obj in titlebar.objects
-            if 'lt-tool-pencil' in (getattr(obj, 'css_classes', None) or [])
-        ]
-        assert len(pencils) == 1
-        assert 'lt-cell-r0c0' in pencils[0].css_classes
+        for tool in ('lt-tool-settings', 'lt-tool-pencil', 'lt-tool-layer-details'):
+            matches = [
+                obj
+                for obj in titlebar.objects
+                if tool in (getattr(obj, 'css_classes', None) or [])
+            ]
+            assert len(matches) == 1, tool
+            assert 'lt-cell-r0c0' in matches[0].css_classes, tool
 
 
 class _FakeParams(TimeWindowMixin):


### PR DESCRIPTION
A cell titlebar holds three tools: the gear (a layer-picker menu when the cell has several layers), the pencil, and the layer-details toggle. All three already carried `lt-tool` plus a semantic `lt-tool-*` class, but only the pencil received the caller's `lt-cell-r{row}c{col}` context, so the other two were addressable only by ordinal across the whole grid. The repeated-instance rule in `.claude/rules/dashboard-widgets.md` asks for a context class precisely so that cannot happen, and the gear is the tool automation most wants, since it is what opens the layer config.

Ordinals are not an acceptable substitute here. Cell DOM order is deliberately unstable — a rebuilt cell moves to the end of the document — so `nth(i)` addresses a different cell after any rename, and driving several cells in one session needs a page reload between them just to keep the indices meaningful. I hit exactly that while verifying #1135: reaching each cell's gear took ordinals plus a reload per modal, and one modal still failed to open.

`create_cell_titlebar` now passes its `css_classes` to all three tools instead of to the pencil alone. Each stays distinguishable by its own `lt-tool-*` class, so `.lt-cell-r0c1.lt-tool-settings` names exactly one button. The two hand-rolled widgets (the toggling-icon button and the dropdown) append the context to the hooks they already tag themselves with.

These classes carry no style rules, so the change is visually inert.

**Second commit: a multi-layer cell in the dummy fixture.** Every fixture cell was single-layer, so the gear's layer-picker variant — and cell overlays generally — never appeared in a driven dashboard, leaving the `len(layers) > 1` branch verifiable only by unit test. The Detectors grid gains a third row holding two `lines` layers over the monitor histogram, one per monitor: a config users actually build, and the cheapest overlay the fake backend renders correctly. Existing cells keep their geometry, so `lt-cell-r0c0`/`lt-cell-r0c1` still address what they did and the fixture's tab list is unchanged — which the grid-reordering test asserts against.

## Verification

The existing pencil guard generalizes over the three tools and over both gear shapes (single-layer button and layer menu). It fails on all three tools before this change.

In a fake-backend dashboard, all nine compound selectors across the fixture's three cells resolve to exactly one element each, and `.lt-cell-r0c1.lt-tool-settings` opens the layer config modal — the click that previously had no per-cell selector at all.

A new browser test walks the picker on the multi-layer cell: both entries are listed, and choosing the second opens the config modal for *that* layer rather than the cell's first. It asserts on the source-selector chip, since the dialog's own `inner_text` is empty — Panel renders each widget into its own shadow root. The full browser suite passes (6 tests).

## Test plan

- [x] Cell titlebar renders unchanged (gear, pencil, toggle; classes carry no styles)
- [x] Gear opens layer config for the addressed cell, on a single-layer cell
- [x] Multi-layer cell: the gear is a dropdown, lists the layer titles, and opens the chosen one
