### PR TITLE
Return immutable snapshots from PlotDataService.get()

### DIFF
--- a/docs/developer/adr/0007-single-writer-versioned-pull.md
+++ b/docs/developer/adr/0007-single-writer-versioned-pull.md
@@ -10,7 +10,7 @@ The dashboard runs on two kinds of threads: the shared ingestion thread
 (`DashboardServices._update_loop`, draining Kafka and driving orchestrator
 updates at ~50 ms), and each session's Tornado/Bokeh IOLoop (UI callbacks and
 the 100 ms session poll, under that session's document lock). Layer activation
-runs on the latter — the poll pass calls `LayerStateMachine.set_active`, so
+runs on the latter — the poll pass calls `PlotDataService.set_active`, so
 activation flushes and Kafka-delta builds enter the same gate from opposite
 threads. Session-bound objects (`Pipe`, `DynamicMap`, Bokeh documents) may only
 be mutated on their own session's IOLoop — a hard constraint established in

--- a/docs/developer/adr/0007-single-writer-versioned-pull.md
+++ b/docs/developer/adr/0007-single-writer-versioned-pull.md
@@ -9,7 +9,9 @@
 The dashboard runs on two kinds of threads: the shared ingestion thread
 (`DashboardServices._update_loop`, draining Kafka and driving orchestrator
 updates at ~50 ms), and each session's Tornado/Bokeh IOLoop (UI callbacks and
-the 100 ms session poll, under that session's document lock). Layer activation
+the 100 ms session poll, under that session's document lock; the fixed-cadence
+poll has since been replaced by wake ticks plus a slow housekeeping tick — see
+the end of ADR 0005). Layer activation
 runs on the latter — the poll pass calls `PlotDataService.set_active`, so
 activation flushes and Kafka-delta builds enter the same gate from opposite
 threads. Session-bound objects (`Pipe`, `DynamicMap`, Bokeh documents) may only

--- a/src/ess/livedata/dashboard/plot_data_service.py
+++ b/src/ess/livedata/dashboard/plot_data_service.py
@@ -406,6 +406,10 @@ class PlotDataService:
         watching (see ``has_viewers``), so the caller must then rebuild the
         layer from current DataService content.
 
+        The layer need not have a lifecycle snapshot: viewer interest is
+        independent state, so tokens acquired before ``job_started`` are
+        retained rather than dropped.
+
         A ``weakref.finalize`` is attached on first acquire so the token is
         auto-released if the caller is garbage-collected without an explicit
         release. Explicit ``set_active(..., False)`` remains the fast path;
@@ -414,21 +418,26 @@ class PlotDataService:
         """
         key = id(token)
         with self._lock:
+            if not active:
+                # Don't resurrect an entry for a removed layer: releases keep
+                # arriving after ``remove`` (e.g. the session poll's orphan
+                # sweep), and layer ids are never reused.
+                tokens = self._viewers.get(layer_id)
+                if tokens is not None:
+                    tokens.discard(key)
+                return False
             tokens = self._viewers.setdefault(layer_id, set())
             was_active = bool(tokens)
-            if active:
-                tokens.add(key)
-                if (layer_id, key) not in self._finalized_keys:
-                    self._finalized_keys.add((layer_id, key))
-                    # Captures ``key`` (an int) and a bound method, not the
-                    # token itself — so the finalizer does not keep the token
-                    # alive. CPython runs the finalizer before the token's
-                    # memory can be reused for a different object, so an
-                    # ``id()`` collision cannot race with an active token.
-                    weakref.finalize(token, self._release_token, layer_id, key)
-            else:
-                tokens.discard(key)
-            return active and not was_active
+            tokens.add(key)
+            if (layer_id, key) not in self._finalized_keys:
+                self._finalized_keys.add((layer_id, key))
+                # Captures ``key`` (an int) and a bound method, not the
+                # token itself — so the finalizer does not keep the token
+                # alive. CPython runs the finalizer before the token's
+                # memory can be reused for a different object, so an
+                # ``id()`` collision cannot race with an active token.
+                weakref.finalize(token, self._release_token, layer_id, key)
+            return not was_active
 
     def has_viewers(self, layer_id: LayerId) -> bool:
         """Whether any viewer token is held on a layer; gates frame-flush compute."""

--- a/src/ess/livedata/dashboard/plot_data_service.py
+++ b/src/ess/livedata/dashboard/plot_data_service.py
@@ -3,9 +3,9 @@
 """
 Plot data service for multi-session synchronization.
 
-Provides storage for plot layer state using an explicit state machine.
-Each layer transitions through well-defined states: WAITING_FOR_DATA,
-READY, STOPPED, and ERROR.
+Provides storage for plot layer state as immutable snapshots. Each layer
+transitions through well-defined states: WAITING_FOR_DATA, READY, STOPPED,
+and ERROR.
 
 Change notification uses version-based polling - UI components track
 last-seen versions and rebuild when versions change.
@@ -13,6 +13,7 @@ last-seen versions and rebuild when versions change.
 
 from __future__ import annotations
 
+import dataclasses
 import threading
 import weakref
 from collections.abc import Callable
@@ -59,64 +60,48 @@ class LayerState(Enum):
     ERROR = auto()
 
 
-class LayerStateMachine:
-    """Manages state transitions for a single plot layer.
+@dataclasses.dataclass(frozen=True, slots=True)
+class LayerSnapshot:
+    """Immutable lifecycle state of a single plot layer.
 
-    Encapsulates state, version tracking, and associated data (plotter, error).
-    State transitions are validated and increment the version counter.
+    Readers obtain a snapshot from :meth:`PlotDataService.get` and may read
+    any combination of its fields without further synchronization: the four
+    fields always describe one point in the layer's history, so a half-applied
+    transition cannot be observed. This is the reader-side half of the
+    single-writer versioned-pull model (ADR 0007).
 
-    Thread-safe: all state modifications happen through atomic operations.
+    Transitions are pure: each returns the successor snapshot, or None when
+    the transition is a no-op or invalid from the current state. Only
+    :class:`PlotDataService` applies them, under its lock.
 
-    Viewer gate
-    -----------
-    Tokens express viewer interest, per (session, layer) — decoupled from
-    lifecycle state, which is per-layer. ``has_viewers`` is consulted at
-    frame-flush time on the ingestion thread: layers without viewers are
-    skipped (no extraction, no compute). ``set_active`` is called from the
-    per-session polling thread (Bokeh main); on the 0→1 transition it returns
-    True and the orchestrator rebuilds the layer from a fresh DataService
-    snapshot, synchronously on the polling thread — deliberately, so the same
-    poll pass's component rebuild observes fresh ``has_cached_state``.
+    ``plotter`` is a mutable object shared with the compute path, so a
+    snapshot pins *which* plotter the layer had, not that plotter's contents.
+    That is exactly what callers need: a plotter is created fresh per
+    ``job_started``, so snapshot identity answers "is my plotter still the
+    current one?".
+
+    Parameters
+    ----------
+    state:
+        Current lifecycle state.
+    version:
+        Counter incremented on every effective transition. UI components
+        compare versions to detect when rebuilds are needed. Tracked
+        separately from ``state`` because some transitions (e.g. plotter
+        replacement while in WAITING_FOR_DATA) don't change state but still
+        require UI updates.
+    plotter:
+        Plotter instance, set when a job starts.
+    error_message:
+        Error message if in ERROR state.
     """
 
-    def __init__(self) -> None:
-        self._state = LayerState.WAITING_FOR_DATA
-        self._version = 0
-        self._plotter: Plotter | None = None
-        self._error_message: str | None = None
-        self._active_tokens: set[int] = set()
-        # Tokens we've already attached a weakref finalizer to, so we don't
-        # register a second one on a False→True re-acquire.
-        self._finalized_keys: set[int] = set()
-        self._gate_lock = threading.Lock()
+    state: LayerState = LayerState.WAITING_FOR_DATA
+    version: int = 0
+    plotter: Plotter | None = None
+    error_message: str | None = None
 
-    @property
-    def state(self) -> LayerState:
-        """Current state of the layer."""
-        return self._state
-
-    @property
-    def version(self) -> int:
-        """Version counter, incremented on every state change.
-
-        UI components compare versions to detect when rebuilds are needed.
-        We track version rather than just state because some transitions
-        (e.g., plotter replacement while in WAITING_FOR_DATA) don't change
-        state but still require UI updates.
-        """
-        return self._version
-
-    @property
-    def plotter(self) -> Plotter | None:
-        """Plotter instance, set when job starts."""
-        return self._plotter
-
-    @property
-    def error_message(self) -> str | None:
-        """Error message if in ERROR state."""
-        return self._error_message
-
-    def job_started(self, plotter: Plotter) -> None:
+    def job_started(self, plotter: Plotter) -> LayerSnapshot:
         """
         Transition to WAITING_FOR_DATA when a job starts.
 
