### PR TITLE
Add single-command launcher for the local development stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ docs/reports/
 *.zip
 *.sqw
 *.nxspe
+
+# Machine-local settings for the dev stack launcher (ess.livedata.scripts.dev)
+dev.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,17 @@ Uses [Copier](https://copier.readthedocs.io/) with [Scipp template](https://gith
 
 Services require Kafka (`docker-compose up kafka`). Use `--dev` for simplified topic structure.
 
+The whole stack runs in one terminal via `esslivedata-dev <instrument>` (or
+`python -m ess.livedata.scripts.dev`): it creates the topics, starts the fakes, the
+backend services and the dashboard, prefixes their logs per service, and stops them
+together on Ctrl-C. Name groups (`detectors`, `monitors`, `reduction`, `timeseries`) to
+run a subset, `--reload` to restart the stack on source changes. Per-machine NeXus
+files to replay come from a git-ignored `dev.toml` (`[nexus_files]` keyed by
+instrument), so switching instrument stays a one-token change.
+
 Services: `fake_monitors`, `fake_detectors`, `fake_logdata`, `monitor_data`, `detector_data`, `data_reduction`, `timeseries`.
-Run as: `python -m ess.livedata.services.<name> --instrument dummy [--dev]`
+Run individually as: `python -m ess.livedata.services.<name> --instrument dummy [--dev]`
+The fakes always publish to the dev topic names, so consuming services need `--dev`.
 
 Dashboard: `python -m ess.livedata.dashboard.reduction --instrument dummy`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,19 +54,15 @@ Uses [Copier](https://copier.readthedocs.io/) with [Scipp template](https://gith
 
 ### Running Services Locally
 
-Services require Kafka (`docker-compose up kafka`). Use `--dev` for simplified topic structure.
-
-The whole stack runs in one terminal via `esslivedata-dev <instrument>` (or
-`python -m ess.livedata.scripts.dev`): it creates the topics, starts the fakes, the
-backend services and the dashboard, prefixes their logs per service, and stops them
-together on Ctrl-C. Name groups (`detectors`, `monitors`, `reduction`, `timeseries`) to
-run a subset, `--reload` to restart the stack on source changes. Per-machine NeXus
-files to replay come from a git-ignored `dev.toml` (`[nexus_files]` keyed by
-instrument), so switching instrument stays a one-token change.
+Services require Kafka (`docker-compose up kafka`), which the devcontainer does not have.
+Use `--dev` for simplified topic structure. The fakes always publish to the dev topic
+names, so consuming services need `--dev` too, or they subscribe to production topics
+and see nothing.
 
 Services: `fake_monitors`, `fake_detectors`, `fake_logdata`, `monitor_data`, `detector_data`, `data_reduction`, `timeseries`.
-Run individually as: `python -m ess.livedata.services.<name> --instrument dummy [--dev]`
-The fakes always publish to the dev topic names, so consuming services need `--dev`.
+Run as: `python -m ess.livedata.services.<name> --instrument dummy [--dev]`, or the whole
+stack in one terminal with `esslivedata-dev <instrument>` (see the
+`ess.livedata.scripts.dev` docstring).
 
 Dashboard: `python -m ess.livedata.dashboard.reduction --instrument dummy`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dashboard = [
 
 [project.scripts]
 ess-livedata-make-geometry-nexus = "ess.livedata.scripts.make_geometry_nexus:main"
+esslivedata-dev = "ess.livedata.scripts.dev:main"
 esslivedata-workflows = "ess.livedata.scripts.visualize_workflows:main"
 
 [project.urls]

--- a/src/ess/livedata/scripts/dev.py
+++ b/src/ess/livedata/scripts/dev.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Run a local development stack -- fakes, backend services and dashboard.
+
+``esslivedata-dev dream`` replaces the one-terminal-per-service workflow: it
+creates the Kafka topics, starts every service the instrument needs, merges
+their logs into the current terminal with a per-service prefix, and shuts the
+whole stack down on Ctrl-C. ``--reload`` additionally restarts the stack
+whenever a source file under ``ess.livedata`` changes.
+
+Naming a subset of ``SERVICE_GROUPS`` limits what is started, e.g.
+``esslivedata-dev dream monitors timeseries``. The dashboard always runs unless
+``--no-dashboard`` is given.
+
+Machine-local settings -- currently only the NeXus files replayed by
+``fake_detectors`` -- come from a ``dev.toml`` in the current directory or any
+parent, so that switching instrument stays a one-token change::
+
+    [nexus_files]
+    dream = "~/data/268227_00024779_Si_BC_offset_240_deg_wlgth.hdf"
+    loki = "~/data/coda_loki_999999_00008957.hdf"
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import tomllib
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TextIO
+
+from confluent_kafka import KafkaError, KafkaException
+from confluent_kafka.admin import AdminClient, NewTopic  # type: ignore[attr-defined]
+
+from ess.livedata.config import config_names
+from ess.livedata.config.config_loader import load_config
+from ess.livedata.config.instruments import available_instruments
+from ess.livedata.config.streams import get_stream_mapping
+
+SERVICE_GROUPS: dict[str, tuple[str, ...]] = {
+    'detectors': ('fake_detectors', 'detector_data'),
+    'monitors': ('fake_monitors', 'monitor_data'),
+    # data_reduction consumes the raw streams itself, so it needs the fakes but
+    # not detector_data or monitor_data.
+    'reduction': ('fake_detectors', 'fake_monitors', 'data_reduction'),
+    'timeseries': ('fake_logdata', 'timeseries'),
+}
+
+# The fakes publish to the dev topic names unconditionally, so every consuming
+# service has to run with --dev for the topics to line up.
+_FAKES = frozenset({'fake_detectors', 'fake_monitors', 'fake_logdata'})
+
+_COLORS = ('36', '32', '33', '35', '34', '31', '96', '92')
+
+_LOG_LEVELS = ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+
+
+@dataclass(frozen=True)
+class Options:
+    """Everything the stack needs beyond the choice of services."""
+
+    instrument: str
+    log_level: str = 'INFO'
+    nexus_file: str | None = None
+    monitor_mode: str = 'ev44'
+    num_monitors: int = 2
+    port: int = 5009
+
+
+@dataclass(frozen=True)
+class Job:
+    """A subprocess to run as part of the stack."""
+
+    name: str
+    argv: list[str]
+    env: dict[str, str] = field(default_factory=dict)
+
+
+def resolve_services(groups: Sequence[str]) -> list[str]:
+    """Return the services of the named groups, deduplicated, in start order.
+
+    Parameters
+    ----------
+    groups:
+        Names of :data:`SERVICE_GROUPS`. Empty selects all groups.
+    """
+    selected = groups or list(SERVICE_GROUPS)
+    services = [service for name in selected for service in SERVICE_GROUPS[name]]
+    return list(dict.fromkeys(services))
+
+
+def make_jobs(services: Sequence[str], opts: Options, *, dashboard: bool) -> list[Job]:
+    """Build the subprocess commands for the selected services."""
+    jobs = [
+        Job(name=service, argv=_service_command(service, opts)) for service in services
+    ]
+    if dashboard:
+        jobs.append(
+            Job(
+                name='dashboard',
+                argv=[
+                    sys.executable,
+                    '-m',
+                    'ess.livedata.dashboard.reduction',
+                    '--instrument',
+                    opts.instrument,
+                    '--dev',
+                    '--log-level',
+                    opts.log_level,
+                    '--port',
+                    str(opts.port),
+                ],
+                env={'BOKEH_ALLOW_WS_ORIGIN': '*'},
+            )
+        )
+    return jobs
+
+
+def _service_command(service: str, opts: Options) -> list[str]:
+    argv = [
+        sys.executable,
+        '-m',
+        f'ess.livedata.services.{service}',
+        '--instrument',
+        opts.instrument,
+        '--log-level',
+        opts.log_level,
+    ]
+    if service not in _FAKES:
+        argv.append('--dev')
+    if service == 'fake_detectors' and opts.nexus_file is not None:
+        argv += ['--nexus-file', opts.nexus_file]
+    if service == 'fake_monitors':
+        argv += ['--mode', opts.monitor_mode, '--num-monitors', str(opts.num_monitors)]
+    return argv
+
+
+def load_dev_config(start: Path | None = None) -> dict[str, Any]:
+    """Load ``dev.toml`` from ``start`` or the closest parent that has one."""
+    start = (start or Path.cwd()).resolve()
+    for directory in (start, *start.parents):
+        path = directory / 'dev.toml'
+        if path.is_file():
+            with path.open('rb') as file:
+                return tomllib.load(file)
+    return {}
+
+
+def nexus_file_for(instrument: str, config: dict[str, Any]) -> str | None:
+    """Return the configured NeXus file for ``instrument``, if any."""
+    path = config.get('nexus_files', {}).get(instrument)
+    if path is None:
+        return None
+    file = Path(path).expanduser()
+    if not file.is_file():
+        raise SystemExit(f"dev.toml: no such nexus_files[{instrument!r}]: {file}")
+    return str(file)
+
+
+def check_broker_reachable() -> None:
+    """Fail before starting anything if the dev Kafka broker is not up."""
+    servers = load_config(namespace=config_names.kafka, env='dev')['bootstrap.servers']
+    host, _, port = servers.split(',')[0].rpartition(':')
+    try:
+        with socket.create_connection((host, int(port)), timeout=2.0):
+            pass
+    except OSError as e:
+        raise SystemExit(
+            f"No Kafka broker at {servers}: {e}\n"
+            "Start it with 'docker compose up -d kafka'."
+        ) from e
+
+
+def ensure_topics_exist(instrument: str) -> None:
+    """Create the topics consumers validate at startup.
+
+    Consumers fail fast on missing topics (``validate_topics_exist``), and
+    broker-side auto-creation only triggers on produce, so a pristine broker
+    (CI, fresh local setup) needs the topics created up front. Idempotent.
+    """
+    mapping = get_stream_mapping(instrument=instrument, dev=True)
+    topics = (
+        mapping.detector_topics
+        | mapping.area_detector_topics
+        | mapping.monitor_topics
+        | mapping.log_topics
+        | {
+            mapping.topics.livedata_commands,
+            mapping.topics.livedata_data,
+            mapping.topics.livedata_responses,
+            mapping.topics.livedata_roi,
+            mapping.topics.livedata_status,
+            mapping.topics.filewriter,
+        }
+    )
+    admin = AdminClient(load_config(namespace=config_names.kafka, env='dev'))
+    futures = admin.create_topics(
+        [NewTopic(topic, num_partitions=1) for topic in sorted(topics)]
+    )
+    for future in futures.values():
+        try:
+            future.result()
+        except KafkaException as e:
+            if e.args[0].code() != KafkaError.TOPIC_ALREADY_EXISTS:
+                raise
+
+
+class Stack:
+    """A group of subprocesses that are started, logged and stopped together."""
+
+    def __init__(self, jobs: Sequence[Job]) -> None:
+        self._jobs = jobs
+        self._procs: dict[str, subprocess.Popen[str]] = {}
+        self._threads: list[threading.Thread] = []
+        self._width = max(len(job.name) for job in jobs)
+        self._write_lock = threading.Lock()
+
+    def start(self) -> None:
+        self._threads = []
+        for index, job in enumerate(self._jobs):
+            # Unbuffered output, else the pipe holds back log lines in 8k chunks.
+            env = {**os.environ, 'PYTHONUNBUFFERED': '1', **job.env}
+            proc = subprocess.Popen(  # noqa: S603
+                job.argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                env=env,
+            )
+            self._procs[job.name] = proc
+            thread = threading.Thread(
+                target=self._forward_output,
+                args=(job.name, _COLORS[index % len(_COLORS)], proc.stdout),
+                daemon=True,
+            )
+            thread.start()
+            self._threads.append(thread)
+
+    def _forward_output(self, name: str, color: str, stream: TextIO) -> None:
+        prefix = f'\033[{color}m{name:>{self._width}}\033[0m | '
+        with stream:  # closes the pipe once the job stops writing
+            for line in stream:
+                with self._write_lock:
+                    sys.stdout.write(prefix + line)
+                    sys.stdout.flush()
+
+    @property
+    def running(self) -> list[str]:
+        """Names of the jobs that are still alive."""
+        return [name for name, proc in self._procs.items() if proc.poll() is None]
+
+    def exited(self) -> str | None:
+        """Name of a job that is no longer running, if there is one."""
+        return next(
+            (name for name, proc in self._procs.items() if proc.poll() is not None),
+            None,
+        )
+
+    def stop(self, timeout: float = 15.0) -> None:
+        for proc in self._procs.values():
+            if proc.poll() is None:
+                proc.send_signal(signal.SIGINT)
+        deadline = time.monotonic() + timeout
+        for proc in self._procs.values():
+            try:
+                proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+        # Drain what the children logged on their way out before returning.
+        for thread in self._threads:
+            thread.join(timeout=1.0)
+
+
+class SourceWatcher:
+    """Detects edits to the package sources by polling modification times."""
+
+    def __init__(self, root: Path, *, interval: float = 1.0) -> None:
+        self._root = root
+        self._interval = interval
+        self._due = time.monotonic() + interval
+        self._state = self._scan()
+
+    def _scan(self) -> dict[Path, int]:
+        return {path: path.stat().st_mtime_ns for path in self._root.rglob('*.py')}
+
+    def changed(self) -> bool:
+        now = time.monotonic()
+        if now < self._due:
+            return False
+        self._due = now + self._interval
+        state = self._scan()
+        if state == self._state:
+            return False
+        # Let a burst of writes (editor save, git checkout) settle, so that it
+        # triggers a single restart rather than one per file.
+        while True:
+            time.sleep(0.3)
+            settled = self._scan()
+            if settled == state:
+                break
+            state = settled
+        self._state = state
+        return True
+
+
+def run(jobs: Sequence[Job], *, reload: bool) -> int:
+    """Run the stack until Ctrl-C or until one of the jobs exits."""
+    watcher = SourceWatcher(Path(__file__).parents[1]) if reload else None
+    stack = Stack(jobs)
+    stack.start()
+    try:
+        while True:
+            time.sleep(0.2)
+            if (name := stack.exited()) is not None:
+                print(f'\n*** {name} exited, stopping the stack ***')
+                return 1
+            if watcher is not None and watcher.changed():
+                print('\n*** sources changed, restarting ***')
+                stack.stop()
+                stack.start()
+    except KeyboardInterrupt:
+        # Ctrl-C reached the children via the foreground process group already;
+        # stop() below only waits for them and reaps stragglers.
+        print()
+        return 0
+    finally:
+        stack.stop()
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        'instrument', nargs='?', default='dummy', choices=available_instruments()
+    )
+    parser.add_argument(
+        'groups',
+        nargs='*',
+        # Not default=[]: argparse would validate the default against choices.
+        default=None,
+        choices=list(SERVICE_GROUPS),
+        help='Service groups to run. Defaults to all of them.',
+    )
+    parser.add_argument(
+        '--reload',
+        action='store_true',
+        help='Restart the stack when a source file changes.',
+    )
+    parser.add_argument(
+        '--no-dashboard', action='store_true', help='Run backend services only.'
+    )
+    parser.add_argument(
+        '--nexus-file', help='NeXus file to replay, overriding dev.toml.'
+    )
+    parser.add_argument('--log-level', choices=_LOG_LEVELS, default='INFO')
+    parser.add_argument('--port', type=int, default=5009, help='Dashboard port.')
+    parser.add_argument('--monitor-mode', choices=['ev44', 'da00'], default='ev44')
+    parser.add_argument('--num-monitors', type=int, default=2)
+    return parser
+
+
+def main() -> int:
+    args = make_parser().parse_args()
+
+    services = resolve_services(args.groups)
+    opts = Options(
+        instrument=args.instrument,
+        log_level=args.log_level,
+        nexus_file=args.nexus_file
+        or nexus_file_for(args.instrument, load_dev_config()),
+        monitor_mode=args.monitor_mode,
+        num_monitors=args.num_monitors,
+        port=args.port,
+    )
+    check_broker_reachable()
+    ensure_topics_exist(opts.instrument)
+
+    jobs = make_jobs(services, opts, dashboard=not args.no_dashboard)
+    print(f"instrument: {opts.instrument}")
+    print(f"services:   {', '.join(job.name for job in jobs)}")
+    if 'fake_detectors' in services:
+        print(
+            f"nexus file: {opts.nexus_file}"
+            if opts.nexus_file is not None
+            else "nexus file: none, generating random events (set "
+            f"nexus_files.{opts.instrument} in dev.toml to replay a file)"
+        )
+    if not args.no_dashboard:
+        print(f"dashboard:  http://localhost:{opts.port}")
+    return run(jobs, reload=args.reload)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/dev_test.py
+++ b/tests/dev_test.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Tests for the development stack launcher."""
+
+import os
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from ess.livedata.scripts.dev import (
+    SERVICE_GROUPS,
+    Job,
+    Options,
+    SourceWatcher,
+    Stack,
+    load_dev_config,
+    make_jobs,
+    make_parser,
+    nexus_file_for,
+    resolve_services,
+)
+
+
+@pytest.fixture
+def opts() -> Options:
+    return Options(instrument='dream')
+
+
+def commands(opts: Options, groups: list[str] | None = None) -> dict[str, list[str]]:
+    jobs = make_jobs(resolve_services(groups or []), opts, dashboard=True)
+    return {job.name: job.argv for job in jobs}
+
+
+def test_no_groups_selects_all_services() -> None:
+    assert set(resolve_services([])) == {
+        service for group in SERVICE_GROUPS.values() for service in group
+    }
+
+
+def test_services_shared_between_groups_are_started_once() -> None:
+    assert resolve_services(['detectors', 'reduction']).count('fake_detectors') == 1
+
+
+def test_consuming_services_run_in_dev_mode_matching_the_fakes(opts: Options) -> None:
+    argv = commands(opts)
+    assert '--dev' in argv['detector_data']
+    assert '--dev' in argv['data_reduction']
+    # The fakes have no --dev flag, they always publish to the dev topic names.
+    assert '--dev' not in argv['fake_detectors']
+
+
+def test_instrument_is_passed_to_every_job(opts: Options) -> None:
+    for argv in commands(opts).values():
+        assert argv[argv.index('--instrument') + 1] == 'dream'
+
+
+def test_nexus_file_is_passed_to_fake_detectors_only() -> None:
+    argv = commands(Options(instrument='dream', nexus_file='/data/run.hdf'))
+    fake_detectors = argv['fake_detectors']
+    assert fake_detectors[fake_detectors.index('--nexus-file') + 1] == '/data/run.hdf'
+    assert '--nexus-file' not in argv['fake_monitors']
+
+
+def test_dashboard_allows_any_websocket_origin(opts: Options) -> None:
+    (dashboard,) = make_jobs([], opts, dashboard=True)
+    assert dashboard.name == 'dashboard'
+    assert dashboard.env['BOKEH_ALLOW_WS_ORIGIN'] == '*'
+
+
+def test_dashboard_can_be_omitted(opts: Options) -> None:
+    jobs = make_jobs(resolve_services(['monitors']), opts, dashboard=False)
+    assert [job.name for job in jobs] == ['fake_monitors', 'monitor_data']
+
+
+def test_dev_config_is_found_in_parent_directory(tmp_path: Path) -> None:
+    (tmp_path / 'dev.toml').write_text('[nexus_files]\ndream = "run.hdf"\n')
+    nested = tmp_path / 'a' / 'b'
+    nested.mkdir(parents=True)
+    assert load_dev_config(nested) == {'nexus_files': {'dream': 'run.hdf'}}
+
+
+def test_dev_config_is_empty_when_absent(tmp_path: Path) -> None:
+    assert load_dev_config(tmp_path) == {}
+
+
+def test_nexus_file_for_returns_none_for_unconfigured_instrument(
+    tmp_path: Path,
+) -> None:
+    file = tmp_path / 'run.hdf'
+    file.touch()
+    config = {'nexus_files': {'dream': str(file)}}
+    assert nexus_file_for('dream', config) == str(file)
+    assert nexus_file_for('loki', config) is None
+
+
+def test_configured_nexus_file_must_exist(tmp_path: Path) -> None:
+    config = {'nexus_files': {'dream': str(tmp_path / 'missing.hdf')}}
+    with pytest.raises(SystemExit, match=r'missing\.hdf'):
+        nexus_file_for('dream', config)
+
+
+def test_source_watcher_reports_edits(tmp_path: Path) -> None:
+    source = tmp_path / 'mod.py'
+    source.write_text('x = 1\n')
+    watcher = SourceWatcher(tmp_path, interval=0.0)
+    assert not watcher.changed()
+    source.write_text('x = 2\n')
+    os.utime(source, ns=(0, 10**9))  # avoid depending on filesystem mtime resolution
+    assert watcher.changed()
+    assert not watcher.changed()
+
+
+def test_source_watcher_reports_new_and_removed_files(tmp_path: Path) -> None:
+    (tmp_path / 'mod.py').write_text('x = 1\n')
+    watcher = SourceWatcher(tmp_path, interval=0.0)
+    (tmp_path / 'other.py').write_text('y = 1\n')
+    assert watcher.changed()
+    (tmp_path / 'other.py').unlink()
+    assert watcher.changed()
+
+
+def sleeper(name: str) -> Job:
+    return Job(name=name, argv=[sys.executable, '-c', 'import time; time.sleep(60)'])
+
+
+def wait_for_exit(stack: Stack, timeout: float = 20.0) -> str | None:
+    deadline = time.monotonic() + timeout
+    exited: str | None
+    while (exited := stack.exited()) is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    return exited
+
+
+def test_stack_stops_all_jobs() -> None:
+    stack = Stack([sleeper('a'), sleeper('b')])
+    stack.start()
+    assert sorted(stack.running) == ['a', 'b']
+    stack.stop(timeout=20.0)
+    assert stack.running == []
+
+
+def test_stack_reports_a_job_that_died() -> None:
+    stack = Stack([sleeper('alive'), Job(name='dead', argv=[sys.executable, '-c', ''])])
+    try:
+        stack.start()
+        assert wait_for_exit(stack) == 'dead'
+        assert stack.running == ['alive']
+    finally:
+        stack.stop(timeout=20.0)
+
+
+def test_stack_kills_jobs_that_ignore_sigint() -> None:
+    stubborn = textwrap.dedent(
+        """
+        import signal, time
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        print('ready')
+        time.sleep(60)
+        """
+    )
+    stack = Stack([Job(name='stubborn', argv=[sys.executable, '-c', stubborn])])
+    stack.start()
+    time.sleep(1.0)  # let the child install its signal handler
+    stack.stop(timeout=1.0)
+    assert stack.running == []
+
+
+def test_stack_prefixes_output_with_the_job_name(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    stack = Stack([Job(name='talker', argv=[sys.executable, '-c', 'print("hello")'])])
+    stack.start()
+    wait_for_exit(stack)
+    stack.stop(timeout=20.0)
+    out = capfd.readouterr().out
+    assert 'talker' in out  # colour codes sit between the name and the pipe
+    assert '| hello' in out
+
+
+@pytest.mark.parametrize(
+    ('argv', 'instrument', 'groups'),
+    [
+        ([], 'dummy', []),
+        (['dream'], 'dream', []),
+        (['dream', 'monitors', 'detectors'], 'dream', ['monitors', 'detectors']),
+    ],
+)
+def test_cli_takes_instrument_and_groups_as_positionals(
+    argv: list[str], instrument: str, groups: list[str]
+) -> None:
+    args = make_parser().parse_args(argv)
+    assert args.instrument == instrument
+    assert args.groups == groups
+
+
+def test_cli_rejects_unknown_group() -> None:
+    with pytest.raises(SystemExit):
+        make_parser().parse_args(['dream', 'not-a-group'])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,51 +7,12 @@ from collections.abc import Generator
 from dataclasses import dataclass
 
 import pytest
-from confluent_kafka import KafkaError, KafkaException
-from confluent_kafka.admin import AdminClient, NewTopic
 
-from ess.livedata.config import config_names
-from ess.livedata.config.config_loader import load_config
-from ess.livedata.config.streams import get_stream_mapping
+from ess.livedata.scripts.dev import ensure_topics_exist
 from tests.integration.backend import DashboardBackend
 from tests.integration.service_process import ServiceGroup, ServiceProcess
 
 logger = logging.getLogger(__name__)
-
-
-def _ensure_topics_exist(instrument: str) -> None:
-    """Create the topics consumers validate at startup.
-
-    Consumers fail fast on missing topics (``validate_topics_exist``), and
-    broker-side auto-creation only triggers on produce, so a pristine broker
-    (CI, fresh local setup) needs the topics created up front. Idempotent.
-    """
-    mapping = get_stream_mapping(instrument=instrument, dev=True)
-    topics = (
-        mapping.detector_topics
-        | mapping.area_detector_topics
-        | mapping.monitor_topics
-        | mapping.log_topics
-        | {
-            mapping.topics.livedata_commands,
-            mapping.topics.livedata_data,
-            mapping.topics.livedata_responses,
-            mapping.topics.livedata_roi,
-            mapping.topics.livedata_status,
-            mapping.topics.filewriter,
-        }
-    )
-    admin = AdminClient(load_config(namespace=config_names.kafka, env='dev'))
-    futures = admin.create_topics(
-        [NewTopic(topic, num_partitions=1) for topic in sorted(topics)]
-    )
-    for topic, future in futures.items():
-        try:
-            future.result()
-        except KafkaException as e:
-            if e.args[0].code() != KafkaError.TOPIC_ALREADY_EXISTS:
-                raise
-            logger.debug("Topic already exists: %s", topic)
 
 
 @dataclass
@@ -106,7 +67,7 @@ def create_service_group(
         ServiceGroup instance
     """
     instrument, log_level = _get_instrument_and_log_level(request)
-    _ensure_topics_exist(instrument)
+    ensure_topics_exist(instrument)
 
     services_dict = {}
     for name, (module_path, extra_kwargs) in services_config.items():
@@ -151,7 +112,7 @@ def dashboard_backend(request) -> Generator[DashboardBackend, None, None]:
     """
     instrument, log_level_name = _get_instrument_and_log_level(request)
 
-    _ensure_topics_exist(instrument)
+    ensure_topics_exist(instrument)
 
     logger.info("Creating dashboard backend for instrument: %s", instrument)
     with DashboardBackend(


### PR DESCRIPTION
Running the dev stack meant one terminal per service, retyping the instrument (and the NeXus file to replay) everywhere on a switch, and restarting every process by hand after a code change.

`esslivedata-dev <instrument>` (or `python -m ess.livedata.scripts.dev`) now creates the topics, starts the fakes, the backend services and the dashboard as subprocesses, merges their logs into one terminal with a colour-coded per-service prefix, and stops them all together on Ctrl-C or when any of them dies.

```
esslivedata-dev dream                      # everything
esslivedata-dev dream monitors timeseries  # groups as positionals, no flags
esslivedata-dev dream --reload             # restart the stack when sources change
```

Groups are `detectors`, `monitors`, `reduction` and `timeseries`; the dashboard runs unless `--no-dashboard` is given. The `reduction` group starts the fakes plus `data_reduction` only, since reduction consumes the raw streams itself.

The remaining per-machine detail, the NeXus file to replay, comes from a git-ignored `dev.toml` found by walking up from the working directory, so that switching instrument stays a one-token change:

```toml
[nexus_files]
dream = "~/data/268227_00024779_Si_BC_offset_240_deg_wlgth.hdf"
```

Pairing the fakes with `--dev` consumers is now done by construction. Hand-written command lists tend to get this wrong: the fakes publish to the dev topic names unconditionally, so a consumer started without `--dev` subscribes to the production topics and silently sees nothing.

Topic creation moves out of the integration-test conftest into the launcher, which needs the same thing against a pristine broker.

## Test plan

Unit tests cover command construction, group resolution, `dev.toml` lookup, the source watcher and the subprocess supervisor (including killing a job that ignores SIGINT). The full stack against a live broker was not run, as the dev container this was written in has neither docker nor Kafka. Every generated backend command was instead checked against the real service parsers via `--check`.

- [x] `esslivedata-dev dummy` brings up the whole stack and the dashboard shows data
- [ ] `esslivedata-dev dream detectors` with a `dev.toml` entry replays the configured file
- [x] Ctrl-C shuts everything down, leaving no stray processes
- [ ] `--reload` restarts the stack on a source edit
