### PR TITLE
Drop the cosmetic projection enum from detector view specs

### DIFF
--- a/docs/user-guide/adding-new-instruments.md
+++ b/docs/user-guide/adding-new-instruments.md
@@ -474,37 +474,64 @@ instrument.add_logical_view(
 
 #### Geometric Projections (complex geometries)
 
-For detectors with complex 3D geometries, use helper functions to register projections:
+Detectors with complex 3D geometries are projected using their calibrated pixel
+positions. This follows the two-phase pattern: `specs.py` registers *that* there is a
+projection workflow, `factories.py` declares *which* projection each bank uses.
+
+In `specs.py`:
 
 ```python
-from ess.livedata.workflows.detector_view_specs import register_detector_view_spec
-
-# Single projection for all detectors
-xy_handle = register_detector_view_spec(
-    instrument=instrument,
-    projection='xy_plane',
-    source_names=['detector_0', 'detector_1'],
+from ess.livedata.config.workflow_spec import DETECTORS
+from ess.livedata.workflows.detector_view_specs import (
+    DetectorROIAuxSources,
+    DetectorViewOutputs,
+    DetectorViewParams,
 )
 
-# Mixed projections - different projection types per detector
-# Creates a unified "Detector Projection" workflow
-# source_names defaults to the dict keys
-projection_handle = register_detector_view_spec(
-    instrument=instrument,
-    projection={
-        'mantle_detector': 'cylinder_mantle_z',
-        'endcap_backward_detector': 'xy_plane',
-        'endcap_forward_detector': 'xy_plane',
-    },
+projection_handle = instrument.register_spec(
+    group=DETECTORS,
+    name='detector_projection',
+    version=1,
+    title='Detector Projection',
+    description='Projection of the detector banks onto 2D screens.',
+    source_names=detector_names,
+    aux_sources=DetectorROIAuxSources(),
+    params=DetectorViewParams,
+    outputs=DetectorViewOutputs,
 )
 ```
 
-Available projections:
-- `xy_plane`: 2D projection onto XY plane
-- `cylinder_mantle_z`: Cylindrical projection (for detectors like DREAM's mantle)
+In `factories.py`, one `GeometricViewConfig` per bank. Banks with different geometries
+can use different projections and still appear under a single workflow in the UI:
 
-When using a dict for `projection`, each detector can use a different projection type,
-but they will all appear under a single "Detector Projection" workflow in the UI.
+```python
+_view_config = {
+    'mantle_detector': GeometricViewConfig(
+        projection_type='cylinder_mantle_z',
+        resolution={'arc_length': 128, 'z': 128},
+        pixel_noise=sc.scalar(2.0, unit='mm'),
+    ),
+    'endcap_backward_detector': GeometricViewConfig(
+        projection_type='xy_plane',
+        resolution={'x': 128, 'y': 128},
+        pixel_noise=sc.scalar(2.0, unit='mm'),
+    ),
+}
+
+
+@projection_handle.attach_factory()
+def _projection_factory(source_name, params, aux_source_names):
+    factory = DetectorViewFactory(
+        data_source=NeXusDetectorSource(get_nexus_geometry_filename('myinst')),
+        view_config=_view_config,
+    )
+    return factory.make_workflow(source_name, params, aux_source_names)
+```
+
+Available projections (`ProjectionType` in `workflows/detector_view/types.py`):
+- `xy_plane`: projection onto the XY plane
+- `cylinder_mantle_z`: cylinder mantle about Z (e.g. DREAM's mantle)
+- `cylinder_mantle_y`: cylinder mantle about Y (e.g. MAGIC's banks)
 
 Geometric projections are towards the sample position (assumed at the origin).
 For more details see [ess.reduce.live.raw](https://scipp.github.io/essreduce/generated/modules/ess.reduce.live.raw.html).

--- a/src/ess/livedata/config/instruments/dream/specs.py
+++ b/src/ess/livedata/config/instruments/dream/specs.py
@@ -178,15 +178,6 @@ instrument.add_logical_view(
     reduction_dim='other',
 )
 
-# Mapping of detector names to their projection types
-_projections: dict[str, str] = {
-    'mantle_detector': 'cylinder_mantle_z',
-    'endcap_backward_detector': 'xy_plane',
-    'endcap_forward_detector': 'xy_plane',
-    'high_resolution_detector': 'xy_plane',
-    'sans_detector': 'xy_plane',
-}
-
 
 class DreamDetectorViewParams(DetectorViewParams):
     """DREAM-specific detector view parameters with chopper settings."""
@@ -200,7 +191,8 @@ class DreamDetectorViewParams(DetectorViewParams):
 
 # Register detector projection spec with DreamDetectorViewParams for TOF mode.
 # Replaces both the legacy DetectorProjection and the Sciline detector view
-# registrations.
+# registrations. Which projection each bank uses is declared once, on the
+# ``GeometricViewConfig`` entries in ``factories.py``.
 projection_handle = instrument.register_spec(
     group=DETECTORS,
     name='detector_projection',
@@ -210,7 +202,7 @@ projection_handle = instrument.register_spec(
         'Projection of detector banks onto 2D planes. '
         'Uses the appropriate projection for each detector.'
     ),
-    source_names=list(_projections.keys()),
+    source_names=detector_names,
     aux_sources=DetectorROIAuxSources(),
     params=DreamDetectorViewParams,
     outputs=DetectorViewOutputs,

--- a/src/ess/livedata/config/instruments/dummy/specs.py
+++ b/src/ess/livedata/config/instruments/dummy/specs.py
@@ -53,8 +53,6 @@ register_monitor_workflow_specs(
 )
 
 # Register detector view spec.
-# Note: We don't use register_detector_view_specs here because dummy uses
-# DetectorLogicalView which doesn't follow the projection pattern.
 panel_0_view_handle = instrument.register_spec(
     group=DETECTORS,
     name='panel_0_xy',

--- a/src/ess/livedata/config/instruments/loki/specs.py
+++ b/src/ess/livedata/config/instruments/loki/specs.py
@@ -18,13 +18,16 @@ from ess.livedata.config import (
     name_streams,
 )
 from ess.livedata.config.workflow_spec import (
+    DETECTORS,
     MONITORS,
     AuxInput,
     AuxSources,
     WorkflowOutputsBase,
 )
 from ess.livedata.workflows.detector_view_specs import (
-    register_detector_view_spec,
+    DetectorROIAuxSources,
+    DetectorViewOutputs,
+    DetectorViewParams,
 )
 from ess.livedata.workflows.monitor_workflow_specs import (
     MonitorDataParams,
@@ -255,10 +258,16 @@ instrument.add_logical_view(
     output_ndim=1,
 )
 
-xy_projection_handle = register_detector_view_spec(
-    instrument=instrument,
-    projection='xy_plane',
+xy_projection_handle = instrument.register_spec(
+    group=DETECTORS,
+    name='detector_xy_projection',
+    version=1,
+    title='Detector XY Projection',
+    description='Projection of a detector bank onto an XY-plane.',
     source_names=detector_names,
+    aux_sources=DetectorROIAuxSources(),
+    params=DetectorViewParams,
+    outputs=DetectorViewOutputs,
 )
 
 # Register tube view for all detector banks

--- a/src/ess/livedata/workflows/detector_view/projectors.py
+++ b/src/ess/livedata/workflows/detector_view/projectors.py
@@ -7,8 +7,8 @@ This module provides the Projector protocol and concrete implementations for
 projecting detector events from pixel coordinates to screen coordinates.
 
 Two projection strategies are supported:
-1. GeometricProjector: Uses calibrated positions to project to xy_plane or
-   cylinder_mantle_z coordinates.
+1. GeometricProjector: Uses calibrated positions to project to a plane or a
+   cylinder mantle.
 2. LogicalProjector: Reshapes detector data using fold/slice transforms,
    optionally reducing dimensions.
 """
@@ -48,7 +48,7 @@ class GeometricProjector:
     Projects events using geometric coordinate transformation.
 
     Uses calibrated positions (with optional noise replicas) to project
-    detector pixels to screen coordinates (xy_plane or cylinder_mantle_z).
+    detector pixels to screen coordinates (a plane or a cylinder mantle).
     Bins events instead of histogramming counts, preserving TOF information.
 
     Parameters
@@ -317,7 +317,7 @@ def make_geometric_projector(
     coords:
         Calibrated position with noisy replicas from NeXus workflow.
     projection_type:
-        Type of geometric projection ('xy_plane' or 'cylinder_mantle_z').
+        Type of geometric projection; see ``GeometricViewConfig``.
     resolution:
         Resolution (number of bins) for each screen dimension.
     flip_x:

--- a/src/ess/livedata/workflows/detector_view/types.py
+++ b/src/ess/livedata/workflows/detector_view/types.py
@@ -154,7 +154,7 @@ ReductionDim = NewType('ReductionDim', str | list[str] | None)
 # Projection type for geometric views
 ProjectionType = NewType(
     'ProjectionType',
-    str | None,  # Literal['xy_plane', 'cylinder_mantle_z'] | None
+    str | None,  # GeometricViewConfig.projection_type, or None
 )
 """Type of geometric projection to use, or None for logical view."""
 

--- a/src/ess/livedata/workflows/detector_view_specs.py
+++ b/src/ess/livedata/workflows/detector_view_specs.py
@@ -22,9 +22,7 @@ import scipp as sc
 
 from .. import parameter_models
 from ..config import models
-from ..config.instrument import Instrument
 from ..config.workflow_spec import (
-    DETECTORS,
     AuxSources,
     CumulativeOutput,
     JobId,
@@ -32,7 +30,6 @@ from ..config.workflow_spec import (
     WindowOutput,
     WorkflowOutputsBase,
 )
-from .workflow_factory import SpecHandle
 
 CoordinateMode = Literal['toa', 'wavelength']
 
@@ -477,9 +474,6 @@ def make_detector_view_params(
     return DetectorViewWithSpectrumParams
 
 
-ProjectionType = Literal["xy_plane", "cylinder_mantle_z"]
-
-
 class DetectorROIAuxSources(AuxSources):
     """Auxiliary source spec for ROI configuration in detector workflows.
 
@@ -526,109 +520,3 @@ class DetectorROIAuxSources(AuxSources):
             'roi_rectangle': f"{job_id}/roi_rectangle",
             'roi_polygon': f"{job_id}/roi_polygon",
         }
-
-
-def register_detector_view_spec(
-    *,
-    instrument: Instrument,
-    projection: ProjectionType | dict[str, ProjectionType],
-    source_names: list[str] | None = None,
-    spectrum_view: SpectrumViewSpec | None = None,
-) -> SpecHandle:
-    """
-    Register detector view specs for a given projection.
-
-    This is a lightweight helper that registers workflow specs without creating
-    the actual detector view objects.
-
-    Parameters
-    ----------
-    instrument:
-        Instrument to register specs with.
-    projection:
-        Projection type(s) to register. Either a single projection type applied to
-        all sources, or a dict mapping source names to projection types. When a dict
-        is provided, this creates a unified "Detector Projection" workflow that
-        uses different projections for different detector banks.
-    source_names:
-        List of detector source names. Required when projection is a single type.
-        When projection is a dict, defaults to the dict keys if not specified.
-    spectrum_view:
-        Optional spectrum-view configuration. When provided, the registered
-        params/outputs include the spectrum-specific rebin param and the
-        ``spectrum_view`` output field. The factory is still responsible for
-        wiring the transform into the Sciline workflow (pass ``spectrum_view`` on
-        the Sciline ``GeometricViewConfig`` / ``LogicalViewConfig`` when
-        constructing ``DetectorViewFactory``).
-
-    Returns
-    -------
-    :
-        A SpecHandle.
-
-    Example
-    -------
-    Single projection for all detectors:
-
-    .. code-block:: python
-
-        handle = register_detector_view_spec(
-            instrument=instrument,
-            projection='xy_plane',
-            source_names=['detector_0', 'detector_1'],
-        )
-
-    Mixed projections (unified workflow):
-
-    .. code-block:: python
-
-        handle = register_detector_view_spec(
-            instrument=instrument,
-            projection={
-                'mantle_detector': 'cylinder_mantle_z',
-                'endcap_backward_detector': 'xy_plane',
-                'endcap_forward_detector': 'xy_plane',
-            },
-        )
-    """
-    if isinstance(projection, dict):
-        # Mixed projections - create unified "Detector Projection" workflow
-        if source_names is None:
-            source_names = list(projection.keys())
-        name = "detector_projection"
-        title = "Detector Projection"
-        description = (
-            "Projection of detector banks onto 2D planes. "
-            "Uses the appropriate projection for each detector."
-        )
-    elif projection == "xy_plane":
-        if source_names is None:
-            raise ValueError("source_names is required when projection is a string")
-        name = "detector_xy_projection"
-        title = "Detector XY Projection"
-        description = "Projection of a detector bank onto an XY-plane."
-    elif projection == "cylinder_mantle_z":
-        if source_names is None:
-            raise ValueError("source_names is required when projection is a string")
-        name = "detector_cylinder_mantle_z"
-        title = "Detector Cylinder Mantle Z Projection"
-        description = (
-            "Projection of a detector bank onto a cylinder mantle along Z-axis."
-        )
-    else:
-        raise ValueError(f"Unsupported projection: {projection}")
-
-    handle = instrument.register_spec(
-        group=DETECTORS,
-        name=name,
-        version=1,
-        title=title,
-        description=description,
-        source_names=source_names,
-        aux_sources=DetectorROIAuxSources(),
-        params=make_detector_view_params(spectrum_view=spectrum_view),
-        outputs=make_detector_view_outputs(
-            roi_support=True, spectrum_view=spectrum_view
-        ),
-    )
-    return handle

--- a/tests/workflows/detector_view_specs_test.py
+++ b/tests/workflows/detector_view_specs_test.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import subprocess
+import sys
 import uuid
 
 import pytest
 
 from ess.livedata.config.instrument import Instrument
-from ess.livedata.config.workflow_spec import JobId
+from ess.livedata.config.workflow_spec import DETECTORS, JobId
 from ess.livedata.parameter_models import (
     TimeUnit,
     TOARange,
@@ -14,206 +16,52 @@ from ess.livedata.parameter_models import (
 )
 from ess.livedata.workflows.detector_view_specs import (
     CoordinateModeSettings,
+    DetectorROIAuxSources,
+    DetectorViewOutputs,
     DetectorViewParams,
 )
-from ess.livedata.workflows.workflow_factory import SpecHandle
 
 
-class TestRegisterDetectorViewSpecs:
-    """Test the lightweight register_detector_view_specs() function."""
+def test_import_does_not_pull_in_ess_reduce() -> None:
+    """This module is imported to build the spec list, so it must stay cheap.
 
-    def test_register_detector_view_specs_returns_handles(self):
-        """Test that register_detector_view_spec() returns a handle."""
-        from ess.livedata.workflows.detector_view_specs import (
-            register_detector_view_spec,
-        )
-
-        instrument = Instrument(name="test_instrument")
-        source_names = ["detector1", "detector2"]
-
-        handle = register_detector_view_spec(
-            instrument=instrument, projection="xy_plane", source_names=source_names
-        )
-
-        assert isinstance(handle, SpecHandle)
-
-    def test_register_multiple_projections_via_separate_calls(self):
-        """Test registering multiple projections via separate calls."""
-        from ess.livedata.workflows.detector_view_specs import (
-            register_detector_view_spec,
-        )
-
-        instrument = Instrument(name="test_instrument")
-        source_names = ["detector1"]
-
-        xy_handle = register_detector_view_spec(
-            instrument=instrument,
-            projection="xy_plane",
-            source_names=source_names,
-        )
-        cylinder_handle = register_detector_view_spec(
-            instrument=instrument,
-            projection="cylinder_mantle_z",
-            source_names=source_names,
-        )
-
-        assert isinstance(xy_handle, SpecHandle)
-        assert isinstance(cylinder_handle, SpecHandle)
-
-        # Verify both are registered in the factory
-        xy_id = xy_handle.workflow_id
-        cylinder_id = cylinder_handle.workflow_id
-        assert xy_id in instrument.workflow_factory
-        assert cylinder_id in instrument.workflow_factory
-
-    def test_register_mixed_projections_as_dict(self):
-        """Test registering mixed projections with a dict mapping sources to types."""
-        from ess.livedata.workflows.detector_view_specs import (
-            register_detector_view_spec,
-        )
-
-        instrument = Instrument(name="test_instrument")
-        projections = {
-            "mantle_detector": "cylinder_mantle_z",
-            "endcap_detector": "xy_plane",
-        }
-
-        handle = register_detector_view_spec(
-            instrument=instrument,
-            projection=projections,
-        )
-
-        assert isinstance(handle, SpecHandle)
-
-        # Verify spec is registered with unified name
-        spec_id = handle.workflow_id
-        assert spec_id in instrument.workflow_factory
-
-        spec = instrument.workflow_factory[spec_id]
-        assert spec.name == "detector_projection"
-        assert spec.title == "Detector Projection"
-        # source_names should be derived from dict keys
-        assert set(spec.source_names) == {"mantle_detector", "endcap_detector"}
-
-    def test_mixed_projections_spec_includes_roi_aux_sources(self):
-        """Test that mixed projection spec exposes ROI auxiliary sources."""
-        from ess.livedata.workflows.detector_view_specs import (
-            register_detector_view_spec,
-        )
-
-        instrument = Instrument(name="test_instrument")
-        projections = {
-            "detector1": "xy_plane",
-            "detector2": "cylinder_mantle_z",
-        }
-
-        handle = register_detector_view_spec(
-            instrument=instrument,
-            projection=projections,
-        )
-
-        spec = instrument.workflow_factory[handle.workflow_id]
-        assert set(spec.aux_sources.inputs) == {'roi_rectangle', 'roi_polygon'}
-        # ROI is not a context binding (not gated).
-        reg = instrument.workflow_factory.registration(handle.workflow_id)
-        assert reg.context_bindings == ()
-
-    def test_single_projection_requires_source_names(self):
-        """Test that source_names is required when projection is a string."""
-        from ess.livedata.workflows.detector_view_specs import (
-            register_detector_view_spec,
-        )
-
-        instrument = Instrument(name="test_instrument")
-
-        with pytest.raises(ValueError, match="source_names is required"):
-            register_detector_view_spec(
-                instrument=instrument,
-                projection="xy_plane",
-            )
-
-    def test_specs_registered_in_workflow_factory(self):
-        """Test that spec is actually registered in the workflow factory."""
-        from ess.livedata.workflows.detector_view_specs import (
-            register_detector_view_spec,
-        )
-
-        instrument = Instrument(name="test_instrument")
-        source_names = ["detector1"]
-
-        handle = register_detector_view_spec(
-            instrument=instrument, projection="xy_plane", source_names=source_names
-        )
-
-        # Verify spec is in the workflow factory
-        spec_id = handle.workflow_id
-
-        assert spec_id in instrument.workflow_factory
-
-        # Verify spec details
-        spec = instrument.workflow_factory[spec_id]
-        assert spec.instrument == "test_instrument"
-        assert spec.group.name == "detector_data"
-        assert spec.name == "detector_xy_projection"
-        assert spec.source_names == source_names
-
-    def test_specs_have_correct_params(self):
-        """Test that registered spec has the correct params."""
-        from ess.livedata.workflows.detector_view_specs import (
-            DetectorViewParams,
-            register_detector_view_spec,
-        )
-
-        instrument = Instrument(name="test_instrument")
-        source_names = ["detector1"]
-
-        handle = register_detector_view_spec(
-            instrument=instrument, projection="xy_plane", source_names=source_names
-        )
-
-        spec_id = handle.workflow_id
-        spec = instrument.workflow_factory[spec_id]
-
-        assert spec.params is DetectorViewParams
-
-    def test_no_heavy_imports(self):
-        """Test that importing detector_view_specs doesn't import heavy dependencies."""
-        import sys
-
-        # Ensure ess.reduce is not loaded yet
-        if 'ess.reduce' in sys.modules:
-            pytest.skip("ess.reduce already loaded, cannot test import isolation")
-
-        # Import the lightweight module
-        from ess.livedata.preprocessors import detector_view_specs  # noqa: F401
-
-        # Verify ess.reduce was NOT imported
-        assert 'ess.reduce' not in sys.modules
-        assert 'ess.reduce.live' not in sys.modules
-        assert 'ess.reduce.live.raw' not in sys.modules
+    Runs in a subprocess: in-process the check is worthless, since any earlier
+    test may already have imported ess.reduce.
+    """
+    script = (
+        "import sys, ess.livedata.workflows.detector_view_specs;"
+        "leaked = sorted(m for m in sys.modules if m.startswith('ess.reduce'));"
+        "assert not leaked, leaked"
+    )
+    subprocess.run([sys.executable, '-c', script], check=True)  # noqa: S603
 
 
-class TestRegisterDetectorViewSpecROIAuxSources:
-    """ROI auxiliary sources registered by register_detector_view_spec().
+def _register_detector_view(instrument: Instrument, source_names: list[str]):
+    """Register a detector view spec the way an instrument's specs.py does."""
+    return instrument.register_spec(
+        group=DETECTORS,
+        name='detector_xy_projection',
+        version=1,
+        title='Detector XY Projection',
+        description='Projection of a detector bank onto an XY-plane.',
+        source_names=source_names,
+        aux_sources=DetectorROIAuxSources(),
+        params=DetectorViewParams,
+        outputs=DetectorViewOutputs,
+    )
+
+
+class TestDetectorROIAuxSources:
+    """ROI auxiliary sources on detector view specs.
 
     ROI is an auxiliary source, not a gated context binding: the factory wires
     the ROI streams into ``set_context`` itself and the providers treat a
     missing/empty request as "no ROI selected", so there is nothing to gate.
     """
 
-    def test_register_adds_roi_rectangle_and_polygon_aux_sources(self) -> None:
-        from ess.livedata.workflows.detector_view_specs import (
-            DetectorROIAuxSources,
-            register_detector_view_spec,
-        )
-
+    def test_spec_exposes_roi_rectangle_and_polygon_aux_sources(self) -> None:
         instrument = Instrument(name="test_instrument")
-        source_names = ["detector1", "detector2"]
-        handle = register_detector_view_spec(
-            instrument=instrument,
-            projection="xy_plane",
-            source_names=source_names,
-        )
+        handle = _register_detector_view(instrument, ["detector1", "detector2"])
 
         spec = instrument.workflow_factory[handle.workflow_id]
         assert isinstance(spec.aux_sources, DetectorROIAuxSources)
@@ -223,26 +71,13 @@ class TestRegisterDetectorViewSpecROIAuxSources:
         assert reg.context_bindings == ()
 
     def test_roi_aux_render_prefixes_with_job_id(self) -> None:
-        from ess.livedata.workflows.detector_view_specs import (
-            register_detector_view_spec,
-        )
-
-        instrument = Instrument(name="test_instrument")
-        handle = register_detector_view_spec(
-            instrument=instrument,
-            projection="xy_plane",
-            source_names=["detector1"],
-        )
-        spec = instrument.workflow_factory[handle.workflow_id]
         job_id = JobId(source_name='detector1', job_number=uuid.uuid4())
-        assert spec.aux_sources.render(job_id) == {
+        assert DetectorROIAuxSources().render(job_id) == {
             'roi_rectangle': f"{job_id}/roi_rectangle",
             'roi_polygon': f"{job_id}/roi_polygon",
         }
 
     def test_logical_view_with_roi_support_adds_roi_aux_sources(self) -> None:
-        from ess.livedata.workflows.detector_view_specs import DetectorROIAuxSources
-
         instrument = Instrument(name="test_instrument")
         handle = instrument.add_logical_view(
             name='custom_view',


### PR DESCRIPTION
`register_detector_view_spec` took a `projection` argument typed against its own `ProjectionType` literal, but never passed it to a workflow — it selected only the spec's name, title and description. The projection actually performed comes from `GeometricViewConfig.projection_type` in the instrument's factories, and nothing checked that the two agreed, so a spec could advertise "Detector XY Projection" while projecting onto a cylinder mantle.

Two enums for one concept also meant they could drift, and they had. The cosmetic one never gained `cylinder_mantle_y`, so MAGIC had to bypass the helper to register its spec; DREAM kept a bank-to-projection dict whose values nothing read; and the docstrings in `projectors.py` still described the dispatch as handling only `xy_plane` and `cylinder_mantle_z` although it had handled the Y case for a while.

The helper had one caller left, LOKI, which now registers its spec directly the way DREAM, MAGIC and dummy already did. `GeometricViewConfig.projection_type` is now the only place a projection is named.

## No user-visible change

All 56 registered workflow specs across every instrument compare byte-identical before and after (title, description, source names, params, aux sources, group), so no persisted dashboard config is invalidated. LOKI's `detector_xy_projection` keeps its WorkflowId in particular.

## Docs

The instrument guide taught the helper as *the* way to declare a geometric projection. It now shows the two-phase pattern instruments actually use — spec in `specs.py`, one `GeometricViewConfig` per bank in `factories.py` — and lists the projections from the surviving enum.

## Drive-by

`test_no_heavy_imports` asserted nothing. It imported `ess.livedata.preprocessors.detector_view_specs`, which does not exist — the module is under `workflows/` — and only ever passed because its own `ess.reduce in sys.modules` guard skipped it in a full run; in isolation it raised ImportError. It now runs the import in a subprocess, where the check is meaningful. Verified it fails if `ess.reduce` is pulled in.

## Test plan

- [x] Full suite passes. The four `to_nxlog_test.py` failures are pre-existing on `main` (numpy timedelta deprecation) and reproduce with this branch's changes stashed.
- [x] Registered specs diffed before/after across all instruments: identical.
- [x] Import-isolation test verified against a negative control.