@@ -129,13 +114,21 @@ class LayerStateMachine:
         ----------
         plotter:
             The plotter instance for this job.
-        """
-        self._state = LayerState.WAITING_FOR_DATA
-        self._error_message = None
-        self._version += 1
-        self._plotter = plotter
 
-    def data_arrived(self) -> None:
+        Returns
+        -------
+        :
+            The successor snapshot; never None, as this is valid from any state.
+        """
+        return dataclasses.replace(
+            self,
+            state=LayerState.WAITING_FOR_DATA,
+            version=self.version + 1,
+            plotter=plotter,
+            error_message=None,
+        )
+
+    def data_arrived(self) -> LayerSnapshot | None:
         """
         Transition to READY when data arrives.
 
@@ -143,102 +136,73 @@ class LayerStateMachine:
         No-op from READY (data continues to arrive after first update) and
         from STOPPED (a layer bound to a stopped workflow's retained data
         renders it but stays STOPPED).
-        """
-        if self._state in {LayerState.READY, LayerState.STOPPED}:
-            return
 
-        if self._state != LayerState.WAITING_FOR_DATA:
+        Returns
+        -------
+        :
+            The successor snapshot, or None if this was a no-op or invalid.
+        """
+        if self.state in {LayerState.READY, LayerState.STOPPED}:
+            return None
+
+        if self.state != LayerState.WAITING_FOR_DATA:
             logger.warning(
                 "Invalid transition: data_arrived() called in state %s (expected %s)",
-                self._state.name,
+                self.state.name,
                 LayerState.WAITING_FOR_DATA.name,
             )
-            return
+            return None
 
-        self._state = LayerState.READY
-        self._version += 1
+        return dataclasses.replace(
+            self, state=LayerState.READY, version=self.version + 1
+        )
 
-    def job_stopped(self) -> None:
+    def job_stopped(self) -> LayerSnapshot | None:
         """
         Transition to STOPPED when job is stopped.
 
         Valid from: WAITING_FOR_DATA, READY.
-        Marks presenters dirty so sessions see the change.
+
+        Returns
+        -------
+        :
+            The successor snapshot, or None if invalid from the current state.
         """
         valid_from = {LayerState.WAITING_FOR_DATA, LayerState.READY}
-        if self._state not in valid_from:
+        if self.state not in valid_from:
             logger.warning(
                 "Invalid transition: job_stopped() called in state %s (expected %s)",
-                self._state.name,
+                self.state.name,
                 [s.name for s in valid_from],
             )
-            return
+            return None
 
-        self._state = LayerState.STOPPED
-        self._version += 1
-        if self._plotter is not None:
-            self._plotter.mark_presenters_dirty()
+        return dataclasses.replace(
+            self, state=LayerState.STOPPED, version=self.version + 1
+        )
 
-    def error_occurred(self, error_msg: str) -> None:
+    def error_occurred(self, error_msg: str) -> LayerSnapshot:
         """
         Transition to ERROR state.
 
         Valid from: any state.
-        Marks presenters dirty so sessions see the change.
 
         Parameters
         ----------
         error_msg:
             Error message to display.
+
+        Returns
+        -------
+        :
+            The successor snapshot; never None, as this is valid from any state.
         """
-        self._state = LayerState.ERROR
-        self._error_message = error_msg
-        self._version += 1
-        if self._plotter is not None:
-            self._plotter.mark_presenters_dirty()
-
-    def set_active(self, token: object, active: bool) -> bool:
-        """Acquire or release a viewer interest token on this layer.
-
-        Returns True on the 0→1 transition, i.e. when the first token is
-        acquired. Frame flushes skipped the layer while no viewer was
-        watching (see ``has_viewers``), so the caller must then rebuild the
-        layer from current DataService content.
-
-        A ``weakref.finalize`` is attached on first acquire so the token is
-        auto-released if the caller is garbage-collected without an explicit
-        release. Explicit ``set_active(token, False)`` remains the fast path;
-        the finalizer is belt-and-braces against missed cleanup (e.g., a
-        session disposed without ``PlotGridTabs.shutdown`` running).
-        """
-        key = id(token)
-        with self._gate_lock:
-            was_active = bool(self._active_tokens)
-            if active:
-                self._active_tokens.add(key)
-                if key not in self._finalized_keys:
-                    self._finalized_keys.add(key)
-                    # Captures ``key`` (an int) and a bound method, not the
-                    # token itself — so the finalizer does not keep the token
-                    # alive. CPython runs the finalizer before the token's
-                    # memory can be reused for a different object, so an
-                    # ``id()`` collision cannot race with an active token.
-                    weakref.finalize(token, self._release_token, key)
-            else:
-                self._active_tokens.discard(key)
-            return active and not was_active
-
-    @property
-    def has_viewers(self) -> bool:
-        """Whether any viewer token is held; gates frame-flush compute."""
-        with self._gate_lock:
-            return bool(self._active_tokens)
-
-    def _release_token(self, key: int) -> None:
-        """Drop a token key from the gate (called by the weakref finalizer)."""
-        with self._gate_lock:
-            self._active_tokens.discard(key)
-            self._finalized_keys.discard(key)
+        return dataclasses.replace(
+            self,
+            state=LayerState.ERROR,
+            version=self.version + 1,
+            error_message=error_msg,
+        )
 
     def has_displayable_plot(self) -> bool:
         """
@@ -247,34 +211,60 @@ class LayerStateMachine:
         Returns True if in READY or STOPPED state with a plotter that has
         cached state.
         """
-        if self._state not in {LayerState.READY, LayerState.STOPPED}:
+        if self.state not in {LayerState.READY, LayerState.STOPPED}:
             return False
-        return self._plotter is not None and self._plotter.has_cached_state()
+        return self.plotter is not None and self.plotter.has_cached_state()
 
 
 LayerId = NewType('LayerId', UUID)
 
+#: States that change what a cell renders without producing new data, so
+#: nothing else will nudge sessions to re-render. Entering one marks the
+#: layer's presenters dirty.
+_PRESENTATION_CHANGING_STATES = frozenset({LayerState.STOPPED, LayerState.ERROR})
+
 
 class PlotDataService:
     """
-    Manages plot layer state using explicit state machines.
+    Manages plot layer state as immutable snapshots.
 
-    PlotOrchestrator controls layer lifecycle through state machine transitions:
+    PlotOrchestrator controls layer lifecycle through state transitions:
     - job_started(): Called at layer setup and when a run-state poll observes
       a new generation (with a fresh plotter)
     - data_arrived(): Called when first data arrives for a layer
     - job_stopped(): Called when a run-state poll observes the workflow stopped
     - error_occurred(): Called when an error occurs
 
