### PR TITLE
Install npm 12 in CI for pre-commit's node hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
+      # pre-commit 4.6.1 installs `language: node` hooks with
+      # `npm install --allow-git=root`, a flag that only exists in npm 12. The
+      # runner image ships npm 10, where the install leaves no executable
+      # behind and the hook fails with "Executable not found". See #1162.
+      - name: Update npm for pre-commit's node hooks
+        run: npm install -g npm@^12
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files


### PR DESCRIPTION
`pre-commit` 4.6.1 installs `language: node` hooks with `npm install --allow-git=root`. That flag only exists in npm 12, and the runner image ships npm 10.9.8, so the install leaves no executable behind and our one node hook fails:

```
Detect unicode bidi attacks..............................................Failed
- hook id: anti-trojan-source
Executable `anti-trojan-source` not found
```

Isolated locally with a cold `PRE_COMMIT_HOME`, same machine and Node, varying only the two versions:

| pre-commit | npm | result |
| --- | --- | --- |
| 4.5.0 | 11.12.1 | passes (pre-4.6.1 install path) |
| 4.6.1 | 10.9.8 | `Executable anti-trojan-source not found` — matches CI |
| 4.6.1 | 11.12.1 | `EALLOWGIT`, "Fetching non-root packages of type git have been disabled" |
| 4.6.1 | 12.0.2 | passes |

`pre-commit/action@v3.0.1` always installs the latest pre-commit and exposes no version input, so 4.6.1 arrived with no pin on our side. Upgrading npm is preferred over pinning pre-commit: it follows where upstream is going rather than holding the toolchain back, and needs no follow-up to unwind. The runner has Node.js 22.23.1 and npm 12 supports `^22.22.2 || ^24.15.0 || >=26.0.0`, so no `actions/setup-node` step is required.

This only reproduces on a cold hook cache, which is why main has stayed green. The pre-commit cache key includes the interpreter path, so a warm cache never re-runs the node install. Any cache miss surfaces it — a `.pre-commit-config.yaml` edit, a Python version change (how #1160 hit it), or GitHub evicting the entry after 7 days unused.

Fixes #1162

## Test plan

- [ ] CI green, including a cold-cache run of the `anti-trojan-source` hook
