### PR TITLE
Print browser-test failure diagnostics, and reap killed dashboards

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -103,6 +103,26 @@ UI, then copying the persisted `workflow_configs.yaml` (strip the runtime
 `current_job` key, keep `jobs`) and `plot_configs.yaml` from the config
 dir back into the fixture; `ui_config_fixtures_test.py` guards against drift.
 
+**Diagnosing a failure.** When a block driving a session raises, everything is printed
+to **stdout** — browser console tail, page state (active tab, dialog count and how many
+of them are visible, `lt-*` hook inventory), a base64 JPEG screenshot, and the
+dashboard's server log tail. Nothing is uploaded as a CI artifact, deliberately: the
+artifact endpoint is firewalled in the devcontainer, whereas stdout lands in the pytest
+failure report and in the run-level log zip, which is allowlisted and readable mid-run
+(`gh api repos/scipp/esslivedata/actions/runs/<id>/logs > run.zip`). Recover the
+screenshot with the `base64 -d` pipeline the log prints next to it.
+
+`dialogs` vs `dialogs_visible` is the first thing to read on a modal timeout: a dialog
+present but not visible means it rendered and was hidden, none at all means the click
+never reached its handler.
+
+One console line is a red herring: `pageerror: Cannot read properties of undefined
+(reading 'parent_style')` fires on **every** run, passing or failing. It is
+[bokeh#15274](https://github.com/bokeh/bokeh/issues/15274) — our plot grid is a
+`pn.GridSpec`, i.e. a Bokeh `GridBox`, and Panel emits a `children` change and the
+recomputed sizing props in one patch, which that view indexes inconsistently. Real bug
+(it drops the rest of the patch), but it is not the cause of any intermittent failure.
+
 **Ports.** `fake_dashboard(...)` without a port takes one the OS reports free — how the
 browser tests launch, so two checkouts (or a suite next to an interactive dashboard) can
 run at once. Do not hand a test a port literal; they collide silently across branches.

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -27,6 +27,13 @@ Two ways to use it:
       # launch fake backend + fixture, screenshot the Detectors grid, tear down
       python scripts/drive_dashboard.py --launch --tab Detectors --screenshot out.png
 
+When a block driving a :class:`Dashboard` raises, everything known about the
+session is printed to stdout: the browser console tail, the page state (active
+tab, dialogs, ``lt-*`` hooks), a base64 PNG screenshot, and the dashboard's own
+log tail. An intermittent failure is over by the time it is known to be one, so
+it has to be captured as it happens -- and on stdout, where pytest folds it into
+the failure report and the run-level log carries it out of CI.
+
 The ``lt-*`` classes are the stable automation contract (see the rule file).
 Plain Playwright CSS locators pierce the dashboard's open shadow DOM, so
 ``page.locator(".lt-tool-settings")`` works -- but **descendant combinators do
@@ -38,6 +45,7 @@ descendant one (``.lt-wf-total_counts .lt-tool-player-stop`` matches nothing).
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import shutil
@@ -47,6 +55,8 @@ import sys
 import tempfile
 import time
 import urllib.request
+from collections import deque
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -72,6 +82,15 @@ SETTLE_MS = 5000
 # Override the Chromium binary when the installed playwright package does not
 # match the browsers available on disk (e.g. a preprovisioned container).
 _CHROMIUM_ENV = "PLAYWRIGHT_CHROMIUM_EXECUTABLE"
+# Console lines kept per session. A dashboard session logs steadily, so the tail
+# is what matters and the cap keeps a long run from growing without bound.
+CONSOLE_LIMIT = 200
+# Server log lines printed when a driven session fails.
+SERVER_LOG_TAIL = 60
+# Base64 wraps at this width so no single log line grows unbounded. Failure
+# screenshots stay PNG: they are inlined into the log, and a dashboard is flat
+# colour and text, which PNG encodes smaller than even a lossy JPEG.
+BASE64_WIDTH = 120
 
 
 def _launch_browser(playwright) -> Browser:
@@ -79,20 +98,18 @@ def _launch_browser(playwright) -> Browser:
     return playwright.chromium.launch(executable_path=executable or None)
 
 
-def _open_session(browser: Browser, url: str, settle_ms: int) -> Page:
-    """One dashboard session: an isolated context, loaded and settled."""
-    context = browser.new_context(viewport={"width": 1600, "height": 1000})
-    page = context.new_page()
-    page.goto(url, wait_until="networkidle")
-    page.wait_for_timeout(settle_ms)
-    return page
-
-
 class Dashboard:
     """Thin Playwright wrapper exposing the dashboard's stable automation hooks."""
 
     def __init__(self, page: Page):
         self.page = page
+        # A click that reaches a widget whose JS never acted on it looks like a
+        # success from Python: the element was there, the click landed, nothing
+        # happened. The browser console is the only place that leaves a trace,
+        # so collect it from construction rather than from first failure.
+        self.console: deque[str] = deque(maxlen=CONSOLE_LIMIT)
+        page.on("console", lambda msg: self.console.append(f"{msg.type}: {msg.text}"))
+        page.on("pageerror", lambda err: self.console.append(f"pageerror: {err}"))
 
     @classmethod
     @contextmanager
@@ -101,7 +118,8 @@ class Dashboard:
         with sync_playwright() as p:
             browser = _launch_browser(p)
             try:
-                yield cls(_open_session(browser, url, settle_ms))
+                with _sessions(browser, url, 1, settle_ms) as dashboards:
+                    yield dashboards[0]
             finally:
                 browser.close()
 
@@ -122,7 +140,8 @@ class Dashboard:
         with sync_playwright() as p:
             browser = _launch_browser(p)
             try:
-                yield [cls(_open_session(browser, url, settle_ms)) for _ in range(n)]
+                with _sessions(browser, url, n, settle_ms) as dashboards:
+                    yield dashboards
             finally:
                 browser.close()
 
@@ -187,6 +206,87 @@ class Dashboard:
         return {"tabs": self.tab_names(), "lt_hooks": dict(sorted(hooks.items()))}
 
 
+def _open_session(browser: Browser, url: str, settle_ms: int) -> Dashboard:
+    """One dashboard session: an isolated context, loaded and settled."""
+    context = browser.new_context(viewport={"width": 1600, "height": 1000})
+    dash = Dashboard(context.new_page())
+    dash.page.goto(url, wait_until="networkidle")
+    dash.page.wait_for_timeout(settle_ms)
+    return dash
+
+
+@contextmanager
+def _sessions(
+    browser: Browser, url: str, count: int, settle_ms: int
+) -> Iterator[list[Dashboard]]:
+    """Open ``count`` sessions, dumping diagnostics if the caller's block raises."""
+    dashboards = [_open_session(browser, url, settle_ms) for _ in range(count)]
+    try:
+        yield dashboards
+    except BaseException:
+        _dump_diagnostics(dashboards)
+        raise
+
+
+def _dump_diagnostics(dashboards: list[Dashboard]) -> None:
+    """Print everything known about each session at the moment it failed.
+
+    Everything goes to stdout, including the screenshot, because that is the
+    one channel that reaches whoever is reading. pytest folds captured output
+    into the failure report, and the run-level log zip is downloadable while
+    the run is still going; CI artifacts are not reachable from every
+    environment we debug from, and an upload that silently matches no files
+    looks exactly like a run that captured nothing.
+
+    Every capture is guarded: this runs while an exception propagates, and a
+    diagnostic that raised would replace the failure it exists to explain.
+    """
+    for index, dash in enumerate(dashboards):
+        for line in dash.console:
+            print(f"[browser-console {index}] {line}")
+        try:
+            print(f"[browser-state {index}] {_page_state(dash)}")
+        except Exception as exc:
+            print(f"[browser-state {index}] unavailable: {exc}")
+        try:
+            shot = dash.page.screenshot(full_page=True)
+        except Exception as exc:
+            print(f"[browser-screenshot {index}] unavailable: {exc}")
+            continue
+        encoded = base64.b64encode(shot).decode()
+        # The note carries a different tag to the payload it describes, so that
+        # the command it quotes does not also match the line quoting it.
+        print(
+            f"[browser-diagnostics] session {index} screenshot: {len(shot)} bytes "
+            f"of png as base64; decode with: grep -o "
+            f"'\\[browser-screenshot {index}\\] .*' log | sed 's/.*\\] //' "
+            f"| tr -d '\\n' | base64 -d > shot.png"
+        )
+        for start in range(0, len(encoded), BASE64_WIDTH):
+            chunk = encoded[start : start + BASE64_WIDTH]
+            print(f"[browser-screenshot {index}] {chunk}")
+
+
+def _page_state(dash: Dashboard) -> dict:
+    """What the page held when it failed: the tab shown, dialogs, and hooks.
+
+    A driven step fails because something it addressed was absent, stale, or
+    never rendered, so the answer is nearly always in one of these three: which
+    tab is actually up, whether a modal exists in the DOM but never became
+    visible (as opposed to never being created), and which ``lt-*`` hooks are
+    present to be clicked.
+    """
+    dialogs = dash.page.locator("[role=dialog]")
+    count = dialogs.count()
+    return {
+        "url": dash.page.url,
+        "active_tab": dash.page.locator(".bk-tab.bk-active").first.inner_text().strip(),
+        "dialogs": count,
+        "dialogs_visible": sum(dialogs.nth(i).is_visible() for i in range(count)),
+        **dash.inventory(),
+    }
+
+
 def _port_in_use(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("127.0.0.1", port)) == 0
@@ -213,6 +313,23 @@ def _free_port() -> int:
 
 def _log_tail(log: Path, lines: int = 15) -> str:
     return "\n".join(log.read_text().splitlines()[-lines:])
+
+
+def _terminate(proc: subprocess.Popen, *, timeout_s: float = 10.0) -> None:
+    """Stop a launched dashboard and reap it.
+
+    Reaping matters on the kill path too: a child that was never waited on is
+    still running when its ``Popen`` is garbage-collected, and the
+    ``ResourceWarning`` that ``__del__`` then raises surfaces as an unraisable
+    exception in whichever test happens to be running at the time -- a failure
+    with no relation to the code under test.
+    """
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
 
 
 def _wait_until_ready(
@@ -318,12 +435,13 @@ def _fake_dashboard(instrument: str, port: int | None = None):
             try:
                 _wait_until_ready(f"http://localhost:{port}", log, proc)
                 yield FakeDashboard(url=f"http://localhost:{port}", log=log)
+            except BaseException:
+                # A browser-side symptom usually has a server-side cause, and
+                # the log dies with the temporary directory below.
+                print(f"[dashboard-log tail]\n{_log_tail(log, SERVER_LOG_TAIL)}")
+                raise
             finally:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
+                _terminate(proc)
 
 
 def main() -> None:

--- a/tests/dashboard/drive_dashboard_test.py
+++ b/tests/dashboard/drive_dashboard_test.py
@@ -62,3 +62,30 @@ def test_wait_until_ready_reports_a_dead_server_instead_of_waiting_it_out(tmp_pa
         )
     assert time.monotonic() - started < 10, "did not fail fast on a dead server"
     assert "Address already in use" in str(exc_info.value)
+
+
+@pytest.mark.browser
+def test_terminate_reaps_a_server_that_ignores_sigterm():
+    # A dashboard too busy to act on SIGTERM has to be killed, and a kill that
+    # is not waited on leaves the child unreaped. ``Popen.__del__`` warns about
+    # exactly that ("still running", i.e. ``returncode is None``) whenever the
+    # object is collected, and pytest turns the warning into a failure of
+    # whichever test is running by then -- never this one. Asserting the child
+    # was reaped is what keeps that failure from being planted here.
+    proc = subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "time.sleep(60)",
+        ],
+    )
+    try:
+        drive_dashboard._terminate(proc, timeout_s=0.5)
+        reaped = proc.returncode
+    finally:
+        # Read the verdict before this net can reap the child itself.
+        proc.kill()
+        proc.wait()
+
+    assert reaped is not None, "killed server was left unreaped"


