### PR TITLE
Fix duplicate session-callback registration on every session open

### DIFF
--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -226,6 +226,31 @@ class DashboardBase(ServiceBase, ABC):
 
     def create_layout(self) -> pn.template.MaterialTemplate:
         """Create the basic dashboard layout."""
+        # Own the document hold for the whole build so that widget code using
+        # ``pn.io.hold()`` nests inside it instead of taking its own.
+        #
+        # A nested ``pn.io.hold()`` would not release here (holoviz/panel#8691):
+        # it decides whether it was called off the document's thread by comparing
+        # against ``state._thread_id``, which Panel only assigns once it
+        # initializes the document -- after this function returns. Every hold
+        # taken here is therefore misclassified as off-thread and defers its
+        # unhold to a next-tick callback. Bokeh constructs the ServerSession in
+        # between and registers every session callback already on the document;
+        # the deferred unhold then replays the queued SessionCallbackAdded
+        # events, registering the same callbacks a second time. Bokeh rejects
+        # that with "A callback of the same type has already been added with this
+        # ID" and aborts dispatch of every event still queued behind it.
+        doc = pn.state.curdoc
+        doc.hold('combine')
+        try:
+            return self._build_layout()
+        finally:
+            # Flushes while the session does not exist yet, so the callbacks
+            # registered above are announced to nobody and are picked up exactly
+            # once, by the ServerSession's initial sweep of the document.
+            doc.unhold()
+
+    def _build_layout(self) -> pn.template.MaterialTemplate:
         # Create session updater first so widgets can register handlers
         session_updater = self._create_session_updater()
 

--- a/tests/dashboard/layout_build_test.py
+++ b/tests/dashboard/layout_build_test.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import logging
+from pathlib import Path
+
+import pytest
+from bokeh.document import Document
+from panel.io.state import set_curdoc
+
+from ess.livedata.dashboard.reduction import ReductionApp
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> ReductionApp:
+    return ReductionApp(
+        log_level=logging.INFO, transport='none', config_dir=str(tmp_path)
+    )
+
+
+def test_layout_build_leaves_no_document_hold(app: ReductionApp) -> None:
+    """
+    Building the layout must not leave the document held.
+
+    Bokeh constructs the ServerSession right after the app callable returns and
+    registers every session callback the build put on the document. A hold
+    surviving the build defers the corresponding SessionCallbackAdded events past
+    that point, so unholding registers the same callbacks a second time and Bokeh
+    raises "A callback of the same type has already been added with this ID".
+    """
+    doc = Document()
+    with set_curdoc(doc):
+        app.create_layout()
+    assert doc.callbacks.hold_value is None


### PR DESCRIPTION
Every browser session opening the dashboard logged an unhandled `ValueError: A callback of the same type has already been added with this ID`, raised inside Bokeh's `with_document_locked`.

Panel's `pn.io.hold()` cannot release a hold taken while the app callable runs: it classifies the caller as off-thread whenever `state._thread_id` is unset, and Panel only assigns that once it initializes the document — after `create_layout` returns. So the first widget to use `pn.io.hold()` during the build (`DerivedDevicesOverview`) left the document held for the remainder of the build, with its unhold deferred to a next-tick callback. Filed upstream as holoviz/panel#8691.

The per-session periodic callback started at the end of `create_layout` was therefore registered under that hold, so its `SessionCallbackAdded` event was queued rather than dispatched. Bokeh's `ServerSession` constructor registered the callback while sweeping the callbacks already on the document, and the deferred unhold replayed the queued event afterwards — a second registration of the same callback id.

Beyond the log noise, `unhold()` dispatches queued events in a plain loop, so the exception discarded the 38 document events queued behind the offending one. That is benign only because no websocket is attached that early.

`create_layout` now takes the hold explicitly for the whole build and releases it deterministically. Nested `pn.io.hold()` calls see a hold already active, so they neither re-hold nor defer an unhold, and the flush happens while no session exists — each callback is then picked up exactly once by the session's initial sweep. This closes the whole class rather than the one call site: the announcements pane and the dev-mode log producer register callbacks during the build too, and today escape only by running before the first hold.

Once holoviz/panel#8691 is fixed and released the workaround becomes redundant, but it stays correct either way (verified against an emulated upstream fix).

## Test plan

- New unit test asserts the build leaves no hold on the document; it fails on the previous code with `assert 'combine' is None`.
- Full fast suite passes; `-m browser` suite passes.
- Manually verified against a running dashboard: repeated session opens produce zero occurrences of the error (previously one per open), and the UI renders and receives data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
