### PR TITLE
Allocate browser-test dashboard ports from the OS

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -97,6 +97,11 @@ UI, then copying the persisted `workflow_configs.yaml` (strip the runtime
 `current_job` key, keep `jobs`) and `plot_configs.yaml` from the config
 dir back into the fixture; `ui_config_fixtures_test.py` guards against drift.
 
+**Ports.** `fake_dashboard(...)` without a port takes one the OS reports free — how the
+browser tests launch, so two checkouts (or a suite next to an interactive dashboard) can
+run at once. Do not hand a test a port literal; they collide silently across branches.
+Pass an explicit port only when the URL must be known up front, e.g. to open it by hand.
+
 **Shadow DOM selectors.** Tool buttons and rows live in per-widget *open* shadow roots.
 Plain Playwright CSS locators pierce these, so `page.locator(".lt-tool-settings")` works
 — **but descendant combinators do not cross shadow boundaries.** Target a workflow's

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -192,7 +192,38 @@ def _port_in_use(port: int) -> bool:
         return s.connect_ex(("127.0.0.1", port)) == 0
 
 
-def _wait_until_ready(url: str, log: Path, *, timeout_s: float = 60.0) -> None:
+def _free_port() -> int:
+    """Return a port the OS reports as free, for a server we are about to spawn.
+
+    Hand-picked port numbers collide: two checkouts running the browser suite at
+    once, or a suite running alongside an interactive dashboard, both bind the
+    same literal and one of them dies. Asking the OS for an ephemeral port scopes
+    the choice to the machine's actual usage instead of to a constant in this
+    repo.
+
+    The port is only reserved while the probe socket is open, so a racing process
+    can still take it in the gap before our server binds. That race is not closed
+    here; it surfaces as an immediate, readable startup failure in
+    :func:`_wait_until_ready` rather than as a silent hang.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _log_tail(log: Path, lines: int = 15) -> str:
+    return "\n".join(log.read_text().splitlines()[-lines:])
+
+
+def _wait_until_ready(
+    url: str, log: Path, proc: subprocess.Popen, *, timeout_s: float = 60.0
+) -> None:
+    """Block until the dashboard serves 200, or fail with its log tail.
+
+    A server that exits before serving -- most often because its port was taken
+    between being chosen and being bound -- is reported as soon as it exits, so
+    the caller does not wait out the whole timeout on a process already gone.
+    """
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         try:
@@ -200,9 +231,15 @@ def _wait_until_ready(url: str, log: Path, *, timeout_s: float = 60.0) -> None:
                 if resp.status == 200:
                     return
         except (URLError, ConnectionError, OSError):
+            if proc.poll() is not None:
+                raise RuntimeError(
+                    f"Dashboard at {url} exited with code {proc.returncode} before "
+                    f"serving.\n{_log_tail(log)}"
+                ) from None
             time.sleep(0.5)
-    tail = "\n".join(log.read_text().splitlines()[-15:])
-    raise TimeoutError(f"Dashboard at {url} not ready within {timeout_s}s.\n{tail}")
+    raise TimeoutError(
+        f"Dashboard at {url} not ready within {timeout_s}s.\n{_log_tail(log)}"
+    )
 
 
 @dataclass
@@ -223,7 +260,7 @@ class FakeDashboard:
 
 
 @contextmanager
-def _fake_dashboard(instrument: str, port: int):
+def _fake_dashboard(instrument: str, port: int | None = None):
     """Launch a Kafka-free fake-backend dashboard seeded from the fixture.
 
     Copies the committed fixture to a writable scratch dir (the dashboard writes
@@ -231,11 +268,23 @@ def _fake_dashboard(instrument: str, port: int):
     The sidebar starts collapsed: it is static here (announcements are off), so
     an open drawer would only narrow the plots under test and their screenshots.
     Yields a :class:`FakeDashboard`.
+
+    Parameters
+    ----------
+    instrument:
+        Name of the committed UI config fixture to seed the dashboard from.
+    port:
+        Port to serve on. Omit to have one allocated (see :func:`_free_port`);
+        tests should, so that concurrent runs cannot collide. Pass an explicit
+        port only when the URL has to be known in advance, e.g. to open it by
+        hand.
     """
     fixture = REPO_ROOT / "tests/dashboard/ui_config_fixtures" / instrument
     if not fixture.is_dir():
         raise SystemExit(f"No UI config fixture for instrument {instrument!r}")
-    if _port_in_use(port):
+    if port is None:
+        port = _free_port()
+    elif _port_in_use(port):
         raise SystemExit(
             f"Port {port} is already in use (a prior dashboard?). Stop it or pass "
             f"--port with a free port."
@@ -267,7 +316,7 @@ def _fake_dashboard(instrument: str, port: int):
                 stderr=subprocess.STDOUT,
             )
             try:
-                _wait_until_ready(f"http://localhost:{port}", log)
+                _wait_until_ready(f"http://localhost:{port}", log, proc)
                 yield FakeDashboard(url=f"http://localhost:{port}", log=log)
             finally:
                 proc.terminate()
@@ -288,7 +337,11 @@ def main() -> None:
         help="Start a fake-backend dashboard from the fixture, then tear it down.",
     )
     parser.add_argument("--instrument", default="dummy", help="For --launch.")
-    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="For --launch.")
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="For --launch. Defaults to a free port, so parallel runs do not collide.",
+    )
     parser.add_argument("--tab", help="Activate this tab before acting.")
     parser.add_argument("--screenshot", help="Write a full-page screenshot here.")
     parser.add_argument(

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -14,8 +14,9 @@ through the stable ``lt-*`` automation hooks:
 - two sessions racing to save edits on the same grid converge on one title,
   without a server-side exception or a duplicated/lost tab.
 
-Each test launches its own dashboard on a dedicated port for isolation, since
-grid topology changes are process-global. Runs via ``pytest -m browser``
+Each test launches its own dashboard for isolation, since grid topology changes
+are process-global; ports are allocated per launch, so concurrent runs of this
+suite do not fight over them. Runs via ``pytest -m browser``
 (excluded from the default run; CI runs them via ``tox -e browser``; skips
 cleanly where Playwright is absent).
 """
@@ -57,7 +58,7 @@ def _add_grid(dash: Dashboard, title: str) -> None:
 
 @pytest.mark.browser
 def test_session_reload_restores_tabs_and_live_updates():
-    with fake_dashboard("dummy", 5033) as fake, Dashboard.connect(fake.url) as dash:
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
         dash.goto_tab("Detectors")
         assert_updating(dash, "session before reload")
 
@@ -74,7 +75,7 @@ def test_session_reload_restores_tabs_and_live_updates():
 @pytest.mark.browser
 def test_grid_created_in_one_session_appears_in_other_without_stealing_focus():
     with (
-        fake_dashboard("dummy", 5034) as fake,
+        fake_dashboard("dummy") as fake,
         Dashboard.connect_many(2, fake.url) as (creator, observer),
     ):
         observer_tab = _active_tab(observer)
@@ -103,7 +104,7 @@ def test_cell_title_survives_noop_save_of_cell_properties_modal():
     # The per-cell hook (not DOM order) addresses the cell: a rebuilt cell --
     # e.g. after the rename below -- moves to the end of the document.
     pencil = ".lt-cell-r0c0.lt-tool-pencil"
-    with fake_dashboard("dummy", 5035) as fake, Dashboard.connect(fake.url) as dash:
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
         page = dash.page
         dash.goto_tab("Detectors")
 
@@ -133,7 +134,7 @@ def test_cell_title_survives_noop_save_of_cell_properties_modal():
 
 @pytest.mark.browser
 def test_remaining_tabs_keep_updating_after_disabling_and_removing_grids():
-    with fake_dashboard("dummy", 5036) as fake, Dashboard.connect(fake.url) as dash:
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
         # Arrange three grids ordered [Bravo, Charlie, Detectors]: two empty
         # grids ahead of the fixture's populated one, so disabling the first
         # and removing the middle both shift the Detectors tab position --
@@ -184,7 +185,7 @@ def test_multi_layer_cell_gear_picks_the_layer_to_configure():
     # gear and the entry it routes to are addressed per cell, since DOM order
     # across cells is not stable.
     gear = ".lt-cell-r2c0.lt-tool-settings"
-    with fake_dashboard("dummy", 5038) as fake, Dashboard.connect(fake.url) as dash:
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
         page = dash.page
         dash.goto_tab("Detectors")
 
@@ -233,7 +234,7 @@ def test_concurrent_grid_property_edits_resolve_to_one_title_without_crash():
     first_title = "First Session Title"
     second_title = "Second Session Title"
     with (
-        fake_dashboard("dummy", 5037) as fake,
+        fake_dashboard("dummy") as fake,
         Dashboard.connect_many(2, fake.url) as (first, second),
     ):
         for dash in (first, second):

--- a/tests/dashboard/drive_dashboard_test.py
+++ b/tests/dashboard/drive_dashboard_test.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for the launch plumbing in ``scripts/drive_dashboard.py``.
+
+No browser is driven here, but the module imports Playwright at import time, so
+these carry the ``browser`` marker to run in the environment that has it
+(``tox -e browser``) rather than being silently skipped everywhere.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+from tests.helpers.browser import drive_dashboard
+
+
+@pytest.mark.browser
+def test_free_port_offers_a_port_nothing_is_listening_on():
+    port = drive_dashboard._free_port()
+    assert 1024 < port <= 65535
+    assert not drive_dashboard._port_in_use(port)
+
+
+@pytest.mark.browser
+def test_free_port_releases_the_port_it_offers():
+    # The probe socket must not still hold the port it just reported, or every
+    # launch would hand its server a port the server cannot bind.
+    port = drive_dashboard._free_port()
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", port))
+
+
+@pytest.mark.browser
+def test_wait_until_ready_reports_a_dead_server_instead_of_waiting_it_out(tmp_path):
+    # A server whose port was taken between being chosen and being bound exits
+    # at once. Waiting out the full timeout would bury the reason; the caller
+    # gets the exit code and the server's own log tail instead.
+    log = tmp_path / "dashboard.log"
+    with log.open("w") as logf:
+        proc = subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                "-c",
+                "print('OSError: [Errno 98] Address already in use'); "
+                "raise SystemExit(3)",
+            ],
+            stdout=logf,
+            stderr=subprocess.STDOUT,
+        )
+    proc.wait(timeout=10)
+
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match="exited with code 3") as exc_info:
+        drive_dashboard._wait_until_ready(
+            f"http://localhost:{drive_dashboard._free_port()}", log, proc
+        )
+    assert time.monotonic() - started < 10, "did not fail fast on a dead server"
+    assert "Address already in use" in str(exc_info.value)

