### PR TITLE
Pop a cell's plot out into a floating window

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -60,11 +60,14 @@ no text, `title`, or `aria-label` — leaving nothing semantic for browser autom
 *name* identity to slug (`workflow_status_widget.py`'s `_tool_css_class`), but a grid has
 none, so `lt-grid-*` slugs the grid *title* instead (`plot_grid_manager.py`) — the same
 title that also drives the grid's download filename. Plot cells have neither a name nor
-a stable title, so every button in their titlebar — gear (or layer menu), pencil, and
-layer-details toggle — carries the grid position as `lt-cell-r{row}c{col}` (`cell.py`),
-unique per grid, and only the active tab's grid is rendered. Address one with a compound
-selector: `.lt-cell-r0c1.lt-tool-settings`. Do not rely on DOM order for cells: a rebuilt
-cell (e.g. after a rename) moves to the end of the document.
+a stable title, so every button in their titlebar — pop-out, gear (or layer menu),
+pencil, and layer-details toggle — carries the grid position as `lt-cell-r{row}c{col}`
+(`cell.py`), unique per grid, and only the active tab's grid is rendered. Address one
+with a compound selector: `.lt-cell-r0c1.lt-tool-settings`. Do not rely on DOM order for
+cells: a rebuilt cell (e.g. after a rename) moves to the end of the document.
+
+A cell's pop-out window (`plot_popout.py`) is slugged by the same grid position:
+`lt-popout` + `lt-popout-r{row}c{col}`, one per cell at most.
 
 These classes have no associated style rules — adding/removing them is visually inert.
 Treat them as a stable contract: do not drop them in refactors (a test in
@@ -123,6 +126,16 @@ titles are code constants: **Workflows**, **System Status**, **Manage Plots**; f
 tabs are user/fixture plot-grid titles (the dummy fixture adds **Detectors**). With
 `dynamic=True` only the active tab's models exist, so a DOM/`lt-*` inventory reflects the
 *current* tab only — switch tabs before querying that tab's hooks.
+
+**Pop-out windows.** The cell titlebar's pop-out tool
+(`.lt-cell-r0c0.lt-tool-arrows-maximize`) opens a jsPanel `FloatPanel`, *not* a dialog —
+`Dashboard.open_modal` times out on it. Wait on `.lt-popout-r0c0` instead, and close it
+with `.jsPanel-btn-close` (or by clicking the tool again, which replaces the window).
+Two windows opened back to back cascade by a few pixels; without that offset the second
+would cover the first's close button and intercept the click. A window keeps rendering
+while another tab is shown, so with `dynamic=True` tearing down the hidden grid's models
+it is then the only plot in the document — which is what makes `assert_updating` on
+another tab a pop-out liveness check.
 
 **Modals.** Settings (gear), cell edit (pencil), and workflow config open a `pn.Modal`
 rendered as `[role=dialog]` — use that as the open/visible signal (`Dashboard.open_modal`

--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -144,6 +144,23 @@ viewport" — drive the strip instead (`.jsPanel-btn-sm.jsPanel-btn-normalize`, 
 matching `-close`). A minimized pop-out is deliberately *not* live, so
 `assert_stops_updating` is the check there.
 
+The window hangs from the top of the viewport and is sized in `vh`, because its title
+bar holds the only close/minimize controls: centring a fixed pixel height puts them
+above `y=0` on any viewport shorter than the window, and the window then cannot be
+dismissed at all. Test viewports are 1000 px tall by default, which is *above* the
+threshold — regressions here only show at laptop heights, so the geometry test
+parametrizes over 700 px as well. Note `maxSize` is not a fix: jsPanel applies it to
+interactive resizing only, not to the size the panel opens at; override `contentSize`
+via `config` instead, which takes precedence over the size Panel derives from
+`width`/`height`.
+
+**Clicks that silently do nothing.** A rebuild racing a click detaches the target
+between locating and pressing it; Playwright reports success and nothing happens. The
+cold-start tick after load triggers this often enough to make a single click on a
+freshly loaded tab roughly a 3-in-4 proposition. `click_until(dash, selector, condition,
+label=...)` retries until the effect is observable — use it for the first click of a
+session rather than `dash.click` plus a `wait_until`, which cannot recover.
+
 **Modals.** Settings (gear), cell edit (pencil), and workflow config open a `pn.Modal`
 rendered as `[role=dialog]` — use that as the open/visible signal (`Dashboard.open_modal`
 waits on it). Footer buttons are reachable by text (`Cancel`, `Update Plot`, `Back`). To

--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -137,6 +137,13 @@ while another tab is shown, so with `dynamic=True` tearing down the hidden grid'
 it is then the only plot in the document — which is what makes `assert_updating` on
 another tab a pop-out liveness check.
 
+Minimizing parks the panel *off-screen* (x ≈ −9000) and leaves a replacement strip of
+small buttons at the bottom of the viewport. So after a minimize, `.jsPanel-btn-close`
+still matches the parked panel and any click on it times out as "outside of the
+viewport" — drive the strip instead (`.jsPanel-btn-sm.jsPanel-btn-normalize`, or the
+matching `-close`). A minimized pop-out is deliberately *not* live, so
+`assert_stops_updating` is the check there.
+
 **Modals.** Settings (gear), cell edit (pencil), and workflow config open a `pn.Modal`
 rendered as `[role=dialog]` — use that as the open/visible signal (`Dashboard.open_modal`
 waits on it). Footer buttons are reachable by text (`Cancel`, `Update Plot`, `Back`). To

--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -154,6 +154,24 @@ interactive resizing only, not to the size the panel opens at; override `content
 via `config` instead, which takes precedence over the size Panel derives from
 `width`/`height`.
 
+**Getting a plot to fill a FloatPanel** takes two things, both handled once per session
+by `PopoutWindowFitter` (`plot_popout.py`) — expect neither to work by default:
+
+- The height chain `.jsPanel-content` → `#float` (Panel's template root) → `#flex-item`
+  is broken: those wrappers have no height, so nothing carries the window's size inward.
+  A `stretch_both` child then collapses to a ~66 px sliver, and a child with a fixed
+  height survives but can never follow the window. `stylesheets=` on the `FloatPanel`
+  does **not** reach these wrappers — they are light DOM, so it takes a document-level
+  rule (`.jsPanel-content > .bk-root`).
+- Panel re-lays out only on `jspanelresizestop`, which a drag fires but maximize,
+  normalize and smallify do not. Re-dispatch that event on `jspanelstatuschange` with
+  `event.panel` copied across (Panel's handler matches on it) rather than reimplementing
+  the layout call. A synthetic `window` resize does *not* work.
+
+Any invisible `ReactiveHTML` helper needs a **public** class name: a leading underscore
+yields `could not resolve type '_Foo1'` in the browser and the whole session fails to
+render.
+
 **Clicks that silently do nothing.** A rebuild racing a click detaches the target
 between locating and pressing it; Playwright reports success and nothing happens. The
 cold-start tick after load triggers this often enough to make a single click on a

--- a/src/ess/livedata/dashboard/cell_autoscale.py
+++ b/src/ess/livedata/dashboard/cell_autoscale.py
@@ -5,12 +5,19 @@
 A :class:`CellAutoscaleController` owns the Bokeh ``CustomAction`` tools that
 appear on a plot cell's toolbar (one per autoscalable axis, plus one for Fit)
 and on each HoloViews render writes per-axis ranges based on the toggle state.
+
+One cell can be rendered into several figures at once -- its grid cell and a
+pop-out window (``widgets/plot_popout.py``). They share one controller and one
+set of tool models, so the toolbars show a single toggle state: turning
+autoscale off in the pop-out turns it off in the cell too. Anything the
+controller tracks per render is therefore keyed by figure.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+from weakref import WeakSet
 
 import structlog
 
@@ -85,8 +92,8 @@ class CellAutoscaleController:
 
     Owns one Bokeh ``CustomAction`` per autoscalable axis (toggle) plus one
     for Fit. Exposes a single HoloViews-compatible hook that installs the
-    tools on the figure toolbar and on each render writes per-axis ranges
-    based on each toggle's ``.active``.
+    tools on every figure the cell renders into and on each render writes
+    that figure's per-axis ranges based on each toggle's ``.active``.
 
     Toggles default to ``True`` so the very first render with real data snaps
     the range away from the pipe's dummy bounds (strategy §4.5).
@@ -104,17 +111,22 @@ class CellAutoscaleController:
             *(plotter.autoscale_axes for plotter in self._plotters)
         )
         # Lazy-created on first render so each session's tools live in the
-        # session's own Bokeh document (see dashboard-widgets rules).
+        # session's own Bokeh document (see dashboard-widgets rules). The
+        # models are shared by every figure this cell renders into, which is
+        # what keeps their toggle states in step.
         self._toggles: dict[Axis, Any] = {}
         self._fit_tool: Any | None = None
-        self._tools_installed = False
+        self._figures: WeakSet = WeakSet()
         # Last target written per axis. Read back on subsequent off-state
         # renders so the c-axis freeze has a stable value to apply.
         self._last_targets: dict[Axis, tuple[float, float]] = {}
-        # One-shot Fit signal: set by the Fit on_change handler, honoured on
-        # the next render regardless of toggle state, then cleared. Avoids
-        # writing to potentially-stale handles cached at click time.
-        self._fit_pending: bool = False
+        # Figures that still owe a Fit: filled by the Fit on_change handler,
+        # honoured on each figure's next render regardless of toggle state,
+        # then dropped. Per figure rather than a single flag because sibling
+        # figures render from one pipe push, so whichever ran first would
+        # consume a shared flag and leave the other unfitted. Deferring to the
+        # render also avoids writing to handles cached at click time.
+        self._fit_pending: WeakSet = WeakSet()
 
     @property
     def axes(self) -> frozenset[Axis]:
@@ -143,14 +155,14 @@ class CellAutoscaleController:
 
         On every render the hook:
 
-        1. Installs the ``CustomAction`` tools on the figure toolbar (once
-           per session, idempotent).
+        1. Installs the ``CustomAction`` tools on the figure's toolbar (once
+           per figure, idempotent).
         2. For each axis whose toggle is active, writes ``(lo, hi)`` to the
            current Bokeh handle. Handles are read from ``plot.handles`` per
            render -- HoloViews swaps the figure on kdim/Layout transitions,
            so a cached handle would soon point at a detached model.
-        3. If a Fit click is pending, writes all axes regardless of toggle
-           state, then clears the flag.
+        3. If a Fit click is pending for this figure, writes all axes
+           regardless of toggle state, then drops the figure's claim.
 
         When :attr:`axes` is empty the hook is a no-op.
         """
@@ -180,15 +192,43 @@ class CellAutoscaleController:
                 pass
         self._toggles = {}
         self._fit_tool = None
-        self._tools_installed = False
+        self._figures.clear()
+        self._fit_pending.clear()
 
     def _install_tools(self, plot: Any) -> None:
-        """Install ``CustomAction`` tools on the figure toolbar once.
+        """Install this cell's ``CustomAction`` tools on a figure's toolbar.
 
-        Idempotent: subsequent calls are no-ops, mirroring the pattern in
-        ``flatten_plotter._make_hover_hook``.
+        Idempotent per *figure*, mirroring the pattern in
+        ``flatten_plotter._make_hover_hook``: a cell rendered into both its
+        grid cell and a pop-out window needs buttons on both toolbars. The
+        tool models themselves are created once and shared, so the two
+        toolbars drive -- and display -- one toggle state.
         """
-        if self._tools_installed:
+        figure = getattr(plot, 'state', None)
+        if figure is None or figure in self._figures:
+            return
+        toolbar = getattr(figure, 'toolbar', None)
+        if toolbar is None:
+            # Don't record the figure -- a subsequent render with a real
+            # toolbar should retry rather than silently lose the toggles.
+            logger.warning(
+                "No Bokeh toolbar found for cell autoscale controller; "
+                "toggles will be unavailable until the next render."
+            )
+            return
+        self._create_tools()
+        # Tools are added via assignment to keep Bokeh's property setter
+        # notified; in-place append would not trigger change events.
+        toolbar.tools = [
+            *toolbar.tools,
+            *self._toggles.values(),
+            self._fit_tool,
+        ]
+        self._figures.add(figure)
+
+    def _create_tools(self) -> None:
+        """Create the shared toggle and Fit tool models, once per controller."""
+        if self._toggles:
             return
         from .widgets.icons import get_icon_data_uri
 
@@ -199,7 +239,6 @@ class CellAutoscaleController:
             )
             for axis in self._axes
         }
-        fit_icon = get_icon_data_uri('arrows-minimize')
 
         for axis in sorted(self._axes):
             on_icon, off_icon = axis_icons[axis]
@@ -211,40 +250,24 @@ class CellAutoscaleController:
             )
         self._fit_tool = _make_fit_action(
             description='Fit ranges to current data',
-            icon=fit_icon,
+            icon=get_icon_data_uri('arrows-minimize'),
         )
         self._fit_tool.on_change('active', self._on_fit_active_change)
-
-        toolbar = getattr(getattr(plot, 'state', None), 'toolbar', None)
-        if toolbar is None:
-            # Don't mark installed -- a subsequent render with a real toolbar
-            # should retry rather than silently lose the toggles forever.
-            logger.warning(
-                "No Bokeh toolbar found for cell autoscale controller; "
-                "toggles will be unavailable until the next render."
-            )
-            return
-        # Tools are added via assignment to keep Bokeh's property setter
-        # notified; in-place append would not trigger change events.
-        toolbar.tools = [
-            *toolbar.tools,
-            *self._toggles.values(),
-            self._fit_tool,
-        ]
-        self._tools_installed = True
 
     def _apply_targets(self, plot: Any) -> None:
         """Write current targets to handles based on toggle / Fit state.
 
-        For x/y the hook writes only when the toggle is active or Fit is
-        pending; HoloViews honours ``framewise=False`` for ``Range1d`` so the
-        previous range (and any manual pan/zoom) is preserved when we skip.
+        For x/y the hook writes only when the toggle is active or a Fit is
+        pending for this figure; HoloViews honours ``framewise=False`` for
+        ``Range1d`` so the previous range (and any manual pan/zoom) is
+        preserved when we skip.
         For ``c`` the hook also re-applies the last target when the toggle is
         off -- a belt-and-suspenders safety net alongside the ``clim`` write
         in ``_apply_clim_freeze`` (which is what actually freezes the
         colorbar by making HV's next ``_get_colormapper`` use our value).
         """
-        fit = self._fit_pending
+        figure = getattr(plot, 'state', None)
+        fit = figure in self._fit_pending
         for axis in self._axes:
             toggle = self._toggles.get(axis)
             active = fit or (toggle is not None and toggle.active)
@@ -271,7 +294,7 @@ class CellAutoscaleController:
             elif axis == 'c' and (frozen := self._last_targets.get(axis)) is not None:
                 RangeHandles.write(plot, axis, *frozen)
         if fit:
-            self._fit_pending = False
+            self._fit_pending.discard(figure)
 
     def _apply_clim_freeze(self, plot: Any) -> None:
         """Pin ``cm_plot.clim`` so HV's next render keeps our color range.
@@ -301,15 +324,17 @@ class CellAutoscaleController:
     def _on_fit_active_change(self, attr: str, old: bool, new: bool) -> None:
         """Bokeh server-side handler for the Fit tool's ``active`` property.
 
-        When the user clicks Fit, ``active`` flips to ``True``; we set a
-        one-shot pending flag that the next hook invocation honours
-        regardless of toggle state. Robust to figure swaps between the click
-        and the next render: the hook writes through the live handles.
+        When the user clicks Fit, ``active`` flips to ``True``; every figure
+        this cell renders into is marked as owing a fit, which its next hook
+        invocation honours regardless of toggle state. One click therefore
+        fits the grid cell and the pop-out alike -- they share the tool, so
+        there is only one click to observe. Robust to figure swaps between the
+        click and the next render: the hook writes through the live handles.
         """
         del attr, old
         if not new:
             return
-        self._fit_pending = True
+        self._fit_pending.update(self._figures)
         if self._fit_tool is not None:
             self._fit_tool.active = False
 

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -49,7 +49,9 @@ ANNOUNCEMENTS_URL = (
     'https://public.esss.dk/groups/scipp/esslivedata/_static/announcements.md'
 )
 
-pn.extension('holoviews', 'modal', notifications=True, template='material')
+pn.extension(
+    'holoviews', 'modal', 'floatpanel', notifications=True, template='material'
+)
 hv.extension('bokeh')
 
 # Remove Bokeh logo from Layout toolbars by patching LayoutPlot.initialize_plot

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -207,7 +207,7 @@ class CellDeps:
     ``session_layers`` is the session's shared layer render-state registry
     (owned by the poll loop, read here when composing plots); the callbacks
     route modal interactions back to the owning ``PlotGridTabs`` (which holds
-    the shared modal container).
+    the shared modal and pop-out containers).
     """
 
     orchestrator: PlotOrchestrator
@@ -216,6 +216,170 @@ class CellDeps:
     session_layers: dict[LayerId, SessionLayer]
     on_edit_title: Callable[[CellId, str, bool], None]
     on_reconfigure_layer: Callable[[LayerId], None]
