### PR TITLE
Fix slicer plots failing to render inside a grid cell

### DIFF
--- a/src/ess/livedata/dashboard/slicer_plotter.py
+++ b/src/ess/livedata/dashboard/slicer_plotter.py
@@ -16,13 +16,11 @@ from ess.livedata.config.workflow_spec import DataKey
 from .data_roles import PRIMARY
 from .plot_params import PlotParams3d, PlotScale, PlotScaleParams2d, TickParams
 from .plots import (
-    _HOVER_ELEMENTS_2D,
     Plotter,
     PresenterBase,
     _hv_axis_padding,
     _normalize_to_rate,
     _pad_range,
-    _typed_opts,
 )
 from .range_hook import Axis
 from .scipp_to_holoviews import to_holoviews
@@ -57,8 +55,9 @@ class SlicerPresenter(PresenterBase):
         sizing_opts: dict[str, Any],
     ) -> None:
         super().__init__(plotter)
-        self._base_opts = base_opts
         self._sizing_opts = sizing_opts
+        # Built once so the per-slice ``.opts()`` call does not reassemble it.
+        self._element_opts = {**base_opts, **sizing_opts, 'tools': ['hover']}
         self._kdims: list[hv.Dimension] | None = None
 
     def present(self, pipe: hv.streams.Pipe) -> hv.DynamicMap:
@@ -94,18 +93,12 @@ class SlicerPresenter(PresenterBase):
                 array_data, data.clim, mode=mode, slice_dim=slice_dim, **kwargs
             )
 