-    Each transition increments the layer's version counter. UI components poll
-    for version changes to detect when they need to rebuild.
+    Each effective transition replaces the layer's snapshot and increments its
+    version counter. UI components poll for version changes to detect when they
+    need to rebuild.
+
+    Viewer gate
+    -----------
+    Tokens express viewer interest, per (session, layer) — decoupled from
+    lifecycle state, which is per-layer, hence held separately from the
+    snapshots. ``has_viewers`` is consulted at frame-flush time on the
+    ingestion thread: layers without viewers are skipped (no extraction, no
+    compute). ``set_active`` is called from the per-session polling thread
+    (Bokeh main); on the 0→1 transition it returns True and the orchestrator
+    rebuilds the layer from a fresh DataService snapshot, synchronously on the
+    polling thread — deliberately, so the same poll pass's component rebuild
+    observes fresh ``has_cached_state``.
 
     Thread-safe: can be called from background threads and periodic callbacks.
+    Snapshots are replaced wholesale under the lock, so readers never need it.
     """
 
     def __init__(self) -> None:
-        self._layers: dict[LayerId, LayerStateMachine] = {}
-        self._lock = threading.Lock()
+        self._layers: dict[LayerId, LayerSnapshot] = {}
+        self._viewers: dict[LayerId, set[int]] = {}
+        # Token keys we've already attached a weakref finalizer to, so we don't
+        # register a second one on a False→True re-acquire.
+        self._finalized_keys: set[tuple[LayerId, int]] = set()
+        # Reentrant: a token's weakref finalizer calls back into
+        # ``_release_token``, and garbage collection can run it on a thread
+        # that already holds the lock.
+        self._lock = threading.RLock()
         self._version = 0
 
     @property
@@ -292,42 +282,54 @@ class PlotDataService:
     def _apply(
         self,
         layer_id: LayerId,
-        transition: Callable[[LayerStateMachine], None],
+        transition: Callable[[LayerSnapshot], LayerSnapshot | None],
         *,
         create: bool,
     ) -> None:
         """Run a state transition, advancing ``version`` if it took effect.
 
-        Transitions that the state machine rejects or treats as a no-op leave
-        the layer's version untouched and must not advance the aggregate, or
-        every data message would arm every session's poll gate.
+        Transitions that the snapshot rejects or treats as a no-op return None
+        and must not advance the aggregate, or every data message would arm
+        every session's poll gate.
 
         Parameters
         ----------
         layer_id:
             Layer to transition.
         transition:
-            State-machine call to run under the lock.
+            Pure state transition to run under the lock.
         create:
-            Whether an unknown ``layer_id`` starts a fresh state machine or the
+            Whether an unknown ``layer_id`` starts a fresh layer or the
             transition is dropped. Required, since which of the two is correct
             depends on whether the caller can legitimately arrive first.
         """
         with self._lock:
-            if create:
-                state = self._layers.setdefault(layer_id, LayerStateMachine())
-            else:
-                state = self._layers.get(layer_id)
-                if state is None:
+            current = self._layers.get(layer_id)
+            if current is None:
+                if not create:
                     return
-            before = state.version
-            transition(state)
-            if state.version != before:
-                self._version += 1
+                current = LayerSnapshot()
+            updated = transition(current)
+            if updated is None:
+                return
+            self._layers[layer_id] = updated
+            self._version += 1
+        # Outside the lock: this calls into the plotter, and holding the
+        # service lock across foreign code invites lock-order inversions.
+        if updated.state in _PRESENTATION_CHANGING_STATES and (
+            updated.plotter is not None
+        ):
+            updated.plotter.mark_presenters_dirty()
 
-    def get(self, layer_id: LayerId) -> LayerStateMachine | None:
+    def get(self, layer_id: LayerId) -> LayerSnapshot | None:
         """
-        Get current state for a layer.
+        Get the current snapshot for a layer.
+
+        The returned snapshot is immutable, so all of its fields may be read
+        without synchronization and always describe one consistent point in
+        the layer's history. Snapshot identity doubles as a change check: a
+        later ``get`` returning the same object means no transition took
+        effect in between.
 
         Parameters
         ----------
@@ -337,7 +339,7 @@ class PlotDataService:
         Returns
         -------
         :
-            Current layer state, or None if not set.
+            Current layer snapshot, or None if not set.
         """
         with self._lock:
             return self._layers.get(layer_id)
@@ -396,6 +398,51 @@ class PlotDataService:
             layer_id, lambda state: state.error_occurred(error_msg), create=True
         )
 
+    def set_active(self, layer_id: LayerId, token: object, active: bool) -> bool:
+        """Acquire or release a viewer interest token on a layer.
+
+        Returns True on the 0→1 transition, i.e. when the first token is
+        acquired. Frame flushes skipped the layer while no viewer was
+        watching (see ``has_viewers``), so the caller must then rebuild the
+        layer from current DataService content.
+
+        A ``weakref.finalize`` is attached on first acquire so the token is
+        auto-released if the caller is garbage-collected without an explicit
+        release. Explicit ``set_active(..., False)`` remains the fast path;
+        the finalizer is belt-and-braces against missed cleanup (e.g., a
+        session disposed without ``PlotGridTabs.shutdown`` running).
+        """
+        key = id(token)
+        with self._lock:
+            tokens = self._viewers.setdefault(layer_id, set())
+            was_active = bool(tokens)
+            if active:
+                tokens.add(key)
+                if (layer_id, key) not in self._finalized_keys:
+                    self._finalized_keys.add((layer_id, key))
+                    # Captures ``key`` (an int) and a bound method, not the
+                    # token itself — so the finalizer does not keep the token
+                    # alive. CPython runs the finalizer before the token's
+                    # memory can be reused for a different object, so an
+                    # ``id()`` collision cannot race with an active token.
+                    weakref.finalize(token, self._release_token, layer_id, key)
+            else:
+                tokens.discard(key)
+            return active and not was_active
+
+    def has_viewers(self, layer_id: LayerId) -> bool:
+        """Whether any viewer token is held on a layer; gates frame-flush compute."""
+        with self._lock:
+            return bool(self._viewers.get(layer_id))
+
+    def _release_token(self, layer_id: LayerId, key: int) -> None:
+        """Drop a token key from the gate (called by the weakref finalizer)."""
+        with self._lock:
+            tokens = self._viewers.get(layer_id)
+            if tokens is not None:
+                tokens.discard(key)
+            self._finalized_keys.discard((layer_id, key))
+
     def remove(self, layer_id: LayerId) -> None:
         """
         Remove state for a layer.
@@ -407,8 +454,14 @@ class PlotDataService:
         """
         with self._lock:
             self._layers.pop(layer_id, None)
+            self._viewers.pop(layer_id, None)
+            self._finalized_keys = {
+                entry for entry in self._finalized_keys if entry[0] != layer_id
+            }
 
     def clear(self) -> None:
         """Clear all state."""
         with self._lock:
             self._layers.clear()
+            self._viewers.clear()
+            self._finalized_keys.clear()

--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -39,7 +39,7 @@ from .config_store import ConfigStore
 from .data_roles import PRIMARY
 from .data_service import DataService
 from .frame_clock import FrameClock
-from .plot_data_service import LayerId, PlotDataService
+from .plot_data_service import LayerId, LayerSnapshot, PlotDataService
 from .plot_params import WindowModeMixin
 from .plotting_controller import PlottingController
 
@@ -1139,8 +1139,7 @@ class PlotOrchestrator:
         for grid_id, layer_ids in buckets.items():
             computed = False
             for layer_id in layer_ids:
-                state = self._plot_data_service.get(layer_id)
-                if state is None or not state.has_viewers:
+                if not self._plot_data_service.has_viewers(layer_id):
                     continue
                 computed |= self._pull_and_build(layer_id)
             if computed:
@@ -1156,10 +1155,7 @@ class PlotOrchestrator:
         the same poll pass's component rebuild seeing fresh
         ``has_cached_state``.
         """