+    on_popout: Callable[[CellId], None]
+
+
+@dataclass(frozen=True)
+class ComposedPlot:
+    """A cell's composed plot together with the autoscale controller driving it.
+
+    Composition is per *view*, not per cell: the autoscale controller installs
+    its Bokeh toolbar tools on the first figure it renders into and ignores
+    later ones, so a second view of the same cell (a pop-out window) needs its
+    own controller. The underlying layer ``DynamicMap``s are shared, so every
+    view of a cell repaints from the same ``Pipe``.
+    """
+
+    plot: hv.DynamicMap | hv.Element
+    autoscale: CellAutoscaleController | None
+    sizing_mode: str
+
+    def dispose(self) -> None:
+        """Dispose the autoscale controller, breaking its reference cycle."""
+        if self.autoscale is not None:
+            self.autoscale.dispose()
+
+    def build_pane(self) -> pn.viewable.Viewable:
+        """
+        Wrap the plot in a HoloViews pane ready for placement in a layout.
+
+        Returns
+        -------
+        :
+            Layout containing the plot pane and any DynamicMap kdim widgets.
+        """
+        # Use .layout to preserve widgets for DynamicMaps with kdims.
+        # When pn.pane.HoloViews wraps a DynamicMap with kdims, it generates
+        # widgets. However, these widgets don't render when the pane is placed
+        # in a Panel layout (Tabs, Column, etc.). The .layout property contains
+        # both the plot and widgets, which renders correctly in layouts.
+        # See: https://github.com/holoviz/panel/issues/5628
+        #
+        # CRITICAL: Use linked_axes=False to prevent unintended axis linking (#607)
+        #
+        # Problem: By default, Panel's HoloViews pane links axes across different
+        # plots based on their axis labels (e.g., all plots with 'x' and 'y' axes
+        # get linked). For detector panels in different grid cells, this is unwanted:
+        # - Different detector panels have independent spatial coordinates
+        # - Zooming one panel shouldn't affect others
+        # - Each panel needs independent autoscaling
+        #
+        # Previous workarounds and why they failed:
+        # - shared_axes=False (HoloViews): Breaks dynamic features that rely on
+        #   shared axis infrastructure
+        # - Wrapping in hv.Layout: Prevents multi-layer composition with hv.Overlay,
+        #   which was needed for the layer system (#606)
+        #
+        # Solution: linked_axes=False on the Panel pane
+        # - Disables Panel's cross-plot axis linking while preserving HoloViews
+        #   features (autoscaling, dynamic updates)
+        # - Allows proper multi-layer composition via hv.Overlay
+        # - Each grid cell's plot remains independent
+        return pn.pane.HoloViews(
+            self.plot, sizing_mode=self.sizing_mode, linked_axes=False
+        ).layout
+
+
+def compose_cell_plot(cell: PlotCell, deps: CellDeps) -> ComposedPlot | None:
+    """
+    Compose a cell's plot from session-local DynamicMaps or static elements.
+
+    Ensures session components exist when data is available. Sets a descriptive
+    SaveTool filename on the result so that browser "Save" downloads get a
+    meaningful name, suspends hover while an ROI edit tool is active, and builds
+    an autoscale controller for the composed view.
+
+    Parameters
+    ----------
+    cell:
+        Plot cell configuration with all layers.
+    deps:
+        Shared session dependencies (services and session layer registry).
+
+    Returns
+    -------
+    :
+        Composed plot and its controller, or None if no layer is displayable.
+    """
+    plots = []
+    non_overlayable = False
+    cell_plotters: list = []
+    for layer in cell.layers:
+        layer_id = layer.layer_id
+        session_layer = deps.session_layers.get(layer_id)
+        if session_layer is None:
+            continue
+
+        # Ensure components exist if data is now available
+        state = deps.plot_data_service.get(layer_id)
+        if state is not None:
+            session_layer.ensure_components(state)
+            # Static overlays (vlines/hlines/rectangles) are not Plotters
+            # and carry no autoscale axes; exclude them from the controller.
+            if state.plotter is not None and not layer.config.is_static():
+                cell_plotters.append(state.plotter)
+            # Tables and layout-mode plotters produce a DataTable/Layout with
+            # no single figure for the SaveTool/aspect hooks to act on. Such
+            # layers are forbidden from sharing a cell, so this flags a
+            # solitary non-overlayable layer; hooks are skipped below.
+            if state.plotter is not None and not getattr(
+                state.plotter, 'is_overlayable', True
+            ):
+                non_overlayable = True
+
+        dmap = session_layer.dmap
+        if dmap is not None:
+            plots.append(dmap)
+
+    if not plots:
+        return None
+
+    # Layers of one cell are consistent for overlay, so the first one's aspect
+    # config sets the sizing mode for the whole composition.
+    sizing_mode = _get_sizing_mode(cell.layers[0].config)
+
+    result: hv.DynamicMap | hv.Element
+    if len(plots) == 1:
+        result = plots[0]
+    else:
+        # Collate so hooks survive for any number of DynamicMap layers.
+        # Without collation, HoloViews drops overlay-level opts (including
+        # hooks) when an Overlay contains 3+ DynamicMaps.  Collating first
+        # produces a single DynamicMap whose outputs are plain Overlays;
+        # opts applied afterwards land on the OverlayPlot and persist.
+        result = hv.Overlay(plots).collate()
+
+    # Skip the cell-level hooks for a non-overlayable layer: a Layout's
+    # sub-figures each carry their own SaveTool, and a Table's DataTable
+    # widget has no figure for the SaveTool/autoscale hooks to act on. The
+    # frame-aspect hook is not among these — it is declared per element type
+    # by the plotter (see Plotter._sizing_opts), so it reaches every
+    # sub-figure of a Layout regardless.
+    if non_overlayable:
+        return ComposedPlot(plot=result, autoscale=None, sizing_mode=sizing_mode)
+
+    hooks: list = [make_hover_suspend_hook()]
+    filename = build_save_filename_from_cell(
+        cell, deps.workflow_registry, deps.orchestrator.get_source_title
+    )
+    if filename is not None:
+        hooks.append(make_save_filename_hook(filename))
+    # Fresh controller on every composition: keeps tools and toggle state local
+    # to the figure this view renders. The previous view's controller is
+    # disposed by its owner after the swap, breaking its on_change reference
+    # cycle (would otherwise leak across the session).
+    controller = build_controller_from_layers(cell_plotters)
+    if controller is not None:
+        hooks.append(controller.make_hook())
+    # clone=True: ``opts`` otherwise mutates the layer's DynamicMap in place, so
+    # composing a second view of the same cell (a pop-out) would overwrite the
+    # first view's hooks and leave it driven by the wrong controller. The clone
+    # keeps the same stream objects, so both views stay live off one pipe.
+    return ComposedPlot(
+        plot=result.opts(hooks=hooks, clone=True),
+        autoscale=controller,
+        sizing_mode=sizing_mode,
+    )
 
 
 class CellWidget:
@@ -253,19 +417,40 @@ class CellWidget:
         self._cell = cell
         self._deps = deps
         self._toolbars_shown = toolbars_visible
-        self._autoscale_controller: CellAutoscaleController | None = None
         self._freshness_pane = create_freshness_pane()
         self._stopped_layers: frozenset[LayerId] = frozenset()
         self._pill_frozen = False
         self._layer_time_panes: dict[LayerId, pn.pane.HTML] = {}
-        # Composing builds the autoscale controller as a side effect.
-        self._plot = self._compose_plot()
+        self._composed = compose_cell_plot(cell, deps)
+        self._title = (
+            cell.user_title
+            if cell.user_title is not None
+            else derive_cell_title(
+                cell,
+                deps.workflow_registry,
+                get_source_title=deps.orchestrator.get_source_title,
+            )
+        )
         self._view = self._build()
 
     @property
     def view(self) -> pn.Column:
         """The Panel widget for this cell."""
         return self._view
+
+    @property
+    def title(self) -> str:
+        """The cell's displayed title (user-defined or derived)."""
+        return self._title
+
+    def compose_detached_view(self) -> ComposedPlot | None:
+        """Compose an independent view of this cell's plot for a pop-out window.
+
+        Shares the layer ``DynamicMap``s with the in-grid view — both repaint
+        from the same ``Pipe`` — but gets its own autoscale controller, which
+        the caller must dispose.
+        """
+        return compose_cell_plot(self._cell, self._deps)
 
     @property
     def geometry(self) -> CellGeometry:
@@ -275,7 +460,7 @@ class CellWidget:
     @property
     def has_plot(self) -> bool:
         """Whether the cell currently shows a composed plot (vs. placeholder)."""
-        return self._plot is not None
+        return self._composed is not None
 
     @property
     def toolbars_shown(self) -> bool:
@@ -294,8 +479,8 @@ class CellWidget:
 
     @property
     def autoscale_controller(self) -> CellAutoscaleController | None:
