### PR TITLE
Give the dashboard's static tabs icons

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -43,6 +43,12 @@ def refresh(self):
 
 Do not use Unicode characters for button icons. Use embedded SVG icons from `dashboard/widgets/icons.py` via `get_icon()`. Use the `create_tool_button()` helper from `dashboard/widgets/buttons.py` for consistent styling.
 
+Where the icon cannot be a widget — a Bokeh tab label is plain text, for instance —
+paint it on a `::before` pseudo-element with `mask-image: url(get_icon_data_uri(name,
+color=None))` and `background-color: currentColor`. A mask reads only the alpha channel,
+so the icon inherits the element's text color and follows its active/hover states without
+a second, recolored copy (see `_static_tab_stylesheet` in `plot_grid_tabs.py`).
+
 ## Stable CSS hooks for automation
 
 Tool buttons render as label-less icons inside per-widget shadow DOM, so they carry
@@ -120,7 +126,10 @@ arrives collapsed — no clicking the hamburger, and it survives `page.reload()`
 **Tabs.** The top-level tabs are Bokeh-owned `.bk-tab` divs with no `lt-*` hooks, so
 navigate by visible text (`page.get_by_text("Detectors", exact=True)`). Static tab
 titles are code constants: **Workflows**, **System Status**, **Manage Plots**; further
-tabs are user/fixture plot-grid titles (the dummy fixture adds **Detectors**). With
+tabs are user/fixture plot-grid titles (the dummy fixture adds **Detectors**). Only the
+static tabs carry a leading icon, keyed to their position, so a bare label identifies a
+plot-grid tab visually — but the icon is a CSS pseudo-element, invisible to text
+locators. With
 `dynamic=True` only the active tab's models exist, so a DOM/`lt-*` inventory reflects the
 *current* tab only — switch tabs before querying that tab's hooks.
 

--- a/src/ess/livedata/dashboard/widgets/icons.py
+++ b/src/ess/livedata/dashboard/widgets/icons.py
@@ -50,9 +50,9 @@ def _svg_filled(paths: str) -> str:
     return f'<svg {_SVG_ATTRS_FILLED}>{paths}</svg>'
 
 
-def _rotate90(paths: str) -> str:
-    """Rotate path elements 90° about the 24x24 viewBox centre."""
-    return f'<g transform="rotate(90 12 12)">{paths}</g>'
+def _rotate(paths: str, degrees: int) -> str:
+    """Rotate path elements clockwise about the 24x24 viewBox centre."""
+    return f'<g transform="rotate({degrees} 12 12)">{paths}</g>'
 
 
 # Icon registry: name -> SVG content
@@ -148,6 +148,35 @@ _ICONS: dict[str, str] = {
         '<path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12"/>'
         '<path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"/>'
     ),
