### PR TITLE
Size table columns from their content

### DIFF
--- a/src/ess/livedata/dashboard/table_plotter.py
+++ b/src/ess/livedata/dashboard/table_plotter.py
@@ -19,30 +19,54 @@ from .plot_params import PlotParamsTable, TableNotation
 from .plots import Plotter, TitleResolver
 from .range_hook import Axis
 
+# Bokeh renders the table in 12px Helvetica/Arial. Seven pixels per character is
+# a deliberate overestimate of the average advance width there, so columns are
+# never so tight that Bokeh truncates a cell to an ellipsis.
+_CHAR_PX = 7
+_CELL_PADDING_PX = 12
+
 
 class _FormattedTablePlot(TablePlot):
-    """HoloViews bokeh ``Table`` plot whose value columns carry a custom formatter.
+    """HoloViews bokeh ``Table`` plot with custom column formatters and widths.
 
     HoloViews hardcodes the numeric column formatter and rebuilds every column on
     each streaming update (``update_frame``) without re-running ``hooks``, so a
     post-render hook is reverted on the first data update. Overriding column
-    construction makes the formatter persist across updates.
+    construction makes formatter and width persist across updates.
+
+    Widths are set here because Bokeh cannot derive them: its content-fitting
+    modes (``autosize_mode`` ``fit_columns``/``fit_viewport``) raise in the
+    bundled SlickGrid as soon as a column holds strings, and the default
+    ``force_fit`` ignores content entirely -- it stretches every column to the
+    same share of the widget, leaving short values stranded in half-empty cells.
     """
+
+    style_opts: ClassVar = [*TablePlot.style_opts, 'autosize_mode']
 
     value_formatter = param.Callable(
         default=None,
         doc="Factory returning a fresh Bokeh formatter for each value column.",
     )
 
+    value_chars = param.Callable(
+        default=None,
+        doc="Maps a value column's data to the character budget of its widest cell.",
+    )
+
     def _get_columns(self, element, data):
         columns = super()._get_columns(element, data)
         if self.value_formatter is None:
             return columns
-        # Only numeric value columns get the formatter; string columns (source
-        # index, per-row unit) keep HoloViews' default StringFormatter.
         for column in columns:
-            if np.asarray(data[column.field]).dtype.kind in 'iuf':
+            values = np.asarray(data[column.field])
+            # Only numeric value columns get the formatter; string columns (source
+            # index, per-row unit) keep HoloViews' default StringFormatter.
+            if values.dtype.kind in 'iuf':
                 column.formatter = self.value_formatter()
+                chars = self.value_chars(values)
+            else:
+                chars = max((len(str(value)) for value in values), default=0)
+            column.width = _CELL_PADDING_PX + _CHAR_PX * max(chars, len(column.title))
         return columns
 
 
@@ -172,12 +196,44 @@ class TablePlotter(Plotter):
         # 1e-3..1e5 and switch to scientific for magnitudes outside that window.
         return ScientificFormatter(precision=decimals, text_align='right')
 
+    def _value_chars(self, values: np.ndarray) -> int:
+        """Character budget of the widest value the configured notation produces.
+
+        The Bokeh formatters run in the browser, so the rendered strings are not
+        available here; the budget mirrors :meth:`_value_formatter` instead.
+        Scientific and auto notation cap the mantissa at one digit plus a
+        four-character exponent (``e+05``), and compact notation abbreviates to
+        at most four digits, so only decimal notation depends on the data -- its
+        width steps when values cross an order of magnitude.
+        """
+        decimals = max(self._precision, 0)
+        # Decimals are preceded by the decimal point.
+        fraction = decimals + 1 if decimals else 0
+        sign = 1 if np.any(values < 0) else 0
+        if self._notation is TableNotation.decimal:
+            finite = values[np.isfinite(values)]
+            largest = float(np.abs(finite).max()) if finite.size else 0.0
+            digits = 1 + int(np.log10(largest)) if largest >= 1 else 1
+        elif self._notation is TableNotation.compact:
+            digits = 4
+        else:
+            digits = 5
+        return sign + digits + fraction
+
     def style_opts(self) -> list[hv.Options]:
         # HoloViews' Table plot exposes only fixed width/height (no responsive
         # sizing); container sizing is left to the enclosing Panel pane.
-        # ``value_formatter`` is a plot option of _FormattedTablePlot; it must
-        # persist across streaming updates, which a post-render hook cannot.
+        # ``autosize_mode='none'`` makes Bokeh honour the column widths computed
+        # in _FormattedTablePlot instead of stretching columns to fill the
+        # widget. The formatter and width callables are plot options of that
+        # class; they must persist across streaming updates, which a post-render
+        # hook cannot.
         return [
-            hv.opts.Table(index_position=None, value_formatter=self._value_formatter),
+            hv.opts.Table(
+                index_position=None,
+                autosize_mode='none',
+                value_formatter=self._value_formatter,
+                value_chars=self._value_chars,
+            ),
             *super().style_opts(),
         ]

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1798,6 +1798,82 @@ class TestTablePlotter:
         assert isinstance(counts.formatter, ScientificFormatter)
         assert counts.formatter.text_align == 'right'
 
+    def _widths(self, plotter, sources, values, output='counts'):
+        from bokeh.models import DataTable
+
+        data = {
+            self._key(source, output): sc.DataArray(sc.scalar(value, unit='counts'))
+            for source, value in zip(sources, values, strict=True)
+        }
+        fig = present_figure(plotter, data)
+        table = next(m for m in fig.references() if isinstance(m, DataTable))
+        return {c.field: c.width for c in table.columns}
+
+    def test_columns_keep_their_width_instead_of_filling_the_widget(
+        self, table_plotter
+    ):
+        # Bokeh's default 'force_fit' stretches every column to an equal share of
+        # the widget, which is what made short values sit in half-empty cells.
+        from bokeh.models import DataTable
+
+        data = {self._key('bank0', 'counts'): sc.DataArray(sc.scalar(10.0))}
+        fig = present_figure(table_plotter, data)
+        table = next(m for m in fig.references() if isinstance(m, DataTable))
+        assert table.autosize_mode == 'none'
+
+    def test_source_column_width_follows_longest_source_name(self, table_plotter):
+        narrow = self._widths(table_plotter, ['b0', 'b1'], [1.0, 2.0])
+        wide = self._widths(table_plotter, ['bank_with_a_long_name', 'b1'], [1.0, 2.0])
+        assert wide['source'] > narrow['source']
+
+    def test_column_width_covers_the_header(self, table_plotter):
+        # Source names shorter than the 'Source' header leave the column at the
+        # width the header needs.
+        tiny = self._widths(table_plotter, ['a'], [1.0])
+        small = self._widths(table_plotter, ['abcde'], [1.0])
+        assert tiny['source'] == small['source']
+
+    def test_bounded_notation_width_is_independent_of_magnitude(self):
+        from ess.livedata.dashboard.plot_params import TableNotation
+
+        for notation in (
+            TableNotation.auto,
+            TableNotation.scientific,
+            TableNotation.compact,
+        ):
+            plotter = self._plotter(notation=notation, precision=2)
+            small = self._widths(plotter, ['b0'], [1.0])
+            large = self._widths(plotter, ['b0'], [1.2e12])
+            assert small['counts'] == large['counts']
+
+    def test_decimal_notation_width_grows_with_magnitude(self):
+        # Decimal notation spells out every digit, so the column has to follow
+        # the data -- it is the one notation without a bounded width.
+        from ess.livedata.dashboard.plot_params import TableNotation
+
+        plotter = self._plotter(notation=TableNotation.decimal, precision=2)
+        small = self._widths(plotter, ['b0'], [1.0])
+        large = self._widths(plotter, ['b0'], [1.2e12])
+        assert large['counts'] > small['counts']
+
+    def test_precision_widens_value_column(self):
+        from ess.livedata.dashboard.plot_params import TableNotation
+
+        # A short output name keeps the header from setting the column width.
+        coarse = self._widths(
+            self._plotter(notation=TableNotation.scientific, precision=1),
+            ['b0'],
+            [1.0],
+            output='c',
+        )
+        fine = self._widths(
+            self._plotter(notation=TableNotation.scientific, precision=6),
+            ['b0'],
+            [1.0],
+            output='c',
+        )
+        assert fine['c'] > coarse['c']
+
 
 class TestOverlay1DPlotter:
     """Tests for Overlay1DPlotter with 2D data."""


### PR DESCRIPTION
Closes #1146.

Table columns were split 50/50 regardless of content: Bokeh's `DataTable` defaults to `autosize_mode='force_fit'`, which stretches every column to an equal share of the widget (HoloViews leaves all column widths at Bokeh's 300px default, so the ratio is always 1:1). Short source names and values ended up stranded in half-empty cells, with the right-aligned numbers pinned to the far edge of the widget instead of sitting next to the row they belong to.

Widths are now computed from the content: string columns from their longest entry, value columns from a character budget derived from the configured notation and precision. Scientific, auto and compact notation are bounded by their format; only decimal notation follows the data, and only in steps of an order of magnitude, so widths do not jitter as values update.

This also removes the reported horizontal scrollbar. It came from force-fit sizing the grid canvas to the widget width and then leaving it a few pixels stale after a resize or zoom change (reproduced in a browser: a zoom change alone flips the scrollbar on). With the canvas sized from the columns it no longer tracks the widget width, so the slack absorbs any rounding.

Bokeh's own content-fitting modes are not usable: `fit_columns` and `fit_viewport` raise `ReferenceError: row is not defined` in the SlickGrid bundled with bokeh 3.9.1 (`getColContentSize`, the `GetLongestText` branch) as soon as a column holds strings, which aborts the render and collapses the pane.

Because the plot is only ever driven from Python, the pixel-per-character estimate is deliberately generous, so a column is a little wider than it needs rather than truncating a cell to an ellipsis.

## Test plan

- Unit tests cover the width behaviour: content-derived widths, header floor, bounded vs. data-dependent notation, and `autosize_mode`.
- Verified in a browser (Playwright, classic scrollbars) against the real plotter: no truncated cells and no horizontal scrollbar across container widths 300-700px, fractional widths, and zoom 0.67-1.5, where the old code showed the scrollbar.
- [x] Check a real table plot in the dashboard (e.g. a total-counts view with several detector banks) looks right.