-        state = self._plot_data_service.get(layer_id)
-        if state is None:
-            return
-        if state.set_active(token, active):
+        if self._plot_data_service.set_active(layer_id, token, active):
             self._refresh_layer(layer_id)
 
     def _refresh_layer(self, layer_id: LayerId) -> None:
@@ -1187,68 +1183,55 @@ class PlotOrchestrator:
             subscriber = self._data_subscriptions.get(layer_id)
         if subscriber is None:
             return False
-        state = self._plot_data_service.get(layer_id)
-        if state is None or state.plotter is None:
+        snapshot = self._plot_data_service.get(layer_id)
+        if snapshot is None or snapshot.plotter is None:
             return False
-        # ``state`` is the live state machine, so these two reads are not
-        # atomic against a concurrent ``job_started`` on the UI thread.
-        # Capturing version first rules out the harmful pairing (stale version
-        # with new plotter): ``job_started`` bumps the version before swapping
-        # the plotter, so an old version implies the swap had not yet run.
-        # The converse pairing (new version, old plotter) is possible and
-        # tolerated: the check in ``_compute_layer`` then passes and flips the
-        # layer READY on the old plotter's result. The swap also replaced this
-        # layer's subscription and re-marked it dirty, so the next flush
-        # overwrites that frame. See #1060.
-        version = state.version
-        plotter = state.plotter
         try:
             assembled = subscriber.assemble(self._data_service.snapshot(subscriber))
         except Exception:
             error_msg = traceback.format_exc()
             self._logger.exception('Failed to extract data for layer_id=%s', layer_id)
-            if self._layer_version(layer_id) == version:
+            if self._plot_data_service.get(layer_id) is snapshot:
                 self._plot_data_service.error_occurred(layer_id, error_msg)
             return True
         if assembled is None:
             return False
-        self._compute_layer(layer_id, plotter, version, assembled)
+        self._compute_layer(layer_id, snapshot, assembled)
         return True
 
     def _compute_layer(
         self,
         layer_id: LayerId,
-        plotter: Any,
-        version: int,
+        snapshot: LayerSnapshot,
         data: dict[str, dict[DataKey, Any]],
     ) -> None:
         """Run ``plotter.compute`` and transition the layer to READY or ERROR.
 
-        ``plotter`` and ``version`` are the caller's pre-pull capture. If the
-        layer's version moved on by compute end, the plotter was swapped (job
-        restart on the UI thread) and both transitions are skipped: the stale
-        result must neither flip the new plotter READY nor mark it ERROR. The
-        replacement subscription re-marked the layer dirty, so the next flush
-        rebuilds it consistently.
+        ``snapshot`` is the caller's pre-pull capture, carrying the plotter to
+        compute on. If the service no longer holds that same snapshot by
+        compute end, some transition took effect meanwhile — a job restart
+        swapping the plotter, most importantly — and both transitions are
+        skipped: the stale result must neither flip the new plotter READY nor
+        mark it ERROR. A restart also replaced the layer's subscription and
+        re-marked it dirty, so the next flush rebuilds it consistently.
 
         Thread-agnostic: runs on whatever thread the caller is on — the bg
         ingestion thread when entered via ``flush_frames``, the polling thread
         when entered via ``activate_layer``, the UI thread for setup-time
         static-overlay builds.
         """
+        plotter = snapshot.plotter
+        if plotter is None:
+            raise ValueError(f"Layer {layer_id} has no plotter to compute on")
         try:
             plotter.compute(data, title_resolver=self._layer_resolvers.get(layer_id))
-            if self._layer_version(layer_id) == version:
+            if self._plot_data_service.get(layer_id) is snapshot:
                 self._plot_data_service.data_arrived(layer_id)
         except Exception:
             error_msg = traceback.format_exc()
             self._logger.exception('Failed to compute state for layer_id=%s', layer_id)
-            if self._layer_version(layer_id) == version:
+            if self._plot_data_service.get(layer_id) is snapshot:
                 self._plot_data_service.error_occurred(layer_id, error_msg)
-
-    def _layer_version(self, layer_id: LayerId) -> int | None:
-        state = self._plot_data_service.get(layer_id)
-        return None if state is None else state.version
 
     def _setup_layer(self, layer: Layer) -> None:
         """
@@ -1279,11 +1262,11 @@ class PlotOrchestrator:
             # Static overlay: built unconditionally (no viewer gate): there is
             # no data subscription to pull from later, and the build is a
             # one-off.
-            plotter = self._create_and_register_plotter(layer_id, config)
-            state = self._plot_data_service.get(layer_id)
-            if plotter is not None and state is not None:
+            self._create_and_register_plotter(layer_id, config)
+            snapshot = self._plot_data_service.get(layer_id)
+            if snapshot is not None and snapshot.plotter is not None:
                 # Empty input: a static overlay computes from its params alone.
-                self._compute_layer(layer_id, plotter, state.version, {})
+                self._compute_layer(layer_id, snapshot, {})
                 self._frame_clock.commit(self._grid_of_layer(layer_id))
             self._bump_topology_version()
             self._persist_to_store()

--- a/src/ess/livedata/dashboard/session_layer.py
+++ b/src/ess/livedata/dashboard/session_layer.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 
 import holoviews as hv
 
-from .plot_data_service import LayerId, LayerStateMachine
+from .plot_data_service import LayerId, LayerSnapshot
 from .plots import Plotter, PresenterBase
 
 
@@ -64,7 +64,7 @@ class SessionComponents:
         return plotter is not None and self.presenter.is_owned_by(plotter)
 
     @classmethod
-    def create(cls, state: LayerStateMachine) -> SessionComponents | None:
+    def create(cls, state: LayerSnapshot) -> SessionComponents | None:
         """
         Create session components if data is available.
 
@@ -131,7 +131,7 @@ class SessionLayer:
             return False
         return self.components.update_pipe()
 
-    def ensure_components(self, state: LayerStateMachine) -> bool:
+    def ensure_components(self, state: LayerSnapshot) -> bool:
         """
         Ensure components exist if data is now available.
 

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -29,7 +29,7 @@ from ..cell_autoscale import CellAutoscaleController, build_controller_from_laye
 from ..format_utils import extract_error_summary
 from ..frame_aspect import pane_sizing_mode
 from ..hover_suspend import make_hover_suspend_hook
-from ..plot_data_service import LayerState, LayerStateMachine, PlotDataService
+from ..plot_data_service import LayerSnapshot, LayerState, PlotDataService
 from ..plot_orchestrator import (
     CellGeometry,
     CellId,
@@ -318,9 +318,9 @@ class CellWidget:
             self._autoscale_controller.dispose()
             self._autoscale_controller = None
 
-    def _layer_states(self) -> dict[LayerId, LayerStateMachine]:
+    def _layer_states(self) -> dict[LayerId, LayerSnapshot]:
         """Get layer states from PlotDataService for all layers in the cell."""
-        result: dict[LayerId, LayerStateMachine] = {}
+        result: dict[LayerId, LayerSnapshot] = {}
         for layer in self._cell.layers:
             state = self._deps.plot_data_service.get(layer.layer_id)
             if state is None:
@@ -333,7 +333,7 @@ class CellWidget:
         return result
 
     def _freeze_pill_for_status(
-        self, layer_states: dict[LayerId, LayerStateMachine]
+        self, layer_states: dict[LayerId, LayerSnapshot]
     ) -> None:
         """Freeze the titlebar pill to a status pill when the cell is not live.
 