-        dmap = hv.DynamicMap(render, streams=[pipe], kdims=self._kdims, cache_size=1)
-        return dmap.opts(*self._style_opts())
-
-    def _style_opts(self) -> list[hv.Options]:
-        """Static styling declared once on the DynamicMap (see
-        :meth:`Plotter.style_opts`); the data-dependent clim stays per slice."""
-        return _typed_opts(
-            _HOVER_ELEMENTS_2D,
-            **self._base_opts,
-            **self._sizing_opts,
-            tools=['hover'],
-        )
+        # Unlike DefaultPresenter, styling is applied per rendered slice rather
+        # than declared on the DynamicMap: element options on a DynamicMap wrap
+        # it in a HoloViews operation, and a kdim-carrying DynamicMap tolerates
+        # only one such wrap. The grid cell adds a second one when it attaches
+        # its hooks, and the wrapper is then unable to reconstruct the kdim key.
+        return hv.DynamicMap(render, streams=[pipe], kdims=self._kdims, cache_size=1)
 
     def _initialize_kdims(self, state: SlicerState) -> None:
         """
@@ -205,12 +198,10 @@ class SlicerPresenter(PresenterBase):
             plot_data = self._slice_data(data, slice_dim, kwargs)
 
         image = to_holoviews(plot_data)
-        # base_opts/sizing are declared once on the DynamicMap (see _style_opts);
-        # only the data-dependent clim is applied per slice here for a consistent
-        # color scale across slices.
-        if clim is not None:
-            return image.opts(clim=clim)
-        return image
+        # The pre-computed clim keeps the color scale consistent across slices.
+        if clim is None:
+            return image.opts(**self._element_opts)
+        return image.opts(**self._element_opts, clim=clim)
 
     def _slice_data(
         self, data: sc.DataArray, slice_dim: str, kwargs: dict

--- a/tests/dashboard/plot_sizing_invariant_test.py
+++ b/tests/dashboard/plot_sizing_invariant_test.py
@@ -35,8 +35,10 @@ from ess.livedata.dashboard.plot_params import (
     PlotAspectType,
     PlotParams1d,
     PlotParams2d,
+    PlotParams3d,
     StretchMode,
 )
+from ess.livedata.dashboard.slicer_plotter import SlicerPlotter
 
 hv.extension('bokeh')
 
@@ -82,6 +84,18 @@ def _data_2d(n: int) -> dict:
         },
     )
     return dict.fromkeys(_keys(n), da)
+
+
+def _data_3d() -> dict:
+    da = sc.DataArray(
+        sc.array(dims=['z', 'y', 'x'], values=np.arange(24.0).reshape(2, 3, 4)),
+        coords={
+            'x': sc.arange('x', 4, dtype='float64'),
+            'y': sc.arange('y', 3, dtype='float64'),
+            'z': sc.arange('z', 2, dtype='float64'),
+        },
+    )
+    return dict.fromkeys(_keys(1), da)
 
 
 # Every aspect type, and both stretch modes for the constrained ones, since the
@@ -130,3 +144,23 @@ def test_every_figure_adopts_the_panes_sizing_mode(
     assert len(figures) == (n_sources if combine == CombineMode.layout else 1)
     for fig in figures:
         assert fig.sizing_mode == pane_sizing_mode(aspect)
+
+
+@pytest.mark.parametrize(
+    'aspect', _ASPECTS, ids=lambda a: f'{a.aspect_type.name}-{a.stretch_mode.name}'
+)
+def test_slicer_figure_adopts_the_panes_sizing_mode(aspect):
+    """The slicer styles each rendered slice instead of its DynamicMap.
+
+    It has to: element options on a kdim-carrying DynamicMap wrap it in an
+    operation that the grid cell's own ``.opts()`` call then cannot see through.
+    That makes the sizing easy to drop on the render path, so pin it here. The
+    slicer takes a single source and produces a single figure, hence no
+    combine-mode or source-count axis.
+    """
+    figures = _present_figures(
+        SlicerPlotter.from_params(PlotParams3d(plot_aspect=aspect)), _data_3d()
+    )
+
+    assert len(figures) == 1
+    assert figures[0].sizing_mode == pane_sizing_mode(aspect)

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -130,6 +130,20 @@ def present_figure(plotter, data_dict):
     return render_to_bokeh(presenter.present(pipe)).state
 
 
+def present_figure_with_cell_hooks(plotter, data_dict):
+    """Render a plotter the way a grid cell does: present, then attach hooks.
+
+    ``CellWidget`` attaches its own hooks (SaveTool filename, hover suspend,
+    autoscale) with a further ``.opts()`` call on whatever the presenter
+    returned, so every presenter's output must survive that.
+    """
+    plotter.compute({'primary': data_dict})
+    presenter = plotter.create_presenter()
+    pipe = hv.streams.Pipe(data=plotter.get_cached_state())
+    composed = presenter.present(pipe).opts(hooks=[lambda plot, element: None])
+    return render_to_bokeh(composed).state
+
+
 class TestTitleResolver:
     def test_get_legend_label_includes_output_by_default(self):
         from ess.livedata.dashboard.plots import TitleResolver
@@ -200,6 +214,12 @@ class TestImagePlotter:
                 "ignore", "All-NaN slice encountered", RuntimeWarning
             )
             render_to_bokeh(hv_element)
+
+    def test_renders_with_cell_hooks(
+        self, image_plotter, constant_nonzero_data, data_key
+    ):
+        """Cell-attached hooks must not break the presenter's DynamicMap."""
+        present_figure_with_cell_hooks(image_plotter, {data_key: constant_nonzero_data})
 
     def test_plot_with_constant_nonzero_values_does_not_raise(
         self, image_plotter, constant_nonzero_data, data_key
@@ -1089,6 +1109,12 @@ class TestSlicerPlotter:
 
         result = dmap['slice', 'z', z_value, y_value, x_value]
         assert isinstance(result, hv.Image)
+
+    def test_presenter_dmap_renders_with_cell_hooks(
+        self, slicer_plotter, data_3d, data_key
+    ):
+        """Cell-attached hooks must not break the slicer's kdim-driven DynamicMap."""
+        present_figure_with_cell_hooks(slicer_plotter, {data_key: data_3d})
 
     # === Edge coordinate tests ===
 


### PR DESCRIPTION
Any 3D output plotted with the slicer raised an `AssertionError` deep inside HoloViews instead of rendering. This is not data-specific — it reproduces with the `(z, y, x)` fixture the existing slicer unit tests already use, and it affects every 3D logical view (ESTIA and TBL multiblade, and BEER's forthcoming panel view).

## Cause

`SlicerPresenter.present()` declared the static element options on its DynamicMap. HoloViews cannot apply element options to a DynamicMap statically, so it wraps it in a `Dynamic` operation whose callback takes `*args`; `validate_dynamic_argspec` therefore leaves that wrapper without `_posarg_keys`. The grid cell then attaches its own hooks (SaveTool filename, hover suspend, autoscale) with a second `.opts()` call, and the resulting outer wrapper passes the kdim values as keywords. Rebuilding the positional key from those keywords requires the inner wrapper's `_posarg_keys`, so the inner map ends up indexed with an empty key and `_validate_key` asserts.

Put differently: a DynamicMap that carries kdims tolerates exactly one `.opts()` call. Either half alone renders fine; both together fail. Only the slicer is affected, because every other presenter builds a DynamicMap with no kdims, where indexing with an empty key is valid.

Introduced when the slicer's styling was hoisted onto the DynamicMap to stop it being reassembled on every render.

## Fix

Style each rendered slice instead, folded into the `.opts()` call that already applied the pre-computed clim. The options dict is assembled once in the presenter, and the number of `.opts()` calls per render is unchanged, so the measured extra cost is ~40 us per slice.

Cell-side workarounds were tried first and none help: `clone=False`, element-typed hooks, and collating through a single-layer `hv.Overlay` all still produce the second wrapper.

## Tests

Red/green, both verified to fail before the fix and pass after:

- `test_presenter_dmap_renders_with_cell_hooks` — renders the slicer the way a grid cell does (present, then attach hooks) and would have caught this directly. A sibling test pins the same invariant for the 2D image presenter.
- `test_slicer_figure_adopts_the_panes_sizing_mode` — extends the render-geometry invariant to the slicer. Moving styling onto the render path makes it easy to drop silently; deleting the styling makes this fail for every aspect type.

## Test plan

- [x] Full test suite passes (four pre-existing `to_nxlog_test.py` failures from a numpy deprecation, also failing on `main`)
- [x] A 3D detector view renders in a grid cell (confirmed against BEER's per-panel view on #1164)
- [ ] Slice/flatten controls work and the plot resizes with the cell

