### PR TITLE
tests: guard against collapsed/inconsistently-sized plots

### DIFF
--- a/src/ess/livedata/dashboard/frame_aspect.py
+++ b/src/ess/livedata/dashboard/frame_aspect.py
@@ -246,3 +246,28 @@ def make_frame_aspect_opts(aspect: PlotAspect) -> dict[str, Any]:
             return {'responsive': True}
     cross = 'height' if aspect.stretch_mode == StretchMode.width else 'width'
     return {'responsive': True, cross: _INITIAL_CROSS_SIZE_PX, 'hooks': [hook]}
+
+
+def pane_sizing_mode(aspect: PlotAspect) -> str:
+    """Panel ``sizing_mode`` for the pane wrapping a figure sized by this aspect.
+
+    Must agree with the sizing mode HoloViews derives from
+    :func:`make_frame_aspect_opts`: a pane that stretches along only one axis
+    around a ``stretch_both`` figure leaves the other axis unconstrained, and
+    the figure collapses to zero size.
+
+    Parameters
+    ----------
+    aspect:
+        Plot aspect configuration.
+
+    Returns
+    -------
+    :
+        Panel sizing_mode ('stretch_both', 'stretch_width' or 'stretch_height').
+    """
+    if aspect.aspect_type == PlotAspectType.free:
+        return 'stretch_both'
+    if aspect.stretch_mode == StretchMode.width:
+        return 'stretch_width'
+    return 'stretch_height'

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -27,6 +27,7 @@ from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
 
 from ..cell_autoscale import CellAutoscaleController, build_controller_from_layers
 from ..format_utils import extract_error_summary