--- a/tests/dashboard/multisession_smoke_test.py
+++ b/tests/dashboard/multisession_smoke_test.py
@@ -38,7 +38,7 @@ from tests.helpers.browser import (
 @pytest.mark.browser
 def test_two_sessions_see_plots_and_keep_receiving_updates():
     with (
-        fake_dashboard("dummy", 5032) as fake,
+        fake_dashboard("dummy") as fake,
         Dashboard.connect_many(2, fake.url) as (
             first,
             second,

--- a/tests/helpers/browser.py
+++ b/tests/helpers/browser.py
@@ -15,6 +15,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+# Re-exported so tests reach the driving kit through this module, which owns the
+# scripts/ sys.path seam above, rather than each repeating it.
+import drive_dashboard  # noqa: E402,F401
 from drive_dashboard import Dashboard, _fake_dashboard  # noqa: E402
 
 fake_dashboard = _fake_dashboard


### PR DESCRIPTION
Browser tests each hand-picked a dashboard port literal (5032-5038). Nothing enforced that the set stayed disjoint, and the failure mode is silent: two checkouts running the suite at once, or a suite running alongside an interactive dashboard, land on the same port and one of the servers dies. Keeping the literals disjoint was also manual work every time a test landed on a parallel branch — #1143 picked 5037 by reading off what #1145 had already taken.

`fake_dashboard` now takes a port from the OS when it is not given one, which is how all the tests call it. `--launch` does the same, so parallel driving sessions no longer fight over 5011 either. Passing an explicit port keeps the existing in-use guard, for the case where the URL has to be known up front.

A port chosen this way is only reserved until our server binds it, so a racing process can still take it in between. That race is not closed — closing it would mean handing the listening socket to the Panel server — but it no longer hides: `_wait_until_ready` reports a server that exited before serving as soon as it exits, so this and any other startup failure surface immediately with the server's log tail instead of after a 60s wait.

The three new tests are marked `browser` despite driving no browser: `drive_dashboard` imports Playwright at import time, so that marker is what gets them run rather than skipped everywhere.

## Test plan

- [x] Full browser suite (10 passed)
- [x] Fast suite
- [x] `--launch --map` with an allocated port, and the in-use guard still firing on an explicit taken port
- [x] `tox -e static`