@@ -470,7 +470,7 @@ class CellWidget:
 
     def _build_layer_toolbars(
         self,
-        layer_states: dict[LayerId, LayerStateMachine],
+        layer_states: dict[LayerId, LayerSnapshot],
     ) -> list[pn.Row | pn.Column]:
         """
         Create per-layer info rows (title + time range) for the cell's layers.
@@ -528,7 +528,7 @@ class CellWidget:
 
     def _build_placeholder(
         self,
-        layer_states: dict[LayerId, LayerStateMachine],
+        layer_states: dict[LayerId, LayerSnapshot],
     ) -> pn.pane.Markdown:
         """
         Create placeholder content showing layer status.

--- a/tests/dashboard/plot_data_service_test.py
+++ b/tests/dashboard/plot_data_service_test.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-"""Tests for PlotDataService and LayerStateMachine."""
+"""Tests for PlotDataService and LayerSnapshot."""
 
 from uuid import uuid4
 
 from ess.livedata.dashboard.plot_data_service import (
     LayerId,
+    LayerSnapshot,
     LayerState,
-    LayerStateMachine,
     PlotDataService,
 )
 
@@ -33,152 +33,136 @@ class FakePlotter:
         pass
 
 
-class TestLayerStateMachineVersionInvariant:
+class TestLayerSnapshotVersionInvariant:
     """Test version invariant: plotter change always increments version."""
 
     def test_job_started_increments_version_from_initial_state(self):
-        """Version increments when job_started called on a fresh machine."""
-        state = LayerStateMachine()
+        """Version increments when job_started called on a fresh snapshot."""
+        state = LayerSnapshot()
         assert state.version == 0
         assert state.state == LayerState.WAITING_FOR_DATA
 
         plotter = FakePlotter()
-        state.job_started(plotter)
+        state = state.job_started(plotter)
 
         assert state.version == 1
         assert state.plotter is plotter
 
     def test_job_started_increments_version_from_stopped(self):
         """Version increments when job_started called from STOPPED."""
-        state = LayerStateMachine()
         plotter_a = FakePlotter()
         plotter_a.compute({'data': 1})
 
-        state.job_started(plotter_a)
-        state.data_arrived()
-        state.job_stopped()
+        state = LayerSnapshot().job_started(plotter_a)
+        state = state.data_arrived().job_stopped()
 
         version_after_stop = state.version
         assert state.state == LayerState.STOPPED
 
         # Simulate workflow restart with new plotter
         plotter_b = FakePlotter()
-        state.job_started(plotter_b)
+        state = state.job_started(plotter_b)
 
         assert state.version == version_after_stop + 1
         assert state.plotter is plotter_b
 
     def test_job_started_increments_version_from_ready(self):
         """Version increments when job_started called from READY (workflow restart)."""
-        state = LayerStateMachine()
         plotter_a = FakePlotter()
         plotter_a.compute({'data': 1})
 
-        state.job_started(plotter_a)
-        state.data_arrived()
+        state = LayerSnapshot().job_started(plotter_a)
+        state = state.data_arrived()
 
         version_after_ready = state.version
         assert state.state == LayerState.READY
 
         # Simulate workflow restart with new plotter while still running
         plotter_b = FakePlotter()
-        state.job_started(plotter_b)
+        state = state.job_started(plotter_b)
 
         assert state.version == version_after_ready + 1
         assert state.plotter is plotter_b
 
     def test_job_started_increments_version_from_waiting_for_data(self):
         """Version increments when plotter replaced while waiting for data."""
-        state = LayerStateMachine()
-        plotter_a = FakePlotter()
-        state.job_started(plotter_a)
+        state = LayerSnapshot().job_started(FakePlotter())
 
         version_after_first_start = state.version
         assert state.state == LayerState.WAITING_FOR_DATA
 
         # Workflow restarted before data arrived
         plotter_b = FakePlotter()
-        state.job_started(plotter_b)
+        state = state.job_started(plotter_b)
 
         assert state.version == version_after_first_start + 1
         assert state.plotter is plotter_b
 
     def test_job_started_increments_version_from_error(self):
         """Version increments when job_started called from ERROR state."""
-        state = LayerStateMachine()
-        state.error_occurred("test error")
+        state = LayerSnapshot().error_occurred("test error")
 
         version_after_error = state.version
         assert state.state == LayerState.ERROR
 
         plotter = FakePlotter()
-        state.job_started(plotter)
+        state = state.job_started(plotter)
 
         assert state.version == version_after_error + 1
         assert state.plotter is plotter
 
     def test_job_started_with_same_plotter_still_increments_version(self):
         """Version increments even when called with the same plotter instance."""
-        state = LayerStateMachine()
         plotter = FakePlotter()
 
-        state.job_started(plotter)
+        state = LayerSnapshot().job_started(plotter)
         version_after_first = state.version
 
-        state.job_stopped()
-        state.job_started(plotter)  # Same plotter instance
+        state = state.job_stopped()
+        state = state.job_started(plotter)  # Same plotter instance
 
         assert state.version == version_after_first + 2  # +1 for stop, +1 for start
 
 
-class TestLayerStateMachineOtherTransitions:
+class TestLayerSnapshotOtherTransitions:
     """Tests for other state transitions that also affect version."""
 
     def test_data_arrived_increments_version(self):
         """Version increments when data arrives."""
-        state = LayerStateMachine()
-        plotter = FakePlotter()
-        state.job_started(plotter)
+        state = LayerSnapshot().job_started(FakePlotter())
         version_before = state.version
 
-        state.data_arrived()
+        state = state.data_arrived()
 
         assert state.version == version_before + 1
         assert state.state == LayerState.READY
 
     def test_data_arrived_no_op_when_already_ready(self):
-        """Subsequent data arrivals don't increment version."""
-        state = LayerStateMachine()
-        plotter = FakePlotter()
-        state.job_started(plotter)
-        state.data_arrived()
-        version_at_ready = state.version
+        """Subsequent data arrivals are rejected, leaving the snapshot in place."""
+        state = LayerSnapshot().job_started(FakePlotter())
+        state = state.data_arrived()
 
         # Subsequent data arrivals are no-ops
-        state.data_arrived()
-        state.data_arrived()
-
-        assert state.version == version_at_ready
+        assert state.data_arrived() is None
+        assert state.data_arrived() is None
 
     def test_job_stopped_increments_version(self):
         """Version increments when job is stopped."""
-        state = LayerStateMachine()
-        plotter = FakePlotter()
-        state.job_started(plotter)
-        state.data_arrived()
+        state = LayerSnapshot().job_started(FakePlotter())
+        state = state.data_arrived()
         version_before = state.version
 
-        state.job_stopped()
+        state = state.job_stopped()
 
         assert state.version == version_before + 1
         assert state.state == LayerState.STOPPED
 
     def test_error_occurred_increments_version(self):
         """Version increments when error occurs."""
-        state = LayerStateMachine()
+        state = LayerSnapshot()
         version_before = state.version
 
-        state.error_occurred("test error")
+        state = state.error_occurred("test error")
 
         assert state.version == version_before + 1
         assert state.state == LayerState.ERROR
@@ -311,74 +295,149 @@ class _Token:
 
 
 class TestLayerViewerGate:
-    """Tests for the viewer gate on LayerStateMachine.
+    """Tests for the viewer gate on PlotDataService.
 
