### PR TITLE
Let a plot layer recover from a transient error

### DIFF
--- a/src/ess/livedata/dashboard/plot_data_service.py
+++ b/src/ess/livedata/dashboard/plot_data_service.py
@@ -46,11 +46,17 @@ class LayerState(Enum):
     STOPPED → WAITING_FOR_DATA           [job_started(plotter)]
     STOPPED → ERROR                      [error_occurred(msg)]
 
+    ERROR → READY                        [data_arrived()]
     ERROR → WAITING_FOR_DATA             [job_started(plotter)]
 
     A layer in STOPPED may still display retained data: ``data_arrived``
     while STOPPED is a no-op and ``has_displayable_plot`` reports True once
     the plotter holds a computed frame.
+
+    ERROR is left by evidence that the layer works again — a completed build
+    — or by a fresh job. A stop is not such evidence, so ``job_stopped`` while
+    in ERROR is a no-op: an error needs attention and outranks the frozen-
+    snapshot presentation of STOPPED.
     """
 
     WAITING_FOR_DATA = auto()
@@ -139,7 +145,13 @@ class LayerStateMachine:
         """
         Transition to READY when data arrives.
 
-        Valid from: WAITING_FOR_DATA.
+        Valid from: WAITING_FOR_DATA and ERROR. Recovering from ERROR is
+        deliberate: extraction and compute keep running for an errored layer,
+        so a completed build proves the fault cleared and a transient failure
+        must not blank the plot until the workflow restarts. An intermittent
+        fault therefore makes the cell alternate between plot and error —
+        noisier than settling, but not stale.
+
         No-op from READY (data continues to arrive after first update) and
         from STOPPED (a layer bound to a stopped workflow's retained data
         renders it but stays STOPPED).
@@ -147,24 +159,21 @@ class LayerStateMachine:
         if self._state in {LayerState.READY, LayerState.STOPPED}:
             return
 
-        if self._state != LayerState.WAITING_FOR_DATA:
-            logger.warning(
-                "Invalid transition: data_arrived() called in state %s (expected %s)",
-                self._state.name,
-                LayerState.WAITING_FOR_DATA.name,
-            )
-            return
-
         self._state = LayerState.READY
+        self._error_message = None
         self._version += 1
 
     def job_stopped(self) -> None:
         """
         Transition to STOPPED when job is stopped.
 
-        Valid from: WAITING_FOR_DATA, READY.
+        Valid from: WAITING_FOR_DATA, READY. No-op from ERROR, where the error
+        is the more informative presentation and is kept.
         Marks presenters dirty so sessions see the change.
         """
