### PR TITLE
Bound ToNXlog history by size and age

### DIFF
--- a/src/ess/livedata/preprocessors/data_reduction.py
+++ b/src/ess/livedata/preprocessors/data_reduction.py
@@ -23,7 +23,9 @@ class ReductionPreprocessorFactory(JobBasedPreprocessorFactoryBase):
             case StreamKind.MONITOR_COUNTS:
                 return Cumulative(clear_on_get=True)
             case StreamKind.LOG | StreamKind.DEVICE:
-                return nxlog_for_stream(self._instrument.streams.get(key.name))
+                return nxlog_for_stream(
+                    self._instrument.streams.get(key.name), name=key.name
+                )
             case StreamKind.MONITOR_EVENTS:
                 return ToNXevent_data()
             case StreamKind.DETECTOR_EVENTS:

--- a/src/ess/livedata/preprocessors/detector_data.py
+++ b/src/ess/livedata/preprocessors/detector_data.py
@@ -53,7 +53,9 @@ class DetectorPreprocessorFactory(JobBasedPreprocessorFactoryBase):
             case StreamKind.LIVEDATA_ROI:
                 return LatestValueAccumulator()
             case StreamKind.LOG | StreamKind.DEVICE:
-                return nxlog_for_stream(self._instrument.streams.get(key.name))
+                return nxlog_for_stream(
+                    self._instrument.streams.get(key.name), name=key.name
+                )
             case _:
                 return None
 

--- a/src/ess/livedata/preprocessors/timeseries.py
+++ b/src/ess/livedata/preprocessors/timeseries.py
@@ -26,6 +26,21 @@ logger = structlog.get_logger(__name__)
 #: would have).
 _SYNTHETIC_LOG_SOURCES: frozenset[str] = frozenset({CHOPPER_CASCADE_SOURCE})
 
