### PR TITLE
Keep cell titlebar panes visible and current after a rebuild

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -207,8 +207,8 @@ against `cdn.holoviz.org` URLs — its model is not in a document yet, so Panel 
 to the CDN — and Panel then swaps those links for the locally served copies. The load
 events the reveal waits on belong to the discarded links, so the pane can stay invisible
 for the rest of the session while its model, text and layout are all correct and
-live-updating (#1154). `dashboard/design.py` overrides the latch for the whole app; a
-template built without `LivedataDesign` brings the bug back.
+live-updating (#1154, holoviz/panel#8696). `dashboard/design.py` overrides the latch for
+the whole app; a template built without `LivedataDesign` brings the bug back.
 
 ## Colors and styling
 

--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -198,6 +198,18 @@ Note that `dynamic=True` only gates Bokeh model creation. Python-side periodic c
 (e.g., `SessionUpdater` custom handlers) still run for all registered widgets regardless
 of which tab is visible. Use an `is_visible` predicate to skip refresh work for hidden tabs.
 
+### Markup panes built after page load
+
+Panel keeps a markup pane (`pn.pane.HTML`, `Markdown`, `Str`) behind
+`visibility: hidden` until every `<link>` stylesheet in it has fired `load`, and arms
+that reveal exactly once, while rendering. A pane built after page load first renders
+against `cdn.holoviz.org` URLs — its model is not in a document yet, so Panel falls back
+to the CDN — and Panel then swaps those links for the locally served copies. The load
+events the reveal waits on belong to the discarded links, so the pane can stay invisible
+for the rest of the session while its model, text and layout are all correct and
+live-updating (#1154). `dashboard/design.py` overrides the latch for the whole app; a
+template built without `LivedataDesign` brings the bug back.
+
 ## Colors and styling
 
 All colors must come from `dashboard/widgets/styles.py`. Do not hard-code hex color values

--- a/src/ess/livedata/dashboard/dashboard.py
+++ b/src/ess/livedata/dashboard/dashboard.py
@@ -14,6 +14,7 @@ from ess.livedata import ServiceBase, __version__, format_version
 
 from .config_store import ConfigStoreManager
 from .dashboard_services import DashboardServices
+from .design import LivedataDesign
 from .fake_backend import FakeBackendTransport
 from .kafka_transport import DashboardKafkaTransport
 from .session_registry import SessionId
@@ -294,6 +295,7 @@ class DashboardBase(ServiceBase, ABC):
 
         template = pn.template.MaterialTemplate(
             title=self.get_dashboard_title(),
+            design=LivedataDesign,
             sidebar=sidebar_with_heartbeat,
             collapsed_sidebar=self._collapsed_sidebar,
             main=main_content,

--- a/src/ess/livedata/dashboard/design.py
+++ b/src/ess/livedata/dashboard/design.py
@@ -18,11 +18,11 @@ patches those URLs to the locally served copies, swapping the pane's ``<link>``
 elements for new ones. The load events the reveal is waiting on belong to the
 discarded elements and never arrive, so the pane stays invisible for the rest of
 the session while its Bokeh model, text and layout are all correct and
-live-updating (#1154).
+live-updating (#1154, holoviz/panel#8696).
 
 Overriding the reveal is safe here: our markup carries inline styling, so there
 is no unstyled-content flash to suppress, and the content has to show the moment
-it is inserted.
+it is inserted. Drop this design once a Panel release re-arms the reveal.
 """
 
 from typing import Any, ClassVar

--- a/src/ess/livedata/dashboard/design.py
+++ b/src/ess/livedata/dashboard/design.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Panel :class:`~panel.theme.Design` used by the dashboard template.
+
+Exists to keep markup panes visible when they are built after page load.
+
+Panel keeps a markup pane's content container behind ``visibility: hidden`` from
+the moment it renders and reveals it only once every ``<link>`` stylesheet in the
+pane's shadow root has fired a ``load`` event
+(``PanelMarkupView.watch_stylesheets`` -> ``style_redraw``). That reveal is armed
+exactly once, during ``render()``.
+
+A pane built after the page has loaded -- every cell the plot poll loop rebuilds,
+every widget a callback adds to a live layout -- first renders with the design's
+stylesheet URLs still pointing at cdn.holoviz.org, because its model is not
+attached to a document yet and Panel falls back to ``CDN_DIST``. Panel then
+patches those URLs to the locally served copies, swapping the pane's ``<link>``
+elements for new ones. The load events the reveal is waiting on belong to the
+discarded elements and never arrive, so the pane stays invisible for the rest of
+the session while its Bokeh model, text and layout are all correct and
+live-updating (#1154).
+
+Overriding the reveal is safe here: our markup carries inline styling, so there
+is no unstyled-content flash to suppress, and the content has to show the moment
+it is inserted.
+"""
+
+from typing import Any, ClassVar
+
+from panel.pane.markup import HTMLBasePane
+from panel.theme import Material
+from panel.theme.base import Inherit
+from panel.viewable import Viewable
+
+_ALWAYS_VISIBLE_MARKUP = ':host > div { visibility: visible !important; }'
+
+
+class LivedataDesign(Material):
+    """Material design that keeps markup panes visible when built post-load."""
+
+    modifiers: ClassVar[dict[type[Viewable], dict[str, Any]]] = {
+        HTMLBasePane: {'stylesheets': [Inherit, _ALWAYS_VISIBLE_MARKUP]}
+    }

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -818,14 +818,6 @@ class PlotGridTabs:
                         )
                         continue
 
-                    if is_active:
-                        bounds = (
-                            state.plotter.time_bounds
-                            if state.plotter is not None
-                            else None
-                        )
-                        active_cell_bounds.setdefault(cell_id, {})[layer_id] = bounds
-
                     # Get or create session layer for version tracking
                     session_layer = self._session_layers.get(layer_id)
                     if session_layer is None:
@@ -847,6 +839,19 @@ class PlotGridTabs:
                     self._orchestrator.activate_layer(
                         layer_id, session_layer, is_active
                     )
+
+                    # Sample time bounds after activation, not before: the 0→1
+                    # transition above is what computes the layer's first frame,
+                    # and with it the bounds. Reading earlier would hand the
+                    # pill a pre-compute None on the very pass that reveals the
+                    # cell, blanking it until a later freshness-due poll.
+                    if is_active:
+                        bounds = (
+                            state.plotter.time_bounds
+                            if state.plotter is not None
+                            else None
+                        )
+                        active_cell_bounds.setdefault(cell_id, {})[layer_id] = bounds
 
                     # Push pending data to the browser. Runs after activate_layer
                     # so a tab-switch 0→1 build is sent on this same tick. Gated
@@ -916,10 +921,18 @@ class PlotGridTabs:
         # cadence -- ticking it every poll just animates aging with no new info.
         # The per-layer time/lag row only changes on a new frame, so it tracks
         # the data flush too.
+        #
+        # A rebuild is due as well: a rebuilt cell carries brand-new, blank
+        # panes, so without this it would show no age and no time range until
+        # the next frame or stall tick, however good the data behind it is.
         now_mono = time.monotonic()
         stalled = now_mono - self._last_freshness_update
-        freshness_due = flush_due or stalled >= _FRESHNESS_STALL_INTERVAL_S
-        if freshness_due:
+        rebuilt = bool(cells_to_rebuild)
+        freshness_due = flush_due or rebuilt or stalled >= _FRESHNESS_STALL_INTERVAL_S
+        # Only start the stall interval over when there was something to update:
+        # a pass over a hidden or empty grid would otherwise consume the very
+        # interval a rebuild landing just after it depends on.
+        if freshness_due and active_cell_bounds:
             self._last_freshness_update = now_mono
         for cell_id, per_layer in active_cell_bounds.items():
             cell_widget = self._cells.get(cell_id)
@@ -927,7 +940,7 @@ class PlotGridTabs:
                 continue
             if freshness_due:
                 cell_widget.update_freshness(per_layer)
-            if flush_due:
+            if flush_due or rebuilt:
                 for layer_id, bounds in per_layer.items():
                     cell_widget.update_layer_time(layer_id, bounds)
 

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -175,9 +175,9 @@ def test_rebuilt_cell_titlebar_panes_are_visible_without_cdn_access():
     in it has fired ``load``, and arms that reveal once, while rendering. A pane
     built after page load -- every cell the poll loop rebuilds -- first renders
     against cdn.holoviz.org URLs, which Panel then swaps for the locally served
-    copies; the load events the reveal waits on belong to the discarded links.
-    The pane's model, text and layout stay correct, so the failure is invisible
-    to every assertion except a visibility check.
+    copies; the load events the reveal waits on belong to the discarded links
+    (holoviz/panel#8696). The pane's model, text and layout stay correct, so the
+    failure is invisible to every assertion except a visibility check.
 
     Blocking the CDN, as the deployment network does, makes those links fail for
     certain instead of racing the swap, which is what makes this deterministic.

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -9,6 +9,8 @@ through the stable ``lt-*`` automation hooks:
 - session reload restores tabs and live updates;
 - a grid created in one session appears in others without stealing focus;
 - a cell title survives a no-op Save of the cell-properties modal;
+- a cell rebuilt in an open session renders its titlebar rather than an
+  invisible one;
 - disabling or removing a grid keeps the remaining tabs resolving and
   updating;
 - two sessions racing to save edits on the same grid converge on one title,
@@ -25,6 +27,7 @@ cleanly where Playwright is absent).
 from __future__ import annotations
 
 import copy
+import re
 from pathlib import Path
 
 import pytest
@@ -162,6 +165,45 @@ def test_cell_title_survives_noop_save_of_cell_properties_modal():
         assert page.get_by_text("My Cell", exact=True).first.is_visible()
         dash.open_modal(pencil)
         assert page.locator(_CELL_TITLE_INPUT).input_value() == "My Cell"
+
+
+@pytest.mark.browser
+def test_rebuilt_cell_titlebar_panes_are_visible_without_cdn_access():
+    """A cell rebuilt in an open session must show its titlebar, not hide it.
+
+    Panel reveals a markup pane's content only once every stylesheet ``<link>``
+    in it has fired ``load``, and arms that reveal once, while rendering. A pane
+    built after page load -- every cell the poll loop rebuilds -- first renders
+    against cdn.holoviz.org URLs, which Panel then swaps for the locally served
+    copies; the load events the reveal waits on belong to the discarded links.
+    The pane's model, text and layout stay correct, so the failure is invisible
+    to every assertion except a visibility check.
+
+    Blocking the CDN, as the deployment network does, makes those links fail for
+    certain instead of racing the swap, which is what makes this deterministic.
+    Which pane loses that race varies, so both titlebar panes are checked.
+    """
+    with fake_dashboard("dummy") as fake, Dashboard.connect(fake.url) as dash:
+        page = dash.page
+        page.route("**cdn.holoviz.org/**", lambda route: route.abort())
+        dash.goto_tab("Detectors")
+
+        # Renaming rebuilds the cell, minting fresh titlebar panes.
+        dash.open_modal(".lt-cell-r0c0.lt-tool-pencil")
+        page.locator(_CELL_TITLE_INPUT).fill("Rebuilt Cell")
+        page.get_by_role("button", name="Save", exact=True).click()
+
+        title = page.get_by_text("Rebuilt Cell", exact=True).first
+        wait_until(
+            dash, lambda: title.count() > 0, label="renamed cell title in the DOM"
+        )
+        assert title.is_visible(), "rebuilt cell title is in the DOM but invisible"
+
+        # The freshness pill is the same kind of pane and the symptom that was
+        # reported; it fills on the first freshness-due poll after the rebuild.
+        pill = page.get_by_text(re.compile(r"^\d+(\.\d+)?[sm]$")).first
+        wait_until(dash, lambda: pill.count() > 0, label="freshness pill in the DOM")
+        assert pill.is_visible(), "freshness pill is in the DOM but invisible"
 
 
 @pytest.mark.browser

--- a/tests/dashboard/design_test.py
+++ b/tests/dashboard/design_test.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from __future__ import annotations
+
+import panel as pn
+import pytest
+from bokeh.models import InlineStyleSheet
+
+from ess.livedata.dashboard.design import LivedataDesign
+
+
+@pytest.mark.parametrize(
+    'pane', [pn.pane.HTML('<b>x</b>'), pn.pane.Markdown('x'), pn.pane.Str('x')]
+)
+def test_design_keeps_markup_panes_visible(pane: pn.pane.PaneBase) -> None:
+    """Markup panes must not depend on Panel's stylesheet-load reveal.
+
+    Panel hides a markup pane until every stylesheet link in it fires ``load``,
+    which never happens for panes built after page load, leaving them invisible
+    for the rest of the session (see ``dashboard.design``).
+    """
+    model = pane.get_root()
+    LivedataDesign().apply(pane, model)
+
+    css = [
+        sheet.css if isinstance(sheet, InlineStyleSheet) else sheet
+        for sheet in model.stylesheets
+        if isinstance(sheet, InlineStyleSheet | str)
+    ]
+    assert any('visibility: visible !important' in rule for rule in css)

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -372,6 +372,63 @@ class TestFreshnessIndicator:
         # The cell pill must still show with two layers.
         assert 'border-radius' in cell_widget.freshness_pane.object
 
+    def test_rebuilt_cell_refills_its_time_panes_on_the_same_poll(
+        self, plot_orchestrator, plot_data_service, plot_grid_tabs
+    ):
+        """A rebuild mints blank panes, so the poll that rebuilds must refill them.
+
+        Otherwise the cell shows no age and no time range until the next frame
+        or the stall tick, however good the data behind it is.
+        """
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        layer_id = _inject_layer(
+            plot_orchestrator,
+            plot_data_service,
+            grid_id,
+            FakePlotter(cached_state=_make_layout(), time_bounds=_make_bounds(2.0)),
+        )
+        plot_grid_tabs._poll_for_plot_updates()
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+        plot_grid_tabs._poll_for_plot_updates()
+
+        # A new plotter bumps the layer version, so the next poll rebuilds the
+        # cell -- without a new frame, which would have refreshed it anyway.
+        plot_data_service.job_started(
+            layer_id,
+            FakePlotter(cached_state=_make_layout(), time_bounds=_make_bounds(3.0)),
+        )
+        plot_data_service.data_arrived(layer_id)
+        plot_grid_tabs._poll_for_plot_updates()
+
+        (cell_widget,) = plot_grid_tabs._cells.values()
+        assert 'border-radius' in cell_widget.freshness_pane.object
+        assert 'Lag:' in cell_widget.layer_time_panes[layer_id].object
+
+    def test_poll_updating_nothing_does_not_consume_the_stall_interval(
+        self, plot_orchestrator, plot_data_service, plot_grid_tabs
+    ):
+        """The stall clock budgets the next update; it is not a poll counter.
+
+        Polls over a hidden grid update no cell. Restarting the interval on
+        them would make a cell revealed just afterwards wait a further full
+        interval before the stall path could fill its pill.
+        """
+        grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
+        _inject_layer(
+            plot_orchestrator,
+            plot_data_service,
+            grid_id,
+            FakePlotter(cached_state=_make_layout(), time_bounds=_make_bounds(2.0)),
+        )
+        # Leave a non-plot static tab active so the grid is hidden.
+        plot_grid_tabs.tabs.active = 0
+        stall_clock = plot_grid_tabs._last_freshness_update
+
+        plot_grid_tabs._poll_for_plot_updates()
+        plot_grid_tabs._poll_for_plot_updates()
+
+        assert plot_grid_tabs._last_freshness_update == stall_clock
+
     def test_hidden_grid_does_not_update_freshness(
         self, plot_orchestrator, plot_data_service, plot_grid_tabs
     ):


### PR DESCRIPTION
Cells rebuilt while their tab is open lost their whole titlebar — cell title and freshness pill both — until the page was reloaded. The plots themselves kept updating, which is what made this look like a freshness-data bug.

## Root cause

Panel keeps a markup pane's content behind `visibility: hidden` from the moment it renders and reveals it only once every `<link>` stylesheet in the pane has fired `load` (`PanelMarkupView.watch_stylesheets` -> `style_redraw`). That reveal is armed exactly once, during `render()`.

A pane built after page load — every cell the plot poll loop rebuilds — first renders with the design's stylesheet URLs pointing at cdn.holoviz.org, because its model is not attached to a document yet and Panel falls back to `CDN_DIST`. Panel then patches those URLs to the locally served copies, which swaps the pane's `<link>` elements. The load events the reveal is waiting on belong to the discarded elements and never arrive, so the pane stays invisible for the rest of the session with a correct, live-updating Bokeh model behind it.

CDN reachability is not the trigger, only who wins the race: stubbing every CDN request with a `200` still reproduced it, because the links are detached before they finish. That is why it looked intermittent. It reproduces in ~20 lines of plain Panel 1.9.3 (`MaterialTemplate` plus a pane appended from a periodic callback) and does not reproduce without the template, so it is an upstream bug — reported as holoviz/panel#8696. A `Design` modifier overrides the reveal for every markup pane in the app until a Panel release re-arms it.

## Also fixed

The structural contributors listed in the issue, which delayed a rebuilt cell's pill and time range by up to a poll each: bounds were sampled before `activate_layer` (i.e. before the 0->1 transition that computes a newly revealed layer's first frame), a rebuild did not make the panes due for a refresh, and the stall clock restarted on passes that updated nothing.

The fourth item — a `STOPPED`-at-setup layer not being un-frozen by data alone — is left alone. `data_arrived()` is a deliberate no-op in `STOPPED` ("a layer bound to a stopped workflow's retained data renders it but stays STOPPED"), so the gap is in how `_setup_layer` classifies "job number not observed yet" versus "genuinely stopped". That is a state-machine design question, not a drive-by.

## Tests

A browser regression test rebuilds a cell in an open session and asserts the title and the pill are visible; it blocks cdn.holoviz.org, as the deployment network does, so the discarded links fail for certain rather than racing the swap. It fails on `main` and passes here. Two unit tests cover the refresh timing, and one covers the design modifier. The reordering of the bounds sample has no unit coverage: the poll-test harness bypasses data subscriptions, so `activate_layer` never computes there.

## Test plan

- [x] `pytest tests/dashboard` (1972 passed)
- [x] `pytest -m browser` (12 passed)
- [x] Manual: open a session, start a stopped workflow from the Workflows tab, return to the plot tab — pills and titles show without a reload


Closes #1154. Workaround-removal reminder: #1175.