-    The gate tracks viewer interest tokens. On 0→1 transition (first viewer),
-    the orchestrator rebuilds the layer from DataService; on 1→0 (last
-    viewer released), the layer is skipped at frame flushes.
+    The gate tracks viewer interest tokens, keyed per layer. It is held apart
+    from the lifecycle snapshots because interest is per (session, layer)
+    while lifecycle state is per layer. On the 0→1 transition (first viewer)
+    the orchestrator rebuilds the layer from DataService; on 1→0 (last viewer
+    released), the layer is skipped at frame flushes.
     """
 
-    def _ready_state(self) -> tuple[LayerStateMachine, FakePlotter]:
-        state = LayerStateMachine()
-        plotter = FakePlotter()
-        state.job_started(plotter)
-        return state, plotter
+    def _started_layer(self) -> tuple[PlotDataService, LayerId]:
+        service = PlotDataService()
+        layer_id = LayerId(uuid4())
+        service.job_started(layer_id, FakePlotter())
+        return service, layer_id
 
     def test_set_active_reports_zero_to_one_transition(self):
         """set_active returns True on the 0→1 transition only."""
-        state, _plotter = self._ready_state()
+        service, layer_id = self._started_layer()
         token = _Token()
-        assert state.set_active(token, True) is True
+        assert service.set_active(layer_id, token, True) is True
         # Re-activating the same token is not a transition.
-        assert state.set_active(token, True) is False
-        state.set_active(token, False)
-        assert state.set_active(token, True) is True
+        assert service.set_active(layer_id, token, True) is False
+        service.set_active(layer_id, token, False)
+        assert service.set_active(layer_id, token, True) is True
 
     def test_has_viewers_tracks_active_tokens(self):
         """has_viewers reflects whether any viewer holds a token."""
-        state, _plotter = self._ready_state()
+        service, layer_id = self._started_layer()
         t1, t2 = _Token(), _Token()
-        assert not state.has_viewers
-        state.set_active(t1, True)
-        state.set_active(t2, True)
-        assert state.has_viewers
-        state.set_active(t1, False)
-        assert state.has_viewers
-        state.set_active(t2, False)
-        assert not state.has_viewers
+        assert not service.has_viewers(layer_id)
+        service.set_active(layer_id, t1, True)
+        service.set_active(layer_id, t2, True)
+        assert service.has_viewers(layer_id)
+        service.set_active(layer_id, t1, False)
+        assert service.has_viewers(layer_id)
+        service.set_active(layer_id, t2, False)
+        assert not service.has_viewers(layer_id)
 
     def test_multiple_tokens_keep_layer_active(self):
         """Layer stays active while any viewer holds a token."""
-        state, _plotter = self._ready_state()
+        service, layer_id = self._started_layer()
         t1, t2 = _Token(), _Token()
-        assert state.set_active(t1, True) is True
+        assert service.set_active(layer_id, t1, True) is True
         # Second token while already active is not a transition.
-        assert state.set_active(t2, True) is False
-        assert state.has_viewers
+        assert service.set_active(layer_id, t2, True) is False
+        assert service.has_viewers(layer_id)
         # Release one; still active (t2 holds it).
-        state.set_active(t1, False)
-        assert state.has_viewers
+        service.set_active(layer_id, t1, False)
+        assert service.has_viewers(layer_id)
         # Release the second; gate closes.
-        state.set_active(t2, False)
-        assert not state.has_viewers
+        service.set_active(layer_id, t2, False)
+        assert not service.has_viewers(layer_id)
+
+    def test_gate_is_per_layer(self):
+        """A viewer on one layer must not open another layer's gate."""
+        service, layer_id = self._started_layer()
+        other_id = LayerId(uuid4())
+        service.job_started(other_id, FakePlotter())
+        token = _Token()
+
+        service.set_active(layer_id, token, True)
+
+        assert service.has_viewers(layer_id)
+        assert not service.has_viewers(other_id)
 
     def test_release_of_unknown_token_is_noop(self):
         """Releasing a token never acquired is safe."""
-        state, _plotter = self._ready_state()
+        service, layer_id = self._started_layer()
         unknown = _Token()
-        assert state.set_active(unknown, False) is False
-        assert not state.has_viewers
+        assert service.set_active(layer_id, unknown, False) is False
+        assert not service.has_viewers(layer_id)
+
+    def test_has_viewers_on_unknown_layer_is_false(self):
+        service = PlotDataService()
+        assert not service.has_viewers(LayerId(uuid4()))
+
+    def test_remove_drops_viewer_gate(self):
+        """Removing a layer must not leave its gate open for a recreated id."""
+        service, layer_id = self._started_layer()
+        token = _Token()
+        service.set_active(layer_id, token, True)
+
+        service.remove(layer_id)
+
+        assert not service.has_viewers(layer_id)
 
     def test_token_auto_released_on_garbage_collection(self):
         """Finalizer closes gate if caller is gc'd without explicit release."""
         import gc
 
-        state, _plotter = self._ready_state()
+        service, layer_id = self._started_layer()
         token = _Token()
-        state.set_active(token, True)
-        assert state.has_viewers
+        service.set_active(layer_id, token, True)
+        assert service.has_viewers(layer_id)
         # Drop the only reference and force gc; finalizer must release the key.
         del token
         gc.collect()
         # Gate is now closed.
-        assert not state.has_viewers
+        assert not service.has_viewers(layer_id)
+
+
+class TestSnapshotIdentity:
+    """Snapshot identity is the orchestrator's staleness check.
+
+    ``PlotOrchestrator`` captures a snapshot before a pull and, after compute,
+    re-reads it and compares by identity to decide whether its result is still
+    current. That only works if an effective transition always yields a new
+    object and a rejected one never does.
+    """
+
+    def test_effective_transition_replaces_snapshot(self):
+        service = PlotDataService()
+        layer_id = LayerId(uuid4())
+        service.job_started(layer_id, FakePlotter())
+        before = service.get(layer_id)
+
+        service.data_arrived(layer_id)
+
+        assert service.get(layer_id) is not before
+
+    def test_rejected_transition_keeps_snapshot(self):
+        service = PlotDataService()
+        layer_id = LayerId(uuid4())
+        service.job_started(layer_id, FakePlotter())
+        service.data_arrived(layer_id)
+        before = service.get(layer_id)
+
+        service.data_arrived(layer_id)  # no-op: already READY
+
+        assert service.get(layer_id) is before
+
+    def test_plotter_swap_replaces_snapshot(self):
+        """The pairing #1060 was about: a swap must invalidate a held capture."""
+        service = PlotDataService()
+        layer_id = LayerId(uuid4())
+        service.job_started(layer_id, FakePlotter())
+        captured = service.get(layer_id)
+
+        service.job_started(layer_id, FakePlotter())
+
+        current = service.get(layer_id)
+        assert current is not captured
+        assert captured.plotter is not current.plotter
+        # The capture still describes the state it was taken in.
+        assert captured.version == 1
+        assert current.version == 2

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -1199,14 +1199,16 @@ class TestBuildRobustness:
         commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
         feed_result_data(fake_data_service, plot_cell[1], workflow_id)
 
-        state = plot_data_service.get(layer_id)
         old_plotter = fake_plotting_controller.created_plotters[0]
         new_plotter = FakePlotter()
-        old_plotter.on_compute = lambda: state.job_started(new_plotter)
+        old_plotter.on_compute = lambda: plot_data_service.job_started(
+            layer_id, new_plotter
+        )
 
         plot_orchestrator.flush_frames()
 
         assert old_plotter.compute_calls  # the stale build did run
+        state = plot_data_service.get(layer_id)
         assert state.plotter is new_plotter
         assert state.state is LayerState.WAITING_FOR_DATA
 