+#: Retained samples per log in this service, shallower than
+#: :data:`DEFAULT_MAX_SIZE`, which detector and reduction workflows need for their
+#: lookups. Here the buffer has a single consumer: the backfill a job receives on
+#: activation, published as its first ``delta`` (the wavelength-LUT workflow reads
+#: only the newest sample). Retention is therefore a backfill budget, capping both
+#: that message and the RAM held for every log stream, plotted or not. Instruments
+#: declare hundreds of log streams and the dashboard can start a job for each at
+#: one click, which publishes every buffer at once. This keeps a week for a log
+#: ticking once a minute -- the regime long experiments depend on -- and ~160 kB
+#: of backfill for a 14 Hz chopper. Raise it when a concrete requirement for
+#: deeper backfill appears. It must stay well above the samples one stream can
+#: deliver between two service cycles, or they are dropped before publication --
+#: the gap :class:`TimeseriesStreamProcessor` warns about.
+BACKFILL_MAX_SIZE = 10_000
+
 
 class LogdataPreprocessorFactory(
     JobBasedPreprocessorFactoryBase[LogData, sc.DataArray]
@@ -45,16 +60,20 @@ class LogdataPreprocessorFactory(
         match key.kind:
             case StreamKind.DEVICE:
                 return nxlog_for_stream(
-                    self._instrument.streams.get(key.name), name=key.name
+                    self._instrument.streams.get(key.name),
+                    name=key.name,
+                    max_size=BACKFILL_MAX_SIZE,
                 )
             case StreamKind.LOG:
                 accumulator = nxlog_for_stream(
-                    self._instrument.streams.get(key.name), name=key.name
+                    self._instrument.streams.get(key.name),
+                    name=key.name,
+                    max_size=BACKFILL_MAX_SIZE,
                 )
                 if accumulator is not None:
                     return accumulator
                 if key.name in _SYNTHETIC_LOG_SOURCES:
-                    return ToNXlog(attrs={})
+                    return ToNXlog(attrs={}, max_size=BACKFILL_MAX_SIZE)
                 logger.warning(
                     "No attributes found for source name '%s'. "
                     "Messages will be dropped.",

--- a/src/ess/livedata/preprocessors/timeseries.py
+++ b/src/ess/livedata/preprocessors/timeseries.py
@@ -44,9 +44,13 @@ class LogdataPreprocessorFactory(
     def make_preprocessor(self, key: StreamId) -> Accumulator | None:
         match key.kind:
             case StreamKind.DEVICE:
-                return nxlog_for_stream(self._instrument.streams.get(key.name))
+                return nxlog_for_stream(
+                    self._instrument.streams.get(key.name), name=key.name
+                )
             case StreamKind.LOG:
-                accumulator = nxlog_for_stream(self._instrument.streams.get(key.name))
+                accumulator = nxlog_for_stream(
+                    self._instrument.streams.get(key.name), name=key.name
+                )
                 if accumulator is not None:
                     return accumulator
                 if key.name in _SYNTHETIC_LOG_SOURCES:

--- a/src/ess/livedata/preprocessors/to_nxlog.py
+++ b/src/ess/livedata/preprocessors/to_nxlog.py
@@ -25,6 +25,16 @@ DEFAULT_MAX_SIZE = 1_000_000
 DEFAULT_MAX_AGE = sc.scalar(30, unit='day')
 
 
+def _empty_with_capacity(var: sc.Variable, capacity: int) -> sc.Variable:
+    """Uninitialized variable like ``var`` but with ``capacity`` time points."""
+    return sc.empty(
+        sizes={**var.sizes, 'time': capacity},
+        unit=var.unit,
+        dtype=var.dtype,
+        with_variances=var.variances is not None,
+    )
+
+
 class ToNXlog(Accumulator[LogData, sc.DataArray]):
     """
     Preprocessor for log data.
@@ -145,22 +155,17 @@ class ToNXlog(Accumulator[LogData, sc.DataArray]):
         that are still reading it. The old buffer stays alive for as long as any
         such view does.
         """
-        template = self._timeseries
-        live = self._end - self._start
-        data = sc.empty(
-            dims=template.data.dims,
-            shape=(capacity, *template.data.shape[1:]),
-            unit=template.data.unit,
-            dtype=template.data.dtype,
-            with_variances=template.data.variances is not None,
-        )
-        data['time', :live] = template.data['time', self._start : self._end]
+        old = self._timeseries['time', self._start : self._end]
+        live = old.sizes['time']
+        # Data and coords are copied variable by variable: assigning a DataArray
+        # slice would compare the coords of both sides, which the uninitialized
+        # destination cannot satisfy.
+        data = _empty_with_capacity(old.data, capacity)
+        data['time', :live] = old.data
         coords = {}
-        for name, coord in template.coords.items():
-            new = sc.empty(
-                dims=coord.dims, shape=(capacity,), unit=coord.unit, dtype=coord.dtype
-            )
-            new['time', :live] = coord['time', self._start : self._end]
+        for name, coord in old.coords.items():
+            new = _empty_with_capacity(coord, capacity)
+            new['time', :live] = coord
             coords[name] = new
         self._timeseries = sc.DataArray(data, coords=coords)
         self._start = 0

--- a/src/ess/livedata/preprocessors/to_nxlog.py
+++ b/src/ess/livedata/preprocessors/to_nxlog.py
@@ -1,3 +1,4 @@
+import zlib
 from typing import Any
 
 import numpy as np
@@ -11,14 +12,33 @@ from ess.livedata.preprocessors.accumulators import LogData
 
 logger = structlog.get_logger(__name__)
 
+#: Retained samples per log. Sized so that logs slow enough to matter for
+#: long-running experiments keep more than a week of history: a sample every
+#: two seconds fills this in 23 days, one per second in 12 days. Fast logs
+#: (choppers at the 14 Hz pulse rate) hit it after ~20 hours, which is the
+#: intended asymmetry -- they are read for recent behaviour, not for history.
+DEFAULT_MAX_SIZE = 1_000_000
+
+#: Retained timespan per log. Binds only for logs too slow to reach
+#: :data:`DEFAULT_MAX_SIZE`, bounding the history of a device that ticks once a
+#: minute just as the size cap bounds a chopper.
+DEFAULT_MAX_AGE = sc.scalar(30, unit='day')
+
 
 class ToNXlog(Accumulator[LogData, sc.DataArray]):
     """
     Preprocessor for log data.
 
     Accumulates LogData objects and returns a single DataArray as it would be read from
-    an NXlog in a NeXus file. The DataArray grows as data is added and is not cleared
-    until explicitly requested.
+    an NXlog in a NeXus file.
+
+    History is bounded by ``max_size`` samples and ``max_age`` of timespan,
+    whichever binds first; the oldest samples are dropped once either is
+    exceeded. Age is measured against the newest buffered sample rather than
+    wall clock, so a device that stops reporting keeps its last known value
+    instead of ageing out to an empty buffer -- consumers rely on the buffer
+    being non-empty, and the last value of a stalled device is exactly what
+    NXlog semantics must preserve.
 
     Timestamps must be monotonically increasing. Messages with duplicate or out-of-order
     timestamps are skipped to prevent unbounded buffer growth from upstream re-sends.
@@ -37,6 +57,9 @@ class ToNXlog(Accumulator[LogData, sc.DataArray]):
         data_dims: tuple[str, ...] = (),
         has_target: bool = False,
         has_idle: bool = False,
+        max_size: int = DEFAULT_MAX_SIZE,
+        max_age: sc.Variable = DEFAULT_MAX_AGE,
+        phase: int = 0,
     ) -> None:
         self._attrs = attrs
         # Values with no unit are ok
@@ -47,22 +70,101 @@ class ToNXlog(Accumulator[LogData, sc.DataArray]):
             self._unit = sc.Unit(maybe_unit)
         # Hard-coded time unit and start in the ESS NeXus filewriter
         self._time_unit = 'ns'
-        self._start = sc.epoch(unit='ns')
+        self._epoch = sc.epoch(unit='ns')
 
         # Initialize with None, will be created on first add
         self._timeseries: sc.DataArray | None = None
+        self._start = 0
         self._end = 0
         self._last_time: int | None = None
         self._data_dims = data_dims
         self._has_target = has_target
         self._has_idle = has_idle
 
+        if max_size < 1:
+            raise ValueError(f"max_size must be at least 1, got {max_size}")
+        self._max_size = max_size
+        self._max_age = int(max_age.to(unit='ns', dtype='int64').value)
+        # Free slots left by a relocation, i.e. how many appends it is amortized
+        # over. ``phase`` spreads the relocation point across streams: the period
+        # is a fixed number of samples, so equal-rate logs that start together
+        # would otherwise relocate in the same batch forever, multiplying the
+        # worst-case pause by the number of such logs.
+        base = max(1, max_size // 8)
+        self._slack = base + phase % base
+
     @property
     def unit(self) -> sc.Unit | None:
         return self._unit
 
-    def _at_capacity(self) -> bool:
-        return self._end >= self._timeseries.sizes['time']
+    def _trim(self, newest_time: int) -> None:
+        """Drop samples falling outside the retention window.
+
+        Moves the start offset only, leaving the buffer contents untouched, so
+        this is O(1) unless the age cutoff bites and cheap enough to run on
+        every append -- which is what makes ``max_age`` an actual bound rather
+        than a floor that is only enforced when the buffer happens to fill.
+
+        Always keeps the newest sample at or before the age cutoff.
+        ``sc.lookup(..., mode='previous')`` against this buffer (BIFROST's
+        rotation lookup) returns NaN for queries before the first retained
+        entry, so that sample anchors every query inside the window.
+        """
+        if self._end == self._start:
+            return
+        # The incoming sample claims one slot of the size budget. This may empty
+        # the buffer when max_size is 1, which is safe because add() writes that
+        # sample immediately; the age cutoff below never empties it, since a
+        # sample older than the cutoff is by definition an anchor to retain.
+        start = max(self._start, self._end - self._max_size + 1)
+        if start < self._end:
+            times = self._timeseries.coords['time'].values.view('int64')
+            cutoff = newest_time - self._max_age
+            if times[start] < cutoff:
+                expired = int(
+                    np.searchsorted(times[start : self._end], cutoff, 'right')
+                )
+                start += expired - 1  # retain the anchor
+        self._start = start
+
+    def _target_capacity(self, needed: int) -> int:
+        """Capacity to hold ``needed`` live samples.
+
+        Doubles while the buffer is still filling, then settles at
+        ``max_size + slack`` once retention caps the live size, so relocations
+        are amortized over ``slack`` appends instead of running per append.
+        """
+        return max(2, min(2 * needed, self._max_size + self._slack))
+
+    def _relocate(self, capacity: int) -> None:
+        """Move the live range into a freshly allocated buffer.
+
+        Reallocates rather than shifting in place because :meth:`get` hands out
+        views aliasing this buffer and ``sc.lookup`` holds a reference to them
+        rather than copying; an in-place shift rewrites data behind consumers
+        that are still reading it. The old buffer stays alive for as long as any
+        such view does.
+        """
+        template = self._timeseries
+        live = self._end - self._start
+        data = sc.empty(
+            dims=template.data.dims,
+            shape=(capacity, *template.data.shape[1:]),
+            unit=template.data.unit,
+            dtype=template.data.dtype,
+            with_variances=template.data.variances is not None,
+        )
+        data['time', :live] = template.data['time', self._start : self._end]
+        coords = {}
+        for name, coord in template.coords.items():
+            new = sc.empty(
+                dims=coord.dims, shape=(capacity,), unit=coord.unit, dtype=coord.dtype
+            )
+            new['time', :live] = coord['time', self._start : self._end]
+            coords[name] = new
+        self._timeseries = sc.DataArray(data, coords=coords)
+        self._start = 0
+        self._end = live
 
     def _ensure_capacity(self, data: LogData) -> None:
         if self._timeseries is None:
@@ -78,7 +180,7 @@ class ToNXlog(Accumulator[LogData, sc.DataArray]):
             times = sc.zeros(
                 dims=['time'], shape=[2], unit=self._time_unit, dtype='int64'
             )
-            coords: dict[str, sc.Variable] = {'time': self._start + times}
+            coords: dict[str, sc.Variable] = {'time': self._epoch + times}
             if self._has_target:
                 coords['target'] = sc.zeros(
                     dims=['time'], shape=[2], unit=self._unit, dtype='float64'
@@ -88,11 +190,8 @@ class ToNXlog(Accumulator[LogData, sc.DataArray]):
                 # flatbuffer schema has no bool dtype. Values stay 0/1.
                 coords['idle'] = sc.zeros(dims=['time'], shape=[2], dtype='int32')
             self._timeseries = sc.DataArray(values, coords=coords)
-        elif self._at_capacity():
-            # Double capacity when full
-            self._timeseries = sc.concat(
-                [self._timeseries, self._timeseries], dim='time'
-            )
+        elif self._end >= self._timeseries.sizes['time']:
+            self._relocate(self._target_capacity(self._end - self._start + 1))
 
     def add(self, timestamp: Timestamp, data: LogData) -> bool:
         if self._last_time is not None:
@@ -112,6 +211,8 @@ class ToNXlog(Accumulator[LogData, sc.DataArray]):
                     )
                 return False
 
+        if self._timeseries is not None:
+            self._trim(data.time)
         self._ensure_capacity(data)
         self._timeseries.coords['time'].values[self._end] = data.time
         self._timeseries.data.values[self._end] = data.value
@@ -134,28 +235,35 @@ class ToNXlog(Accumulator[LogData, sc.DataArray]):
             raise RuntimeError("No data has been added yet.")
 
         # Monotonic timestamps are enforced by add(), no sorting needed
-        return self._timeseries['time', : self._end]
+        return self._timeseries['time', self._start : self._end]
 
     def clear(self) -> None:
+        self._start = 0
         self._end = 0
         self._last_time = None
         # Keep the allocated array to avoid reallocations
 
 
-def nxlog_for_stream(stream: Stream | None) -> ToNXlog | None:
+def nxlog_for_stream(stream: Stream | None, *, name: str = '') -> ToNXlog | None:
     """ToNXlog preprocessor for a Device or F144Stream entry, or None.
 
     Maps the two stream types that produce NXlog-shaped time series to a
     correctly-parameterised :class:`ToNXlog`. Returns ``None`` for any other
     stream type or ``None`` input so factories can fall through to their own
     handling.
+
+    ``name`` seeds the buffer's relocation phase and must be the stream name, so
+    that logs sharing a publishing rate do not relocate in lock-step. A stable
+    hash is used rather than :func:`hash` so the phase survives restarts.
     """
+    phase = zlib.crc32(name.encode())
     if isinstance(stream, Device):
         return ToNXlog(
             attrs={'units': stream.units},
             has_target=stream.target is not None,
             has_idle=stream.idle is not None,
+            phase=phase,
         )
     if isinstance(stream, F144Stream):
-        return ToNXlog(attrs={'units': stream.units})
+        return ToNXlog(attrs={'units': stream.units}, phase=phase)
     return None

--- a/src/ess/livedata/preprocessors/to_nxlog.py
+++ b/src/ess/livedata/preprocessors/to_nxlog.py
@@ -244,7 +244,9 @@ class ToNXlog(Accumulator[LogData, sc.DataArray]):
         # Keep the allocated array to avoid reallocations
 
 
-def nxlog_for_stream(stream: Stream | None, *, name: str = '') -> ToNXlog | None:
+def nxlog_for_stream(
+    stream: Stream | None, *, name: str = '', max_size: int = DEFAULT_MAX_SIZE
+) -> ToNXlog | None:
     """ToNXlog preprocessor for a Device or F144Stream entry, or None.
 
     Maps the two stream types that produce NXlog-shaped time series to a
@@ -255,6 +257,9 @@ def nxlog_for_stream(stream: Stream | None, *, name: str = '') -> ToNXlog | None
     ``name`` seeds the buffer's relocation phase and must be the stream name, so
     that logs sharing a publishing rate do not relocate in lock-step. A stable
     hash is used rather than :func:`hash` so the phase survives restarts.
+
+    ``max_size`` overrides :data:`DEFAULT_MAX_SIZE` for services that read the
+    buffer differently; see ``BACKFILL_MAX_SIZE`` in the timeseries factory.
     """
     phase = zlib.crc32(name.encode())
     if isinstance(stream, Device):
@@ -262,8 +267,9 @@ def nxlog_for_stream(stream: Stream | None, *, name: str = '') -> ToNXlog | None
             attrs={'units': stream.units},
             has_target=stream.target is not None,
             has_idle=stream.idle is not None,
+            max_size=max_size,
             phase=phase,
         )
     if isinstance(stream, F144Stream):
-        return ToNXlog(attrs={'units': stream.units}, phase=phase)
+        return ToNXlog(attrs={'units': stream.units}, max_size=max_size, phase=phase)
     return None

--- a/src/ess/livedata/workflows/timeseries.py
+++ b/src/ess/livedata/workflows/timeseries.py
@@ -3,16 +3,29 @@
 from __future__ import annotations
 
 from collections.abc import Hashable
+from typing import Any
 
+import numpy as np
 import scipp as sc
 
 from .workflow_factory import Workflow
 
 
 class TimeseriesStreamProcessor(Workflow):
+    """Publishes newly arrived samples of a cumulative timeseries as deltas.
+
+    The upstream preprocessor (``ToNXlog``) hands out its whole cumulative
+    buffer on every cycle. This workflow republishes only the samples appended
+    since the previous ``finalize``, identified by the timestamp of the last
+    published sample rather than by a positional index: the preprocessor may
+    drop samples off the front of its buffer to bound retention, which shifts
+    every remaining sample's position. Timestamps are strictly increasing
+    (enforced by ``ToNXlog.add``), so they are a stable cursor under trimming.
+    """
+
     def __init__(self) -> None:
         self._data: sc.DataArray | None = None
-        self._last_returned_index = 0
+        self._last_returned_time: Any = None
 
     @staticmethod
     def create_workflow() -> Workflow:
@@ -31,16 +44,19 @@ class TimeseriesStreamProcessor(Workflow):
         if self._data is None:
             raise ValueError("No data has been added")
 
-        # Return only new data since last finalize to avoid republishing full history
-        current_size = self._data.sizes['time']
-        if self._last_returned_index >= current_size:
+        times = self._data.coords['time'].values
+        if self._last_returned_time is None:
+            first_new = 0
+        else:
+            first_new = int(np.searchsorted(times, self._last_returned_time, 'right'))
+        if first_new >= len(times):
             raise ValueError("No new data since last finalize")
 
-        result = self._data['time', self._last_returned_index :]
-        self._last_returned_index = current_size
+        result = self._data['time', first_new:]
+        self._last_returned_time = times[-1]
 
         return {'delta': result}
 
     def clear(self) -> None:
         self._data = None
-        self._last_returned_index = 0
+        self._last_returned_time = None

--- a/src/ess/livedata/workflows/timeseries.py
+++ b/src/ess/livedata/workflows/timeseries.py
@@ -7,8 +7,11 @@ from typing import Any
 
 import numpy as np
 import scipp as sc
+import structlog
 
 from .workflow_factory import Workflow
+
+logger = structlog.get_logger(__name__)
 
 
 class TimeseriesStreamProcessor(Workflow):
@@ -21,10 +24,16 @@ class TimeseriesStreamProcessor(Workflow):
     drop samples off the front of its buffer to bound retention, which shifts
     every remaining sample's position. Timestamps are strictly increasing
     (enforced by ``ToNXlog.add``), so they are a stable cursor under trimming.
+
+    Trimming is only safe while it stays behind the cursor. Once more samples
+    arrive between two ``finalize`` calls than the preprocessor retains, samples
+    are dropped before they are ever published and the delta stream has a silent
+    gap; ``finalize`` warns when that becomes possible.
     """
 
     def __init__(self) -> None:
         self._data: sc.DataArray | None = None
+        self._source_name: Hashable | None = None
         self._last_returned_time: Any = None
 
     @staticmethod
@@ -38,7 +47,7 @@ class TimeseriesStreamProcessor(Workflow):
         if len(data) != 1:
             raise ValueError("Timeseries processor expects exactly one data item.")
         # Store the full cumulative data (including history from preprocessor)
-        self._data = next(iter(data.values()))
+        self._source_name, self._data = next(iter(data.items()))
 
     def finalize(self) -> dict[str, sc.DataArray]:
         if self._data is None:
@@ -48,6 +57,20 @@ class TimeseriesStreamProcessor(Workflow):
         if self._last_returned_time is None:
             first_new = 0
         else:
+            if times[0] > self._last_returned_time:
+                # The last published sample is gone from the retained window, so
+                # anything between it and times[0] was dropped before it could be
+                # published. Whether such a sample existed is not observable from
+                # the window alone, so this fires whenever loss is possible: in
+                # steady state that means one cycle delivered more samples than
+                # retention holds, and the retention bound is too tight for the
+                # stream's rate.
+                logger.warning(
+                    "publication_cursor_outside_retained_window",
+                    source_name=str(self._source_name),
+                    last_published_time=str(self._last_returned_time),
+                    oldest_retained_time=str(times[0]),
+                )
             first_new = int(np.searchsorted(times, self._last_returned_time, 'right'))
         if first_new >= len(times):
             raise ValueError("No new data since last finalize")
@@ -59,4 +82,5 @@ class TimeseriesStreamProcessor(Workflow):
 
     def clear(self) -> None:
         self._data = None
+        self._source_name = None
         self._last_returned_time = None

--- a/tests/preprocessors/timeseries_test.py
+++ b/tests/preprocessors/timeseries_test.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import pytest
+
+from ess.livedata import StreamId, StreamKind
+from ess.livedata.config.instrument import Instrument
+from ess.livedata.config.stream import Device, F144Stream
+from ess.livedata.core.preprocessor import Accumulator
+from ess.livedata.preprocessors.accumulators import LogData
+from ess.livedata.preprocessors.timeseries import (
+    BACKFILL_MAX_SIZE,
+    LogdataPreprocessorFactory,
+)
+from ess.livedata.workflows.wavelength_lut_workflow_specs import CHOPPER_CASCADE_SOURCE
+
+
+class TestBackfillBudget:
+    """Retention in this service is the budget for a job's activation backfill.
+
+    Every log stream holds a buffer whether or not anyone plots it, and starting
+    one job per stream publishes all of them at once, so the bound applies to
+    every path that creates a preprocessor here.
+    """
+
+    @pytest.fixture
+    def factory(self) -> LogdataPreprocessorFactory:
+        streams = {
+            'temp_sensor': F144Stream(source='temp_sensor', topic='topic', units='K'),
+            'motion': Device(value='motion_rbv', target='motion_val', units='mm'),
+            'motion_rbv': F144Stream(source='motion_rbv', topic='topic', units='mm'),
+            'motion_val': F144Stream(source='motion_val', topic='topic', units='mm'),
+        }
+        return LogdataPreprocessorFactory(
+            instrument=Instrument(name='test_instrument', streams=streams)
+        )
+
+    def fill(self, accumulator: Accumulator, n: int) -> None:
+        for i in range(n):
+            accumulator.add(
+                0, LogData(time=i * 1_000_000_000, value=float(i), target=0.0)
+            )
+
+    @pytest.mark.parametrize(
+        'stream_id',
+        [
+            StreamId(kind=StreamKind.LOG, name='temp_sensor'),
+            StreamId(kind=StreamKind.DEVICE, name='motion'),
+            StreamId(kind=StreamKind.LOG, name=CHOPPER_CASCADE_SOURCE),
+        ],
+        ids=['f144', 'device', 'synthetic'],
+    )
+    def test_retention_is_bounded_by_backfill_budget(self, factory, stream_id):
+        accumulator = factory.make_preprocessor(stream_id)
+        self.fill(accumulator, BACKFILL_MAX_SIZE + 100)
+        assert accumulator.get().sizes['time'] == BACKFILL_MAX_SIZE

--- a/tests/preprocessors/to_nxlog_test.py
+++ b/tests/preprocessors/to_nxlog_test.py
@@ -6,7 +6,7 @@ from scipp.testing import assert_identical
 
 from ess.livedata.core.timestamp import Timestamp
 from ess.livedata.preprocessors.accumulators import LogData
-from ess.livedata.preprocessors.to_nxlog import ToNXlog
+from ess.livedata.preprocessors.to_nxlog import ToNXlog, nxlog_for_stream
 
 
 def test_to_nxlog_initialization():
@@ -585,3 +585,175 @@ def test_missing_idle_raises_when_has_idle():
     accumulator = ToNXlog(attrs={'units': 'mm'}, has_idle=True)
     with pytest.raises(ValueError, match="Idle"):
         accumulator.add(Timestamp.from_ns(0), LogData(time=1000, value=1.0))
+
+
+class TestRetention:
+    """History is bounded by max_size and max_age, whichever binds first."""
+
+    def make(self, *, max_size=1_000_000, max_age_s=30 * 86400, **kwargs):
+        return ToNXlog(
+            attrs={'units': 'm'},
+            max_size=max_size,
+            max_age=sc.scalar(max_age_s, unit='s'),
+            **kwargs,
+        )
+
+    def push(self, acc, times, *, scale=1_000_000_000):
+        for t in times:
+            acc.add(0, LogData(time=int(t * scale), value=float(t)))
+
+    def times(self, acc):
+        return [
+            int(t) // 1_000_000_000
+            for t in acc.get().coords['time'].values.view('int64')
+        ]
+
+    def test_max_size_drops_oldest_samples(self):
+        acc = self.make(max_size=5)
+        self.push(acc, range(1, 12))
+        assert self.times(acc) == [7, 8, 9, 10, 11]
+
+    def test_below_max_size_keeps_everything(self):
+        acc = self.make(max_size=100)
+        self.push(acc, range(1, 12))
+        assert self.times(acc) == list(range(1, 12))
+
+    def test_max_age_drops_expired_samples(self):
+        acc = self.make(max_age_s=10)
+        self.push(acc, [1, 2, 3, 20, 21])
+        # Cutoff is 21-10=11; samples 1 and 2 are expired, 3 is the anchor.
+        assert self.times(acc) == [3, 20, 21]
+
+    def test_age_cutoff_retains_anchor_for_previous_mode_lookup(self):
+        acc = self.make(max_age_s=10)
+        self.push(acc, [0, 100])
+        # Everything is older than the cutoff, but dropping the last sample at
+        # or before it would make sc.lookup(mode='previous') return NaN.
+        assert self.times(acc) == [0, 100]
+        lut = sc.lookup(acc.get(), 'time', mode='previous')
+        query = sc.epoch(unit='ns') + sc.array(
+            dims=['t'], values=[50_000_000_000], unit='ns'
+        )
+        assert lut[query].values.tolist() == [0.0]
+
+    def test_age_measured_against_newest_sample_not_wall_clock(self):
+        acc = self.make(max_age_s=10)
+        self.push(acc, [1, 2, 3])
+        # A stalled device keeps its history; nothing ages out without new data.
+        assert self.times(acc) == [1, 2, 3]
+
+    def test_never_trims_below_one_sample(self):
+        acc = self.make(max_size=1, max_age_s=1)
+        self.push(acc, [1, 100, 1000])
+        assert self.times(acc) == [1000]
+
+    def test_size_and_age_combined_take_the_tighter_bound(self):
+        acc = self.make(max_size=3, max_age_s=100)
+        self.push(acc, range(1, 10))
+        assert self.times(acc) == [7, 8, 9]
+
+    def test_retained_window_survives_many_relocations(self):
+        acc = self.make(max_size=4)
+        self.push(acc, range(1, 500))
+        assert self.times(acc) == [496, 497, 498, 499]
+        assert list(acc.get().values) == [496.0, 497.0, 498.0, 499.0]
+
+    def test_values_and_coords_stay_aligned_across_relocation(self):
+        acc = ToNXlog(
+            attrs={'units': 'm'},
+            max_size=4,
+            has_target=True,
+            has_idle=True,
+        )
+        for t in range(1, 200):
+            acc.add(
+                0,
+                LogData(
+                    time=t * 1_000_000_000,
+                    value=float(t),
+                    target=float(-t),
+                    idle=t % 2,
+                ),
+            )
+        result = acc.get()
+        assert list(result.values) == [196.0, 197.0, 198.0, 199.0]
+        assert list(result.coords['target'].values) == [-196.0, -197.0, -198.0, -199.0]
+        assert list(result.coords['idle'].values) == [0, 1, 0, 1]
+
+    def test_variances_survive_relocation(self):
+        acc = ToNXlog(attrs={'units': 'm'}, max_size=3)
+        for t in range(1, 100):
+            acc.add(
+                0,
+                LogData(time=t * 1_000_000_000, value=float(t), variances=float(t) * 2),
+            )
+        result = acc.get()
+        assert list(result.values) == [97.0, 98.0, 99.0]
+        assert list(result.variances) == [194.0, 196.0, 198.0]
+
+    def test_buffer_capacity_stays_bounded(self):
+        acc = self.make(max_size=100)
+        self.push(acc, range(1, 5000))
+        assert acc.get().sizes['time'] == 100
+        assert acc._timeseries.sizes['time'] <= 100 + 100  # max_size + max slack
+
+    def test_get_view_is_not_rewritten_by_later_relocation(self):
+        acc = self.make(max_size=4)
+        self.push(acc, range(1, 20))
+        view = acc.get()
+        before = list(view.values)
+        self.push(acc, range(20, 500))
+        assert list(view.values) == before
+
+    def test_clear_resets_retention_state(self):
+        acc = self.make(max_size=4)
+        self.push(acc, range(1, 50))
+        acc.clear()
+        self.push(acc, [100, 101])
+        assert self.times(acc) == [100, 101]
+
+    def test_rejects_non_positive_max_size(self):
+        with pytest.raises(ValueError, match="max_size must be at least 1"):
+            ToNXlog(attrs={}, max_size=0)
+
+
+class TestRelocationPhase:
+    """Equal-rate logs must not relocate in the same batch forever."""
+
+    MAX_SIZE = 64
+
+    def relocation_points(self, phase: int, n: int) -> set[int]:
+        """Sample counts at which the buffer is reallocated.
+
+        Points during the initial fill are excluded: capacity doubles from 2
+        regardless of phase, so every log necessarily reallocates at the same
+        counts then. That is a one-off warm-up, whereas the steady-state period
+        repeats for the process lifetime and is what must be spread out.
+        """
+        acc = ToNXlog(attrs={'units': 'm'}, max_size=self.MAX_SIZE, phase=phase)
+        points = set()
+        previous = None
+        for t in range(1, n):
+            acc.add(0, LogData(time=t * 1_000_000_000, value=float(t)))
+            current = id(acc._timeseries)
+            if previous is not None and current != previous and t > 2 * self.MAX_SIZE:
+                points.add(t)
+            previous = current
+        return points
+
+    def test_distinct_phases_relocate_at_distinct_points(self):
+        streams = [self.relocation_points(phase, 2000) for phase in (0, 1, 2, 3)]
+        assert all(len(points) > 1 for points in streams)
+        # No batch ever relocates every log at once.
+        assert set.intersection(*streams) == set()
+
+    def test_phase_is_stable_across_instances(self):
+        assert self.relocation_points(5, 500) == self.relocation_points(5, 500)
+
+    def test_stream_name_determines_phase(self):
+        from ess.livedata.config.stream import F144Stream
+
+        stream = F144Stream(units='m', topic='t', source='s')
+        a = nxlog_for_stream(stream, name='chopper_1')
+        b = nxlog_for_stream(stream, name='chopper_2')
+        assert a._slack != b._slack

--- a/tests/workflows/timeseries_test.py
+++ b/tests/workflows/timeseries_test.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import pytest
+import scipp as sc
+
+from ess.livedata.preprocessors.accumulators import LogData
+from ess.livedata.preprocessors.to_nxlog import ToNXlog
+from ess.livedata.workflows.timeseries import TimeseriesStreamProcessor
+
+
+@pytest.fixture
+def nxlog() -> ToNXlog:
+    return ToNXlog(attrs={'units': 'mm'})
+
+
+@pytest.fixture
+def processor() -> TimeseriesStreamProcessor:
+    return TimeseriesStreamProcessor()
+
+
+def push(nxlog: ToNXlog, *samples: tuple[int, float]) -> None:
+    for time, value in samples:
+        nxlog.add(0, LogData(time=time, value=value))
+
+
+def run_cycle(
+    processor: TimeseriesStreamProcessor, nxlog: ToNXlog
+) -> dict[str, sc.DataArray]:
+    processor.accumulate({'log': nxlog.get()}, start_time=0, end_time=0)
+    return processor.finalize()
+
+
+def values(result: dict[str, sc.DataArray]) -> list[float]:
+    return list(result['delta'].values)
+
+
+def test_first_finalize_returns_full_retained_history(processor, nxlog):
+    push(nxlog, (10, 1.0), (20, 2.0), (30, 3.0))
+    assert values(run_cycle(processor, nxlog)) == [1.0, 2.0, 3.0]
+
+
+def test_subsequent_finalize_returns_only_new_samples(processor, nxlog):
+    push(nxlog, (10, 1.0), (20, 2.0))
+    run_cycle(processor, nxlog)
+
+    push(nxlog, (30, 3.0), (40, 4.0))
+    assert values(run_cycle(processor, nxlog)) == [3.0, 4.0]
+
+
+def test_finalize_without_new_samples_raises(processor, nxlog):
+    push(nxlog, (10, 1.0))
+    run_cycle(processor, nxlog)
+
+    with pytest.raises(ValueError, match="No new data"):
+        run_cycle(processor, nxlog)
+
+
+def test_finalize_before_accumulate_raises(processor):
+    with pytest.raises(ValueError, match="No data has been added"):
+        processor.finalize()
+
+
+def test_accumulate_rejects_multiple_items(processor):
+    with pytest.raises(ValueError, match="exactly one data item"):
+        processor.accumulate(
+            {'a': sc.scalar(1), 'b': sc.scalar(2)}, start_time=0, end_time=0
+        )
+
+
+def test_clear_resets_cursor_so_full_history_is_republished(processor, nxlog):
+    push(nxlog, (10, 1.0), (20, 2.0))
+    run_cycle(processor, nxlog)
+
+    processor.clear()
+    assert values(run_cycle(processor, nxlog)) == [1.0, 2.0]
+
+
+class TestTrimmedBuffer:
+    """Publication must stay correct when the preprocessor drops old samples.
+
+    A positional cursor breaks under front-trimming: it either skips genuinely
+    new samples or reports "no new data" until the buffer regrows past the
+    stale watermark. These cases pin the timestamp-based behaviour that bounded
+    retention (#1127) depends on.
+    """
+
+    def trimmed(self, nxlog: ToNXlog, drop: int) -> sc.DataArray:
+        return nxlog.get()['time', drop:]
+
+    def test_new_samples_after_trim_are_not_skipped(self, processor, nxlog):
+        push(nxlog, (10, 1.0), (20, 2.0), (30, 3.0))
+        run_cycle(processor, nxlog)
+
+        push(nxlog, (40, 4.0), (50, 5.0))
+        processor.accumulate(
+            {'log': self.trimmed(nxlog, drop=3)}, start_time=0, end_time=0
+        )
+        assert values(processor.finalize()) == [4.0, 5.0]
+
+    def test_trim_shrinking_buffer_below_published_count_still_emits(
+        self, processor, nxlog
+    ):
+        push(nxlog, (10, 1.0), (20, 2.0), (30, 3.0), (40, 4.0))
+        run_cycle(processor, nxlog)
+
+        push(nxlog, (50, 5.0))
+        # Retain only the last two samples: fewer than were already published.
+        processor.accumulate(
+            {'log': self.trimmed(nxlog, drop=3)}, start_time=0, end_time=0
+        )
+        assert values(processor.finalize()) == [5.0]
+
+    def test_trim_without_new_samples_still_raises(self, processor, nxlog):
+        push(nxlog, (10, 1.0), (20, 2.0), (30, 3.0))
+        run_cycle(processor, nxlog)
+
+        processor.accumulate(
+            {'log': self.trimmed(nxlog, drop=2)}, start_time=0, end_time=0
+        )
+        with pytest.raises(ValueError, match="No new data"):
+            processor.finalize()
+
+    def test_already_published_samples_are_never_re_emitted(self, processor, nxlog):
+        push(nxlog, (10, 1.0), (20, 2.0), (30, 3.0))
+        run_cycle(processor, nxlog)
+
+        push(nxlog, (40, 4.0))
+        # Trim keeps a sample that was already published; it must not reappear.
+        processor.accumulate(
+            {'log': self.trimmed(nxlog, drop=1)}, start_time=0, end_time=0
+        )
+        assert values(processor.finalize()) == [4.0]

--- a/tests/workflows/timeseries_test.py
+++ b/tests/workflows/timeseries_test.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import pytest
 import scipp as sc
+from structlog.testing import capture_logs
 
 from ess.livedata.preprocessors.accumulators import LogData
 from ess.livedata.preprocessors.to_nxlog import ToNXlog
@@ -130,3 +131,33 @@ class TestTrimmedBuffer:
             {'log': self.trimmed(nxlog, drop=1)}, start_time=0, end_time=0
         )
         assert values(processor.finalize()) == [4.0]
+
+    def test_trim_past_the_cursor_warns(self, processor, nxlog):
+        push(nxlog, (10, 1.0), (20, 2.0))
+        run_cycle(processor, nxlog)
+
+        # Retention drops t=30 before it is ever published: a silent gap.
+        push(nxlog, (30, 3.0), (40, 4.0))
+        with capture_logs() as captured:
+            processor.accumulate(
+                {'motion1': self.trimmed(nxlog, drop=3)}, start_time=0, end_time=0
+            )
+            processor.finalize()
+
+        assert [entry['event'] for entry in captured] == [
+            'publication_cursor_outside_retained_window'
+        ]
+        assert captured[0]['source_name'] == 'motion1'
+
+    def test_trim_behind_the_cursor_does_not_warn(self, processor, nxlog):
+        push(nxlog, (10, 1.0), (20, 2.0), (30, 3.0))
+        run_cycle(processor, nxlog)
+
+        push(nxlog, (40, 4.0))
+        with capture_logs() as captured:
+            processor.accumulate(
+                {'motion1': self.trimmed(nxlog, drop=1)}, start_time=0, end_time=0
+            )
+            processor.finalize()
+
+        assert captured == []


### PR DESCRIPTION
Closes #1127.

`ToNXlog` accumulated every f144 sample for the process lifetime. Measured on this branch, the cost of that grew without limit: the capacity-doubling `sc.concat([ts, ts])` took 7.5 ms at 1M samples, 44 ms at 16M and 86 ms at 33M, and transiently needed **3x** the allocated capacity — 1.4 GB for a single 16M-sample device log.

History is now bounded by `max_size` samples and `max_age` of timespan, whichever binds first. One pair of defaults (1M samples, 30 days) covers both regimes without per-stream config, because the two knobs bind on different logs:

| log | binding knob | retained |
|---|---|---|
| slow f144, one sample / 2 s | `max_size` | 23 days |
| medium, 1 Hz | `max_size` | 12 days |
| chopper, 14 Hz | `max_size` | 20 hours |
| sample environment, 1/min | `max_age` | 30 days |

That asymmetry is the point: week-long experiments depend on the slow logs, and fast logs are read for recent behaviour rather than history.

## Three properties worth reviewing

**Trimming copies nothing.** It moves a start offset, so it is affordable on every append. Without that, `max_age` can only be enforced when the buffer happens to fill — which is what makes the dashboard's equivalent a retention *floor* rather than a bound.

**Compaction reallocates instead of shifting in place.** `get()` hands out views aliasing the buffer, and `sc.lookup` holds a reference to them rather than copying. I verified an in-place shift rewrites data behind live consumers: BIFROST's rotation lookup then fails with `Coordinate of lookup function must be sorted`. So the pattern `VariableBuffer.drop` uses on the dashboard side is not transplantable here — it is safe there only because `DataService` copies extractor output before handing it out. Reallocating leaves outstanding views owning the old buffer.

The pause is then bounded by `max_size` alone — 0.24 ms at 50k samples, 0.90 ms at 200k, 2.9 ms at 1M — so no incremental or background compaction scheme is warranted.

**Relocations are phase-shifted per stream.** The relocation period is a fixed number of *samples*, so equal-rate logs that start together stay in phase for the process lifetime and relocate in the same batch every time. Measured at 109 ms for 100 logs relocating together. Seeding the slack from a stable hash of the stream name (not `hash`, so it survives restarts) spreads them: with 100 equal-rate logs, the worst batch relocates 4.

Age is measured against the newest buffered sample rather than wall clock, so a device that stops reporting keeps its last known value instead of ageing out to an empty buffer — consumers rely on the buffer being non-empty, and retention always keeps the newest sample at or before the age cutoff so `sc.lookup(mode='previous')` has an anchor for every query inside the window.

## The timeseries service gets a shallower bound

Bounding retention exposed what retention is actually *for* in each service. Detector and reduction read the buffer as a lookup window and need the depth. The timeseries service does not: its only reader of history is the backfill a job receives on activation, published as its first `delta`. The wavelength-LUT workflow hosted by the same service reads only the newest sample, and reset was removed in #1126. Retention there is a backfill budget.

That distinction matters because the budget is paid per stream, all at once. Instruments declare hundreds of log streams — ODIN close to 300 — and the dashboard can start a job for each at one click. At 1M samples that is 16 MB per stream and over a gigabyte published in a single cycle, and it is not recoverable traffic: the sink drops what it cannot produce or queue while the workflow has already advanced its publication cursor, so an oversized backfill is lost rather than retried.

`BACKFILL_MAX_SIZE = 10_000` keeps a week of history for a log ticking once a minute — the regime long experiments depend on — while capping a 14 Hz chopper's backfill at ~160 kB. Starting every job at once then moves tens of megabytes. No evidence exists that anyone needs deeper backfill here; the number is trivially raised once a requirement appears.

Its floor is the number of samples one stream can deliver between two service cycles. Below that, retention drops samples before the workflow publishes them and the delta stream has a silent gap, which `TimeseriesStreamProcessor` now warns about — conservatively, since the retained window alone cannot prove a sample existed in the gap. Without that warning, any future tightening of the bound would be unfalsifiable.

## Not addressed here

The frontend `TemporalBuffer` still has the same unbounded-growth property, bounded only by a hardcoded 20 MB per key. Its cap and the backend's are really the two ends of one policy: `FullHistoryExtractor` asks for `float('inf')`, so the dashboard keeps whatever the backend sends and backend retention silently determines correlation-plot history after any workflow restart (generation flip → refill). The two should eventually become one finite window rather than independently drifting policies. A hundred plots at 20 MB each is also unbudgeted in aggregate on the dashboard side.

Per-log caps still do not bound the aggregate across streams in the detector and reduction services. In the timeseries service the aggregate is now bounded in practice, which is where the one-click fan-out lives.

## Test plan

- [x] `tests/preprocessors/to_nxlog_test.py`: 17 new cases covering both bounds, the lookup anchor, relocation integrity (values/coords/variances), view aliasing, and phase spreading
- [x] `tests/workflows/timeseries_test.py` (new, 12 cases) — the timestamp-cursor prerequisite, plus the silent-gap warning firing and staying quiet while trimming stays behind the cursor
- [x] `tests/preprocessors/timeseries_test.py` (new) — the backfill budget applies to all three preprocessor-creation paths (f144, device, synthetic `chopper_cascade`)
- [x] Full non-integration suite: 4428 passed. The 4 `to_nxlog_test.py` failures are pre-existing numpy-timedelta deprecations in the test file, confirmed identical on `main`.
