### PR TITLE
Migrate generics to PEP 695 syntax (UP046/UP047)

### DIFF
--- a/docs/about/loader.py
+++ b/docs/about/loader.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from dataclasses import dataclass
-from typing import NewType, TypeVar
+from typing import NewType
 
 import pandas as pd
 from environments import BenchmarkResultFilePath, BenchmarkRootDir
@@ -9,10 +9,8 @@ from runner import BenchmarkReport
 
 ResultPath = BenchmarkResultFilePath
 
-T = TypeVar("T")
 
-
-def _extract_only_if_one(values: list[T], target_name: str) -> T | None:
+def _extract_only_if_one[T](values: list[T], target_name: str) -> T | None:
     if len(cands := set(values)) > 1:
         raise ValueError(f"More than 1 {target_name} found in the list.")
     elif len(cands) == 0:
@@ -25,7 +23,7 @@ def _extract_unit(units: list[str | None]) -> str | None:
     return _extract_only_if_one([unit for unit in units if unit is not None], "unit")
 
 
-def _extract_dtype(values: list[T]) -> type[T] | str | None:
+def _extract_dtype[T](values: list[T]) -> type[T] | str | None:
     none_type = type(None)
     cands = [valt for val in values if (valt := type(val)) is not none_type]
     if (extracted := _extract_only_if_one(cands, "type")) is str:
@@ -47,10 +45,7 @@ def _reconstruct(contents: dict | list | tuple, target_type: type, strict: bool)
         return contents
 
 