--- a/tests/dashboard/state_stores_test.py
+++ b/tests/dashboard/state_stores_test.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-"""Tests for PlotDataService and LayerStateMachine."""
+"""Tests for PlotDataService and LayerSnapshot."""
 
 import weakref
 
 from ess.livedata.dashboard.plot_data_service import (
     LayerId,
+    LayerSnapshot,
     LayerState,
-    LayerStateMachine,
     PlotDataService,
 )
 from ess.livedata.dashboard.plots import PresenterBase
@@ -178,195 +178,144 @@ class TestPlotDataService:
         assert service.get(LayerId('layer-1')) is None
 
 
-class TestLayerStateMachine:
-    """Tests for the LayerStateMachine state transitions."""
+class TestLayerSnapshot:
+    """Tests for LayerSnapshot's pure state transitions."""
 
     def test_initial_state_is_waiting_for_data(self):
-        machine = LayerStateMachine()
-        assert machine.state == LayerState.WAITING_FOR_DATA
-        assert machine.version == 0
-        assert machine.plotter is None
-        assert machine.error_message is None
+        snapshot = LayerSnapshot()
+        assert snapshot.state == LayerState.WAITING_FOR_DATA
+        assert snapshot.version == 0
+        assert snapshot.plotter is None
+        assert snapshot.error_message is None
+
+    def test_transitions_do_not_mutate_the_receiver(self):
+        """The whole point of the type: readers holding one are never surprised."""
+        original = LayerSnapshot().job_started(FakePlotter(state='data'))
+
+        updated = original.data_arrived()
+
+        assert updated is not original
+        assert updated.state == LayerState.READY
+        assert original.state == LayerState.WAITING_FOR_DATA
+        assert original.version == 1
 
     def test_job_started_transitions_to_waiting_for_data(self):
-        machine = LayerStateMachine()
         plotter = FakePlotter(state=None)
 
-        machine.job_started(plotter)
+        snapshot = LayerSnapshot().job_started(plotter)
 
-        assert machine.state == LayerState.WAITING_FOR_DATA
-        assert machine.version == 1
-        assert machine.plotter is plotter
+        assert snapshot.state == LayerState.WAITING_FOR_DATA
+        assert snapshot.version == 1
+        assert snapshot.plotter is plotter
 
     def test_data_arrived_transitions_to_ready(self):
-        machine = LayerStateMachine()
         plotter = FakePlotter(state='data')
-        machine.job_started(plotter)
+        snapshot = LayerSnapshot().job_started(plotter)
 
-        machine.data_arrived()
+        snapshot = snapshot.data_arrived()
 
-        assert machine.state == LayerState.READY
-        assert machine.version == 2
-        assert machine.plotter is plotter
+        assert snapshot.state == LayerState.READY
+        assert snapshot.version == 2
+        assert snapshot.plotter is plotter
 
     def test_job_stopped_from_waiting_for_data(self):
-        machine = LayerStateMachine()
-        plotter = FakePlotter(state=None)
-        machine.job_started(plotter)
+        snapshot = LayerSnapshot().job_started(FakePlotter(state=None))
 
-        machine.job_stopped()
+        snapshot = snapshot.job_stopped()
 
-        assert machine.state == LayerState.STOPPED
-        assert machine.version == 2
+        assert snapshot.state == LayerState.STOPPED
+        assert snapshot.version == 2
 
     def test_job_stopped_from_ready(self):
-        machine = LayerStateMachine()
-        plotter = FakePlotter(state='data')
-        machine.job_started(plotter)
-        machine.data_arrived()
+        snapshot = LayerSnapshot().job_started(FakePlotter(state='data'))
+        snapshot = snapshot.data_arrived()
 
-        machine.job_stopped()
+        snapshot = snapshot.job_stopped()
 
-        assert machine.state == LayerState.STOPPED
-        assert machine.version == 3
+        assert snapshot.state == LayerState.STOPPED
+        assert snapshot.version == 3
 
     def test_error_occurred_from_any_state(self):
-        machine = LayerStateMachine()
+        snapshot = LayerSnapshot().error_occurred("test error")
 
-        machine.error_occurred("test error")
-
-        assert machine.state == LayerState.ERROR
-        assert machine.error_message == "test error"
-        assert machine.version == 1
+        assert snapshot.state == LayerState.ERROR
+        assert snapshot.error_message == "test error"
+        assert snapshot.version == 1
 
     def test_job_started_from_stopped_restarts(self):
-        machine = LayerStateMachine()
-        plotter1 = FakePlotter(state='data')
-        machine.job_started(plotter1)
-        machine.data_arrived()
-        machine.job_stopped()
-        assert machine.state == LayerState.STOPPED
+        snapshot = LayerSnapshot().job_started(FakePlotter(state='data'))
+        snapshot = snapshot.data_arrived().job_stopped()
+        assert snapshot.state == LayerState.STOPPED
 
         plotter2 = FakePlotter(state=None)
-        machine.job_started(plotter2)
+        snapshot = snapshot.job_started(plotter2)
 
-        assert machine.state == LayerState.WAITING_FOR_DATA
-        assert machine.plotter is plotter2
-        assert machine.version == 4
+        assert snapshot.state == LayerState.WAITING_FOR_DATA
+        assert snapshot.plotter is plotter2
+        assert snapshot.version == 4
 
     def test_job_started_from_error_recovers(self):
-        machine = LayerStateMachine()
-        machine.error_occurred("some error")
-        assert machine.state == LayerState.ERROR
+        snapshot = LayerSnapshot().error_occurred("some error")
+        assert snapshot.state == LayerState.ERROR
 
         plotter = FakePlotter(state=None)
-        machine.job_started(plotter)
+        snapshot = snapshot.job_started(plotter)
 
-        assert machine.state == LayerState.WAITING_FOR_DATA
-        assert machine.error_message is None
-        assert machine.version == 2
+        assert snapshot.state == LayerState.WAITING_FOR_DATA
+        assert snapshot.error_message is None
+        assert snapshot.version == 2
 
     def test_job_started_from_ready_restarts(self):
         """Test restart while in READY state (workflow restart with data)."""
-        machine = LayerStateMachine()
-        plotter1 = FakePlotter(state='data')
-        machine.job_started(plotter1)
-        machine.data_arrived()
-        assert machine.state == LayerState.READY
+        snapshot = LayerSnapshot().job_started(FakePlotter(state='data'))
+        snapshot = snapshot.data_arrived()
+        assert snapshot.state == LayerState.READY
 
         plotter2 = FakePlotter(state=None)
-        machine.job_started(plotter2)
+        snapshot = snapshot.job_started(plotter2)
 
-        assert machine.state == LayerState.WAITING_FOR_DATA
-        assert machine.plotter is plotter2
-        assert machine.version == 3
+        assert snapshot.state == LayerState.WAITING_FOR_DATA
+        assert snapshot.plotter is plotter2
+        assert snapshot.version == 3
 
     def test_invalid_data_arrived_from_ready_is_ignored(self):
-        machine = LayerStateMachine()
-        plotter = FakePlotter(state='data')
-        machine.job_started(plotter)
-        machine.data_arrived()
-        version_before = machine.version
+        snapshot = LayerSnapshot().job_started(FakePlotter(state='data'))
+        snapshot = snapshot.data_arrived()
 
-        machine.data_arrived()  # Invalid: already in READY
-
-        assert machine.state == LayerState.READY
-        assert machine.version == version_before  # No version increment
+        assert snapshot.data_arrived() is None  # Invalid: already in READY
 
     def test_invalid_job_stopped_when_already_stopped_is_ignored(self):
-        machine = LayerStateMachine()
-        machine.job_stopped()
-        version_before = machine.version
+        snapshot = LayerSnapshot().job_stopped()
 