+        if self._state is LayerState.ERROR:
+            return
+
         valid_from = {LayerState.WAITING_FOR_DATA, LayerState.READY}
         if self._state not in valid_from:
             logger.warning(

--- a/tests/dashboard/plot_data_service_test.py
+++ b/tests/dashboard/plot_data_service_test.py
@@ -184,6 +184,53 @@ class TestLayerStateMachineOtherTransitions:
         assert state.state == LayerState.ERROR
 
 
+class TestLayerStateMachineErrorRecovery:
+    """ERROR must be left by evidence the layer works, not only by a restart."""
+
+    def test_data_arrived_recovers_from_error(self):
+        """A completed build proves the fault cleared, so the layer heals."""
+        state = LayerStateMachine()
+        plotter = FakePlotter()
+        state.job_started(plotter)
+        state.error_occurred("boom")
+        version_at_error = state.version
+
+        state.data_arrived()
+
+        assert state.state == LayerState.READY
+        assert state.error_message is None
+        assert state.version == version_at_error + 1
+
+    def test_recovered_layer_displays_its_plot(self):
+        """The point of recovering: the cell stops showing the error
+        placeholder for a layer whose data computes fine."""
+        state = LayerStateMachine()
+        plotter = FakePlotter()
+        state.job_started(plotter)
+        state.error_occurred("boom")
+        plotter.compute({'data': 1})
+        assert not state.has_displayable_plot()
+
+        state.data_arrived()
+
+        assert state.has_displayable_plot()
+
+    def test_job_stopped_leaves_error_intact(self):
+        """A stop is not evidence the fault cleared; the error needs attention
+        and outranks the frozen-snapshot presentation of STOPPED."""
+        state = LayerStateMachine()
+        plotter = FakePlotter()
+        state.job_started(plotter)
+        state.error_occurred("boom")
+        version_at_error = state.version
+
+        state.job_stopped()
+
+        assert state.state == LayerState.ERROR
+        assert state.error_message == "boom"
+        assert state.version == version_at_error
+
+
 class TestPlotDataService:
     """Tests for PlotDataService."""
 

--- a/tests/dashboard/plot_orchestrator_test.py
+++ b/tests/dashboard/plot_orchestrator_test.py
@@ -1177,6 +1177,56 @@ class TestBuildRobustness:
         assert state.state is LayerState.ERROR
         assert "extractor boom" in state.error_message
 
+    def test_layer_recovers_from_transient_extraction_error(
+        self,
+        workflow_id,
+        workflow_spec,
+        job_orchestrator,
+        fake_data_service,
+        fake_stream_manager,
+    ):
+        """A fault that clears must not leave the layer stuck in ERROR: the
+        next successful build is evidence the layer is healthy again."""
+        from ess.livedata.dashboard.extractors import LatestValueExtractor
+
+        fail = [True]
+
+        class FlakyExtractor(LatestValueExtractor):
+            def extract(self, data):
+                if fail[0]:
+                    raise RuntimeError("extractor boom")
+                return super().extract(data)
+
+        controller = FakePlottingController(
+            stream_manager=fake_stream_manager, extractor_factory=FlakyExtractor
+        )
+        plot_data_service = PlotDataService()
+        orchestrator = PlotOrchestrator(
+            plotting_controller=controller,
+            job_orchestrator=job_orchestrator,
+            data_service=fake_data_service,
+            instrument='dummy',
+            plot_data_service=plot_data_service,
+        )
+        grid_id = orchestrator.add_grid(title='Test Grid', nrows=3, ncols=3)
+        config = make_plot_config(workflow_id)
+        cell_id = add_cell_with_layer(orchestrator, grid_id, DEFAULT_GEOMETRY, config)
+        layer_id = orchestrator.get_cell(cell_id).layers[0].layer_id
+        commit_workflow_for_test(job_orchestrator, workflow_id, workflow_spec)
+
+        feed_result_data(fake_data_service, config, workflow_id)
+        orchestrator.flush_frames()
+        assert plot_data_service.get(layer_id).state is LayerState.ERROR
+
+        fail[0] = False
+        feed_result_data(fake_data_service, config, workflow_id)
+        orchestrator.flush_frames()
+
+        state = plot_data_service.get(layer_id)
+        assert state.state is LayerState.READY
+        assert state.error_message is None
+        assert state.has_displayable_plot()
+
     def test_stale_build_does_not_mark_swapped_plotter_ready(
         self,
         plot_orchestrator,


### PR DESCRIPTION
Fixes #1169.

`LayerState.ERROR` was only ever left via `job_started`, yet the build path keeps running for an errored layer: the data subscription marks it dirty regardless of state and `flush_frames` gates only on `has_viewers`. So a single transient extraction or compute failure left a layer permanently blank — extraction and `plotter.compute` recovered and kept succeeding silently, `has_displayable_plot()` stayed False so the cell rendered the error placeholder, and `Invalid transition: data_arrived() called in state ERROR` was logged once per flush, i.e. at data rate. Recovery required a workflow restart or re-adding the layer.

A completed build is evidence the fault cleared, so `data_arrived()` now recovers the layer to READY and clears the error message. The trade-off, as noted in the issue: a genuinely intermittent fault makes the cell alternate between plot and error rather than settling — noisier, but not stale. Counting consecutive successes before clearing is the fallback if flapping turns out to matter; it does not look warranted yet.

One further consequence worth flagging: a layer whose plotter *re-creation* fails on a generation change (`_reset_layer_presentation`) also self-clears on the next frame, and keeps rendering with the previous generation's plotter — so its internal accumulation, such as autoscale ranges, is not reset. I think that is right, since `create_plotter` succeeded earlier with the same config and such a failure is therefore environmental rather than deterministic, but it does turn that error into a transient one in the UI.

A stop is not evidence the fault cleared, so `job_stopped()` while in ERROR is now an explicit no-op rather than a logged "invalid transition". This is reachable for layers whose plotter creation or pipeline setup failed — no data can flow, so they cannot heal, and the workflow stopping later emitted a spurious warning. Keeping the error also matches the cell titlebar, where an errored layer already outranks a stopped one.

Not observed in production: seven days of dashboard journals across the bifrost, dream, loki and tbl hosts contain no `Invalid transition` lines.

## Test plan

- New orchestrator test with real components (extractor that fails once, then works) reproduces the stuck layer on `main` and passes here.
- New state-machine tests cover ERROR → READY, the resulting `has_displayable_plot()`, and ERROR surviving a stop.
- Full dashboard suite passes. The four `tests/preprocessors/to_nxlog_test.py` failures in the full run are a pre-existing numpy timedelta deprecation, unrelated to this change.