-D = TypeVar("D")
-
-
-def reconstruct_nested_dataclass(
+def reconstruct_nested_dataclass[D](
     contents: dict, root_type: type[D], type_strict: bool = True
 ) -> D:
     """Reconstructs dataclass object from a dictionary.

--- a/docs/about/runner.py
+++ b/docs/about/runner.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
-from typing import Generic, NewType, TypeVar
+from typing import NewType
 
 from environments import (
     BenchmarkEnvironment,
@@ -35,12 +35,9 @@ class BenchmarkResult:  # Measurement results should always have value and unit.
     space: SpaceMeasurement | None = None
 
 
-_Item = TypeVar("_Item")
-
-
-def _append_row(
-    obj: dict[str, list[_Item | None]], row: dict[str, _Item]
-) -> dict[str, list[_Item | None]]:
+def _append_row[Item](
+    obj: dict[str, list[Item | None]], row: dict[str, Item]
+) -> dict[str, list[Item | None]]:
     """
     Helper function to extend Pandas Dataframe-like dictionary.
     All columns(Corresponding to the highest level keys)
@@ -62,11 +59,8 @@ def _append_row(
     return obj
 
 
-R = TypeVar("R")
-
-
 @dataclass
-class SingleRunReport(Generic[R]):
+class SingleRunReport[R]:
     callable_name: BenchmarkTargetName
     benchmark_result: BenchmarkResult
     arguments: dict
@@ -117,7 +111,9 @@ class BenchmarkRunner(ABC):
 class SimpleRunner(BenchmarkRunner):
     """Benchmark runner that simply measures duration of a function call."""
 
-    def __call__(self, func: Callable[..., R], *args, **kwargs) -> SingleRunReport[R]:
+    def __call__[R](
+        self, func: Callable[..., R], *args, **kwargs
+    ) -> SingleRunReport[R]:
         import inspect
         import time
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,10 +133,6 @@ ignore = [
     # Conflict with ruff format, see
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "COM812", "COM819", "D206", "D300", "E111", "E114", "E117", "ISC001", "ISC002", "Q000", "Q001", "Q002", "Q003", "W191",
-    # PEP 695 generics migration is tracked in #1161; it changes typing
-    # semantics (implicit invariance, per-class type parameters) and so is not
-    # a mechanical reformat.
-    "UP046", "UP047",
 ]
 fixable = ["B010", "I001", "PT001", "RUF022"]
 isort.known-first-party = ["ess.livedata"]

--- a/src/ess/livedata/core/message.py
+++ b/src/ess/livedata/core/message.py
@@ -5,13 +5,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Generic, Protocol, TypeVar
+from typing import Protocol
 
 from .timestamp import Timestamp
-
-T = TypeVar('T')
-Tin = TypeVar('Tin')
-Tout = TypeVar('Tout')
 
 
 class StreamKind(StrEnum):
@@ -68,7 +64,7 @@ class RunStop:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class Message(Generic[T]):
+class Message[T]:
     """
     A message with a timestamp and a stream key.
 
@@ -92,12 +88,12 @@ class Message(Generic[T]):
         return self.timestamp < other.timestamp
 
 
-class MessageSource(Protocol, Generic[Tin]):
+class MessageSource[Tin](Protocol):
     # Note that Tin is often (but not always) Message[T]
     def get_messages(self) -> Sequence[Tin]: ...
 
 
-class MessageSink(Protocol, Generic[Tout]):
+class MessageSink[Tout](Protocol):
     def publish_messages(self, messages: list[Message[Tout]]) -> None:
         """
         Publish messages to the producer.

--- a/src/ess/livedata/core/orchestrating_processor.py
+++ b/src/ess/livedata/core/orchestrating_processor.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from collections import defaultdict
 from dataclasses import replace
-from typing import Any, Generic
+from typing import Any
 
 import structlog
 
@@ -37,8 +37,6 @@ from .message import (
     RunStop,
     StreamId,
     StreamKind,
-    Tin,
-    Tout,
 )
 from .message_batcher import (
     AdaptiveMessageBatcher,
@@ -52,7 +50,7 @@ from .timestamp import Duration, Timestamp
 logger = structlog.get_logger(__name__)
 
 
-class MessagePreprocessor(Generic[Tin, Tout]):
+class MessagePreprocessor[Tin, Tout]:
     """Message preprocessor that handles batches of messages."""
 
     def __init__(
@@ -146,7 +144,7 @@ class MessagePreprocessor(Generic[Tin, Tout]):
         )
 
 
-class OrchestratingProcessor(Generic[Tin, Tout]):
+class OrchestratingProcessor[Tin, Tout]:
     def __init__(
         self,
         *,

--- a/src/ess/livedata/core/preprocessor.py
+++ b/src/ess/livedata/core/preprocessor.py
@@ -2,18 +2,14 @@
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from typing import ClassVar, Generic, Protocol, TypeVar
+from typing import ClassVar, Protocol
 
 from ..config.instrument import Instrument
-from .message import StreamId, Tin, Tout
+from .message import StreamId
 from .timestamp import Timestamp
 
-T = TypeVar('T')
-U = TypeVar('U')
-V = TypeVar('V')
 
-
-class Accumulator(Protocol, Generic[T, U]):
+class Accumulator[T, U](Protocol):
     """
     Protocol for an accumulator that accumulates data over time.
 
@@ -57,7 +53,7 @@ class Accumulator(Protocol, Generic[T, U]):
         """
 
 
-class PreprocessorFactory(Protocol, Generic[Tin, Tout]):
+class PreprocessorFactory[Tin, Tout](Protocol):
     """
     Factory for creating preprocessors (accumulators) for message streams.
 
@@ -70,7 +66,7 @@ class PreprocessorFactory(Protocol, Generic[Tin, Tout]):
         return None
 
 
-class JobBasedPreprocessorFactoryBase(PreprocessorFactory[Tin, Tout]):
+class JobBasedPreprocessorFactoryBase[Tin, Tout](PreprocessorFactory[Tin, Tout]):
     """Factory base used by job-based backend services."""
 
     def __init__(self, *, instrument: Instrument) -> None:

--- a/src/ess/livedata/core/processor.py
+++ b/src/ess/livedata/core/processor.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from typing import Generic, Protocol
+from typing import Protocol
 
 import structlog
 
-from .message import Message, MessageSink, MessageSource, Tin, Tout
+from .message import Message, MessageSink, MessageSource
 
 logger = structlog.get_logger(__name__)
 
@@ -27,7 +27,7 @@ class Processor(Protocol):
         """
 
 
-class IdentityProcessor(Generic[Tin, Tout]):
+class IdentityProcessor[Tin, Tout]:
     """
     Simple processor that passes messages directly from source to sink.
 

--- a/src/ess/livedata/dashboard/configuration_adapter.py
+++ b/src/ess/livedata/dashboard/configuration_adapter.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from pydantic import BaseModel, Field
 
 from ess.livedata.config.workflow_spec import AuxSources
-
-Model = TypeVar('Model')
 
 DEFAULT_SOURCE_PRESELECTION_CAP = 5
 """Maximum number of sources to pre-select by default.
@@ -42,7 +40,7 @@ class ConfigurationState(BaseModel):
     )
 
 
-class ConfigurationAdapter(ABC, Generic[Model]):
+class ConfigurationAdapter[Model](ABC):
     """
     Abstract adapter for providing configuration data to generic widgets.
 
@@ -96,6 +94,7 @@ class ConfigurationAdapter(ABC, Generic[Model]):
     @property
     def aux_sources(self) -> AuxSources | None:
         """Auxiliary source specification, or None if the workflow has none."""
+        return None
 
     @property
     def initial_aux_source_names(self) -> dict[str, str]:

--- a/src/ess/livedata/dashboard/data_service.py
+++ b/src/ess/livedata/dashboard/data_service.py
@@ -6,7 +6,7 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Hashable, Iterable, Iterator, Mapping, MutableMapping
 from contextlib import contextmanager
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 import structlog
 
@@ -15,11 +15,8 @@ from .temporal_buffer_manager import TemporalBufferManager
 
 logger = structlog.get_logger(__name__)
 
-K = TypeVar('K', bound=Hashable)
-V = TypeVar('V')
 
-
-class DataServiceSubscriber(ABC, Generic[K]):
+class DataServiceSubscriber[K: Hashable](ABC):
     """Base class for data service subscribers with cached keys and extractors.
 
     Notifications carry no data: :py:meth:`on_updated` only reports which keys
@@ -67,7 +64,7 @@ class DataServiceSubscriber(ABC, Generic[K]):
         """
 
 
-class DataService(MutableMapping[K, V]):
+class DataService[K: Hashable, V](MutableMapping[K, V]):
     """
     A service for managing and retrieving data and derived data.
 

--- a/src/ess/livedata/dashboard/plotter_registry.py
+++ b/src/ess/livedata/dashboard/plotter_registry.py
@@ -9,7 +9,7 @@ import typing
 from collections import UserDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol
 
 import pydantic
 import scipp as sc
@@ -106,11 +106,7 @@ class PlotterSpec(pydantic.BaseModel):
     )
 
 
-# Type variable for parameter types
-P = TypeVar('P', bound=pydantic.BaseModel)
-
-
-class PlotterFactory(Protocol, Generic[P]):
+class PlotterFactory[P: pydantic.BaseModel](Protocol):
     def __call__(self, params: P) -> Plotter: ...
 
 
@@ -132,7 +128,7 @@ class PlotterEntry:
 
 
 class PlotterRegistry(UserDict[str, PlotterEntry]):
-    def register_plotter(
+    def register_plotter[P: pydantic.BaseModel](
         self,
         name: str,
         title: str,

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -2,8 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from collections.abc import Callable, Hashable, Mapping
-from typing import TypeVar
+from collections.abc import Callable, Mapping
 
 import pydantic
 
@@ -28,9 +27,6 @@ from .plotter_registry import (
 from .roi_publisher import ROIPublisher
 from .roi_request_plots import ROIPublisherAware
 from .stream_manager import StreamManager
-
-K = TypeVar('K', bound=Hashable)
-V = TypeVar('V')
 
 
 class PlottingController:

--- a/src/ess/livedata/dashboard/roi_request_plots.py
+++ b/src/ess/livedata/dashboard/roi_request_plots.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import holoviews as hv
 import pydantic
@@ -309,11 +309,6 @@ class PolygonConverter:
 if TYPE_CHECKING:
     from ess.livedata.config.workflow_spec import DataKey
 
-# TypeVars for generic base class
-ROIType = TypeVar('ROIType', RectangleROI, PolygonROI)
-ParamsType = TypeVar('ParamsType', bound=pydantic.BaseModel)
-ConverterType = TypeVar('ConverterType', RectangleConverter, PolygonConverter)
-
 
 class OptionalRectanglesCoordinates(RectanglesCoordinates):
     """Wrapper for optional rectangle coordinate input.
@@ -528,7 +523,11 @@ class PolygonsRequestPresenter(BaseROIRequestPresenter):
         )
 
 
-class BaseROIRequestPlotter(Plotter, ABC, Generic[ROIType, ParamsType, ConverterType]):
+class BaseROIRequestPlotter[
+    ROIType: (RectangleROI, PolygonROI),
+    ParamsType: pydantic.BaseModel,
+    ConverterType: (RectangleConverter, PolygonConverter),
+](Plotter, ABC):
     """Base class for interactive ROI request plotters.
 
     Implements compute() to extract data-dependent info and create_presenter()

--- a/src/ess/livedata/dashboard/temporal_buffer_manager.py
+++ b/src/ess/livedata/dashboard/temporal_buffer_manager.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from collections.abc import Hashable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar
 
 import scipp as sc
 import structlog
@@ -15,8 +14,6 @@ from .extractors import LatestValueExtractor, UpdateExtractor
 from .temporal_buffers import BufferProtocol, SingleValueBuffer, TemporalBuffer
 
 logger = structlog.get_logger()
-
-K = TypeVar('K', bound=Hashable)
 
 
 @dataclass
@@ -29,7 +26,7 @@ class _BufferState:
     )  # Stored as list internally
 
 
-class TemporalBufferManager(Mapping[K, BufferProtocol[sc.DataArray]], Generic[K]):
+class TemporalBufferManager[K: Hashable](Mapping[K, BufferProtocol[sc.DataArray]]):
     """
     Manages buffers, switching between SingleValueBuffer and TemporalBuffer.
 

--- a/src/ess/livedata/dashboard/temporal_buffers.py
+++ b/src/ess/livedata/dashboard/temporal_buffers.py
@@ -6,11 +6,8 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
 
 import scipp as sc
-
-T = TypeVar('T')
 
 
 def _variable_nbytes(var: sc.Variable) -> int:
@@ -22,7 +19,7 @@ def _variable_nbytes(var: sc.Variable) -> int:
     return var.values.nbytes * (2 if var.variances is not None else 1)
 
 
-class BufferProtocol(ABC, Generic[T]):
+class BufferProtocol[T](ABC):
     """Common interface for all buffer types."""
 
     @abstractmethod
@@ -89,7 +86,7 @@ class BufferProtocol(ABC, Generic[T]):
         """
 
 
-class SingleValueBuffer(BufferProtocol[T]):
+class SingleValueBuffer[T](BufferProtocol[T]):
     """
     Buffer that stores only the latest value.
 

--- a/src/ess/livedata/dashboard/transport.py
+++ b/src/ess/livedata/dashboard/transport.py
@@ -5,14 +5,12 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Generic, Protocol, TypeVar
+from typing import Protocol
 
 from ..core.message import Message, MessageSink, MessageSource
 
-TResources = TypeVar('TResources', covariant=True)
 
-
-class Transport(Protocol, Generic[TResources]):
+class Transport[TResources](Protocol):
     """
     Protocol for message transport implementations.
 

--- a/src/ess/livedata/dashboard/widgets/wizard.py
+++ b/src/ess/livedata/dashboard/widgets/wizard.py
@@ -6,17 +6,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 import panel as pn
 
 from .styles import ModalSizing
 
-TInput = TypeVar('TInput')
-TOutput = TypeVar('TOutput')
 
-
-class WizardStep(ABC, Generic[TInput, TOutput]):
+class WizardStep[TInput, TOutput](ABC):
     """
     Base class for wizard step components.
 

--- a/src/ess/livedata/fakes.py
+++ b/src/ess/livedata/fakes.py
@@ -1,14 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
-from typing import Generic, TypeVar
-
 from .core import Message
 from .core.message import RESPONSES_STREAM_ID, STATUS_STREAM_ID
 
-T = TypeVar('T')
 
-
-class FakeMessageSource(Generic[T]):
+class FakeMessageSource[T]:
     """
     A fake message source that returns messages from memory for testing purposes.
     """
@@ -25,7 +21,7 @@ class FakeMessageSource(Generic[T]):
         return messages
 
 
-class FakeMessageSink(Generic[T]):
+class FakeMessageSink[T]:
     """
     A fake message sink that stores messages in memory for testing purposes.
 

--- a/src/ess/livedata/kafka/device_synthesizer.py
+++ b/src/ess/livedata/kafka/device_synthesizer.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Generic, Literal, TypeVar
+from typing import Literal
 
 import structlog
 
@@ -32,14 +32,13 @@ from ..preprocessors.accumulators import LogData
 logger = structlog.get_logger(__name__)
 
 _Role = Literal['value', 'target', 'idle']
-_V = TypeVar('_V', float, bool)
 
 
 @dataclass
-class _Substream(Generic[_V]):
+class _Substream[V: (float, bool)]:
     """Last-seen value and timestamp for one device substream."""
 
-    value: _V
+    value: V
     time: Timestamp
 
 

--- a/src/ess/livedata/kafka/message_adapter.py
+++ b/src/ess/livedata/kafka/message_adapter.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from collections.abc import Sequence
 from dataclasses import replace
-from typing import Any, Generic, Protocol, TypeVar
+from typing import Any, Protocol
 
 import numpy as np
 import pydantic
@@ -46,10 +46,6 @@ from .stream_mapping import InputStreamKey, StreamLUT
 from .x5f2_compat import x5f2_to_status
 
 logger = structlog.get_logger(__name__)
-
-T = TypeVar('T')
-U = TypeVar('U')
-V = TypeVar('V')
 
 
 class KafkaMessage(Protocol):
@@ -123,7 +119,7 @@ class IgnoredMessageError(Exception):
     """
 
 
-class MessageAdapter(Protocol, Generic[T, U]):
+class MessageAdapter[T, U](Protocol):
     def adapt(self, message: T) -> U: ...
 
 
@@ -134,7 +130,7 @@ class NullAdapter(MessageAdapter[KafkaMessage, Any]):
         raise IgnoredMessageError
 
 
-class KafkaAdapter(MessageAdapter[KafkaMessage, Message[T]]):
+class KafkaAdapter[T](MessageAdapter[KafkaMessage, Message[T]]):
     """
     Base class for Kafka adapters.
 
@@ -499,12 +495,12 @@ class ResponsesAdapter(MessageAdapter[KafkaMessage, Message[CommandAcknowledgeme
         return Message(stream=RESPONSES_STREAM_ID, timestamp=timestamp, value=ack)
 
 
-class ChainedAdapter(MessageAdapter[T, V]):
+class ChainedAdapter[T, V](MessageAdapter[T, V]):
     """
     Chains two adapters together.
     """
 
-    def __init__(self, first: MessageAdapter[T, U], second: MessageAdapter[U, V]):
+    def __init__[U](self, first: MessageAdapter[T, U], second: MessageAdapter[U, V]):
         self._first = first
         self._second = second
 
@@ -513,7 +509,7 @@ class ChainedAdapter(MessageAdapter[T, V]):
         return self._second.adapt(intermediate)
 
 
-class RouteBySchemaAdapter(MessageAdapter[KafkaMessage, T]):
+class RouteBySchemaAdapter[T](MessageAdapter[KafkaMessage, T]):
     """
     Routes messages to different adapters based on the schema.
     """
@@ -536,7 +532,7 @@ class RouteBySchemaAdapter(MessageAdapter[KafkaMessage, T]):
         return self._routes[schema].adapt(message)
 
 
-class RouteByTopicAdapter(MessageAdapter[KafkaMessage, T]):
+class RouteByTopicAdapter[T](MessageAdapter[KafkaMessage, T]):
     """
     Routes messages to different adapters based on the topic.
     """
@@ -559,7 +555,7 @@ class RouteByTopicAdapter(MessageAdapter[KafkaMessage, T]):
         return self._routes[topic].adapt(message)
 
 
-class AdaptingMessageSource(MessageSource[U]):
+class AdaptingMessageSource[T, U](MessageSource[U]):
     """
     Wraps a source of messages and adapts them to a different type.
     """

--- a/src/ess/livedata/kafka/sink.py
+++ b/src/ess/livedata/kafka/sink.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from types import TracebackType
-from typing import Any, Generic, Protocol, TypeVar
+from typing import Any, Protocol
 
 import confluent_kafka as kafka
 import scipp as sc
@@ -15,9 +15,6 @@ from ..core.message import Message, MessageSink
 from .errors import is_fatal
 
 logger = structlog.get_logger(__name__)
-
-
-T = TypeVar("T")
 
 
 class SerializationError(Exception):
@@ -38,7 +35,7 @@ class SerializedMessage:
     value: bytes
 
 
-class MessageSerializer(Protocol, Generic[T]):
+class MessageSerializer[T](Protocol):
     """
     Protocol for converting a domain :class:`Message` into a :class:`SerializedMessage`.
 
@@ -50,7 +47,7 @@ class MessageSerializer(Protocol, Generic[T]):
     def serialize(self, message: Message[T]) -> SerializedMessage: ...
 
 
-class KafkaSink(MessageSink[T]):
+class KafkaSink[T](MessageSink[T]):
     """
     Publishes :class:`Message` instances to Kafka.
 
@@ -176,7 +173,7 @@ class KafkaSink(MessageSink[T]):
         self.close()
 
 
-class UnrollingSinkAdapter(MessageSink[T | sc.DataGroup[T]]):
+class UnrollingSinkAdapter[T](MessageSink[T | sc.DataGroup[T]]):
     def __init__(self, sink: MessageSink[T]):
         self._sink = sink
 

--- a/src/ess/livedata/kafka/sink_serializers.py
+++ b/src/ess/livedata/kafka/sink_serializers.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import importlib.metadata
 import os
 import socket
-from typing import TypeVar
 
 import scipp as sc
 from streaming_data_types import dataarray_da00, logdata_f144
@@ -32,8 +31,6 @@ from .sink import MessageSerializer, SerializationError, SerializedMessage
 from .sink_routing import RouteByStatusTypeSerializer, RouteByStreamKindSerializer
 from .x5f2_compat import job_status_to_x5f2, service_status_to_x5f2
 
-T = TypeVar('T')
-
 
 def _get_software_version() -> str:
     """Get the software version for x5f2 messages."""
@@ -43,7 +40,7 @@ def _get_software_version() -> str:
         return '0.0.0'
 
 
-class _TopicResolvingSerializer(MessageSerializer[T]):
+class _TopicResolvingSerializer[T](MessageSerializer[T]):
     """
     Base class for serializers that resolve a Kafka topic from the instrument
     name and stream kind, and wrap encoding errors in :class:`SerializationError`.

--- a/src/ess/livedata/preprocessors/accumulators.py
+++ b/src/ess/livedata/preprocessors/accumulators.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 import scipp as sc
 from ess.reduce import streaming
@@ -15,8 +15,6 @@ from ..core.timestamp import Timestamp
 from .to_nxevent_data import MonitorEvents
 
 __all__ = ["MonitorEvents"]
-
-T = TypeVar('T')
 
 
 @dataclass
@@ -153,7 +151,7 @@ class _NoCopyWindowAccumulator(NoCopyAccumulator):
     Must not be constructed directly — use :func:`make_no_copy_accumulator_pair`.
     """
 
-    def _do_push(self, value: T) -> None:
+    def _do_push[T](self, value: T) -> None:
         self._reset_if_geometry_changed(value)
         if self._value is None:
             self._value = value
@@ -197,7 +195,7 @@ def make_no_copy_accumulator_pair(
     )
 
 
-class LatestValue(streaming.Accumulator[T], Generic[T]):
+class LatestValue[T](streaming.Accumulator[T]):
     """
     Streaming accumulator that keeps only the latest value.
 

--- a/src/ess/livedata/preprocessors/group_by_pixel.py
+++ b/src/ess/livedata/preprocessors/group_by_pixel.py
@@ -11,10 +11,12 @@ import ess.livedata.preprocessors._patch_group_event_data  # noqa: F401
 
 from ..core.preprocessor import Accumulator
 from ..core.timestamp import Timestamp
-from .to_nxevent_data import Events, ToNXevent_data
+from .to_nxevent_data import DetectorEvents, MonitorEvents, ToNXevent_data
 
 
-class GroupByPixel(Accumulator[Events, sc.DataArray]):
+class GroupByPixel[Events: (DetectorEvents, MonitorEvents)](
+    Accumulator[Events, sc.DataArray]
+):
     """Accumulator that groups events by detector pixel.
 
     Wraps a ``ToNXevent_data`` accumulator and applies ``group_event_data``

--- a/src/ess/livedata/preprocessors/to_nxevent_data.py
+++ b/src/ess/livedata/preprocessors/to_nxevent_data.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TypeVar
 
 import numpy as np
 import scipp as sc
@@ -70,9 +69,6 @@ class DetectorEvents(MonitorEvents):
         )
 
 
-Events = TypeVar('Events', DetectorEvents, MonitorEvents)
-
-
 class _ScippBackedBuffer:
     """A growable buffer backed by a scipp Variable.
 
@@ -128,7 +124,9 @@ class _WeightsBuffer:
         return self._var['event', :n]
 
 
-class ToNXevent_data(Accumulator[Events, sc.DataArray]):
+class ToNXevent_data[Events: (DetectorEvents, MonitorEvents)](
+    Accumulator[Events, sc.DataArray]
+):
     def __init__(self):
         self._chunks: list[Events] = []
         self._timestamps: list[int] = []

--- a/src/ess/livedata/service_factory.py
+++ b/src/ess/livedata/service_factory.py
@@ -7,7 +7,7 @@ import logging
 import sys
 from collections.abc import Callable
 from contextlib import ExitStack
-from typing import Any, Generic, NoReturn, TypeVar
+from typing import Any, NoReturn
 
 import structlog
 
@@ -44,10 +44,6 @@ from .logging_config import configure_logging
 
 logger = structlog.get_logger(__name__)
 
-Traw = TypeVar("Traw")
-Tin = TypeVar("Tin")
-Tout = TypeVar("Tout")
-
 
 _INNER_BATCHER_FACTORIES: dict[str, Callable[[float], MessageBatcher]] = {
     'simple': SimpleMessageBatcher,
@@ -55,7 +51,7 @@ _INNER_BATCHER_FACTORIES: dict[str, Callable[[float], MessageBatcher]] = {
 }
 
 
-class DataServiceBuilder(Generic[Traw, Tin, Tout]):
+class DataServiceBuilder[Traw, Tin, Tout]:
     def __init__(
         self,
         *,


### PR DESCRIPTION
## Summary

Closes #1161.

Raising the minimum Python version to 3.12 made ruff infer `target-version = py312`, activating `UP046`/`UP047` (non-PEP-695 generic class/function), suppressed in a follow-up since the rewrite changes typing semantics rather than just formatting.

Converts all flagged classes/functions to `class Foo[T]` / `def f[T]()`, including:
- Implicitly-generic classes that inherited a subscripted generic base without their own `Generic[T]` (e.g. `KafkaAdapter`, `ChainedAdapter`, `DataService`).
- Method-scoped generics distinct from their class's own parameters (e.g. `ChainedAdapter.__init__[U]`, `PlotterRegistry.register_plotter[P]`).
- Module-level `TypeVar`s previously shared across several classes/files, now split into a parameter per class (e.g. `message.py`'s `Tin`/`Tout` used by `processor.py`/`preprocessor.py`; `Events` shared between `to_nxevent_data.py` and `group_by_pixel.py`).
- Bound and constrained type parameters, and a dropped explicit `covariant=True` since PEP 695 infers variance.

`AccumulationMode` and `to_nxevent_data.Events`'s use as a sciline `Scope` specialization key across independent `NewType`/`Scope` declarations in several unrelated files are left as plain `TypeVar`s -- not expressible as a class- or function-scoped PEP 695 parameter.

A before/after mypy diff confirms no new errors and resolves eight pre-existing "invariant type variable used in protocol where covariant/contravariant expected" warnings, since mypy now infers variance for PEP 695 parameters instead of requiring an explicit `covariant=`/`contravariant=` TypeVar.

## Test plan
- [x] `ruff check` / `ruff format --check` clean on all touched files
- [x] Full test suite: 4321 passed, 4 pre-existing failures unrelated to this change (confirmed present on `main`)
- [x] mypy before/after diff: zero new errors, 8 resolved variance warnings