### PR TITLE
Install autoscale tools per toolbar, not once per controller

### DIFF
--- a/src/ess/livedata/dashboard/cell_autoscale.py
+++ b/src/ess/livedata/dashboard/cell_autoscale.py
@@ -107,7 +107,6 @@ class CellAutoscaleController:
         # session's own Bokeh document (see dashboard-widgets rules).
         self._toggles: dict[Axis, Any] = {}
         self._fit_tool: Any | None = None
-        self._tools_installed = False
         # Last target written per axis. Read back on subsequent off-state
         # renders so the c-axis freeze has a stable value to apply.
         self._last_targets: dict[Axis, tuple[float, float]] = {}
@@ -180,50 +179,33 @@ class CellAutoscaleController:
                 pass
         self._toggles = {}
         self._fit_tool = None
-        self._tools_installed = False
 
     def _install_tools(self, plot: Any) -> None:
-        """Install ``CustomAction`` tools on the figure toolbar once.
+        """Ensure this cell's ``CustomAction`` tools are on the figure toolbar.
 
-        Idempotent: subsequent calls are no-ops, mirroring the pattern in
-        ``flatten_plotter._make_hover_hook``.
+        Keyed on the toolbar rather than on a controller-wide latch: a cell's
+        hook is attached to the session's ``DynamicMap``, which HoloViews can
+        render into more than one Bokeh figure (a rebuilt cell whose previous
+        pane is still in the document, a kdim/Layout figure swap). A one-shot
+        latch let whichever figure rendered first consume the installation and
+        left the figure the user sees with no toggles at all.
+
+        The tool models are created once and shared across figures, so the
+        toggle state a user set survives a figure swap.
         """
-        if self._tools_installed:
-            return
-        from .widgets.icons import get_icon_data_uri
-
-        axis_icons: dict[Axis, tuple[str, str]] = {
-            axis: (
-                get_icon_data_uri(f'autoscale-{axis}-on'),
-                get_icon_data_uri(f'autoscale-{axis}'),
-            )
-            for axis in self._axes
-        }
-        fit_icon = get_icon_data_uri('arrows-minimize')
-
-        for axis in sorted(self._axes):
-            on_icon, off_icon = axis_icons[axis]
-            self._toggles[axis] = _make_toggle_action(
-                active=True,
-                description=_TOGGLE_DESCRIPTIONS[axis],
-                on_icon=on_icon,
-                off_icon=off_icon,
-            )
-        self._fit_tool = _make_fit_action(
-            description='Fit ranges to current data',
-            icon=fit_icon,
-        )
-        self._fit_tool.on_change('active', self._on_fit_active_change)
-
         toolbar = getattr(getattr(plot, 'state', None), 'toolbar', None)
         if toolbar is None:
-            # Don't mark installed -- a subsequent render with a real toolbar
-            # should retry rather than silently lose the toggles forever.
             logger.warning(
                 "No Bokeh toolbar found for cell autoscale controller; "
                 "toggles will be unavailable until the next render."
             )
             return
+        if self._fit_tool is not None and any(
+            tool is self._fit_tool for tool in toolbar.tools
+        ):
+            return
+        if self._fit_tool is None:
+            self._create_tools()
         # Tools are added via assignment to keep Bokeh's property setter
         # notified; in-place append would not trigger change events.
         toolbar.tools = [
@@ -231,7 +213,23 @@ class CellAutoscaleController:
             *self._toggles.values(),
             self._fit_tool,
         ]
-        self._tools_installed = True
+
+    def _create_tools(self) -> None:
+        """Create the per-axis toggles and the Fit action."""
+        from .widgets.icons import get_icon_data_uri
+
+        for axis in sorted(self._axes):
+            self._toggles[axis] = _make_toggle_action(
+                active=True,
+                description=_TOGGLE_DESCRIPTIONS[axis],
+                on_icon=get_icon_data_uri(f'autoscale-{axis}-on'),
+                off_icon=get_icon_data_uri(f'autoscale-{axis}'),
+            )
+        self._fit_tool = _make_fit_action(
+            description='Fit ranges to current data',
+            icon=get_icon_data_uri('arrows-minimize'),
+        )
+        self._fit_tool.on_change('active', self._on_fit_active_change)
 
     def _apply_targets(self, plot: Any) -> None:
         """Write current targets to handles based on toggle / Fit state.