+    # Workflow: Tabler ``sitemap`` rotated a quarter turn, so the branches
+    # converge left-to-right rather than fanning out downwards -- several input
+    # streams reduced into one result, in the reading direction.
+    'workflow': _svg(
+        _rotate(
+            '<path d="M3 17a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-2a2 2 0 '
+            '0 1 -2 -2l0 -2"/>'
+            '<path d="M15 17a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-2a2 2 0 '
+            '0 1 -2 -2l0 -2"/>'
+            '<path d="M9 5a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-2a2 2 0 0 '
+            '1 -2 -2l0 -2"/>'
+            '<path d="M6 15v-1a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v1"/>'
+            '<path d="M12 9l0 3"/>',
+            90,
+        )
+    ),
+    # Activity (pulse trace / system health)
+    'activity': _svg('<path d="M3 12h4l3 8l4 -16l3 8h4"/>'),
+    # Layout-grid (plot grid arrangement)
+    'layout-grid': _svg(
+        '<path d="M4 5a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 '
+        '-1 -1l0 -4"/>'
+        '<path d="M14 5a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 '
+        '-1 -1l0 -4"/>'
+        '<path d="M4 15a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 '
+        '-1 -1l0 -4"/>'
+        '<path d="M14 15a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 '
+        '-1 -1l0 -4"/>'
+    ),
     # Arrows-minimize (fit data to viewport)
     'arrows-minimize': _svg(
         '<path d="M5 9l4 0l0 -4"/>'
@@ -203,8 +232,8 @@ _CONTRAST_2_FILLED = (  # Tabler ``contrast-2`` (filled)
 )
 _ICONS['autoscale-x'] = _svg(_AUTOFIT_CONTENT)
 _ICONS['autoscale-x-on'] = _svg_filled(_AUTOFIT_CONTENT_FILLED)
-_ICONS['autoscale-y'] = _svg(_rotate90(_AUTOFIT_CONTENT))
-_ICONS['autoscale-y-on'] = _svg_filled(_rotate90(_AUTOFIT_CONTENT_FILLED))
+_ICONS['autoscale-y'] = _svg(_rotate(_AUTOFIT_CONTENT, 90))
+_ICONS['autoscale-y-on'] = _svg_filled(_rotate(_AUTOFIT_CONTENT_FILLED, 90))
 _ICONS['autoscale-c'] = _svg(_CONTRAST_2)
 _ICONS['autoscale-c-on'] = _svg_filled(_CONTRAST_2_FILLED)
 
@@ -217,11 +246,11 @@ def get_icon(name: str) -> str:
     ----------
     name:
         Icon name. Available icons:
-        arrows-minimize, autoscale-c, autoscale-c-on, autoscale-x,
+        activity, arrows-minimize, autoscale-c, autoscale-c-on, autoscale-x,
         autoscale-x-on, autoscale-y, autoscale-y-on, backspace, check,
-        chevron-down, chevron-right, chevron-up, download, eye, eye-off, pencil,
-        player-pause, player-play, player-stop, plus, refresh, settings, stack,
-        stack-2, trash, x.
+        chevron-down, chevron-right, chevron-up, download, eye, eye-off,
+        layout-grid, pencil, player-pause, player-play, player-stop, plus,
+        refresh, settings, stack, stack-2, trash, workflow, x.
 
     Returns
     -------
@@ -257,7 +286,9 @@ icons visually.
 """
 
 
-def get_icon_data_uri(name: str, *, color: str = BOKEH_TOOLBAR_ICON_COLOR) -> str:
+def get_icon_data_uri(
+    name: str, *, color: str | None = BOKEH_TOOLBAR_ICON_COLOR
+) -> str:
     """Return an icon as a ``data:image/svg+xml;base64,...`` URI.
 
     Useful for Bokeh ``CustomAction(icon=...)``, which accepts a data URI with
@@ -265,11 +296,15 @@ def get_icon_data_uri(name: str, *, color: str = BOKEH_TOOLBAR_ICON_COLOR) -> st
     SVG's ``currentColor`` -- on the ``stroke`` for outline icons and on the
     ``fill`` for solid icons -- so the icon renders in a fixed color rather than
     falling back to black.
+
+    Pass ``color=None`` for a CSS ``mask-image``: a mask reads only the alpha
+    channel and paints in the masked element's own color, so baking one in is
+    pointless and hides that the icon follows the surrounding text color.
     """
-    svg = (
-        get_icon(name)
-        .replace('stroke="currentColor"', f'stroke="{color}"')
-        .replace('fill="currentColor"', f'fill="{color}"')
-    )
+    svg = get_icon(name)
+    if color is not None:
+        svg = svg.replace('stroke="currentColor"', f'stroke="{color}"').replace(
+            'fill="currentColor"', f'fill="{color}"'
+        )
     encoded = base64.b64encode(svg.encode('utf-8')).decode('ascii')
     return f'data:image/svg+xml;base64,{encoded}'

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -11,7 +11,7 @@ session's own periodic tick (see ``PlotOrchestrator`` "Threading").
 from __future__ import annotations
 
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import nullcontext
 
 import panel as pn
@@ -36,6 +36,7 @@ from ..session_layer import SessionLayer
 from ..session_updater import SessionUpdater
 from .cell import CellDeps, CellWidget
 from .cell_properties_modal import CellPropertiesModal
+from .icons import get_icon_data_uri
 from .modal_escape_closer import ModalEscapeCloser
 from .plot_config_modal import PlotConfigModal
 from .plot_grid import PlotGrid
@@ -52,6 +53,61 @@ logger = structlog.get_logger(__name__)
 # path then never triggers and the pill updates once per frame, avoiding a
 # beat between the flush and the timer that would double-update the age.
 _FRESHNESS_STALL_INTERVAL_S = 2.0
+
+
+def _static_tab_stylesheet(icons: Sequence[str]) -> str:
+    """CSS distinguishing the fixed leading tabs from the plot-grid tabs.
+
+    Bokeh renders a tab label as plain text, so an icon cannot be part of the
+    title; it is painted on a ``::before`` pseudo-element selected by tab
+    position (the static tabs are always the first ones). ``mask-image`` rather
+    than ``background-image`` makes the icon take the tab's ``currentColor``, so
+    it follows the label through the active/inactive color change for free.
+
+    Parameters
+    ----------
+    icons:
+        Icon name per static tab, in tab order.
+    """
+    masks = '\n'.join(
+        f"""
+        .bk-tab:nth-child({position})::before {{
+            mask-image: url("{uri}");
+            -webkit-mask-image: url("{uri}");
+        }}"""
+        for position, uri in enumerate(
+            (get_icon_data_uri(icon, color=None) for icon in icons), start=1
+        )
+    )
+    return f"""
+        .bk-tab:nth-child(-n+{len(icons)}) {{
+            font-weight: bold;
+        }}
+        .bk-tab:nth-child(-n+{len(icons)})::before {{
+            content: '';
+            display: inline-block;
+            width: 1.15em;
+            height: 1.15em;
+            margin-right: 0.4em;
+            vertical-align: -0.22em;
+            background-color: currentColor;
+            mask-size: contain;
+            mask-repeat: no-repeat;
+            mask-position: center;
+            -webkit-mask-size: contain;
+            -webkit-mask-repeat: no-repeat;
+            -webkit-mask-position: center;
+        }}
+        {masks}
+        .bk-tab {{
+            border-bottom: 1px solid {Colors.TAB_BORDER} !important;
+        }}
+        .bk-tab.bk-active {{
+            background-color: {Colors.TAB_ACTIVE_BG} !important;
+            border: 1px solid {Colors.TAB_BORDER} !important;
+            border-bottom: none !important;
+        }}
+        """
 
 
 class _BatchedTabs(pn.Tabs):
@@ -178,13 +234,25 @@ class PlotGridTabs:
             on_reconfigure_layer=self._on_reconfigure_layer,
         )
 
-        # Determine number of static tabs for stylesheet
-        static_tab_count = 3 if system_status_widget else 2
-
-        # Build nth-child selectors for static tabs
-        static_tab_selectors = ',\n                '.join(
-            f'.bk-tab:nth-child({i})' for i in range(1, static_tab_count + 1)
+        # The manager reports locally-initiated grid creations so this session
+        # (only) focuses the new tab on its next poll; other sessions merely
+        # gain the tab.
+        self._grid_manager = PlotGridManager(
+            orchestrator=plot_orchestrator,
+            workflow_registry=workflow_registry,
+            on_local_grid_created=self._on_local_grid_created,
         )
+
+        # Fixed tabs, in order, ahead of the variable number of grid tabs. Each
+        # carries an icon so the two groups are distinguishable at a glance;
+        # grid tabs deliberately carry none, making a bare label the mark of a
+        # user-created grid.
+        static_tabs = [('Workflows', 'workflow', workflow_status_widget.panel())]
+        if system_status_widget is not None:
+            static_tabs.append(
+                ('System Status', 'activity', system_status_widget.panel())
+            )
+        static_tabs.append(('Manage Plots', 'layout-grid', self._grid_manager.panel))
 
         # Main tabs widget.
         # IMPORTANT: dynamic=True is critical for performance. Without it, Panel
@@ -197,21 +265,7 @@ class PlotGridTabs:
         self._tabs = _BatchedTabs(
             sizing_mode='stretch_both',
             dynamic=True,
-            stylesheets=[
-                f"""
-                {static_tab_selectors} {{
-                    font-weight: bold;
-                }}
-                .bk-tab {{
-                    border-bottom: 1px solid {Colors.TAB_BORDER} !important;
-                }}
-                .bk-tab.bk-active {{
-                    background-color: {Colors.TAB_ACTIVE_BG} !important;
-                    border: 1px solid {Colors.TAB_BORDER} !important;
-                    border-bottom: none !important;
-                }}
-                """
-            ],
+            stylesheets=[_static_tab_stylesheet([icon for _, icon, _ in static_tabs])],
         )
 
         # Modal container for plot configuration
@@ -236,22 +290,8 @@ class PlotGridTabs:
             sizing_mode='stretch_both',
         )
 
-        # Add Workflows tab (always first)
-        self._tabs.append(('Workflows', workflow_status_widget.panel()))
-
-        # Add System Status tab (second, if widget provided)
-        if system_status_widget is not None:
-            self._tabs.append(('System Status', system_status_widget.panel()))
-
-        # Add Manage tab. The manager reports locally-initiated grid creations
-        # so this session (only) focuses the new tab on its next poll; other
-        # sessions merely gain the tab.
-        self._grid_manager = PlotGridManager(
-            orchestrator=plot_orchestrator,
-            workflow_registry=workflow_registry,
-            on_local_grid_created=self._on_local_grid_created,
-        )
-        self._tabs.append(('Manage Plots', self._grid_manager.panel))
+        for title, _, panel in static_tabs:
+            self._tabs.append((title, panel))
 
         # Store static tabs count for use as offset in grid tab index calculations
         self._static_tabs_count = len(self._tabs)


### PR DESCRIPTION
The three fixed tabs sit next to a variable number of plot-grid tabs, and were distinguishable from them only by bold text. Each now carries a leading icon; grid tabs deliberately carry none, so a bare label is what identifies a user-created grid.

![Dashboard tab bar with icons on the Workflows, System Status and Manage Plots tabs](https://raw.githubusercontent.com/scipp/esslivedata/f99ea51728df688ec86c1af6c07ef72e9aa6005d/tab-icons.png)

Bokeh renders a tab label as plain text, so the icon cannot be part of the title. It is painted on a `::before` pseudo-element selected by tab position — the same positional mechanism the bold rule already used. The icon is a CSS **mask** rather than a background image, so it inherits the tab's `currentColor` and follows the active-tab accent (blue above) without a second, recolored copy.

The Workflows icon is Tabler's `sitemap` rotated 90°, so its branches converge left-to-right: several input streams reduced into one result. It is registered as `workflow` rather than `sitemap` because it is no longer Tabler's glyph in Tabler's orientation — the same reason `autoscale-y` is not called `arrow-autofit-content`.

The screenshot above lives on the throwaway branch `pr-assets-tab-icons`, which can be deleted once this is merged.

## Test plan

Existing dashboard tests cover the wiring: a bad icon name raises `KeyError` from `get_icon` while `PlotGridTabs` is constructed.

- [x] Icons render and are legible at the default zoom
- [x] The active tab's icon takes the accent color, inactive ones stay dark
- [x] Plot-grid tabs remain unstyled, including after adding/renaming a grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
