### PR TITLE
Fix silent drop of multi-ROI edits (numpy-array truthiness)

### DIFF
--- a/src/ess/livedata/dashboard/roi_request_plots.py
+++ b/src/ess/livedata/dashboard/roi_request_plots.py
@@ -107,7 +107,9 @@ class RectangleConverter:
         :
             Dictionary mapping box index to RectangleROI. Empty boxes are skipped.
         """
-        if not data or not data.get("x0"):
+        # Length, not truthiness: the browser syncs the columns back as numpy
+        # arrays, whose truth value raises for every length but one.
+        if len(data.get("x0", ())) == 0:
             return {}
 
         x0_list = data.get("x0", [])
@@ -229,7 +231,7 @@ class PolygonConverter:
         :
             Dictionary mapping polygon index to PolygonROI. Empty polygons are skipped.
         """
-        if not data or not data.get("xs"):
+        if len(data.get("xs", ())) == 0:
             return {}
 
         xs_list = data.get("xs", [])

--- a/tests/dashboard/roi_request_plots_test.py
+++ b/tests/dashboard/roi_request_plots_test.py
@@ -3,6 +3,7 @@
 """Tests for interactive ROI request plotters."""
 
 import holoviews as hv
+import numpy as np
 import pytest
 
 from ess.livedata.config.models import RectangleROI
@@ -96,3 +97,26 @@ def test_edit_persists_and_second_presenter_is_seeded_from_it(
         'x1': [5.0],
         'y1': [6.0],
     }
+
+
+@pytest.mark.parametrize('count', [0, 1, 2])
+def test_edit_from_browser_synced_arrays_is_applied(
+    computed_plotter: RectanglesRequestPlotter, count: int
+) -> None:
+    """The browser syncs the BoxEdit columns back as numpy arrays.
+
+    Their truth value raises for every length but one, so a truthiness guard
+    dropped whole edits (silently -- the handler logs and swallows).
+    """
+    presenter = computed_plotter.create_presenter()
+
+    presenter._handle_edit(
+        {
+            'x0': np.arange(count, dtype=float),
+            'x1': np.arange(count, dtype=float) + 4.0,
+            'y0': np.arange(count, dtype=float),
+            'y1': np.arange(count, dtype=float) + 4.0,
+        }
+    )
+
+    assert len(computed_plotter._current_rois) == count


### PR DESCRIPTION
The browser syncs BoxEdit/PolyDraw columns back as numpy arrays, whose truth value raises for every length but one. The truthiness guards in `RectangleConverter`/`PolygonConverter` therefore raised for 0 or 2+ ROIs, and since the edit handler logs and swallows, drawing more than one ROI — or a single ROI touching coordinate 0 — silently dropped the entire edit. Guard on length instead.

Surfaced by adding an ROI-request cell to the browser-test fixture (follow-up PR), which logged the error on every dashboard start. Parametrized tests (0/1/2 ROIs with array-typed columns) fail on the old guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)