### PR TITLE
Pause the plot poll while the cell-properties modal is open

### DIFF
--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -276,7 +276,7 @@ class PlotGridTabs:
         # individual grid tabs. Panel components can only have one parent, so
         # adding the same container to multiple tabs would break rendering.
         self._modal_container = pn.Row(height=0, sizing_mode='stretch_width')
-        self._current_modal: PlotConfigModal | None = None
+        self._current_modal: PlotConfigModal | CellPropertiesModal | None = None
 
         # Create main widget - tabs with zero-height modal container
         # IMPORTANT: Create the widget once in __init__ (not in the panel property)
@@ -375,9 +375,9 @@ class PlotGridTabs:
         active tab index maps to a grid position. When a static tab is selected
         the result is negative, which the bounds check rejects.
 
-        Returns None when a config modal is open: the modal overlay obscures
-        the plots, so rendering would be wasted. Dirty flags are preserved and
-        the first poll after the modal closes pushes the latest cached state.
+        Returns None while any modal is open: the modal overlay obscures the
+        plots, so rendering would be wasted. Dirty flags are preserved and the
+        first poll after the modal closes pushes the latest cached state.
         """
         if self._current_modal is not None:
             return None
@@ -631,7 +631,7 @@ class PlotGridTabs:
             Whether ``current_title`` is user-defined; if not, the input starts
             empty so the placeholder hints at the derived fallback.
         """
-        modal = CellPropertiesModal(
+        self._current_modal = CellPropertiesModal(
             orchestrator=self._orchestrator,
             workflow_registry=self._workflow_registry,
             plotting_controller=self._plotting_controller,
@@ -642,8 +642,8 @@ class PlotGridTabs:
             on_close=self._cleanup_modal,
         )
         self._modal_container.clear()
-        self._modal_container.append(modal.modal)
-        modal.show()
+        self._modal_container.append(self._current_modal.modal)
+        self._current_modal.show()
 
     @staticmethod
     def _cell_signature(cell: PlotCell) -> tuple:

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -1300,6 +1300,33 @@ class TestCellReconcile:
 
         assert plot_grid_tabs._current_modal is None
 
+    # Opening a Modal outside a served document warns; irrelevant here, since
+    # what is under test is the poll gate the open/close toggles.
+    @pytest.mark.filterwarnings('ignore:To use the Modal:UserWarning')
+    def test_cell_properties_modal_suspends_grid_rendering(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """The cell-properties modal must pause the poll like the config modal.
+
+        Its overlay hides the plots, so rendering behind it is wasted work on
+        the session's event loop -- which is also what the click that opens the
+        next modal has to queue behind (#1174).
+        """
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+        assert plot_grid_tabs._get_active_grid_id() == grid_id
+
+        plot_grid_tabs._show_cell_properties_modal(cell_id, 'G', has_user_title=False)
+        assert plot_grid_tabs._get_active_grid_id() is None
+
+        # Every close path routes through the modal's ``open`` watcher, so
+        # dismissing it must hand rendering back.
+        plot_grid_tabs._current_modal.modal.open = False
+        assert plot_grid_tabs._current_modal is None
+        assert plot_grid_tabs._get_active_grid_id() == grid_id
+
     def test_update_layer_config_rebuilds_cell(self, plot_orchestrator, plot_grid_tabs):
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())


### PR DESCRIPTION
While investigating #1174 I found that the poll-pause gate only ever engaged for one of the two modals.

`_get_active_grid_id` returns `None` while a modal is open, so the poll skips rendering plots the overlay hides anyway. `_show_config_modal` records the modal it opens; `_show_cell_properties_modal` did not. So renaming a cell or editing its layers left the poll rendering — and rebuilding cells — behind the open dialog.

That gate is what keeps the work off the session event loop, which is also where the click that opens the next modal has to be processed. This is not a fix for #1174, but it removes work from the window where that flake happens.

Every close path routes through the modal `open` watcher, so the existing `on_close` teardown clears the gate on Save, Cancel, X and Escape alike — the new test covers the close path as well as the open one, since holding the gate open forever would be the damaging way to get this wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