### PR DESCRIPTION
## Why

The Playwright suite has been failing on roughly a third of CI runs (9 of the last 25 browser jobs; before Aug 2 the preceding 13 were green). It is genuine flakiness, not a regression: runs 30783040638 and 30783040550 are the same commit, one failed and one passed.

There are two distinct failure modes, and only one is fixed here.

## Fixed: killed dashboards were never reaped

The launcher terminates the fake-backend dashboard and, if it does not exit within 10 s, kills it — but never waits on it. An unreaped child is still running when its `Popen` is garbage-collected, so `__del__` raises a `ResourceWarning`, `filterwarnings = ["error"]` turns it into a failure, and it lands on whichever test happened to be running when the collection fired. That is why it always showed up against the session-churn test and never against the test that actually leaked.

## Not fixed: the modal timeouts (#1174)

The other mode is a click that Playwright reports as landed on the cell pencil or the layer-picker entry, followed by a `[role=dialog]` that never becomes visible. It has never reproduced locally — 11 runs here, 6 of them under 8x CPU throttling, all passed — and CI gave nothing but the bare locator timeout, so it has been re-investigated from scratch every time and diagnosed none of the times.

## So: record the failure, on stdout

A failing session now prints what it knew at the moment it failed: the browser console tail, the page state, a base64 PNG screenshot, and the dashboard's server log tail. Capturing unconditionally is the point — by the time a test is known to have failed, the run that failed is over, and a rerun passes.