-        machine.job_stopped()  # Invalid: already stopped
-
-        assert machine.state == LayerState.STOPPED
-        assert machine.version == version_before
+        assert snapshot.job_stopped() is None  # Invalid: already stopped
 
     def test_data_arrived_while_stopped_is_silent_noop(self):
-        machine = LayerStateMachine()
-        machine.job_stopped()
-        version_before = machine.version
+        snapshot = LayerSnapshot().job_stopped()
 
-        machine.data_arrived()  # Retained data rendered while stopped
-
-        assert machine.state == LayerState.STOPPED
-        assert machine.version == version_before
+        # Retained data rendered while stopped
+        assert snapshot.data_arrived() is None
 
     def test_has_displayable_plot_ready_with_data(self):
-        machine = LayerStateMachine()
-        plotter = FakePlotter(state='data')
-        machine.job_started(plotter)
-        machine.data_arrived()
+        snapshot = LayerSnapshot().job_started(FakePlotter(state='data'))
+        snapshot = snapshot.data_arrived()
 
-        assert machine.has_displayable_plot() is True
+        assert snapshot.has_displayable_plot() is True
 
     def test_has_displayable_plot_stopped_with_data(self):
-        machine = LayerStateMachine()
-        plotter = FakePlotter(state='data')
-        machine.job_started(plotter)
-        machine.data_arrived()
-        machine.job_stopped()
+        snapshot = LayerSnapshot().job_started(FakePlotter(state='data'))
+        snapshot = snapshot.data_arrived().job_stopped()
 
-        assert machine.has_displayable_plot() is True
+        assert snapshot.has_displayable_plot() is True
 
     def test_has_displayable_plot_waiting_for_data_is_false(self):
-        machine = LayerStateMachine()
-        plotter = FakePlotter(state=None)
-        machine.job_started(plotter)
+        snapshot = LayerSnapshot().job_started(FakePlotter(state=None))
 
-        assert machine.has_displayable_plot() is False
+        assert snapshot.has_displayable_plot() is False
 
     def test_has_displayable_plot_error_is_false(self):
-        machine = LayerStateMachine()
-        machine.error_occurred("error")
+        snapshot = LayerSnapshot().error_occurred("error")
 
-        assert machine.has_displayable_plot() is False
-
-    def test_job_stopped_marks_presenters_dirty(self):
-        machine = LayerStateMachine()
-        plotter = FakePlotter(state='data')
-        machine.job_started(plotter)
-        machine.data_arrived()
-
-        presenter = plotter.create_presenter()
-        presenter._dirty = False
-
-        machine.job_stopped()
-
-        assert presenter.has_pending_update() is True
-
-    def test_error_occurred_marks_presenters_dirty(self):
-        machine = LayerStateMachine()
-        plotter = FakePlotter(state='data')
-        machine.job_started(plotter)
-
-        presenter = plotter.create_presenter()
-        presenter._dirty = False
-
-        machine.error_occurred("error")
-
-        assert presenter.has_pending_update() is True
+        assert snapshot.has_displayable_plot() is False
 
 
 class TestPlotDataServiceStateMachine:

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -438,11 +438,11 @@ class TestShutdown:
         layer_id = _register_active_layer(
             plot_orchestrator, plot_data_service, plot_grid_tabs
         )
-        assert plot_data_service.get(layer_id).has_viewers
+        assert plot_data_service.has_viewers(layer_id)
 
         plot_grid_tabs.sever()
 
-        assert not plot_data_service.get(layer_id).has_viewers
+        assert not plot_data_service.has_viewers(layer_id)
         assert plot_grid_tabs._session_layers == {}
 
     def test_sever_is_idempotent(self, plot_grid_tabs):
@@ -527,7 +527,7 @@ class TestReaperTeardown:
         )
         # Hold an active viewer token so we can observe tier-2 release it.
         layer_id = _register_active_layer(plot_orchestrator, plot_data_service, widget)
-        assert plot_data_service.get(layer_id).has_viewers
+        assert plot_data_service.has_viewers(layer_id)
 
         cleaned = registry.cleanup_stale_sessions()
 
@@ -535,7 +535,7 @@ class TestReaperTeardown:
         # Tier 2 ran inline on the reaper thread: the session's viewer token was
         # released and its session-layer records cleared. There is no lifecycle
         # subscription to sever under polling.
-        assert not plot_data_service.get(layer_id).has_viewers
+        assert not plot_data_service.has_viewers(layer_id)
         assert widget._session_layers == {}
         # Tier 1 was NOT run on the reaper thread: the periodic callback is not
         # stopped here, it is scheduled onto the session's IOLoop instead.


### PR DESCRIPTION
Fixes #1060.

`PlotDataService.get()` returned the live `LayerStateMachine`, so every consumer read `state` / `version` / `plotter` / `error_message` outside any lock while the service mutated those same fields from another thread. ADR 0007 already prescribes that consumers "pull an immutable snapshot when it advanced"; this was the one remaining reader-side hole in a class that otherwise implements the model.

## Approach

The issue proposed having `get()` build a frozen snapshot from the live machine under the lock. This goes one step further and makes the *stored* state immutable, because copy-on-read would leave two representations of layer state to keep in step as fields are added. Transitions are now pure functions returning the successor snapshot — or `None` when rejected — which the service swaps in under its lock. A half-applied state therefore cannot exist to be observed, rather than being hidden behind the `get()` boundary. It also lets `_apply` ask the transition whether it took effect instead of inferring that from a version diff.

The orchestrator captures one snapshot per build and rechecks it by identity after compute, which replaces the `(plotter, version)` pair whose non-atomic capture was the reachable bug. Identity is equivalent to the version comparison it replaces, since only an effective transition installs a new snapshot, and it is one read rather than two.

The viewer gate moves onto `PlotDataService`. Viewer interest is per (session, layer) while lifecycle state is per layer, so the two never belonged on one object; keeping the gate on the state machine forced a second lock and an exception to the rule that reads go through `get()`. A single reentrant lock now covers both, which additionally removes the chance of a token's weakref finalizer deadlocking against a thread that already holds it.

## Scope beyond the reported symptom

The issue framed the widget consumers as merely unsynchronized. Two of their reads are worse than a stale frame and are closed by the same change: `error_occurred` writes `_state` before `_error_message`, so a session thread reading state-then-message could render `Error: None`; and `SessionComponents.create` tested `has_displayable_plot()` against the current plotter and then re-read `plotter`, so a job restart landing in between could seed a session pipe from a plotter with no cached state.

Moving the gate into its own per-layer dict exposed a small hole in the release path: the session poll's orphan sweep releases tokens for layers `remove` already cleaned up, and `setdefault` resurrected an empty entry for the dead id, permanently since layer ids are never reused. Releases now only touch existing entries. Relatedly, `set_active` no longer requires the layer to have a snapshot — viewer interest is independent state, so tokens acquired before `job_started` are retained instead of dropped (the old code dropped them, self-healing only on a later pass).

One correction worth recording: the comment removed by this PR attributed the plotter swap to the UI thread. The dominant swap path is `sync_job_states`, which runs on the orchestrator update thread — the same thread as `flush_frames`, so those two cannot interleave at all. The race was real via `activate_layer`, which builds on a session polling thread.

## Test plan

- [x] Full dashboard suite passes. Four failures elsewhere in `tests/preprocessors/to_nxlog_test.py` come from a NumPy timedelta deprecation and reproduce unchanged on the base commit.
- [x] New tests cover the snapshot-identity contract the orchestrator's staleness check now depends on, that transitions do not mutate their receiver, and that the viewer gate is per layer and is dropped on `remove`.
- [x] The existing stale-build regression test (`test_stale_build_does_not_mark_swapped_plotter_ready`) previously drove the swap by mutating the leaked live object; it now goes through the service, which is the scenario it meant to exercise.