--- a/tests/dashboard/cell_autoscale_test.py
+++ b/tests/dashboard/cell_autoscale_test.py
@@ -457,8 +457,8 @@ class TestIdempotentInstallation:
         """Missing toolbar on first call must not lock the controller out.
 
         Real Bokeh plots always have a toolbar; this guards against a
-        regression where _tools_installed is set prematurely and a
-        subsequent render with a live toolbar misses tool installation.
+        regression where the controller records the installation prematurely
+        and a subsequent render with a live toolbar misses it.
         """
         k = _key()
         plotter = _FakePlotter(frozenset({'x'}), {k: {'x': (0.0, 1.0)}})
@@ -468,12 +468,33 @@ class TestIdempotentInstallation:
         plot_no_toolbar.state = None  # type: ignore[assignment]
         hook = controller.make_hook()
         hook(plot_no_toolbar, None)
-        assert controller._tools_installed is False
 
         plot, _x, _y, _c = _make_plot_all_handles()
         hook(plot, None)
-        assert controller._tools_installed is True
         assert len(plot.state.toolbar.tools) == 2  # x toggle + Fit
+
+    def test_second_figure_also_gets_tools(self) -> None:
+        """Every figure the cell's hook renders into must carry the tools.
+
+        The hook lives on the session's DynamicMap, which HoloViews can render
+        into more than one Bokeh figure (a rebuilt cell whose previous pane is
+        still in the document, or a kdim/Layout figure swap). Installing only
+        into the figure that happens to render first leaves the figure the
+        user sees with no toggles.
+        """
+        k = _key()
+        plotter = _FakePlotter(frozenset({'x', 'y'}), {k: {'x': (0.0, 1.0)}})
+        controller = CellAutoscaleController([plotter])
+        hook = controller.make_hook()
+
+        first, *_ = _make_plot_all_handles()
+        second, *_ = _make_plot_all_handles()
+        hook(first, None)
+        hook(second, None)
+
+        # Same tool models on both toolbars, so toggle state is shared.
+        assert second.state.toolbar.tools == first.state.toolbar.tools
+        assert len(second.state.toolbar.tools) == 3
 
 
 class TestHandleRefreshPerRender:
@@ -553,7 +574,6 @@ class TestDispose:
         assert fit_tool._callbacks == []
         assert controller._fit_tool is None
         assert controller._toggles == {}
-        assert controller._tools_installed is False
 
     def test_controller_collectable_after_dispose(self) -> None:
         """The on_change cycle (controller -> tool -> bound method ->


### PR DESCRIPTION
A 2D image plot's autoscale toggles (and Fit) sometimes never appeared, or disappeared after switching tabs, leaving the color range frozen at whatever the first frame produced.

A cell's autoscale hook is attached to the session's `DynamicMap`, which HoloViews can render into more than one Bokeh figure: a kdim/Layout figure swap, or — far more often — a rebuilt cell whose previous figure is still alive in the client model graph (#1155). `CellAutoscaleController` installed its `CustomAction` tools behind a one-shot latch, so whichever figure rendered first consumed the installation and the figure the user sees was left with an empty toolbar. Which figure wins is a race, hence the intermittency.

Installation is now keyed on the toolbar. The tool models are still created once and shared across figures, so a toggle the user turned off stays off across a figure swap.

Note this fixes the symptom, not the cause: rebuilt cells should not be leaving detached figures behind at all. That is #1155.

## Test plan

- New regression test: a controller whose hook renders into a second figure installs the tools there too, sharing the same tool models. Fails on `main` (second figure gets zero tools).
- `tests/dashboard`: 1957 passed.
- Manual, fake backend + dummy fixture: 2D image cells keep Color/X/Y autoscale + Fit across four tab-switch cycles, with no duplicated buttons.