+from ..frame_aspect import pane_sizing_mode
 from ..hover_suspend import make_hover_suspend_hook
 from ..plot_data_service import LayerState, LayerStateMachine, PlotDataService
 from ..plot_orchestrator import (
@@ -34,10 +35,9 @@ from ..plot_orchestrator import (
     CellId,
     LayerId,
     PlotCell,
-    PlotConfig,
     PlotOrchestrator,
 )
-from ..plot_params import PlotAspectType, StretchMode
+from ..plot_params import PlotAspect, PlotAspectType
 from ..plots import TimeBounds, format_time_info, merge_time_bounds
 from ..save_filename import build_save_filename_from_cell, make_save_filename_hook
 from ..session_layer import SessionLayer
@@ -54,28 +54,8 @@ from .styles import Colors, StatusColors, StatusPill
 logger = structlog.get_logger(__name__)
 
 
-def _get_sizing_mode(config: PlotConfig) -> str:
-    """Extract Panel sizing_mode from plot configuration.
-
-    Parameters
-    ----------
-    config:
-        Plot configuration containing plotter params.
-
-    Returns
-    -------
-    :
-        Panel sizing_mode string ('stretch_both', 'stretch_width', or 'stretch_height').
-    """
-    params = config.params
-    if hasattr(params, 'plot_aspect'):
-        aspect = params.plot_aspect
-        if aspect.aspect_type == PlotAspectType.free:
-            return 'stretch_both'
-        if aspect.stretch_mode == StretchMode.width:
-            return 'stretch_width'
-        return 'stretch_height'
-    return 'stretch_both'
+# Params without a configurable aspect size like an unconstrained plot.
+_FREE_ASPECT = PlotAspect(aspect_type=PlotAspectType.free)
 
 
 # Data-age thresholds in seconds (now minus the oldest data's end time) that
@@ -626,9 +606,11 @@ class CellWidget:
         """
         # Use sizing mode from first layer (they should be consistent for overlay)
         if self._cell.layers:
-            sizing_mode = _get_sizing_mode(self._cell.layers[0].config)
+            params = self._cell.layers[0].config.params
+            aspect = getattr(params, 'plot_aspect', _FREE_ASPECT)
         else:
-            sizing_mode = 'stretch_both'
+            aspect = _FREE_ASPECT
+        sizing_mode = pane_sizing_mode(aspect)
 
         # Use .layout to preserve widgets for DynamicMaps with kdims.
         # When pn.pane.HoloViews wraps a DynamicMap with kdims, it generates

--- a/tests/dashboard/plot_sizing_invariant_test.py
+++ b/tests/dashboard/plot_sizing_invariant_test.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Render-geometry invariant: a plot's figures must be sized consistently.
+
+The "collapsed detector image" bug (figures left ``stretch_both`` while their
+pane asked for ``stretch_width``, so the free axis was unconstrained and the
+plot rendered at zero height) passed every functional test: the data and the
+figure existed, only the *rendered geometry* was wrong.
+
+Observing the collapse itself needs a real browser (see
+``render_geometry_test.py``), but its cause is observable headlessly: every
+figure a plotter produces must adopt the responsive sizing mode the cell's pane
+will wrap it in, i.e. the one :func:`pane_sizing_mode` returns. These tests
+render each plotter through the real ``compute -> present -> bokeh`` path and
+assert that invariant across aspect types, combine modes and source counts --
+including the layout-mode sub-figures that the original bug skipped.
+"""
+
+from __future__ import annotations
+
+import holoviews as hv
+import numpy as np
+import pytest
+import scipp as sc
+from bokeh.models import Plot
+from holoviews.plotting.bokeh import BokehRenderer
+
+from ess.livedata.config.workflow_spec import DataKey, WorkflowId
+from ess.livedata.dashboard import plots
+from ess.livedata.dashboard.frame_aspect import pane_sizing_mode
+from ess.livedata.dashboard.plot_params import (
+    CombineMode,
+    LayoutParams,
+    PlotAspect,
+    PlotAspectType,
+    PlotParams1d,
+    PlotParams2d,
+    StretchMode,
+)
+
+hv.extension('bokeh')
+
+
+def _figures(hv_obj) -> list[Plot]:
+    """All Bokeh figures in the rendered HoloViews object (Layout -> one per cell)."""
+    state = BokehRenderer.instance().get_plot(hv_obj).state
+    return [m for m in state.references() if isinstance(m, Plot)]
+
+
+def _present_figures(plotter, data: dict) -> list[Plot]:
+    plotter.compute({'primary': data})
+    state = plotter.get_cached_state()
+    # compute() turns any failure into a Text placeholder, which would render a
+    # single default-sized figure and make the assertions below pass vacuously.
+    assert not isinstance(state, hv.Text), f'plotter did not plot the data: {state}'
+    presenter = plotter.create_presenter()
+    return _figures(presenter.present(hv.streams.Pipe(data=state)))
+
+
+def _keys(n: int) -> list[DataKey]:
+    wf = WorkflowId(instrument='test', name='wf', version=1)
+    return [
+        DataKey(workflow_id=wf, source_name=f's{i}', output_name='out')
+        for i in range(n)
+    ]
+
+
+def _data_1d(n: int) -> dict:
+    da = sc.DataArray(
+        sc.array(dims=['x'], values=[1.0, 2.0, 3.0]),
+        coords={'x': sc.array(dims=['x'], values=[10.0, 20.0, 30.0])},
+    )
+    return dict.fromkeys(_keys(n), da)
+
+
+def _data_2d(n: int) -> dict:
+    da = sc.DataArray(
+        sc.array(dims=['y', 'x'], values=np.arange(12.0).reshape(3, 4)),
+        coords={
+            'x': sc.arange('x', 4, dtype='float64'),
+            'y': sc.arange('y', 3, dtype='float64'),
+        },
+    )
+    return dict.fromkeys(_keys(n), da)
+
+
+# Every aspect type, and both stretch modes for the constrained ones, since the
+# stretch mode decides which axis the pane and the figure must agree on.
+_ASPECTS = [
+    PlotAspect(aspect_type=PlotAspectType.free),
+    PlotAspect(aspect_type=PlotAspectType.square, stretch_mode=StretchMode.width),
+    PlotAspect(aspect_type=PlotAspectType.square, stretch_mode=StretchMode.height),
+    PlotAspect(aspect_type=PlotAspectType.equal, stretch_mode=StretchMode.width),
+    PlotAspect(aspect_type=PlotAspectType.equal, stretch_mode=StretchMode.height),
+    PlotAspect(
+        aspect_type=PlotAspectType.aspect, ratio=2.0, stretch_mode=StretchMode.width
+    ),
+    PlotAspect(
+        aspect_type=PlotAspectType.data_aspect,
+        ratio=0.5,
+        stretch_mode=StretchMode.height,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ('plotter_cls', 'params_cls', 'make_data'),
+    [
+        (plots.LinePlotter, PlotParams1d, _data_1d),
+        (plots.ImagePlotter, PlotParams2d, _data_2d),
+    ],
+    ids=['line', 'image'],
+)
+@pytest.mark.parametrize('combine', [CombineMode.overlay, CombineMode.layout])
+@pytest.mark.parametrize('n_sources', [1, 2])
+@pytest.mark.parametrize(
+    'aspect', _ASPECTS, ids=lambda a: f'{a.aspect_type.name}-{a.stretch_mode.name}'
+)
+def test_every_figure_adopts_the_panes_sizing_mode(
+    plotter_cls, params_cls, make_data, combine, n_sources, aspect
+):
+    """A regression skipping the aspect hook for any figure fails here.
+
+    Layout mode yields one figure per source; the collapsed-image bug sized only
+    the cell's pane, leaving those sub-figures ``stretch_both``.
+    """
+    params = params_cls(layout=LayoutParams(combine_mode=combine), plot_aspect=aspect)
+    figures = _present_figures(plotter_cls.from_params(params), make_data(n_sources))
+
+    assert len(figures) == (n_sources if combine == CombineMode.layout else 1)
+    for fig in figures:
+        assert fig.sizing_mode == pane_sizing_mode(aspect)

--- a/tests/dashboard/render_geometry_test.py
+++ b/tests/dashboard/render_geometry_test.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Rendered-geometry smoke test: no plot collapses to zero size in a real browser.
+
+The "collapsed detector image" bug (#1029) left figures with ``inner_height ==
+0`` while every functional and headless test stayed green: the data and the
+figure models were fine, only the browser-computed layout was broken. Sizing is
+settled between Bokeh, HoloViews and Panel in the browser, so the only faithful
+guard renders the dashboard in an actual browser and measures the laid-out
+figures.
+
+This visits every plot-grid tab of the Kafka-free fake dashboard and asserts
+that each figure's data area (the *frame*, not the outer canvas -- a collapsed
+plot still draws its axes) is non-degenerate. It is fix-agnostic: it fails
+whenever a plot renders collapsed, whatever the cause.
+``plot_sizing_invariant_test.py`` is the cheap headless counterpart, pinning the
+known cause across the full aspect matrix.
+
+Runs via ``pytest -m browser`` (excluded from the default run; CI runs them
+via ``tox -e browser``; skips cleanly where Playwright is absent).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+from tests.helpers.browser import Dashboard, fake_dashboard, wait_until
+
+# Below this many CSS pixels a figure's data area is considered collapsed. Real
+# frames here are hundreds of pixels; the bug produced zero.
+_MIN_FRAME_PX = 50
+
+# The last static tab; grid tabs are appended after the static ones.
+_LAST_STATIC_TAB = "Manage Plots"
+
+# Geometry of every figure currently laid out on screen. Figures of tabs visited
+# earlier stay in the document with their last dimensions, so those without a
+# displayed view are excluded -- otherwise a stale figure would be reported
+# against whatever tab is active now.
+_VISIBLE_FIGURE_GEOMETRY_JS = """() => {
+  const out = [];
+  for (const doc of (window.Bokeh && Bokeh.documents) || []) {
+    for (const m of Array.from(doc._all_models.values())) {
+      if (m.type !== 'Figure') continue;
+      const view = Bokeh.index.find_one_by_id(m.id);
+      if (!view || !view.el || !view.el.offsetParent) continue;
+      out.push({iw: m.inner_width, ih: m.inner_height,
+                ow: m.outer_width, oh: m.outer_height});
+    }
+  }
+  return out;
+}"""
+
+
+def _visible_figures(dash: Dashboard) -> list[dict]:
+    return dash.page.evaluate(_VISIBLE_FIGURE_GEOMETRY_JS)
+
+
+@pytest.mark.browser
+def test_no_plot_renders_collapsed():
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
+        tabs = dash.tab_names()
+        grid_tabs = tabs[tabs.index(_LAST_STATIC_TAB) + 1 :]
+        assert grid_tabs, f"fixture exposes no plot-grid tab, only {tabs}"
+
+        collapsed: dict[str, list] = {}
+        for tab in grid_tabs:
+            dash.goto_tab(tab)
+            wait_until(
+                dash,
+                lambda: bool(_visible_figures(dash)),
+                label=f"figures to render on tab {tab!r}",
+            )
+            bad = [
+                fig
+                for fig in _visible_figures(dash)
+                if fig["iw"] < _MIN_FRAME_PX or fig["ih"] < _MIN_FRAME_PX
+            ]
+            if bad:
+                collapsed[tab] = bad
+
+        assert not collapsed, (
+            f"figures with a data area below {_MIN_FRAME_PX}px: {collapsed}"
+        )


### PR DESCRIPTION
Replaces #1030, which was written before the browser-test framework existed and no longer applies. That PR carried four things; only two survive, and both needed rework.

**What was dropped.** The `browser` marker and the `not browser` filters in `tox.ini` landed on main verbatim via #1053, and main now has a `tox -e browser` env with a CI job running it. The plumbing half of #1030 is redundant.

**What changed.** The browser test was written as local-only, on the explicit premise that Playwright-in-CI was a separate, undecided question. That decision has since been made, so this test is now CI-gating rather than a thing to remember to run. It was rewritten against `tests/helpers/browser.py`: no `sys.path` seam, no port literal, no module-scoped fixture. It also now filters to figures with a displayed view — figures of tabs visited earlier stay in the document with their last dimensions, so without that filter a stale figure is reported against whatever tab is active now. Deriving the plot-grid tabs from the last static tab replaces a hardcoded list of the three static tab titles.

The headless invariant test was silently broken by the `ResultKey` → `DataKey` migration of the dashboard data plane: its data no longer reached the plotter, `compute()` turned the failure into a "no data" `Text` placeholder, and the assertions passed against a single default-sized figure. Fixing the keys exposed that this failure mode is invisible, so the placeholder is now rejected explicitly. The matrix gained the missing `data_aspect` type and the second stretch mode for the constrained aspects — the stretch mode decides which axis pane and figure must agree on, so covering only one left half the surface untested.

**Why the source change.** The agreement the invariant asserts — pane sizing mode vs. figure sizing mode — was split across two modules, which is precisely what let them diverge in #1029. Rather than #1030's approach of reaching into `cell._get_sizing_mode` from a test, the mapping moves next to the opts it must agree with, as `frame_aspect.pane_sizing_mode`. Tests then assert against a public function, and the two halves of the invariant are readable side by side.

## Test plan

Both guards were verified to have teeth by mutation: dropping the cross dimension from `make_frame_aspect_opts` (reproducing the #1029 sizing split) fails 48 of 56 headless cases, and the browser test fails with the original symptom, `ih: 0`.

- [x] Headless invariant: 56 cases pass; 48 fail under the mutation.
- [x] Browser test: passes in ~18 s; fails under the mutation with `figures with a data area below 50px: {'Detectors': [{'iw': 631, 'ih': 0, ...}]}`.
- [x] Full default suite green (4236 passed).