All of it goes to stdout rather than a build artifact. pytest folds captured output into the failure report, and the run-level log zip is downloadable while the run is still going, whereas the artifact endpoint is firewalled in the devcontainer where the debugging actually happens. An upload that silently matches no files is also indistinguishable from a run that captured nothing, which is not hypothetical: the first cut of this branch wrote its trace to a dotted directory, `actions/upload-artifact` skips hidden paths unless told otherwise, and it uploaded nothing for the branch's entire life without ever saying so.

The page state is aimed squarely at #1174: which tab is up, how many `[role=dialog]` nodes exist and how many of those are visible, and the `lt-*` hooks present to be clicked. No dialog in the DOM means the click never reached its handler; a dialog present but hidden means it rendered and was hidden again. That is the split the bare timeout never gave us.

One thing to know when reading the console tail: the constant `pageerror: Cannot read properties of undefined (reading 'parent_style')` is *not* the flake. It is bokeh/bokeh#15274 — our plot grid is a `pn.GridSpec`, and Panel emits a `children` change plus the recomputed sizing props in one patch, which `GridBoxView._update_layout` indexes inconsistently. It fires on passing runs too. Real bug, since it drops the rest of the patch, but unrelated to any intermittent failure. The rule file records this so it is not chased twice.

Dropping tracing removes a confound worth naming, too: recording DOM snapshots throughout is not free, and it may itself have shifted the timing of the race being chased. If the modal failures change character rather than staying put, that is the first thing to suspect.

## Test plan

- [x] `pytest -m browser tests/dashboard/` — 14 passed.
- [x] The failure path was exercised with a deliberately raised error: page state, console tail, screenshot and server log tail all appear, and the screenshot round-trips byte-exact out of the captured log via the `base64 -d` pipeline the log prints beside it.
- [x] The reaping fix has a unit test that drives `_terminate` against a process which ignores SIGTERM.