-        """The cell's autoscale controller, if any layer drives autoscale."""
-        return self._autoscale_controller
+        """The in-grid view's autoscale controller, if any layer drives autoscale."""
+        return self._composed.autoscale if self._composed is not None else None
 
     def update_freshness(
         self, bounds_by_layer: Mapping[LayerId, TimeBounds | None]
@@ -334,9 +519,8 @@ class CellWidget:
         on_change-callback → controller reference cycle so long sessions
         don't accumulate detached controllers after cell rebuilds/removals.
         """
-        if self._autoscale_controller is not None:
-            self._autoscale_controller.dispose()
-            self._autoscale_controller = None
+        if self._composed is not None:
+            self._composed.dispose()
 
     def _layer_states(self) -> dict[LayerId, LayerStateMachine]:
         """Get layer states from PlotDataService for all layers in the cell."""
@@ -399,8 +583,8 @@ class CellWidget:
         titlebar = self._build_titlebar(layers_column)
 
         # Create content area (placeholder or plot)
-        if self._plot is not None:
-            content = self._build_plot_content(self._plot)
+        if self._composed is not None:
+            content = self._composed.build_pane()
             border = None
             bg_color = None
         else:
@@ -443,15 +627,7 @@ class CellWidget:
         """
         cell = self._cell
         has_user_title = cell.user_title is not None
-        title = (
-            cell.user_title
-            if has_user_title
-            else derive_cell_title(
-                cell,
-                self._deps.workflow_registry,
-                get_source_title=self._deps.orchestrator.get_source_title,
-            )
-        )
+        title = self._title
 
         configure_layers = [
             (
@@ -481,6 +657,8 @@ class CellWidget:
             on_configure_layer=self._deps.on_reconfigure_layer,
             toolbars_visible=self._toolbars_shown,
             on_toggle_toolbars_callback=on_toggle_toolbars,
+            on_popout_callback=lambda: self._deps.on_popout(self._cell_id),
+            can_popout=self.has_plot,
             freshness_pane=self._freshness_pane,
             # Per-cell automation hook: a rebuilt cell's DOM position is not
             # stable, so the grid position addresses it (unique per grid, and
@@ -606,143 +784,3 @@ class CellWidget:
             content,
             styles={'text-align': 'left', 'padding': '20px'},
         )
-
-    def _build_plot_content(
-        self,
-        plot: hv.DynamicMap | hv.Element | hv.Overlay,
-    ) -> pn.pane.HoloViews:
-        """
-        Create plot content widget.
-
-        Parameters
-        ----------
-        plot
-            The composed plot.
-
-        Returns
-        -------
-        :
-            HoloViews pane containing the plot.
-        """
-        # Use sizing mode from first layer (they should be consistent for overlay)
-        if self._cell.layers:
-            sizing_mode = _get_sizing_mode(self._cell.layers[0].config)
-        else:
-            sizing_mode = 'stretch_both'
-
-        # Use .layout to preserve widgets for DynamicMaps with kdims.
-        # When pn.pane.HoloViews wraps a DynamicMap with kdims, it generates
-        # widgets. However, these widgets don't render when the pane is placed
-        # in a Panel layout (Tabs, Column, etc.). The .layout property contains
-        # both the plot and widgets, which renders correctly in layouts.
-        # See: https://github.com/holoviz/panel/issues/5628
-        #
-        # CRITICAL: Use linked_axes=False to prevent unintended axis linking (#607)
-        #
-        # Problem: By default, Panel's HoloViews pane links axes across different
-        # plots based on their axis labels (e.g., all plots with 'x' and 'y' axes
-        # get linked). For detector panels in different grid cells, this is unwanted:
-        # - Different detector panels have independent spatial coordinates
-        # - Zooming one panel shouldn't affect others
-        # - Each panel needs independent autoscaling
-        #
-        # Previous workarounds and why they failed:
-        # - shared_axes=False (HoloViews): Breaks dynamic features that rely on
-        #   shared axis infrastructure
-        # - Wrapping in hv.Layout: Prevents multi-layer composition with hv.Overlay,
-        #   which was needed for the layer system (#606)
-        #
-        # Solution: linked_axes=False on the Panel pane
-        # - Disables Panel's cross-plot axis linking while preserving HoloViews
-        #   features (autoscaling, dynamic updates)
-        # - Allows proper multi-layer composition via hv.Overlay
-        # - Each grid cell's plot remains independent
-        plot_pane_wrapper = pn.pane.HoloViews(
-            plot, sizing_mode=sizing_mode, linked_axes=False
-        )
-        return plot_pane_wrapper.layout
-
-    def _compose_plot(self) -> hv.DynamicMap | hv.Element | None:
-        """
-        Compose the cell's plot from session-local DynamicMaps or static elements.
-
-        Ensures session components exist when data is available. Sets a
-        descriptive SaveTool filename on the result so that browser "Save"
-        downloads get a meaningful name, suspends hover while an ROI edit tool
-        is active, and builds the cell's autoscale controller as a side effect.
-
-        Returns
-        -------
-        :
-            Composed plot from session DMaps/elements, or None if none available.
-        """
-        plots = []
-        non_overlayable = False
-        cell_plotters: list = []
-        for layer in self._cell.layers:
-            layer_id = layer.layer_id
-            session_layer = self._deps.session_layers.get(layer_id)
-            if session_layer is None:
-                continue
-
-            # Ensure components exist if data is now available
-            state = self._deps.plot_data_service.get(layer_id)
-            if state is not None:
-                session_layer.ensure_components(state)
-                # Static overlays (vlines/hlines/rectangles) are not Plotters
-                # and carry no autoscale axes; exclude them from the controller.
-                if state.plotter is not None and not layer.config.is_static():
-                    cell_plotters.append(state.plotter)
-                # Tables and layout-mode plotters produce a DataTable/Layout with
-                # no single figure for the SaveTool/aspect hooks to act on. Such
-                # layers are forbidden from sharing a cell, so this flags a
-                # solitary non-overlayable layer; hooks are skipped below.
-                if state.plotter is not None and not getattr(
-                    state.plotter, 'is_overlayable', True
-                ):
-                    non_overlayable = True
-
-            dmap = session_layer.dmap
-            if dmap is not None:
-                plots.append(dmap)
-
-        if not plots:
-            return None
-
-        result: hv.DynamicMap | hv.Element
-        if len(plots) == 1:
-            result = plots[0]
-        else:
-            # Collate so hooks survive for any number of DynamicMap layers.
-            # Without collation, HoloViews drops overlay-level opts (including
-            # hooks) when an Overlay contains 3+ DynamicMaps.  Collating first
-            # produces a single DynamicMap whose outputs are plain Overlays;
-            # opts applied afterwards land on the OverlayPlot and persist.
-            result = hv.Overlay(plots).collate()
-
-        # Skip the cell-level hooks for a non-overlayable layer: a Layout's
-        # sub-figures each carry their own SaveTool, and a Table's DataTable
-        # widget has no figure for the SaveTool/autoscale hooks to act on. The
-        # frame-aspect hook is not among these — it is declared per element type
-        # by the plotter (see Plotter._sizing_opts), so it reaches every
-        # sub-figure of a Layout regardless.
-        if non_overlayable:
-            return result
-
-        hooks: list = [make_hover_suspend_hook()]
-        filename = build_save_filename_from_cell(
-            self._cell,
-            self._deps.workflow_registry,
-            self._deps.orchestrator.get_source_title,
-        )
-        if filename is not None:
-            hooks.append(make_save_filename_hook(filename))
-        # Fresh controller on every cell rebuild: keeps tools and toggle state
-        # local to this session's Bokeh document. The previous cell widget's
-        # controller is disposed by the owner after the swap, breaking its
-        # on_change reference cycle (would otherwise leak across the session).
-        controller = build_controller_from_layers(cell_plotters)
-        if controller is not None:
-            self._autoscale_controller = controller
-            hooks.append(controller.make_hook())
-        return result.opts(hooks=hooks)

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -223,11 +223,11 @@ class CellDeps:
 class ComposedPlot:
     """A cell's composed plot together with the autoscale controller driving it.
 
-    Composition is per *view*, not per cell: the autoscale controller installs
-    its Bokeh toolbar tools on the first figure it renders into and ignores
-    later ones, so a second view of the same cell (a pop-out window) needs its
-    own controller. The underlying layer ``DynamicMap``s are shared, so every
-    view of a cell repaints from the same ``Pipe``.
+    One composition per cell, however many times it is rendered: a pop-out
+    window calls :meth:`build_pane` a second time on the same instance. Sharing
+    it is deliberate — the controller then installs one set of tool models on
+    both toolbars, so the views' autoscale toggles move together, and both
+    figures repaint from the layers' single ``Pipe``.
     """
 
     plot: hv.DynamicMap | hv.Element
@@ -242,6 +242,9 @@ class ComposedPlot:
     def build_pane(self) -> pn.viewable.Viewable:
         """
         Wrap the plot in a HoloViews pane ready for placement in a layout.
+
+        Call once per view: a Panel component has a single parent, so a second
+        view of this plot needs its own pane over the same HoloViews object.
 
         Returns
         -------
@@ -371,14 +374,8 @@ def compose_cell_plot(cell: PlotCell, deps: CellDeps) -> ComposedPlot | None:
     controller = build_controller_from_layers(cell_plotters)
     if controller is not None:
         hooks.append(controller.make_hook())
-    # clone=True: ``opts`` otherwise mutates the layer's DynamicMap in place, so
-    # composing a second view of the same cell (a pop-out) would overwrite the
-    # first view's hooks and leave it driven by the wrong controller. The clone
-    # keeps the same stream objects, so both views stay live off one pipe.
     return ComposedPlot(
-        plot=result.opts(hooks=hooks, clone=True),
-        autoscale=controller,
-        sizing_mode=sizing_mode,
+        plot=result.opts(hooks=hooks), autoscale=controller, sizing_mode=sizing_mode
     )
 
 
@@ -443,14 +440,16 @@ class CellWidget:
         """The cell's displayed title (user-defined or derived)."""
         return self._title
 
-    def compose_detached_view(self) -> ComposedPlot | None:
-        """Compose an independent view of this cell's plot for a pop-out window.
+    @property
+    def composed(self) -> ComposedPlot | None:
+        """The cell's composed plot, or None while it shows a placeholder.
 
-        Shares the layer ``DynamicMap``s with the in-grid view — both repaint
-        from the same ``Pipe`` — but gets its own autoscale controller, which
-        the caller must dispose.
+        Rendered a second time by a pop-out window, which shares it rather
+        than composing its own: sharing is what links the two views' autoscale
+        toggles and keeps them both fed by one ``Pipe``. The cell widget owns
+        it and disposes it.
         """
-        return compose_cell_plot(self._cell, self._deps)
+        return self._composed
 
     @property
     def geometry(self) -> CellGeometry:

--- a/src/ess/livedata/dashboard/widgets/icons.py
+++ b/src/ess/livedata/dashboard/widgets/icons.py
@@ -159,6 +159,17 @@ _ICONS: dict[str, str] = {
         '<path d="M19 15l-4 0l0 4"/>'
         '<path d="M15 15l6 6"/>'
     ),
+    # Arrows-maximize (pop the plot out into a floating window)
+    'arrows-maximize': _svg(
+        '<path d="M16 4l4 0l0 4"/>'
+        '<path d="M14 10l6 -6"/>'
+        '<path d="M8 20l-4 0l0 -4"/>'
+        '<path d="M4 20l6 -6"/>'
+        '<path d="M16 20l4 0l0 -4"/>'
+        '<path d="M14 14l6 6"/>'
+        '<path d="M8 4l-4 0l0 4"/>'
+        '<path d="M4 4l6 6"/>'
+    ),
 }
 
 

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -40,6 +40,7 @@ from .modal_escape_closer import ModalEscapeCloser
 from .plot_config_modal import PlotConfigModal
 from .plot_grid import PlotGrid
 from .plot_grid_manager import PlotGridManager
+from .plot_popout import PlotPopoutManager
 from .styles import Colors
 
 logger = structlog.get_logger(__name__)
@@ -153,8 +154,9 @@ class PlotGridTabs:
 
         # Gate state for coalescing plot-data flushes (see _poll_for_plot_updates).
         # The data push runs only when a new data-burst frame is ready or the
-        # visible tab changed; -1 forces a flush on the first poll.
-        self._last_flushed_generation: int = -1
+        # visible tab changed. Keyed by grid: the visible one, plus any grid
+        # holding a popped-out cell. Empty forces a flush on the first poll.
+        self._last_generations: dict[GridId | None, int] = {}
         self._last_active_grid_id: GridId | None = None
         # Wall-clock (monotonic) of the last freshness-pill refresh, throttling
         # the stall-aging path between data frames.
@@ -170,7 +172,13 @@ class PlotGridTabs:
             session_layers=self._session_layers,
             on_edit_title=self._show_cell_properties_modal,
             on_reconfigure_layer=self._on_reconfigure_layer,
+            on_popout=self._show_popout,
         )
+
+        # Floating pop-out windows, one per cell at most. Kept out of
+        # ``_current_modal``: that field gates the poll loop's data flush, and
+        # a pop-out must keep updating.
+        self._popouts = PlotPopoutManager()
 
         # Determine number of static tabs for stylesheet
         static_tab_count = 3 if system_status_widget else 2
@@ -226,6 +234,7 @@ class PlotGridTabs:
         self._widget = pn.Column(
             self._tabs,
             self._modal_container,
+            self._popouts.container,
             ModalEscapeCloser(),
             sizing_mode='stretch_both',
         )
@@ -587,6 +596,12 @@ class PlotGridTabs:
         self._modal_container.append(modal.modal)
         modal.show()
 
+    def _show_popout(self, cell_id: CellId) -> None:
+        """Open the cell's plot in a floating window (see ``plot_popout``)."""
+        cell_widget = self._cells.get(cell_id)
+        if cell_widget is not None:
+            self._popouts.open(cell_id, cell_widget)
+
     @staticmethod
     def _cell_signature(cell: PlotCell) -> tuple:
         """Composition fingerprint of a cell: geometry, title, and layer ids.
@@ -612,12 +627,21 @@ class PlotGridTabs:
         """
         previous = self._cells.get(cell_id)
         toolbars_visible = previous.toolbars_shown if previous is not None else False
+        # A pop-out renders the old composition's DynamicMaps, which the rebuild
+        # replaces, so it has to be rebuilt too. Reopening rather than closing
+        # keeps the window following its cell: a rebuild is triggered by things
+        # the user did elsewhere (a rename, a job restart), and having the
+        # floating view vanish in response would look like a crash.
+        was_popped_out = cell_id in self._popouts.open_cells()
+        self._popouts.close(cell_id)
         cell_widget = CellWidget(
             cell_id, cell, self._cell_deps, toolbars_visible=toolbars_visible
         )
         self._cells[cell_id] = cell_widget
         if previous is not None:
             previous.dispose()
+        if was_popped_out:
+            self._popouts.open(cell_id, cell_widget)
         return cell_widget
 
     def _poll_for_plot_updates(self) -> None:
@@ -663,9 +687,22 @@ class PlotGridTabs:
         # data arriving for another session's tab does not wake this session.
         # The cheap per-tick work below -- version/lifecycle scan, layer
         # activation, freshness-pill aging -- always runs so it stays responsive.
-        generation = self._orchestrator.frame_generation(active_grid_id)
+        # A cell with an open pop-out window counts as live wherever it sits, so
+        # its grid joins the visible one in driving the flush gate. With no
+        # pop-outs open this reduces to the visible grid alone, leaving the gate
+        # exactly as it was.
+        popout_cells = self._popouts.open_cells()
+        live_grids = {active_grid_id} | {
+            grid_id
+            for cell_id in popout_cells
+            if (grid_id := self._cell_grid.get(cell_id)) is not None
+        }
+        generations = {
+            grid_id: self._orchestrator.frame_generation(grid_id)
+            for grid_id in live_grids
+        }
         flush_due = (
-            generation != self._last_flushed_generation
+            generations != self._last_generations
             or active_grid_id != self._last_active_grid_id
         )
 
@@ -674,7 +711,7 @@ class PlotGridTabs:
             if grid_config is None or not grid_config.enabled:
                 continue
 
-            is_active = grid_id == active_grid_id
+            grid_is_visible = grid_id == active_grid_id
 
             for cell_id, cell in grid_config.cells.items():
                 # A cell always has >=1 layer while it exists in topology (the
@@ -682,6 +719,10 @@ class PlotGridTabs:
                 # empty state defensively.
                 if not cell.layers:
                     continue
+
+                # A popped-out cell keeps computing and repainting while the
+                # user works in another tab; the window shows it either way.
+                is_active = grid_is_visible or cell_id in popout_cells
 
                 # Detect composition changes (layer add/remove/reconfigure,
                 # title). Plotter swaps keep the layer ids and are handled by
@@ -768,6 +809,7 @@ class PlotGridTabs:
             cell_widget = self._cells.pop(cell_id)
             self._cell_grid.pop(cell_id, None)
             self._cell_signatures.pop(cell_id, None)
+            self._popouts.close(cell_id)
             plot_grid = self._grid_widgets.get(grid_id) if grid_id is not None else None
             if plot_grid is not None:
                 plot_grid.remove_widget_at(cell_widget.geometry)
@@ -820,11 +862,11 @@ class PlotGridTabs:
                     cell_widget.update_layer_time(layer_id, bounds)
 
         # Record gate state for the next poll. Only advance the flushed
-        # generation when we actually flushed (flush_due), so a tab change that
-        # piggybacks on an unchanged generation does not suppress the flush for
+        # generations when we actually flushed (flush_due), so a tab change that
+        # piggybacks on unchanged generations does not suppress the flush for
         # the next genuine frame.
         if flush_due:
-            self._last_flushed_generation = generation
+            self._last_generations = generations
         self._last_active_grid_id = active_grid_id
 
     def sever(self) -> None:
@@ -847,10 +889,11 @@ class PlotGridTabs:
     def dispose_widgets(self) -> None:
         """Dispose session-bound widgets (tier 1).
 
-        Disposes cell widgets, breaking Bokeh-tool reference cycles. Mutates
-        Bokeh document state, so it must run on the session's IOLoop.
-        Idempotent.
+        Disposes cell widgets and any open pop-out windows, breaking Bokeh-tool
+        reference cycles. Mutates Bokeh document state, so it must run on the
+        session's IOLoop. Idempotent.
         """
+        self._popouts.close_all()
         for cell_widget in self._cells.values():
             cell_widget.dispose()
         self._cells.clear()

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -687,11 +687,12 @@ class PlotGridTabs:
         # data arriving for another session's tab does not wake this session.
         # The cheap per-tick work below -- version/lifecycle scan, layer
         # activation, freshness-pill aging -- always runs so it stays responsive.
-        # A cell with an open pop-out window counts as live wherever it sits, so
+        # A cell whose pop-out is on screen counts as live wherever it sits, so
         # its grid joins the visible one in driving the flush gate. With no
-        # pop-outs open this reduces to the visible grid alone, leaving the gate
-        # exactly as it was.
-        popout_cells = self._popouts.open_cells()
+        # pop-outs showing this reduces to the visible grid alone, leaving the
+        # gate exactly as it was -- which is also what a minimized pop-out gets,
+        # since ``live_cells`` reports what renders, not what exists.
+        popout_cells = self._popouts.live_cells()
         live_grids = {active_grid_id} | {
             grid_id
             for cell_id in popout_cells
@@ -722,6 +723,7 @@ class PlotGridTabs:
 
                 # A popped-out cell keeps computing and repainting while the
                 # user works in another tab; the window shows it either way.
+                # Minimized, it shows nothing and sleeps with its grid.
                 is_active = grid_is_visible or cell_id in popout_cells
 
                 # Detect composition changes (layer add/remove/reconfigure,

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -655,8 +655,10 @@ class PlotGridTabs:
         # replaces, so it has to be rebuilt too. Reopening rather than closing
         # keeps the window following its cell: a rebuild is triggered by things
         # the user did elsewhere (a rename, a job restart), and having the
-        # floating view vanish in response would look like a crash.
-        was_popped_out = cell_id in self._popouts.open_cells()
+        # floating view vanish in response would look like a crash. Carrying
+        # the status over keeps a minimized window minimized -- and its cell
+        # asleep -- rather than popping every parked window open.
+        popout_status = self._popouts.status_of(cell_id)
         self._popouts.close(cell_id)
         cell_widget = CellWidget(
             cell_id, cell, self._cell_deps, toolbars_visible=toolbars_visible
@@ -664,8 +666,8 @@ class PlotGridTabs:
         self._cells[cell_id] = cell_widget
         if previous is not None:
             previous.dispose()
-        if was_popped_out:
-            self._popouts.open(cell_id, cell_widget)
+        if popout_status is not None:
+            self._popouts.open(cell_id, cell_widget, status=popout_status)
         return cell_widget
 
     def _on_active_tab_changed(self, event) -> None:
@@ -692,6 +694,12 @@ class PlotGridTabs:
         Read by both :meth:`_has_pending_work` and the pass it gates, which
         have to agree on what counts as live: a predicate blind to a grid the
         pass would flush leaves that pop-out frozen until the next full pass.
+
+        The clock is per grid, so a pop-out buys wakes for every frame of the
+        grid behind it -- committed whenever any session keeps any of that
+        grid's cells computing -- not just for its own cell. The extra passes
+        are cheap (nothing pending, nothing flushed) and bounded by the frame
+        rate; a per-cell clock is not worth carrying for that.
         """
         live_grids = {active_grid_id} | {
             grid_id
@@ -750,9 +758,10 @@ class PlotGridTabs:
         - Sweeps cells that vanished from topology, removing and disposing them.
         - Creates/updates session layers and pushes data to the active tab.
 
-        Only layers on the currently visible grid tab call ``update_pipe()``,
-        since ``dynamic=True`` on Tabs means hidden tabs have no materialized
-        Bokeh models. Skipped layers keep their dirty flag set; a tab switch
+        Only layers this session renders -- the visible grid tab, plus any
+        cell with a showing pop-out window -- call ``update_pipe()``, since
+        ``dynamic=True`` on Tabs means hidden tabs have no materialized Bokeh
+        models. Skipped layers keep their dirty flag set; a tab switch
         requests its own tick (:meth:`_on_active_tab_changed`), which sends the
         newly visible layers' latest cached state.
 
@@ -789,26 +798,42 @@ class PlotGridTabs:
         active_cell_bounds: dict[CellId, dict[LayerId, TimeBounds | None]] = {}
         active_grid_id = self._get_active_grid_id()
 
-        # Flush plot data only when a new data-burst frame is ready for the
-        # visible tab (so all its layers from one burst repaint in a single
-        # frame, never staggered across poll ticks) or when the visible tab
-        # changed (newly shown cells must render their latest data without
-        # waiting for the next frame). Scoping the generation per grid means
-        # data arriving for another session's tab does not wake this session,
-        # and a cell whose pop-out is on screen counts as live wherever it sits
-        # (see :meth:`_live_generations`).
+        # Flush a grid's plot data only when a new data-burst frame is ready
+        # for that grid (so all its layers from one burst repaint in a single
+        # frame, never staggered across poll ticks) or when it just became
+        # the visible tab (newly shown cells must render their latest data
+        # without waiting for the next frame). Staleness is per grid, not one
+        # flag: a presenter holds pending data as soon as the ingestion
+        # thread builds its layer, before the grid's frame commits, so a
+        # shared flag would let a frame for a pop-out's grid push the visible
+        # grid's half-built burst (or vice versa). Scoping the generation per
+        # grid also means data arriving for another session's tab does not
+        # wake this session, and a cell whose pop-out is on screen counts as
+        # live wherever it sits (see :meth:`_live_generations`).
         # The cheap per-tick work below -- version/lifecycle scan, layer
-        # activation, freshness-pill aging -- always runs so it stays responsive.
+        # activation, freshness-pill aging -- always runs so it stays
+        # responsive.
         popout_cells = self._popouts.live_cells()
         generations = self._live_generations(active_grid_id, popout_cells)
-        flush_due = (
-            generations != self._last_generations
-            or active_grid_id != self._last_active_grid_id
-        )
+        stale_grids = {
+            grid_id
+            for grid_id, generation in generations.items()
+            if generation != self._last_generations.get(grid_id)
+        }
+        if active_grid_id != self._last_active_grid_id:
+            stale_grids.add(active_grid_id)
 
         for grid_id, plot_grid in self._grid_widgets.items():
             grid_config = self._orchestrator.peek_grid(grid_id)
-            if grid_config is None or not grid_config.enabled:
+            if grid_config is None:
+                continue
+            if not grid_config.enabled:
+                # A disabled grid's layers lose their viewers (orphan sweep
+                # below), so a pop-out over one of its cells would float on,
+                # frozen, with no cue. Close it; the cell widget itself is
+                # kept for a re-enable.
+                for cell_id in grid_config.cells:
+                    self._popouts.close(cell_id)
                 continue
 
             grid_is_visible = grid_id == active_grid_id
@@ -824,6 +849,7 @@ class PlotGridTabs:
                 # user works in another tab; the window shows it either way.
                 # Minimized, it shows nothing and sleeps with its grid.
                 is_active = grid_is_visible or cell_id in popout_cells
+                flush_cell = is_active and grid_id in stale_grids
 
                 # Detect composition changes (layer add/remove/reconfigure,
                 # title). Plotter swaps keep the layer ids and are handled by
@@ -880,9 +906,10 @@ class PlotGridTabs:
 
                     # Push pending data to the browser. Runs after activate_layer
                     # so a tab-switch 0→1 build is sent on this same tick. Gated
-                    # on flush_due to coalesce a burst's layers into one frame;
-                    # no-op anyway unless the presenter has a pending update.
-                    if is_active and flush_due:
+                    # on the grid's staleness to coalesce a burst's layers into
+                    # one frame; no-op anyway unless the presenter has a pending
+                    # update.
+                    if flush_cell:
                         session_layer.update_pipe()
 
         # Clean up orphaned session layers (removed from orchestrator). Per-cell
@@ -948,26 +975,29 @@ class PlotGridTabs:
         # The per-layer time/lag row only changes on a new frame, so it tracks
         # the data flush too.
         now_mono = time.monotonic()
-        stalled = now_mono - self._last_freshness_update
-        freshness_due = flush_due or stalled >= _FRESHNESS_STALL_INTERVAL_S
-        if freshness_due:
+        stalled = now_mono - self._last_freshness_update >= _FRESHNESS_STALL_INTERVAL_S
+        # The stall timer serves the visible grid's pills, so only a flush
+        # that reached them resets it: frames for a pop-out's grid must not
+        # keep deferring the aging of a visible grid whose own stream stalled.
+        if active_grid_id in stale_grids or stalled:
             self._last_freshness_update = now_mono
         for cell_id, per_layer in active_cell_bounds.items():
             cell_widget = self._cells.get(cell_id)
             if cell_widget is None:
                 continue
-            if freshness_due:
+            cell_flushed = self._cell_grid.get(cell_id) in stale_grids
+            if cell_flushed or stalled:
                 cell_widget.update_freshness(per_layer)
-            if flush_due:
+            if cell_flushed:
                 for layer_id, bounds in per_layer.items():
                     cell_widget.update_layer_time(layer_id, bounds)
 
-        # Record gate state for the next poll. Only advance the flushed
-        # generations when we actually flushed (flush_due), so a tab change that
-        # piggybacks on unchanged generations does not suppress the flush for
-        # the next genuine frame.
-        if flush_due:
-            self._last_generations = generations
+        # Record gate state for the next poll. Every stale grid was flushed in
+        # the pass above, so the generations read this pass can be recorded
+        # wholesale: a grid that was not stale records the value it already
+        # had. (An exception escaping the pass skips this, leaving the gate
+        # armed so the next tick retries.)
+        self._last_generations = generations
         self._last_active_grid_id = active_grid_id
         self._last_layer_version = layer_version
 

--- a/src/ess/livedata/dashboard/widgets/plot_popout.py
+++ b/src/ess/livedata/dashboard/widgets/plot_popout.py
@@ -39,7 +39,10 @@ topology, so closing the browser tab discards them.
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import panel as pn
+from panel.reactive import ReactiveHTML
 
 from ..plot_orchestrator import CellId
 from .cell import CellWidget, ComposedPlot
@@ -73,6 +76,72 @@ _CASCADE_WRAP = 6
 _TOP_MARGIN = 24
 _CONTENT_HEIGHT = '78vh'
 
+
+class PopoutWindowFitter(ReactiveHTML):
+    """Invisible widget that makes a pop-out's plot follow its window.
+
+    Closes two gaps in Panel's ``FloatPanel``, both of which leave the plot at a
+    size the window no longer has:
+
+    - **The height chain is broken.** jsPanel sizes its own content element, but
+      the wrappers Panel puts between that element and ours have no height, so
+      nothing propagates the window's size inward. A stretching child then has
+      nothing to stretch into and collapses to a sliver; a child with its own
+      fixed height survives but can never follow the window, leaving whitespace
+      once the window grows past it.
+    - **Only drag-resize triggers a re-layout.** Panel listens for
+      ``jspanelresizestop``, which a drag fires but maximize, normalize and
+      smallify do not, so those change the window without resizing the plot in
+      it. Re-dispatching that event on any status change hands the work to
+      Panel's own handler rather than reimplementing it -- the ``panel``
+      property is what its handler matches on.
+
+    One instance per session, covering every pop-out however many are open.
+    Mirrors the ``_scripts['render']`` pattern of
+    :class:`~ess.livedata.dashboard.widgets.modal_escape_closer.ModalEscapeCloser`.
+    """
+
+    _template = """<div id="popout_fit" style="display:none;"></div>"""
+
+    _scripts: ClassVar = {
+        'render': """
+            if (window.__esslivedataPopoutFit) { return; }
+            window.__esslivedataPopoutFit = true;
+            const style = document.createElement('style');
+            style.id = 'esslivedata-popout-fit';
+            style.textContent = `
+                .jsPanel-content > .bk-root {
+                    height: 100%;
+                    box-sizing: border-box;
+                }
+                .jsPanel-content > .bk-root > div { height: 100%; }
+            `;
+            document.head.appendChild(style);
+            state.handler = (event) => {
+                const relayout = new Event('jspanelresizestop');
+                relayout.panel = event.panel;
+                document.dispatchEvent(relayout);
+            };
+            document.addEventListener('jspanelstatuschange', state.handler);
+        """,
+        'remove': """
+            if (state.handler) {
+                document.removeEventListener('jspanelstatuschange', state.handler);
+                const style = document.getElementById('esslivedata-popout-fit');
+                if (style) { style.remove(); }
+                window.__esslivedataPopoutFit = false;
+            }
+        """,
+    }
+
+    def __init__(self, **params):
+        params.setdefault('width', 0)
+        params.setdefault('height', 0)
+        params.setdefault('sizing_mode', 'fixed')
+        params.setdefault('visible', False)
+        super().__init__(**params)
+
+
 # jsPanel statuses in which the window actually renders its content. The others
 # ('minimized', and the two 'smallified' variants, which collapse the window to
 # its title bar) show no plot, so the cell behind them may sleep.
@@ -100,21 +169,14 @@ def _build_window(
     return pn.layout.FloatPanel(
         pn.Column(
             composed.build_pane(),
-            sizing_mode='stretch_width',
-            styles={
-                # An explicit height, not ``stretch_both``: jsPanel moves the
-                # window's DOM out of the Bokeh tree, leaving nothing for a
-                # stretching child to measure itself against, and a free-aspect
-                # plot then collapses to a sliver. Viewport units are explicit
-                # in exactly that sense -- they need no parent to measure
-                # against -- so they cap the height without reintroducing it.
-                # The wrapper is also what gives the relocated content a layout
-                # root of its own: a bare pane does not render once detached.
-                'height': _CONTENT_HEIGHT,
-                # A plot whose locked aspect makes it taller than the window
-                # must stay reachable rather than be clipped.
-                'overflow': 'auto',
-            },
+            # Stretches into the height ``_FILL_WINDOW`` gives the wrappers, so
+            # the plot tracks the window at every size. The wrapper is also what
+            # gives the relocated content a layout root of its own: a bare pane
+            # does not render once jsPanel has moved it out of the Bokeh tree.
+            sizing_mode='stretch_both',
+            # A plot whose locked aspect makes it taller than the window must
+            # stay reachable rather than be clipped.
+            styles={'overflow': 'auto'},
         ),
         name=title,
         # Free-floating rather than contained: the pop-out must be draggable
@@ -147,8 +209,12 @@ class PlotPopoutManager:
 
     def __init__(self) -> None:
         # Zero-height so the container does not compete for vertical space;
-        # the windows themselves render as free-floating overlays.
-        self._container = pn.Column(height=0, sizing_mode='stretch_width')
+        # the windows themselves render as free-floating overlays. The fitter
+        # is invisible and only installs document-level handlers, so it costs
+        # nothing until a window exists.
+        self._container = pn.Column(
+            PopoutWindowFitter(), height=0, sizing_mode='stretch_width'
+        )
         self._open: dict[CellId, pn.layout.FloatPanel] = {}
 
     @property

--- a/src/ess/livedata/dashboard/widgets/plot_popout.py
+++ b/src/ess/livedata/dashboard/widgets/plot_popout.py
@@ -45,21 +45,33 @@ from ..plot_orchestrator import CellId
 from .cell import CellWidget, ComposedPlot
 from .styles import Colors
 
-# Initial window size in pixels. Generous, but small enough that the grid stays
-# partly visible behind it — the pop-out is a detail view of a cell, not a
-# replacement for the dashboard. The user can resize and maximize from there.
-# Near-square on purpose: an aspect-locked plot derives its cross dimension from
-# the stretched one (see ``frame_aspect``), so a wide window would push a square
-# frame taller than the window. The content scrolls when it still does not fit.
+# Initial window size. Generous, but small enough that the grid stays partly
+# visible behind it — the pop-out is a detail view of a cell, not a replacement
+# for the dashboard. The user can resize and maximize from there.
+#
+# The height is a fraction of the viewport rather than a pixel count, so the
+# window fits the screen it opens on. An aspect-locked plot still derives its
+# height from the window's width (see ``frame_aspect``) and can exceed that; it
+# scrolls rather than being clipped.
 _POPOUT_WIDTH = 860
+# Fallback for Panel's own model box; jsPanel opens at ``_CONTENT_HEIGHT``,
+# which ``config`` below overrides it with.
 _POPOUT_HEIGHT = 820
-# Vertical padding the FloatPanel template puts around its content.
-_CONTENT_INSET = 16
 
 # Each further window is offset by this much so a second pop-out does not land
 # exactly on the first, hiding it and its close button.
 _CASCADE_STEP = 28
 _CASCADE_WRAP = 6
+
+# The window hangs from the top of the viewport rather than being centred in it,
+# and is capped in viewport units so it can never grow past the bottom. Centring
+# a fixed pixel height puts the title bar above y=0 on any screen shorter than
+# the window -- and with it the close, minimize and maximize buttons, leaving no
+# way to get rid of the window at all. Anchoring the top means the title bar is
+# always on screen whatever the viewport, and the cap keeps the bottom edge (the
+# resize handle) reachable too.
+_TOP_MARGIN = 24
+_CONTENT_HEIGHT = '78vh'
 
 # jsPanel statuses in which the window actually renders its content. The others
 # ('minimized', and the two 'smallified' variants, which collapse the window to
@@ -88,28 +100,38 @@ def _build_window(
     return pn.layout.FloatPanel(
         pn.Column(
             composed.build_pane(),
-            # An explicit height, not ``stretch_both``: jsPanel moves the
-            # window's DOM out of the Bokeh tree, leaving nothing for a
-            # stretching child to measure itself against, and a free-aspect
-            # plot then collapses to a sliver. The wrapper is also what gives
-            # the relocated content a layout root of its own — a bare pane does
-            # not render once detached.
-            height=_POPOUT_HEIGHT - _CONTENT_INSET,
             sizing_mode='stretch_width',
-            # A plot whose locked aspect makes it taller than the window must
-            # stay reachable rather than be clipped.
-            styles={'overflow': 'auto'},
+            styles={
+                # An explicit height, not ``stretch_both``: jsPanel moves the
+                # window's DOM out of the Bokeh tree, leaving nothing for a
+                # stretching child to measure itself against, and a free-aspect
+                # plot then collapses to a sliver. Viewport units are explicit
+                # in exactly that sense -- they need no parent to measure
+                # against -- so they cap the height without reintroducing it.
+                # The wrapper is also what gives the relocated content a layout
+                # root of its own: a bare pane does not render once detached.
+                'height': _CONTENT_HEIGHT,
+                # A plot whose locked aspect makes it taller than the window
+                # must stay reachable rather than be clipped.
+                'overflow': 'auto',
+            },
         ),
         name=title,
         # Free-floating rather than contained: the pop-out must be draggable
         # across the whole page, not clipped by the zero-height container that
         # roots it in the component tree.
         contained=False,
-        position='center',
+        position='center-top',
         offsetx=offset,
-        offsety=offset,
+        offsety=_TOP_MARGIN + offset,
         width=_POPOUT_WIDTH,
         height=_POPOUT_HEIGHT,
+        # ``config`` overrides the options Panel derives from the parameters
+        # above, which is the only way to reach jsPanel's viewport-relative
+        # sizing -- ``height`` is an int and cannot express it. (``maxSize``
+        # looks like the natural fit but jsPanel applies it only to interactive
+        # resizing, not to the size it opens at.)
+        config={'contentSize': f'{_POPOUT_WIDTH} {_CONTENT_HEIGHT}'},
         theme=Colors.TAB_BORDER,
         css_classes=css_classes,
     )

--- a/src/ess/livedata/dashboard/widgets/plot_popout.py
+++ b/src/ess/livedata/dashboard/widgets/plot_popout.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""
+Pop-out windows: a cell's plot shown large in a draggable floating window.
+
+A pop-out is a *temporary second view* of a cell, for inspecting detail that
+the grid cell is too small to show. The cell itself is untouched: it keeps its
+plot, its toolbars, and its place in the grid, and both views repaint from the
+same layer ``Pipe`` — so the pop-out is live, not a snapshot.
+
+Deliberately a ``FloatPanel`` and not a ``pn.Modal``: a modal would block the
+grid underneath, and several pop-outs can usefully be open at once (comparing
+two detectors side by side). It is also why nothing here touches
+``PlotGridTabs._current_modal``, whose presence suppresses the poll loop's data
+flush.
+
+A pop-out floats above the whole dashboard, so its cell must stay live even
+when its grid is not the visible tab -- ``PlotGridTabs`` asks
+:meth:`PlotPopoutManager.open_cells` which cells to keep computing and
+flushing. That is the cost of a pop-out: one extra rendered copy of the plot,
+plus a hidden grid that no longer sleeps.
+
+Pop-outs are per session and non-persistent: they are not part of the plot
+topology, so closing the browser tab discards them.
+"""
+
+from __future__ import annotations
+
+import panel as pn
+
+from ..plot_orchestrator import CellId
+from .cell import CellWidget, ComposedPlot
+from .styles import Colors
+
+# Initial window size in pixels. Generous, but small enough that the grid stays
+# partly visible behind it — the pop-out is a detail view of a cell, not a
+# replacement for the dashboard. The user can resize and maximize from there.
+# Near-square on purpose: an aspect-locked plot derives its cross dimension from
+# the stretched one (see ``frame_aspect``), so a wide window would push a square
+# frame taller than the window. The content scrolls when it still does not fit.
+_POPOUT_WIDTH = 860
+_POPOUT_HEIGHT = 820
+
+# Each further window is offset by this much so a second pop-out does not land
+# exactly on the first, hiding it and its close button.
+_CASCADE_STEP = 28
+_CASCADE_WRAP = 6
+
+
+class _Popout:
+    """One open floating window showing an independent view of a cell's plot.
+
+    Owns the view's autoscale controller (the in-grid view has its own; a
+    controller binds to the first figure it renders into) and disposes it when
+    the window closes.
+    """
+
+    def __init__(
+        self,
+        title: str,
+        composed: ComposedPlot,
+        css_classes: list[str],
+        cascade: int,
+    ) -> None:
+        self._composed = composed
+        offset = _CASCADE_STEP * (cascade % _CASCADE_WRAP)
+        self.float_panel = pn.layout.FloatPanel(
+            pn.Column(
+                composed.build_pane(),
+                sizing_mode='stretch_both',
+                # A plot whose locked aspect makes it larger than the window
+                # must stay reachable rather than be clipped. The wrapper is
+                # also what gives the relocated content a layout root of its
+                # own: jsPanel moves the window's DOM out of the Bokeh tree,
+                # and the bare pane does not render once detached.
+                styles={'overflow': 'auto'},
+            ),
+            name=title,
+            # Free-floating rather than contained: the pop-out must be
+            # draggable across the whole page, not clipped by the zero-height
+            # container that roots it in the component tree.
+            contained=False,
+            position='center',
+            offsetx=offset,
+            offsety=offset,
+            width=_POPOUT_WIDTH,
+            height=_POPOUT_HEIGHT,
+            theme=Colors.TAB_BORDER,
+            css_classes=css_classes,
+        )
+
+    def dispose(self) -> None:
+        """Close the window client-side and dispose its autoscale controller."""
+        self.float_panel.status = 'closed'
+        self._composed.dispose()
+
+
+class PlotPopoutManager:
+    """Session-scoped registry of open plot pop-out windows.
+
+    Holds the zero-height container that roots the windows in the component
+    tree (the same trick the modal container uses) and keeps at most one
+    pop-out per cell.
+    """
+
+    def __init__(self) -> None:
+        # Zero-height so the container does not compete for vertical space;
+        # the windows themselves render as free-floating overlays.
+        self._container = pn.Column(height=0, sizing_mode='stretch_width')
+        self._open: dict[CellId, _Popout] = {}
+
+    @property
+    def container(self) -> pn.Column:
+        """The container to mount in the session's top-level layout."""
+        return self._container
+
+    def open_cells(self) -> frozenset[CellId]:
+        """Cells that currently have a pop-out window open.
+
+        The poll loop treats these as live even when their grid is not the
+        visible tab: watching a plot while working elsewhere in the dashboard
+        is the point of popping it out, and a silently frozen window would
+        misrepresent the data as current.
+        """
+        return frozenset(self._open)
+
+    def open(self, cell_id: CellId, cell_widget: CellWidget) -> None:
+        """Open (or re-open) the pop-out for a cell.
+
+        Re-opening replaces an existing window for the same cell rather than
+        stacking a second one — a cell has one pop-out, and a stale window
+        hidden behind the new one would keep a disposed view alive.
+
+        A cell showing a status placeholder has nothing to compose, so nothing
+        opens.
+        """
+        composed = cell_widget.compose_detached_view()
+        if composed is None:
+            return
+        self.close(cell_id)
+        geometry = cell_widget.geometry
+        popout = _Popout(
+            cell_widget.title,
+            composed,
+            # Per-cell automation hook, slugged by grid position like the cell
+            # titlebar's — a CellId is a UUID, useless as a stable selector.
+            css_classes=['lt-popout', f'lt-popout-r{geometry.row}c{geometry.col}'],
+            cascade=len(self._open),
+        )
+        popout.float_panel.param.watch(
+            lambda event: self._on_status(cell_id, event.new), 'status'
+        )
+        self._open[cell_id] = popout
+        self._container.append(popout.float_panel)
+
+    def close(self, cell_id: CellId) -> None:
+        """Close and dispose the pop-out for a cell, if one is open.
+
+        Popping the registry entry first makes the re-entrant call from the
+        status watcher (``dispose`` closes the window, which round-trips a
+        status change) a no-op.
+        """
+        popout = self._open.pop(cell_id, None)
+        if popout is None:
+            return
+        popout.dispose()
+        self._container.remove(popout.float_panel)
+
+    def close_all(self) -> None:
+        """Close and dispose every open pop-out."""
+        for cell_id in list(self._open):
+            self.close(cell_id)
+
+    def _on_status(self, cell_id: CellId, status: str) -> None:
+        """Drop the pop-out once the user closes its window.
+
+        ``FloatPanel.status`` round-trips from jsPanel, so the window's own
+        close button lands here; minimize/maximize are left alone.
+        """
+        if status == 'closed':
+            self.close(cell_id)

--- a/src/ess/livedata/dashboard/widgets/plot_popout.py
+++ b/src/ess/livedata/dashboard/widgets/plot_popout.py
@@ -20,9 +20,18 @@ flush.
 
 A pop-out floats above the whole dashboard, so its cell must stay live even
 when its grid is not the visible tab -- ``PlotGridTabs`` asks
-:meth:`PlotPopoutManager.open_cells` which cells to keep computing and
-flushing. That is the cost of a pop-out: one extra rendered copy of the plot,
-plus a hidden grid that no longer sleeps.
+:meth:`PlotPopoutManager.live_cells` which cells to keep computing and
+flushing. Liveness is per cell, not per grid: the rest of a hidden grid still
+sleeps. That is the cost of a pop-out: one extra rendered copy of the plot,
+and one cell that goes on computing while its tab is away.
+
+Liveness follows what the window *shows*, not that it exists, which is the
+same rule a hidden tab already obeys. Minimizing (or smallifying) a pop-out
+puts its cell back to sleep, so a user cannot accumulate cost by popping out
+many cells and minimizing the windows: what is not rendered is not computed.
+This is why there is no cap on the number of pop-outs -- comparing several
+detectors side by side is the point, and the cost of that is bounded by the
+screen it has to fit on.
 
 Pop-outs are per session and non-persistent: they are not part of the plot
 topology, so closing the browser tab discards them.
@@ -51,6 +60,11 @@ _CONTENT_INSET = 16
 # exactly on the first, hiding it and its close button.
 _CASCADE_STEP = 28
 _CASCADE_WRAP = 6
+
+# jsPanel statuses in which the window actually renders its content. The others
+# ('minimized', and the two 'smallified' variants, which collapse the window to
+# its title bar) show no plot, so the cell behind them may sleep.
+_VISIBLE_STATUSES = frozenset({'normalized', 'maximized'})
 
 
 def _build_window(
@@ -121,14 +135,29 @@ class PlotPopoutManager:
         return self._container
 
     def open_cells(self) -> frozenset[CellId]:
-        """Cells that currently have a pop-out window open.
+        """Cells that have a pop-out window, whether or not it is showing.
+
+        Existence, not visibility -- a minimized window is still the user's
+        window and must survive a rebuild of the cell behind it. Use
+        :meth:`live_cells` to decide what to keep computing.
+        """
+        return frozenset(self._open)
+
+    def live_cells(self) -> frozenset[CellId]:
+        """Cells whose pop-out is actually rendering, and must stay computed.
 
         The poll loop treats these as live even when their grid is not the
         visible tab: watching a plot while working elsewhere in the dashboard
         is the point of popping it out, and a silently frozen window would
-        misrepresent the data as current.
+        misrepresent the data as current. A minimized window renders nothing,
+        so it earns no such treatment and its cell sleeps like any other cell
+        on a hidden tab.
         """
-        return frozenset(self._open)
+        return frozenset(
+            cell_id
+            for cell_id, window in self._open.items()
+            if window.status in _VISIBLE_STATUSES
+        )
 
     def open(self, cell_id: CellId, cell_widget: CellWidget) -> None:
         """Open (or re-open) the pop-out for a cell.
@@ -179,7 +208,9 @@ class PlotPopoutManager:
         """Drop the pop-out once the user closes its window.
 
         ``FloatPanel.status`` round-trips from jsPanel, so the window's own
-        close button lands here; minimize/maximize are left alone.
+        close button lands here. Minimize and restore need no handling: they
+        change what :meth:`live_cells` reports, which the next poll pass reads
+        for itself.
         """
         if status == 'closed':
             self.close(cell_id)

--- a/src/ess/livedata/dashboard/widgets/plot_popout.py
+++ b/src/ess/livedata/dashboard/widgets/plot_popout.py
@@ -5,8 +5,12 @@ Pop-out windows: a cell's plot shown large in a draggable floating window.
 
 A pop-out is a *temporary second view* of a cell, for inspecting detail that
 the grid cell is too small to show. The cell itself is untouched: it keeps its
-plot, its toolbars, and its place in the grid, and both views repaint from the
-same layer ``Pipe`` — so the pop-out is live, not a snapshot.
+plot, its toolbars, and its place in the grid. The window renders the cell's
+own composition a second time rather than composing its own, so the two views
+repaint from one layer ``Pipe`` — the pop-out is live, not a snapshot — and
+share one autoscale controller, so turning a toggle off in the window turns it
+off in the cell. The cell widget owns that composition and disposes it; a
+window only ever borrows it.
 
 Deliberately a ``FloatPanel`` and not a ``pn.Modal``: a modal would block the
 grid underneath, and several pop-outs can usefully be open at once (comparing
@@ -40,6 +44,8 @@ from .styles import Colors
 # frame taller than the window. The content scrolls when it still does not fit.
 _POPOUT_WIDTH = 860
 _POPOUT_HEIGHT = 820
+# Vertical padding the FloatPanel template puts around its content.
+_CONTENT_INSET = 16
 
 # Each further window is offset by this much so a second pop-out does not land
 # exactly on the first, hiding it and its close button.
@@ -47,52 +53,52 @@ _CASCADE_STEP = 28
 _CASCADE_WRAP = 6
 
 
-class _Popout:
-    """One open floating window showing an independent view of a cell's plot.
+def _build_window(
+    title: str, composed: ComposedPlot, css_classes: list[str], cascade: int
+) -> pn.layout.FloatPanel:
+    """Build the floating window for one cell's plot.
 
-    Owns the view's autoscale controller (the in-grid view has its own; a
-    controller binds to the first figure it renders into) and disposes it when
-    the window closes.
+    Parameters
+    ----------
+    title:
+        The cell's title, shown in the window header.
+    composed:
+        The cell's composed plot, rendered here a second time.
+    css_classes:
+        Automation hooks for the window element.
+    cascade:
+        How many windows are already open, offsetting this one so it does not
+        land exactly on top of them.
     """
-
-    def __init__(
-        self,
-        title: str,
-        composed: ComposedPlot,
-        css_classes: list[str],
-        cascade: int,
-    ) -> None:
-        self._composed = composed
-        offset = _CASCADE_STEP * (cascade % _CASCADE_WRAP)
-        self.float_panel = pn.layout.FloatPanel(
-            pn.Column(
-                composed.build_pane(),
-                sizing_mode='stretch_both',
-                # A plot whose locked aspect makes it larger than the window
-                # must stay reachable rather than be clipped. The wrapper is
-                # also what gives the relocated content a layout root of its
-                # own: jsPanel moves the window's DOM out of the Bokeh tree,
-                # and the bare pane does not render once detached.
-                styles={'overflow': 'auto'},
-            ),
-            name=title,
-            # Free-floating rather than contained: the pop-out must be
-            # draggable across the whole page, not clipped by the zero-height
-            # container that roots it in the component tree.
-            contained=False,
-            position='center',
-            offsetx=offset,
-            offsety=offset,
-            width=_POPOUT_WIDTH,
-            height=_POPOUT_HEIGHT,
-            theme=Colors.TAB_BORDER,
-            css_classes=css_classes,
-        )
-
-    def dispose(self) -> None:
-        """Close the window client-side and dispose its autoscale controller."""
-        self.float_panel.status = 'closed'
-        self._composed.dispose()
+    offset = _CASCADE_STEP * (cascade % _CASCADE_WRAP)
+    return pn.layout.FloatPanel(
+        pn.Column(
+            composed.build_pane(),
+            # An explicit height, not ``stretch_both``: jsPanel moves the
+            # window's DOM out of the Bokeh tree, leaving nothing for a
+            # stretching child to measure itself against, and a free-aspect
+            # plot then collapses to a sliver. The wrapper is also what gives
+            # the relocated content a layout root of its own — a bare pane does
+            # not render once detached.
+            height=_POPOUT_HEIGHT - _CONTENT_INSET,
+            sizing_mode='stretch_width',
+            # A plot whose locked aspect makes it taller than the window must
+            # stay reachable rather than be clipped.
+            styles={'overflow': 'auto'},
+        ),
+        name=title,
+        # Free-floating rather than contained: the pop-out must be draggable
+        # across the whole page, not clipped by the zero-height container that
+        # roots it in the component tree.
+        contained=False,
+        position='center',
+        offsetx=offset,
+        offsety=offset,
+        width=_POPOUT_WIDTH,
+        height=_POPOUT_HEIGHT,
+        theme=Colors.TAB_BORDER,
+        css_classes=css_classes,
+    )
 
 
 class PlotPopoutManager:
@@ -107,7 +113,7 @@ class PlotPopoutManager:
         # Zero-height so the container does not compete for vertical space;
         # the windows themselves render as free-floating overlays.
         self._container = pn.Column(height=0, sizing_mode='stretch_width')
-        self._open: dict[CellId, _Popout] = {}
+        self._open: dict[CellId, pn.layout.FloatPanel] = {}
 
     @property
     def container(self) -> pn.Column:
@@ -129,17 +135,17 @@ class PlotPopoutManager:
 
         Re-opening replaces an existing window for the same cell rather than
         stacking a second one — a cell has one pop-out, and a stale window
-        hidden behind the new one would keep a disposed view alive.
+        hidden behind the new one would go on rendering unseen.
 
-        A cell showing a status placeholder has nothing to compose, so nothing
+        A cell showing a status placeholder has no plot to show, so nothing
         opens.
         """
-        composed = cell_widget.compose_detached_view()
+        composed = cell_widget.composed
         if composed is None:
             return
         self.close(cell_id)
         geometry = cell_widget.geometry
-        popout = _Popout(
+        window = _build_window(
             cell_widget.title,
             composed,
             # Per-cell automation hook, slugged by grid position like the cell
@@ -147,27 +153,25 @@ class PlotPopoutManager:
             css_classes=['lt-popout', f'lt-popout-r{geometry.row}c{geometry.col}'],
             cascade=len(self._open),
         )
-        popout.float_panel.param.watch(
-            lambda event: self._on_status(cell_id, event.new), 'status'
-        )
-        self._open[cell_id] = popout
-        self._container.append(popout.float_panel)
+        window.param.watch(lambda event: self._on_status(cell_id, event.new), 'status')
+        self._open[cell_id] = window
+        self._container.append(window)
 
     def close(self, cell_id: CellId) -> None:
-        """Close and dispose the pop-out for a cell, if one is open.
+        """Close the pop-out for a cell, if one is open.
 
         Popping the registry entry first makes the re-entrant call from the
-        status watcher (``dispose`` closes the window, which round-trips a
-        status change) a no-op.
+        status watcher (closing the window round-trips a status change) a
+        no-op. The cell's composed plot is left alone: the cell widget owns it.
         """
-        popout = self._open.pop(cell_id, None)
-        if popout is None:
+        window = self._open.pop(cell_id, None)
+        if window is None:
             return
-        popout.dispose()
-        self._container.remove(popout.float_panel)
+        window.status = 'closed'
+        self._container.remove(window)
 
     def close_all(self) -> None:
-        """Close and dispose every open pop-out."""
+        """Close every open pop-out."""
         for cell_id in list(self._open):
             self.close(cell_id)
 

--- a/src/ess/livedata/dashboard/widgets/plot_popout.py
+++ b/src/ess/livedata/dashboard/widgets/plot_popout.py
@@ -33,6 +33,11 @@ This is why there is no cap on the number of pop-outs -- comparing several
 detectors side by side is the point, and the cost of that is bounded by the
 screen it has to fit on.
 
+Known gap: the window shows the plot alone -- the freshness/lag pill stays in
+the cell titlebar, which a hidden tab does not render. A stalled stream
+therefore freezes a pop-out with no staleness cue: the cell keeps computing,
+but nothing in the window marks the data as old.
+
 Session ticks are gated on a ``has_work`` predicate over shared state (ADR
 0007), and working a window's controls touches none of it: closing, minimizing
 and restoring change only what this session shows. So the manager reports them
@@ -157,7 +162,11 @@ _VISIBLE_STATUSES = frozenset({'normalized', 'maximized'})
 
 
 def _build_window(
-    title: str, composed: ComposedPlot, css_classes: list[str], cascade: int
+    title: str,
+    composed: ComposedPlot,
+    css_classes: list[str],
+    cascade: int,
+    status: str,
 ) -> pn.layout.FloatPanel:
     """Build the floating window for one cell's plot.
 
@@ -170,8 +179,11 @@ def _build_window(
     css_classes:
         Automation hooks for the window element.
     cascade:
-        How many windows are already open, offsetting this one so it does not
-        land exactly on top of them.
+        Cascade slot for this window, offsetting it so it does not land
+        exactly on top of an already-open one.
+    status:
+        Initial jsPanel status. ``FloatPanel`` applies a non-default status on
+        render, so a window rebuilt from a minimized one opens minimized.
     """
     offset = _CASCADE_STEP * (cascade % _CASCADE_WRAP)
     return pn.layout.FloatPanel(
@@ -204,6 +216,7 @@ def _build_window(
         config={'contentSize': f'{_POPOUT_WIDTH} {_CONTENT_HEIGHT}'},
         theme=Colors.TAB_BORDER,
         css_classes=css_classes,
+        status=status,
     )
 
 
@@ -234,6 +247,11 @@ class PlotPopoutManager:
             PopoutWindowFitter(), height=0, sizing_mode='stretch_width'
         )
         self._open: dict[CellId, pn.layout.FloatPanel] = {}
+        # Monotone cascade slot counter. Counting open windows instead would
+        # re-issue an occupied slot after a close (open A, open B, close A,
+        # open C lands C exactly on B), hiding the covered window's close
+        # button -- the very thing the cascade offset exists to avoid.
+        self._cascade = 0
         self._on_visibility_change = on_visibility_change
 
     @property
@@ -241,14 +259,16 @@ class PlotPopoutManager:
         """The container to mount in the session's top-level layout."""
         return self._container
 
-    def open_cells(self) -> frozenset[CellId]:
-        """Cells that have a pop-out window, whether or not it is showing.
+    def status_of(self, cell_id: CellId) -> str | None:
+        """The cell's window status ('normalized', 'minimized', ...), or None.
 
-        Existence, not visibility -- a minimized window is still the user's
-        window and must survive a rebuild of the cell behind it. Use
+        None means no window exists; any status means one does, however it is
+        showing -- a minimized window is still the user's window and must
+        survive a rebuild of the cell behind it, minimized. Use
         :meth:`live_cells` to decide what to keep computing.
         """
-        return frozenset(self._open)
+        window = self._open.get(cell_id)
+        return None if window is None else window.status
 
     def live_cells(self) -> frozenset[CellId]:
         """Cells whose pop-out is actually rendering, and must stay computed.
@@ -266,7 +286,9 @@ class PlotPopoutManager:
             if window.status in _VISIBLE_STATUSES
         )
 
-    def open(self, cell_id: CellId, cell_widget: CellWidget) -> None:
+    def open(
+        self, cell_id: CellId, cell_widget: CellWidget, status: str | None = None
+    ) -> None:
         """Open (or re-open) the pop-out for a cell.
 
         Re-opening replaces an existing window for the same cell rather than
@@ -275,6 +297,18 @@ class PlotPopoutManager:
 
         A cell showing a status placeholder has no plot to show, so nothing
         opens.
+
+        Parameters
+        ----------
+        cell_id:
+            The cell to open a window for.
+        cell_widget:
+            The cell's widget, whose composition the window renders.
+        status:
+            jsPanel status to open with; a cell rebuild passes the old
+            window's status so a minimized window stays minimized (and its
+            cell asleep). The window's position and size are not carried
+            over. Defaults to a normal window.
         """
         composed = cell_widget.composed
         if composed is None:
@@ -287,8 +321,10 @@ class PlotPopoutManager:
             # Per-cell automation hook, slugged by grid position like the cell
             # titlebar's — a CellId is a UUID, useless as a stable selector.
             css_classes=['lt-popout', f'lt-popout-r{geometry.row}c{geometry.col}'],
-            cascade=len(self._open),
+            cascade=self._cascade,
+            status=status if status is not None else 'normalized',
         )
+        self._cascade += 1
         window.param.watch(lambda event: self._on_status(cell_id, event.new), 'status')
         self._open[cell_id] = window
         self._container.append(window)

--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -382,6 +382,8 @@ def create_cell_titlebar(
     on_configure_layer: Callable[[LayerId], None],
     toolbars_visible: bool,
     on_toggle_toolbars_callback: Callable[[bool], None],
+    on_popout_callback: Callable[[], None],
+    can_popout: bool,
     freshness_pane: pn.pane.HTML | None = None,
     css_classes: list[str] | None = None,
 ) -> pn.Row:
@@ -389,10 +391,10 @@ def create_cell_titlebar(
     Create the cell-level titlebar shown above the per-layer info rows.
 
     The titlebar holds the cell title on the left and cell-level actions on the
-    right: a gear that configures a layer (directly for one layer, via a layer
-    picker for several), edit cell properties (opens a modal for
-    rename/add/remove layer), and a toggle that hides/shows the per-layer info
-    rows.
+    right: a pop-out that opens the plot in a larger floating window, a gear
+    that configures a layer (directly for one layer, via a layer picker for
+    several), edit cell properties (opens a modal for rename/add/remove layer),
+    and a toggle that hides/shows the per-layer info rows.
 
     Parameters
     ----------
@@ -413,6 +415,12 @@ def create_cell_titlebar(
         Current visibility of the per-layer info rows; sets the toggle icon.
     on_toggle_toolbars_callback:
         Invoked with the new visibility state when the toggle is clicked.
+    on_popout_callback:
+        Invoked when the pop-out button is clicked; opens the cell's plot in a
+        floating window.
+    can_popout:
+        Whether the cell currently shows a plot. A cell showing a status
+        placeholder has nothing to pop out, so the button is disabled.
     freshness_pane:
         Optional pane showing the data freshness/lag indicator, placed between
         the title and the action buttons. Updated in place by the caller.
@@ -452,8 +460,17 @@ def create_cell_titlebar(
         on_toggle=on_toggle_toolbars_callback,
         css_classes=css_classes,
     )
+    popout_button = create_tool_button(
+        icon_name='arrows-maximize',
+        button_color=Colors.TEXT_MUTED,
+        hover_color=HoverColors.MUTED,
+        on_click_callback=on_popout_callback,
+        css_classes=css_classes,
+        disabled=not can_popout,
+        description='Open in a floating window',
+    )
 
-    right_buttons: list = [gear_button, edit_button, toggle_button]
+    right_buttons: list = [popout_button, gear_button, edit_button, toggle_button]
 
     # Freshness pill sits at the far left; the stretch title fills the middle and
     # pushes the action buttons to the right.

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -309,6 +309,74 @@ def test_concurrent_grid_property_edits_resolve_to_one_title_without_crash():
         assert_updating(winner, "surviving grid after concurrent edit race")
 
 
+# Tallest canvas inside the pop-out window. The plot renders into per-widget
+# shadow roots, which descendant CSS selectors do not cross, so walk them.
+_POPOUT_PLOT_HEIGHT = """
+() => {
+  const deep = (root, out) => {
+    root.querySelectorAll('*').forEach(e => {
+      if (e.tagName === 'CANVAS') out.push(e);
+      if (e.shadowRoot) deep(e.shadowRoot, out);
+    });
+    return out;
+  };
+  const panel = document.querySelector('.jsPanel');
+  if (!panel) return 0;
+  const heights = deep(panel, []).map(c => c.getBoundingClientRect().height);
+  return heights.length ? Math.round(Math.max(...heights)) : 0;
+}
+"""
+
+
+def _window_height(dash: Dashboard) -> float:
+    box = dash.page.locator(".jsPanel").first.bounding_box()
+    assert box is not None
+    return box["height"]
+
+
+@pytest.mark.browser
+def test_popped_out_plot_resizes_with_its_window():
+    """The plot must track the window, maximize included.
+
+    jsPanel resizes its own content element, but the wrappers Panel puts below
+    it carry no height, and Panel re-lays out only on a drag-resize. Without
+    both gaps closed the plot keeps whatever size it had when it opened, and
+    the window grows around it into whitespace.
+
+    Uses the free-aspect cell: an aspect-locked plot derives its height from
+    the window's *width*, so it legitimately overflows a wider window.
+    """
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
+        del fake
+        page = dash.page
+        page.set_viewport_size({"width": 1280, "height": 900})
+        dash.goto_tab("Detectors")
+
+        click_until(
+            dash,
+            ".lt-cell-r2c0.lt-tool-arrows-maximize",
+            lambda: page.locator(".lt-popout-r2c0").count() == 1,
+            label="the pop-out window to open",
+        )
+        wait_until(
+            dash,
+            lambda: page.evaluate(_POPOUT_PLOT_HEIGHT) > 0,
+            label="the popped-out plot to render",
+        )
+        opened = page.evaluate(_POPOUT_PLOT_HEIGHT)
+        assert opened > _window_height(dash) * 0.8, (
+            f"plot {opened} does not fill the window it opened in"
+        )
+
+        page.locator(".jsPanel-btn-maximize").first.click()
+        wait_until(
+            dash,
+            lambda: page.evaluate(_POPOUT_PLOT_HEIGHT) > opened,
+            label="the plot to grow with the maximized window",
+        )
+        assert page.evaluate(_POPOUT_PLOT_HEIGHT) > _window_height(dash) * 0.8
+
+
 @pytest.mark.browser
 @pytest.mark.parametrize("viewport_height", [700, 1000])
 def test_popped_out_window_fits_the_viewport_it_opens_on(viewport_height):

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -13,7 +13,8 @@ through the stable ``lt-*`` automation hooks:
   updating;
 - two sessions racing to save edits on the same grid converge on one title,
   without a server-side exception or a duplicated/lost tab;
-- a popped-out plot floats above other tabs and keeps updating there.
+- a popped-out plot opens within the viewport, floats above other tabs and
+  keeps updating there, and stops costing anything once minimized.
 
 Each test launches its own dashboard for isolation, since grid topology changes
 are process-global; ports are allocated per launch, so concurrent runs of this
@@ -31,6 +32,7 @@ from tests.helpers.browser import (
     Dashboard,
     assert_stops_updating,
     assert_updating,
+    click_until,
     fake_dashboard,
     fingerprint,
     wait_until,
@@ -308,6 +310,41 @@ def test_concurrent_grid_property_edits_resolve_to_one_title_without_crash():
 
 
 @pytest.mark.browser
+@pytest.mark.parametrize("viewport_height", [700, 1000])
+def test_popped_out_window_fits_the_viewport_it_opens_on(viewport_height):
+    """The window must never open with its title bar off the top of the screen.
+
+    That title bar carries the only controls for closing, minimizing and
+    maximizing, so a window opening above the fold cannot be dismissed at all.
+    A fixed pixel height centred vertically does exactly that on any screen
+    shorter than the window, which is most laptops.
+    """
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
+        del fake
+        page = dash.page
+        page.set_viewport_size({"width": 1280, "height": viewport_height})
+        dash.goto_tab("Detectors")
+
+        click_until(
+            dash,
+            ".lt-cell-r0c0.lt-tool-arrows-maximize",
+            lambda: page.locator(".lt-popout-r0c0").count() == 1,
+            label="the pop-out window to open",
+        )
+
+        box = page.locator(".jsPanel").first.bounding_box()
+        assert box is not None
+        assert box["y"] >= 0, f"window opened above the viewport: {box}"
+        assert box["y"] + box["height"] <= viewport_height, (
+            f"window opened taller than the viewport: {box}"
+        )
+        # The controls specifically, not just the window's box.
+        close_button = page.locator(".jsPanel-btn-close").first.bounding_box()
+        assert close_button is not None
+        assert close_button["y"] >= 0
+
+
+@pytest.mark.browser
 def test_popped_out_plot_stays_live_across_tabs_and_sleeps_when_minimized():
     """A pop-out is a live second view, and costs nothing while it shows none.
 
@@ -323,9 +360,9 @@ def test_popped_out_plot_stays_live_across_tabs_and_sleeps_when_minimized():
         page = dash.page
         dash.goto_tab("Detectors")
 
-        dash.click(popout)
-        wait_until(
+        click_until(
             dash,
+            popout,
             lambda: page.locator(".lt-popout-r0c0").count() == 1,
             label="the pop-out window to open",
         )

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -29,6 +29,7 @@ import pytest
 pytest.importorskip("playwright.sync_api")
 from tests.helpers.browser import (
     Dashboard,
+    assert_stops_updating,
     assert_updating,
     fake_dashboard,
     fingerprint,
@@ -307,12 +308,14 @@ def test_concurrent_grid_property_edits_resolve_to_one_title_without_crash():
 
 
 @pytest.mark.browser
-def test_popped_out_plot_floats_above_other_tabs_and_keeps_updating():
-    """A pop-out is a live second view, not a snapshot of the cell.
+def test_popped_out_plot_stays_live_across_tabs_and_sleeps_when_minimized():
+    """A pop-out is a live second view, and costs nothing while it shows none.
 
     Switching tabs is the interesting case: ``dynamic=True`` tears down the
     hidden grid's Bokeh models, so the window is then the *only* plot in the
-    document -- and the poll loop must still be feeding it.
+    document -- and the poll loop must still be feeding it. Minimizing it must
+    stop that feed, or popping out many cells and minimizing the windows would
+    pin every one of those cells live for nothing on screen.
     """
     popout = ".lt-cell-r0c0.lt-tool-arrows-maximize"
     with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
@@ -333,6 +336,17 @@ def test_popped_out_plot_floats_above_other_tabs_and_keeps_updating():
         dash.goto_tab("Workflows")
         assert page.locator(".jsPanel").first.is_visible()
         assert_updating(dash, "popped-out plot while another tab is shown")
+
+        # Minimizing must put the cell back to sleep, and restoring must wake
+        # it. Proving both end to end matters because the guard rests on
+        # jsPanel round-tripping the user's click as a ``status`` change.
+        page.locator(".jsPanel-btn-minimize").first.click()
+        assert_stops_updating(dash, "minimized pop-out on a hidden tab")
+
+        # A minimized window is parked off-screen and replaced by a strip of
+        # small buttons; normalize from there rather than from the panel.
+        page.locator(".jsPanel-btn-sm.jsPanel-btn-normalize").click()
+        assert_updating(dash, "restored pop-out on a hidden tab")
 
         page.locator(".jsPanel-btn-close").first.click()
         wait_until(

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -12,7 +12,8 @@ through the stable ``lt-*`` automation hooks:
 - disabling or removing a grid keeps the remaining tabs resolving and
   updating;
 - two sessions racing to save edits on the same grid converge on one title,
-  without a server-side exception or a duplicated/lost tab.
+  without a server-side exception or a duplicated/lost tab;
+- a popped-out plot floats above other tabs and keeps updating there.
 
 Each test launches its own dashboard for isolation, since grid topology changes
 are process-global; ports are allocated per launch, so concurrent runs of this
@@ -303,3 +304,39 @@ def test_concurrent_grid_property_edits_resolve_to_one_title_without_crash():
 
         winner.goto_tab(winning_title)
         assert_updating(winner, "surviving grid after concurrent edit race")
+
+
+@pytest.mark.browser
+def test_popped_out_plot_floats_above_other_tabs_and_keeps_updating():
+    """A pop-out is a live second view, not a snapshot of the cell.
+
+    Switching tabs is the interesting case: ``dynamic=True`` tears down the
+    hidden grid's Bokeh models, so the window is then the *only* plot in the
+    document -- and the poll loop must still be feeding it.
+    """
+    popout = ".lt-cell-r0c0.lt-tool-arrows-maximize"
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
+        del fake
+        page = dash.page
+        dash.goto_tab("Detectors")
+
+        dash.click(popout)
+        wait_until(
+            dash,
+            lambda: page.locator(".lt-popout-r0c0").count() == 1,
+            label="the pop-out window to open",
+        )
+        # The cell is a detail *view*: the grid cell keeps its own plot and
+        # its whole titlebar, including the button that opened the window.
+        assert page.locator(popout).count() == 1
+
+        dash.goto_tab("Workflows")
+        assert page.locator(".jsPanel").first.is_visible()
+        assert_updating(dash, "popped-out plot while another tab is shown")
+
+        page.locator(".jsPanel-btn-close").first.click()
+        wait_until(
+            dash,
+            lambda: page.locator(".lt-popout-r0c0").count() == 0,
+            label="the pop-out window to close",
+        )

--- a/tests/dashboard/cell_autoscale_test.py
+++ b/tests/dashboard/cell_autoscale_test.py
@@ -457,8 +457,8 @@ class TestIdempotentInstallation:
         """Missing toolbar on first call must not lock the controller out.
 
         Real Bokeh plots always have a toolbar; this guards against a
-        regression where _tools_installed is set prematurely and a
-        subsequent render with a live toolbar misses tool installation.
+        regression where the figure is recorded as installed prematurely and
+        a subsequent render with a live toolbar misses tool installation.
         """
         k = _key()
         plotter = _FakePlotter(frozenset({'x'}), {k: {'x': (0.0, 1.0)}})
@@ -468,11 +468,9 @@ class TestIdempotentInstallation:
         plot_no_toolbar.state = None  # type: ignore[assignment]
         hook = controller.make_hook()
         hook(plot_no_toolbar, None)
-        assert controller._tools_installed is False
 
         plot, _x, _y, _c = _make_plot_all_handles()
         hook(plot, None)
-        assert controller._tools_installed is True
         assert len(plot.state.toolbar.tools) == 2  # x toggle + Fit
 
 
@@ -553,7 +551,6 @@ class TestDispose:
         assert fit_tool._callbacks == []
         assert controller._fit_tool is None
         assert controller._toggles == {}
-        assert controller._tools_installed is False
 
     def test_controller_collectable_after_dispose(self) -> None:
         """The on_change cycle (controller -> tool -> bound method ->

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -991,7 +991,7 @@ class TestComposeTableLayer:
         cell_widget = plot_grid_tabs._build_cell(CellId(uuid4()), cell)
 
         assert cell_widget.has_plot
-        assert not isinstance(cell_widget._plot, hv.Layout)
+        assert not isinstance(cell_widget.compose_detached_view().plot, hv.Layout)
 
 
 class TestDisabledGridTabs:

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -991,7 +991,7 @@ class TestComposeTableLayer:
         cell_widget = plot_grid_tabs._build_cell(CellId(uuid4()), cell)
 
         assert cell_widget.has_plot
-        assert not isinstance(cell_widget.compose_detached_view().plot, hv.Layout)
+        assert not isinstance(cell_widget.composed.plot, hv.Layout)
 
 
 class TestDisabledGridTabs:

--- a/tests/dashboard/widgets/plot_popout_test.py
+++ b/tests/dashboard/widgets/plot_popout_test.py
@@ -1,0 +1,430 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""
+Behavior tests for plot pop-out windows.
+
+A pop-out is a second, independent view of a cell's plot in a floating window.
+The tests cover the two properties that make it useful -- the cell is left
+alone, and both views stay live off the same data pipe -- plus the lifecycle
+rules that keep a window from outliving the cell it shows.
+"""
+
+from __future__ import annotations
+
+import holoviews as hv
+import pytest
+import scipp as sc
+
+from ess.livedata.config.workflow_spec import DataKey, WorkflowId
+from ess.livedata.dashboard.data_roles import PRIMARY
+from ess.livedata.dashboard.data_service import DataService
+from ess.livedata.dashboard.job_service import JobService
+from ess.livedata.dashboard.notification_queue import NotificationQueue
+from ess.livedata.dashboard.plot_data_service import PlotDataService
+from ess.livedata.dashboard.plot_orchestrator import (
+    CellGeometry,
+    DataSourceConfig,
+    PlotConfig,
+    PlotOrchestrator,
+)
+from ess.livedata.dashboard.plot_params import PlotParams1d
+from ess.livedata.dashboard.plots import LinePlotter
+from ess.livedata.dashboard.plotting_controller import PlottingController
+from ess.livedata.dashboard.session_layer import SessionLayer
+from ess.livedata.dashboard.session_registry import SessionId, SessionRegistry
+from ess.livedata.dashboard.session_updater import SessionUpdater
+from ess.livedata.dashboard.static_plots import LinesCoordinates, VLinesParams
+from ess.livedata.dashboard.stream_manager import StreamManager
+from ess.livedata.dashboard.widgets.plot_grid_tabs import PlotGridTabs
+from ess.livedata.dashboard.widgets.workflow_status_widget import (
+    WorkflowStatusListWidget,
+)
+
+hv.extension('bokeh')
+
+_WORKFLOW = WorkflowId(instrument='test', name='wf', version=1)
+_GEOMETRY = CellGeometry(row=0, col=0, row_span=1, col_span=1)
+
+
+@pytest.fixture
+def plot_data_service():
+    return PlotDataService()
+
+
+@pytest.fixture
+def data_service():
+    return DataService()
+
+
+@pytest.fixture
+def job_service():
+    return JobService()
+
+
+@pytest.fixture
+def plot_orchestrator(job_orchestrator, data_service, plot_data_service):
+    stream_manager = StreamManager(data_service=data_service)
+    return PlotOrchestrator(
+        plotting_controller=PlottingController(stream_manager=stream_manager),
+        job_orchestrator=job_orchestrator,
+        data_service=data_service,
+        instrument='dummy',
+        plot_data_service=plot_data_service,
+    )
+
+
+@pytest.fixture
+def plot_grid_tabs(
+    plot_orchestrator,
+    workflow_registry,
+    plot_data_service,
+    job_orchestrator,
+    job_service,
+):
+    stream_manager = StreamManager(data_service=DataService())
+    return PlotGridTabs(
+        plot_orchestrator=plot_orchestrator,
+        workflow_registry=workflow_registry,
+        plotting_controller=PlottingController(stream_manager=stream_manager),
+        workflow_status_widget=WorkflowStatusListWidget(
+            orchestrator=job_orchestrator, job_service=job_service
+        ),
+        plot_data_service=plot_data_service,
+        session_updater=SessionUpdater(
+            session_id=SessionId('test'),
+            session_registry=SessionRegistry(),
+            notification_queue=NotificationQueue(),
+        ),
+    )
+
+
+def _curve(values: list[float]) -> sc.DataArray:
+    return sc.DataArray(
+        sc.array(dims=['x'], values=values, unit='counts'),
+        coords={'x': sc.array(dims=['x'], values=[0.0, 1.0, 2.0], unit='m')},
+    )
+
+
+def _line_config() -> PlotConfig:
+    return PlotConfig(
+        data_sources={
+            PRIMARY: DataSourceConfig(
+                workflow_id=_WORKFLOW, source_names=['s1'], view_name='out'
+            )
+        },
+        plot_name='lines',
+        params=PlotParams1d(),
+    )
+
+
+def _static_config() -> PlotConfig:
+    return PlotConfig(
+        data_sources={
+            PRIMARY: DataSourceConfig(
+                workflow_id=_WORKFLOW, source_names=[], view_name='guides'
+            )
+        },
+        plot_name='vlines',
+        params=VLinesParams(geometry=LinesCoordinates(positions='10, 20')),
+    )
+
+
+@pytest.fixture
+def line_cell(plot_orchestrator, plot_grid_tabs, plot_data_service):
+    """A built cell showing a live 1-D line plot, plus its plotter and pipe.
+
+    Uses a real ``LinePlotter``: the pop-out's defining properties (a private
+    autoscale controller, a shared data pipe) only exist for a plot that
+    actually autoscales and actually updates.
+    """
+    grid_id = plot_orchestrator.add_grid(title='G', nrows=1, ncols=1)
+    cell_id = plot_orchestrator.add_cell(grid_id, _GEOMETRY)
+    layer_id = plot_orchestrator.add_layer(cell_id, _line_config())
+
+    plotter = LinePlotter.from_params(PlotParams1d())
+    key = DataKey(workflow_id=_WORKFLOW, source_name='s1', output_name='out')
+    plotter.compute({PRIMARY: {key: _curve([1.0, 2.0, 3.0])}})
+    plot_data_service.job_started(layer_id, plotter)
+    plot_data_service.data_arrived(layer_id)
+
+    state = plot_data_service.get(layer_id)
+    session_layer = SessionLayer(layer_id=layer_id, last_seen_version=state.version)
+    session_layer.ensure_components(state)
+    plot_grid_tabs._session_layers[layer_id] = session_layer
+
+    plot_grid_tabs._poll_for_plot_updates()
+    return cell_id
+
+
+def _open_windows(plot_grid_tabs) -> list:
+    return list(plot_grid_tabs._popouts.container.objects)
+
+
+class TestPopoutOpensAnIndependentView:
+    def test_popout_opens_one_floating_window(self, plot_grid_tabs, line_cell):
+        assert _open_windows(plot_grid_tabs) == []
+
+        plot_grid_tabs._show_popout(line_cell)
+
+        windows = _open_windows(plot_grid_tabs)
+        assert len(windows) == 1
+        assert 'lt-popout-r0c0' in windows[0].css_classes
+
+    def test_window_title_is_the_cell_title(
+        self, plot_grid_tabs, plot_orchestrator, line_cell
+    ):
+        plot_orchestrator.set_cell_title(line_cell, 'Popped')
+        plot_grid_tabs._poll_for_plot_updates()
+
+        plot_grid_tabs._show_popout(line_cell)
+
+        assert _open_windows(plot_grid_tabs)[0].name == 'Popped'
+
+    def test_cell_keeps_its_own_plot_and_autoscale_controller(
+        self, plot_grid_tabs, line_cell
+    ):
+        cell_widget = plot_grid_tabs._cells[line_cell]
+        cell_controller = cell_widget.autoscale_controller
+        assert cell_controller is not None
+
+        plot_grid_tabs._show_popout(line_cell)
+
+        # The cell is untouched: same widget, same plot, same controller.
+        assert plot_grid_tabs._cells[line_cell] is cell_widget
+        assert cell_widget.autoscale_controller is cell_controller
+
+    def test_each_view_gets_its_own_autoscale_controller(
+        self, plot_grid_tabs, line_cell
+    ):
+        cell_widget = plot_grid_tabs._cells[line_cell]
+
+        detached = cell_widget.compose_detached_view()
+
+        # A controller binds its Bokeh tools to the first figure it renders
+        # into, so a shared one would leave the pop-out without toggles.
+        assert detached.autoscale is not None
+        assert detached.autoscale is not cell_widget.autoscale_controller
+
+    def test_both_views_render_their_own_autoscale_tools(
+        self, plot_grid_tabs, line_cell
+    ):
+        """Rendering one view must not strip the hooks off the other.
+
+        HoloViews ``.opts()`` mutates in place unless cloned, so composing a
+        second view of the same single-layer cell can silently replace the
+        first view's hooks -- the cell would lose its autoscale toggles the
+        moment it was popped out.
+        """
+        cell_widget = plot_grid_tabs._cells[line_cell]
+        detached = cell_widget.compose_detached_view()
+        renderer = hv.renderer('bokeh')
+
+        cell_figure = renderer.get_plot(cell_widget.compose_detached_view().plot)
+        popout_figure = renderer.get_plot(detached.plot)
+
+        for figure in (cell_figure, popout_figure):
+            descriptions = {tool.description for tool in figure.state.toolbar.tools}
+            assert 'Fit ranges to current data' in descriptions
+
+    def test_both_views_repaint_from_the_same_pipe(self, plot_grid_tabs, line_cell):
+        """The pop-out is live, not a snapshot: one pipe drives both figures."""
+        cell_widget = plot_grid_tabs._cells[line_cell]
+        detached = cell_widget.compose_detached_view()
+
+        session_layer = next(iter(plot_grid_tabs._session_layers.values()))
+        pipe = session_layer.components.pipe
+        cell_plot = cell_widget.compose_detached_view().plot
+
+        assert pipe in cell_plot.streams
+        assert pipe in detached.plot.streams
+
+
+class TestPopoutLifecycle:
+    def test_reopening_replaces_rather_than_stacks(self, plot_grid_tabs, line_cell):
+        plot_grid_tabs._show_popout(line_cell)
+        plot_grid_tabs._show_popout(line_cell)
+
+        assert len(_open_windows(plot_grid_tabs)) == 1
+
+    def test_closing_the_window_drops_it(self, plot_grid_tabs, line_cell):
+        plot_grid_tabs._show_popout(line_cell)
+
+        # jsPanel round-trips the user's click on the window's close button.
+        _open_windows(plot_grid_tabs)[0].status = 'closed'
+
+        assert _open_windows(plot_grid_tabs) == []
+
+    def test_minimizing_the_window_keeps_it(self, plot_grid_tabs, line_cell):
+        plot_grid_tabs._show_popout(line_cell)
+
+        _open_windows(plot_grid_tabs)[0].status = 'minimized'
+
+        assert len(_open_windows(plot_grid_tabs)) == 1
+
+    def test_cell_rebuild_carries_the_window_along(
+        self, plot_grid_tabs, plot_orchestrator, line_cell
+    ):
+        """A rebuilt cell composes fresh plots, so the window is rebuilt too.
+
+        It must not simply vanish: rebuilds follow ordinary user actions
+        elsewhere in the dashboard (a rename, a job restart), and a floating
+        view disappearing in response would read as a crash.
+        """
+        plot_grid_tabs._show_popout(line_cell)
+        window_before = _open_windows(plot_grid_tabs)[0]
+
+        plot_orchestrator.set_cell_title(line_cell, 'Renamed')
+        plot_grid_tabs._poll_for_plot_updates()
+
+        windows = _open_windows(plot_grid_tabs)
+        assert len(windows) == 1
+        assert windows[0] is not window_before
+        assert windows[0].name == 'Renamed'
+
+    def test_cell_removal_closes_the_window(
+        self, plot_grid_tabs, plot_orchestrator, line_cell
+    ):
+        plot_grid_tabs._show_popout(line_cell)
+        layer_id = plot_orchestrator.get_cell(line_cell).layers[0].layer_id
+
+        plot_orchestrator.remove_layer(layer_id)
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert _open_windows(plot_grid_tabs) == []
+
+    def test_session_teardown_closes_all_windows(self, plot_grid_tabs, line_cell):
+        plot_grid_tabs._show_popout(line_cell)
+
+        plot_grid_tabs.dispose_widgets()
+
+        assert _open_windows(plot_grid_tabs) == []
+
+    def test_placeholder_cell_pops_out_nothing(self, plot_grid_tabs, plot_orchestrator):
+        """A cell waiting for data has no plot to show in a window."""
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=1, ncols=1)
+        cell_id = plot_orchestrator.add_cell(grid_id, _GEOMETRY)
+        plot_orchestrator.add_layer(cell_id, _line_config())
+        plot_grid_tabs._poll_for_plot_updates()
+        assert not plot_grid_tabs._cells[cell_id].has_plot
+
+        plot_grid_tabs._show_popout(cell_id)
+
+        assert _open_windows(plot_grid_tabs) == []
+
+
+class TestPopoutKeepsItsCellLive:
+    """A window floating above another tab must not show frozen data."""
+
+    def test_hidden_grid_sleeps_without_a_popout(
+        self, plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+    ):
+        plot_grid_tabs.tabs.active = 0  # Workflows: no grid is visible
+
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert plot_grid_tabs._popouts.open_cells() == frozenset()
+        assert not _layer_is_active(
+            plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+        )
+
+    def test_popped_out_cell_stays_active_on_another_tab(
+        self, plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+    ):
+        plot_grid_tabs._show_popout(line_cell)
+        plot_grid_tabs.tabs.active = 0
+
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert plot_grid_tabs._popouts.open_cells() == frozenset({line_cell})
+        assert _layer_is_active(
+            plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+        )
+
+    def test_closing_the_window_lets_the_cell_sleep_again(
+        self, plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+    ):
+        plot_grid_tabs._show_popout(line_cell)
+        plot_grid_tabs.tabs.active = 0
+        plot_grid_tabs._poll_for_plot_updates()
+
+        plot_grid_tabs._popouts.close(line_cell)
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert not _layer_is_active(
+            plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+        )
+
+
+def _layer_is_active(plot_grid_tabs, plot_orchestrator, plot_data_service, cell_id):
+    """Whether a viewer still holds interest in the cell's layer.
+
+    The interest token is what keeps a layer computing; a hidden grid's layers
+    lose it, which is exactly what would freeze a pop-out.
+    """
+    layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+    return plot_data_service.get(layer_id).has_viewers
+
+
+class TestPopoutDoesNotBlockDataFlow:
+    def test_open_popout_leaves_the_active_grid_resolvable(
+        self, plot_grid_tabs, line_cell
+    ):
+        """A pop-out must not masquerade as a modal.
+
+        ``_get_active_grid_id`` returns None while a config modal is open,
+        which suppresses the poll loop's data flush. A pop-out that routed
+        through the modal container would therefore freeze every plot.
+        """
+        active_before = plot_grid_tabs._get_active_grid_id()
+
+        plot_grid_tabs._show_popout(line_cell)
+
+        assert plot_grid_tabs._get_active_grid_id() == active_before
+        assert plot_grid_tabs._current_modal is None
+
+
+class TestPopoutButton:
+    def test_button_disabled_without_a_plot(self, plot_grid_tabs, plot_orchestrator):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=1, ncols=1)
+        cell_id = plot_orchestrator.add_cell(grid_id, _GEOMETRY)
+        plot_orchestrator.add_layer(cell_id, _line_config())
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert _popout_button(plot_grid_tabs._cells[cell_id]).disabled
+
+    def test_button_enabled_with_a_plot(self, plot_grid_tabs, line_cell):
+        assert not _popout_button(plot_grid_tabs._cells[line_cell]).disabled
+
+    def test_button_click_opens_the_window(self, plot_grid_tabs, line_cell):
+        button = _popout_button(plot_grid_tabs._cells[line_cell])
+
+        button.clicks += 1
+
+        assert len(_open_windows(plot_grid_tabs)) == 1
+
+
+def _popout_button(cell_widget):
+    titlebar = cell_widget.view[0]
+    (button,) = [
+        obj
+        for obj in titlebar.objects
+        if 'lt-tool-arrows-maximize' in (getattr(obj, 'css_classes', None) or [])
+    ]
+    return button
+
+
+class TestStaticOnlyCell:
+    """A static-overlay-only cell has no autoscale axes but is still poppable."""
+
+    def test_static_cell_pops_out_without_a_controller(
+        self, plot_grid_tabs, plot_orchestrator
+    ):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=1, ncols=1)
+        cell_id = plot_orchestrator.add_cell(grid_id, _GEOMETRY)
+        plot_orchestrator.add_layer(cell_id, _static_config())
+        plot_grid_tabs._poll_for_plot_updates()
+
+        plot_grid_tabs._show_popout(cell_id)
+
+        assert len(_open_windows(plot_grid_tabs)) == 1
+        assert plot_grid_tabs._cells[cell_id].autoscale_controller is None

--- a/tests/dashboard/widgets/plot_popout_test.py
+++ b/tests/dashboard/widgets/plot_popout_test.py
@@ -428,6 +428,53 @@ class TestPopoutKeepsItsCellLive:
             plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
         )
 
+    @pytest.mark.parametrize('status', ['minimized', 'smallified', 'smallifiedmax'])
+    def test_window_showing_no_plot_lets_the_cell_sleep(
+        self, plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell, status
+    ):
+        """Liveness follows what a window renders, not that it exists.
+
+        Otherwise popping out many cells and minimizing the windows would pin
+        every one of those cells live, on every grid, for nothing on screen.
+        """
+        plot_grid_tabs._show_popout(line_cell)
+        plot_grid_tabs.tabs.active = 0
+
+        _open_windows(plot_grid_tabs)[0].status = status
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert not _layer_is_active(
+            plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+        )
+
+    def test_restoring_the_window_wakes_its_cell(
+        self, plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+    ):
+        plot_grid_tabs._show_popout(line_cell)
+        plot_grid_tabs.tabs.active = 0
+        window = _open_windows(plot_grid_tabs)[0]
+        window.status = 'minimized'
+        plot_grid_tabs._poll_for_plot_updates()
+
+        window.status = 'normalized'
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert _layer_is_active(
+            plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+        )
+
+    def test_minimized_window_still_survives_a_cell_rebuild(
+        self, plot_grid_tabs, plot_orchestrator, line_cell
+    ):
+        """Sleeping is not closing: the user's window must still be there."""
+        plot_grid_tabs._show_popout(line_cell)
+        _open_windows(plot_grid_tabs)[0].status = 'minimized'
+
+        plot_orchestrator.set_cell_title(line_cell, 'Renamed')
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert len(_open_windows(plot_grid_tabs)) == 1
+
 
 def _layer_is_active(plot_grid_tabs, plot_orchestrator, plot_data_service, cell_id):
     """Whether a viewer still holds interest in the cell's layer.

--- a/tests/dashboard/widgets/plot_popout_test.py
+++ b/tests/dashboard/widgets/plot_popout_test.py
@@ -12,6 +12,7 @@ rules that keep a window from outliving the cell it shows.
 from __future__ import annotations
 
 import holoviews as hv
+import panel as pn
 import pytest
 import scipp as sc
 
@@ -166,7 +167,16 @@ def line_cell(plot_orchestrator, plot_grid_tabs, plot_data_service, line_plotter
 
 
 def _open_windows(plot_grid_tabs) -> list:
-    return list(plot_grid_tabs._popouts.container.objects)
+    """The floating windows in the manager's container.
+
+    The container also holds the invisible fitter that installs the pop-out's
+    document-level handlers; only the windows are of interest here.
+    """
+    return [
+        obj
+        for obj in plot_grid_tabs._popouts.container.objects
+        if isinstance(obj, pn.layout.FloatPanel)
+    ]
 
 
 class TestPopoutRendersTheCellsPlotAgain:

--- a/tests/dashboard/widgets/plot_popout_test.py
+++ b/tests/dashboard/widgets/plot_popout_test.py
@@ -145,8 +145,7 @@ def _static_config() -> PlotConfig:
     )
 
 
-@pytest.fixture
-def line_plotter():
+def _make_line_plotter() -> LinePlotter:
     """A real ``LinePlotter`` holding one computed curve.
 
     Real rather than a stub: the properties under test — a shared autoscale
@@ -160,13 +159,18 @@ def line_plotter():
 
 
 @pytest.fixture
-def line_cell(plot_orchestrator, plot_grid_tabs, plot_data_service, line_plotter):
-    """A built cell showing a live 1-D line plot."""
-    grid_id = plot_orchestrator.add_grid(title='G', nrows=1, ncols=1)
+def line_plotter():
+    return _make_line_plotter()
+
+
+def _add_line_cell(
+    plot_orchestrator, plot_grid_tabs, plot_data_service, plotter, *, title
+):
+    """Add a 1x1 grid holding one built cell showing a live 1-D line plot."""
+    grid_id = plot_orchestrator.add_grid(title=title, nrows=1, ncols=1)
     cell_id = plot_orchestrator.add_cell(grid_id, _GEOMETRY)
     layer_id = plot_orchestrator.add_layer(cell_id, _line_config())
 
-    plotter = line_plotter
     plot_data_service.job_started(layer_id, plotter)
     plot_data_service.data_arrived(layer_id)
 
@@ -177,6 +181,14 @@ def line_cell(plot_orchestrator, plot_grid_tabs, plot_data_service, line_plotter
 
     plot_grid_tabs._poll_for_plot_updates()
     return cell_id
+
+
+@pytest.fixture
+def line_cell(plot_orchestrator, plot_grid_tabs, plot_data_service, line_plotter):
+    """A built cell showing a live 1-D line plot."""
+    return _add_line_cell(
+        plot_orchestrator, plot_grid_tabs, plot_data_service, line_plotter, title='G'
+    )
 
 
 def _open_windows(plot_grid_tabs) -> list:
@@ -400,6 +412,50 @@ class TestPopoutLifecycle:
 
         assert _open_windows(plot_grid_tabs) == []
 
+    def test_disabling_the_grid_closes_the_window(
+        self, plot_grid_tabs, plot_orchestrator, line_cell
+    ):
+        """A disabled grid's layers stop computing (they lose their viewers),
+        so its pop-out would float on frozen; it is closed instead. The cell
+        itself survives for a re-enable."""
+        plot_grid_tabs._show_popout(line_cell)
+
+        plot_orchestrator.set_grid_enabled(
+            plot_grid_tabs._cell_grid[line_cell], enabled=False
+        )
+        _tick(plot_grid_tabs)
+
+        assert _open_windows(plot_grid_tabs) == []
+        assert line_cell in plot_grid_tabs._cells
+
+    def test_reopening_after_a_close_does_not_cover_an_open_window(
+        self, plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+    ):
+        """Cascade slots are never reused: counting open windows instead
+        would land the third window exactly on the second after the first
+        closed, hiding the covered window's close button."""
+        second = _add_line_cell(
+            plot_orchestrator,
+            plot_grid_tabs,
+            plot_data_service,
+            _make_line_plotter(),
+            title='H',
+        )
+        third = _add_line_cell(
+            plot_orchestrator,
+            plot_grid_tabs,
+            plot_data_service,
+            _make_line_plotter(),
+            title='I',
+        )
+        plot_grid_tabs._show_popout(line_cell)
+        plot_grid_tabs._show_popout(second)
+        _open_windows(plot_grid_tabs)[0].status = 'closed'
+        plot_grid_tabs._show_popout(third)
+
+        offsets = {(w.offsetx, w.offsety) for w in _open_windows(plot_grid_tabs)}
+        assert len(offsets) == 2
+
     def test_session_teardown_closes_all_windows(self, plot_grid_tabs, line_cell):
         plot_grid_tabs._show_popout(line_cell)
 
@@ -430,7 +486,7 @@ class TestPopoutKeepsItsCellLive:
 
         _tick(plot_grid_tabs)
 
-        assert plot_grid_tabs._popouts.open_cells() == frozenset()
+        assert _open_windows(plot_grid_tabs) == []
         assert not _layer_is_active(
             plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
         )
@@ -443,7 +499,7 @@ class TestPopoutKeepsItsCellLive:
 
         _tick(plot_grid_tabs)
 
-        assert plot_grid_tabs._popouts.open_cells() == frozenset({line_cell})
+        assert plot_grid_tabs._popouts.status_of(line_cell) == 'normalized'
         assert _layer_is_active(
             plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
         )
@@ -505,16 +561,28 @@ class TestPopoutKeepsItsCellLive:
         )
 
     def test_minimized_window_still_survives_a_cell_rebuild(
-        self, plot_grid_tabs, plot_orchestrator, line_cell
+        self, plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
     ):
-        """Sleeping is not closing: the user's window must still be there."""
+        """Sleeping is not closing: the user's window must still be there.
+
+        And still be *sleeping*: reopening normalized would pop every parked
+        window open on a job restart and wake every cell behind them, letting
+        rebuilds defeat the minimize-to-sleep handle.
+        """
         plot_grid_tabs._show_popout(line_cell)
+        plot_grid_tabs.tabs.active = 0
         _open_windows(plot_grid_tabs)[0].status = 'minimized'
+        _tick(plot_grid_tabs)
 
         plot_orchestrator.set_cell_title(line_cell, 'Renamed')
         _tick(plot_grid_tabs)
 
-        assert len(_open_windows(plot_grid_tabs)) == 1
+        windows = _open_windows(plot_grid_tabs)
+        assert len(windows) == 1
+        assert windows[0].status == 'minimized'
+        assert not _layer_is_active(
+            plot_grid_tabs, plot_orchestrator, plot_data_service, line_cell
+        )
 
 
 class TestPopoutWakesTheSessionItFloatsOver:
@@ -586,6 +654,112 @@ def _layer_is_active(plot_grid_tabs, plot_orchestrator, plot_data_service, cell_
     """
     layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
     return plot_data_service.get(layer_id).has_viewers
+
+
+class TestPerGridFrameFlush:
+    """The flush gate is per grid, not one flag for the session.
+
+    A presenter holds pending data as soon as the ingestion thread builds its
+    layer, *before* the grid's frame commits. With a pop-out from another grid
+    live, a session renders two grids; a shared gate would let a frame for
+    either push the other's half-built burst, staggering layers of one burst
+    across repaints -- the very thing the frame clock exists to prevent.
+    """
+
+    @pytest.fixture
+    def popped_out_cell(self, plot_orchestrator, plot_grid_tabs, plot_data_service):
+        """A second grid's cell, popped out into a floating window."""
+        cell_id = _add_line_cell(
+            plot_orchestrator,
+            plot_grid_tabs,
+            plot_data_service,
+            _make_line_plotter(),
+            title='H',
+        )
+        plot_grid_tabs._show_popout(cell_id)
+        return cell_id
+
+    def test_frame_for_the_popout_grid_leaves_the_visible_burst_pending(
+        self,
+        plot_grid_tabs,
+        plot_orchestrator,
+        plot_data_service,
+        frame_clock,
+        line_cell,
+        popped_out_cell,
+    ):
+        _show_grid_tab(plot_grid_tabs, line_cell)
+        _tick(plot_grid_tabs)
+
+        _build_layer(plot_orchestrator, plot_data_service, line_cell)
+        _new_frame(frame_clock, plot_grid_tabs, popped_out_cell)
+        _tick(plot_grid_tabs)
+
+        assert _has_pending(plot_grid_tabs, plot_orchestrator, line_cell)
+
+    def test_frame_for_the_own_grid_flushes_the_visible_burst(
+        self,
+        plot_grid_tabs,
+        plot_orchestrator,
+        plot_data_service,
+        frame_clock,
+        line_cell,
+        popped_out_cell,
+    ):
+        _show_grid_tab(plot_grid_tabs, line_cell)
+        _tick(plot_grid_tabs)
+
+        _build_layer(plot_orchestrator, plot_data_service, line_cell)
+        _new_frame(frame_clock, plot_grid_tabs, line_cell)
+        _tick(plot_grid_tabs)
+
+        assert not _has_pending(plot_grid_tabs, plot_orchestrator, line_cell)
+
+    def test_frame_for_the_popout_grid_flushes_the_window(
+        self,
+        plot_grid_tabs,
+        plot_orchestrator,
+        plot_data_service,
+        frame_clock,
+        line_cell,
+        popped_out_cell,
+    ):
+        _show_grid_tab(plot_grid_tabs, line_cell)
+        _tick(plot_grid_tabs)
+
+        _build_layer(plot_orchestrator, plot_data_service, popped_out_cell)
+        _new_frame(frame_clock, plot_grid_tabs, popped_out_cell)
+        _tick(plot_grid_tabs)
+
+        assert not _has_pending(plot_grid_tabs, plot_orchestrator, popped_out_cell)
+
+
+def _show_grid_tab(plot_grid_tabs, cell_id) -> None:
+    """Make the tab of the grid holding a cell the visible one."""
+    grid_id = plot_grid_tabs._cell_grid[cell_id]
+    tabbed = plot_grid_tabs._tabbed_grid_ids()
+    plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count + tabbed.index(
+        grid_id
+    )
+
+
+def _build_layer(plot_orchestrator, plot_data_service, cell_id) -> None:
+    """Recompute the cell's plotter, as the ingestion thread's layer build does.
+
+    Its presenters now hold a pending update, ahead of the grid's frame
+    commit -- the mid-burst state a flush for another grid must not push.
+    """
+    layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+    plotter = plot_data_service.get(layer_id).plotter
+    key = DataKey(workflow_id=_WORKFLOW, source_name='s1', output_name='out')
+    plotter.compute({PRIMARY: {key: _curve([4.0, 5.0, 6.0])}})
+
+
+def _has_pending(plot_grid_tabs, plot_orchestrator, cell_id) -> bool:
+    """Whether the cell's layer still holds an unflushed update."""
+    layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+    session_layer = plot_grid_tabs._session_layers[layer_id]
+    return session_layer.components.presenter.has_pending_update()
 
 
 class TestPopoutDoesNotBlockDataFlow:

--- a/tests/dashboard/widgets/plot_popout_test.py
+++ b/tests/dashboard/widgets/plot_popout_test.py
@@ -44,6 +44,8 @@ hv.extension('bokeh')
 
 _WORKFLOW = WorkflowId(instrument='test', name='wf', version=1)
 _GEOMETRY = CellGeometry(row=0, col=0, row_span=1, col_span=1)
+# Tooltip of the controller's one-shot Fit tool, its handle in a Bokeh toolbar.
+_FIT = 'Fit ranges to current data'
 
 
 @pytest.fixture
@@ -130,20 +132,27 @@ def _static_config() -> PlotConfig:
 
 
 @pytest.fixture
-def line_cell(plot_orchestrator, plot_grid_tabs, plot_data_service):
-    """A built cell showing a live 1-D line plot, plus its plotter and pipe.
+def line_plotter():
+    """A real ``LinePlotter`` holding one computed curve.
 
-    Uses a real ``LinePlotter``: the pop-out's defining properties (a private
-    autoscale controller, a shared data pipe) only exist for a plot that
-    actually autoscales and actually updates.
+    Real rather than a stub: the properties under test — a shared autoscale
+    controller, a shared data pipe — only exist for a plot that actually
+    autoscales and actually updates.
     """
+    plotter = LinePlotter.from_params(PlotParams1d())
+    key = DataKey(workflow_id=_WORKFLOW, source_name='s1', output_name='out')
+    plotter.compute({PRIMARY: {key: _curve([1.0, 2.0, 3.0])}})
+    return plotter
+
+
+@pytest.fixture
+def line_cell(plot_orchestrator, plot_grid_tabs, plot_data_service, line_plotter):
+    """A built cell showing a live 1-D line plot."""
     grid_id = plot_orchestrator.add_grid(title='G', nrows=1, ncols=1)
     cell_id = plot_orchestrator.add_cell(grid_id, _GEOMETRY)
     layer_id = plot_orchestrator.add_layer(cell_id, _line_config())
 
-    plotter = LinePlotter.from_params(PlotParams1d())
-    key = DataKey(workflow_id=_WORKFLOW, source_name='s1', output_name='out')
-    plotter.compute({PRIMARY: {key: _curve([1.0, 2.0, 3.0])}})
+    plotter = line_plotter
     plot_data_service.job_started(layer_id, plotter)
     plot_data_service.data_arrived(layer_id)
 
@@ -160,7 +169,7 @@ def _open_windows(plot_grid_tabs) -> list:
     return list(plot_grid_tabs._popouts.container.objects)
 
 
-class TestPopoutOpensAnIndependentView:
+class TestPopoutRendersTheCellsPlotAgain:
     def test_popout_opens_one_floating_window(self, plot_grid_tabs, line_cell):
         assert _open_windows(plot_grid_tabs) == []
 
@@ -193,50 +202,115 @@ class TestPopoutOpensAnIndependentView:
         assert plot_grid_tabs._cells[line_cell] is cell_widget
         assert cell_widget.autoscale_controller is cell_controller
 
-    def test_each_view_gets_its_own_autoscale_controller(
-        self, plot_grid_tabs, line_cell
-    ):
-        cell_widget = plot_grid_tabs._cells[line_cell]
+    def test_both_views_show_the_same_composed_plot(self, plot_grid_tabs, line_cell):
+        """One composition, rendered twice — not two compositions.
 
-        detached = cell_widget.compose_detached_view()
-
-        # A controller binds its Bokeh tools to the first figure it renders
-        # into, so a shared one would leave the pop-out without toggles.
-        assert detached.autoscale is not None
-        assert detached.autoscale is not cell_widget.autoscale_controller
-
-    def test_both_views_render_their_own_autoscale_tools(
-        self, plot_grid_tabs, line_cell
-    ):
-        """Rendering one view must not strip the hooks off the other.
-
-        HoloViews ``.opts()`` mutates in place unless cloned, so composing a
-        second view of the same single-layer cell can silently replace the
-        first view's hooks -- the cell would lose its autoscale toggles the
-        moment it was popped out.
+        Sharing is what links the two views: one ``Pipe`` feeds both figures,
+        and one autoscale controller drives both toolbars.
         """
         cell_widget = plot_grid_tabs._cells[line_cell]
-        detached = cell_widget.compose_detached_view()
-        renderer = hv.renderer('bokeh')
 
-        cell_figure = renderer.get_plot(cell_widget.compose_detached_view().plot)
-        popout_figure = renderer.get_plot(detached.plot)
+        plot_grid_tabs._show_popout(line_cell)
 
-        for figure in (cell_figure, popout_figure):
-            descriptions = {tool.description for tool in figure.state.toolbar.tools}
-            assert 'Fit ranges to current data' in descriptions
+        window = _open_windows(plot_grid_tabs)[0]
+        assert _rendered_plot(window) is cell_widget.composed.plot
+
+    def test_both_toolbars_get_the_same_autoscale_tools(
+        self, plot_grid_tabs, line_cell
+    ):
+        """Tools install per figure, so neither toolbar goes bare.
+
+        Both toolbars get the *same* tool models: that identity is what makes
+        a toggle flipped in the window show as flipped in the cell.
+        """
+        composed = plot_grid_tabs._cells[line_cell].composed
+
+        cell_tools = _autoscale_tools(_render(composed.plot))
+        popout_tools = _autoscale_tools(_render(composed.plot))
+
+        assert _FIT in cell_tools
+        assert cell_tools.keys() > {_FIT}  # at least one axis toggle too
+        assert cell_tools == popout_tools
+
+    def test_toggling_autoscale_in_one_view_shows_in_the_other(
+        self, plot_grid_tabs, line_cell
+    ):
+        composed = plot_grid_tabs._cells[line_cell].composed
+        cell_tools = _autoscale_tools(_render(composed.plot))
+        popout_tools = _autoscale_tools(_render(composed.plot))
+        toggle = next(name for name in cell_tools if name != _FIT)
+        assert popout_tools[toggle].active
+
+        cell_tools[toggle].active = False
+
+        assert not popout_tools[toggle].active
+
+    def test_fit_reaches_every_rendered_figure(
+        self, plot_grid_tabs, line_cell, line_plotter
+    ):
+        """A Fit click must fit both views, not whichever renders first.
+
+        Both figures repaint from one pipe push, so tracking the pending fit
+        as a single flag would let the first figure consume it and leave the
+        second showing a stale range.
+        """
+        composed = plot_grid_tabs._cells[line_cell].composed
+        figures = [_render(composed.plot).state for _ in range(2)]
+        tools = _autoscale_tools_of(figures[0])
+        for name, tool in tools.items():
+            if name != _FIT:
+                tool.active = False  # ranges now only move on an explicit Fit
+        for figure in figures:
+            figure.x_range.start, figure.x_range.end = -999.0, 999.0
+
+        tools[_FIT].active = True  # the user clicks Fit
+        _repaint(plot_grid_tabs, line_plotter)
+
+        for figure in figures:
+            assert (figure.x_range.start, figure.x_range.end) != (-999.0, 999.0)
 
     def test_both_views_repaint_from_the_same_pipe(self, plot_grid_tabs, line_cell):
         """The pop-out is live, not a snapshot: one pipe drives both figures."""
         cell_widget = plot_grid_tabs._cells[line_cell]
-        detached = cell_widget.compose_detached_view()
-
         session_layer = next(iter(plot_grid_tabs._session_layers.values()))
-        pipe = session_layer.components.pipe
-        cell_plot = cell_widget.compose_detached_view().plot
 
-        assert pipe in cell_plot.streams
-        assert pipe in detached.plot.streams
+        plot_grid_tabs._show_popout(line_cell)
+
+        pipe = session_layer.components.pipe
+        assert pipe in cell_widget.composed.plot.streams
+        assert pipe in _rendered_plot(_open_windows(plot_grid_tabs)[0]).streams
+
+
+def _render(plot):
+    """Render a composed plot into a fresh Bokeh figure, as a view would."""
+    return hv.renderer('bokeh').get_plot(plot)
+
+
+def _autoscale_tools(rendered) -> dict[str, object]:
+    """The controller's toolbar tools on a rendered plot, keyed by tooltip."""
+    return _autoscale_tools_of(rendered.state)
+
+
+def _autoscale_tools_of(figure) -> dict[str, object]:
+    from bokeh.models import CustomAction
+
+    return {
+        tool.description: tool
+        for tool in figure.toolbar.tools
+        if isinstance(tool, CustomAction)
+    }
+
+
+def _repaint(plot_grid_tabs, plotter) -> None:
+    """Push a frame through the layer's pipe, repainting every rendered view."""
+    session_layer = next(iter(plot_grid_tabs._session_layers.values()))
+    session_layer.components.pipe.send(plotter.get_cached_state())
+
+
+def _rendered_plot(window):
+    """The HoloViews object a pop-out window renders."""
+    column = window[0]
+    return column[0][0].object
 
 
 class TestPopoutLifecycle:

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -76,9 +76,16 @@ class TestPerPanelToolHooks:
             on_configure_layer=lambda _: None,
             toolbars_visible=True,
             on_toggle_toolbars_callback=lambda _: None,
+            on_popout_callback=lambda: None,
+            can_popout=True,
             css_classes=['lt-cell-r0c0'],
         )
-        for tool in ('lt-tool-settings', 'lt-tool-pencil', 'lt-tool-layer-details'):
+        for tool in (
+            'lt-tool-settings',
+            'lt-tool-pencil',
+            'lt-tool-layer-details',
+            'lt-tool-arrows-maximize',
+        ):
             matches = [
                 obj
                 for obj in titlebar.objects

--- a/tests/helpers/browser.py
+++ b/tests/helpers/browser.py
@@ -111,6 +111,32 @@ def assert_stops_updating(dash: Dashboard, label: str) -> None:
             raise AssertionError(f"{label} kept receiving data updates")
 
 
+def click_until(
+    dash: Dashboard,
+    selector: str,
+    condition: Callable[[], bool],
+    *,
+    label: str,
+    timeout_ms: int = PROPAGATION_TIMEOUT_MS,
+    interval_ms: int = 500,
+) -> None:
+    """Click ``selector`` until ``condition`` holds.
+
+    A rebuild racing the click detaches the target between locating it and
+    pressing it; the click then lands on an element whose handler is gone and
+    silently does nothing. Playwright reports success, so this cannot be caught
+    as an error -- only observed by the effect not happening. Cold start is the
+    usual trigger, the first refresh tick after load arriving mid-click.
+    """
+    waited = 0
+    while not condition():
+        if waited >= timeout_ms:
+            raise AssertionError(f"Timed out after {timeout_ms} ms waiting for {label}")
+        dash.click(selector)
+        dash.page.wait_for_timeout(interval_ms)
+        waited += interval_ms
+
+
 def wait_until(
     dash: Dashboard,
     condition: Callable[[], bool],

--- a/tests/helpers/browser.py
+++ b/tests/helpers/browser.py
@@ -92,6 +92,25 @@ def assert_updating(dash: Dashboard, label: str) -> None:
     assert after != before, f"{label} stopped receiving data updates: {before}"
 
 
+def assert_stops_updating(dash: Dashboard, label: str) -> None:
+    """Assert the session's rendered data goes quiet and stays quiet.
+
+    Retried rather than sampled once: a frame already in flight when the
+    session went to sleep may still land, and that is not a failure. Data
+    genuinely still flowing never yields two matching samples.
+    """
+    waited = 0
+    while True:
+        before = fingerprint(dash)
+        dash.page.wait_for_timeout(UPDATE_WINDOW_MS)
+        after = fingerprint(dash)
+        if after == before:
+            return
+        waited += UPDATE_WINDOW_MS
+        if waited >= PROPAGATION_TIMEOUT_MS:
+            raise AssertionError(f"{label} kept receiving data updates")
+
+
 def wait_until(
     dash: Dashboard,
     condition: Callable[[], bool],


### PR DESCRIPTION
## What

A tool in the cell titlebar opens that cell's plot in a draggable, resizable floating window. The cell is untouched: it keeps its plot, its toolbars and its place in the grid. The window renders the cell's *own* composition a second time rather than composing its own, so both views repaint from one layer `Pipe` and share one autoscale controller — the window is live rather than a snapshot, and turning an autoscale axis off in either view turns it off in both.

## Why

A grid cell is often too small to read detail from, and the alternatives (resize the grid, open a modal) either disturb the layout or block the dashboard underneath. A *floating* window is also what makes a plot watchable while working elsewhere in the dashboard: a popped-out cell stays live when its grid is not the visible tab. That is the capability that justifies the machinery — an expand-in-place or a modal would be simpler but could not do it.

## Cost, and why there is no cap on the number of pop-outs

Liveness follows what a window *shows*, not that it exists — the same rule a hidden tab already obeys. Minimizing or smallifying a pop-out puts its cell back to sleep, so popping out many cells and minimizing the windows costs nothing: what is not rendered is not computed. A cell rebuild (a rename, a job restart) carries the window along *with its status*, so a parked window stays parked and its cell asleep, rather than every rebuild popping the parked windows open. A cap would punish the case the feature exists for (comparing two detectors side by side) while leaving the actual cost unbounded, since minimized windows would still count against it. Liveness is also per cell rather than per grid, so the rest of a hidden grid still sleeps.

## Liveness under the gated wake ticks (#1105)

Session ticks are gated on a `has_work` predicate over shared state, and this branch widens it. Every term used to be scoped to the *visible* grid, so a session parked on another tab would evaluate the predicate, find no work, and never run the tick body -- which is where cross-tab pop-out liveness lives. The gate now tracks frame generations per grid: the visible one unioned with the grids behind live pop-outs. Predicate and pass read one `_live_generations`, so they cannot disagree about what counts as live; a minimized window drops out of it by the same rule that lets it sleep.

Flushes are per grid for the same reason the predicate is. A presenter holds pending data as soon as the ingestion thread builds its layer, *before* the grid's frame commits, so a single session-wide flush flag would let a frame for the pop-out's grid push the visible grid's half-built burst (and vice versa), staggering one burst's layers across repaints -- the artifact the frame clock exists to prevent. Each grid's pipes flush only when that grid's own generation moved or it just became visible.

Working a window's controls moves no shared state, only what this session shows, so no predicate can see it. The manager reports those changes and the tab widget requests a full tick, exactly as it already does for tab switches and modal closes -- otherwise a restored window sits frozen at whatever it showed when it was minimized. Opening needs no such call: the pop-out button is in a cell titlebar, so the cell is on the visible tab and already live.

A window must not outlive what it shows: removing the cell closes it, and disabling its grid closes it too, since the grid's layers lose their viewers and the window would float on frozen.

The pop-out tests drive the gated helper rather than the pass directly, so a predicate that misses a pop-out fails there instead of passing while the window freezes in the browser.


## Notes for review

Three findings are worth the reviewer's attention because they cost real time and are now recorded in the automation rules. Panel's `FloatPanel` does not carry a window's size down to its content: the wrappers between jsPanel's content element and ours have no height, which both collapses a stretching child to a sliver and prevents a fixed-height child from ever following the window. Panel re-lays out only on `jspanelresizestop`, which a drag fires but maximize and normalize do not. And an invisible `ReactiveHTML` helper needs a public class name — a leading underscore makes Bokeh fail to resolve the model and takes the whole session down with it.

Browser-test viewports default to 1000 px tall, which hid a geometry bug that only appears below roughly 820 px; the geometry test parametrizes over 700 px for that reason.

## Known gaps

A live window shows the plot alone: the freshness/lag pill stays in the cell titlebar, which a hidden tab does not render, so a stalled stream freezes a pop-out with no staleness cue. Recorded in the module docstring; a window-side freshness cue is future work.

ROI-request layers share one edit stream per presenter, so popping out an ROI cell drives a single `BoxEdit`/`PolyDraw` from two figures. This is untested and likely needs handling before the feature is relied on for ROI work.

## Test plan

Automated coverage added with the feature:

- unit tests for the window lifecycle, the shared composition and autoscale controller, cross-tab liveness, sleeping when minimized, and the wake gate (a frame for a popped-out grid wakes a session on another tab; one for a hidden grid alone, or behind a minimized window, does not);
- unit tests for per-grid flushing (a frame for the pop-out's grid leaves the visible grid's mid-burst data pending, and each grid's frame flushes its own), a rebuild preserving a minimized window and its cell's sleep, closing the window when its grid is disabled, and cascade slots not being reused after a close;
- browser tests that the window opens inside the viewport at both 700 px and 1000 px heights, stays live while another tab is shown, sleeps when minimized and wakes on restore, and that the plot tracks the window across maximize and normalize.

Manual checks for the tester:

- [ ] Pop out several cells at once; each window's controls stay reachable as they cascade.
- [ ] Drag and resize a window; the plot follows without leaving whitespace.
- [ ] Open a pop-out on a laptop-height screen; the title bar and its buttons are reachable.
- [ ] The popped-out toolbar's hover and save tools behave as they do in the cell.
- [ ] Rename a cell that has a pop-out open; the window follows the rebuilt cell.
- [ ] Minimize a pop-out, then rename its cell; the rebuilt window arrives minimized in the taskbar strip, not reopened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
