### PR TITLE
tests: Re-click rather than wait once for a modal to open

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -116,6 +116,14 @@ screenshot with the `base64 -d` pipeline the log prints next to it.
 present but not visible means it rendered and was hidden, none at all means the click
 never reached its handler.
 
+The server log tail is what distinguishes *why* it never reached the handler. Static
+assets are served off the same IOLoop as everything else, so their `tornado.access`
+timings measure how long that loop was blocked: a `GET /static/...` taking seconds
+means the click's round-trip was queued behind the session's periodic pass, not lost
+(#1185). Sub-millisecond serves with no post-click activity at all point at a dropped
+click instead. `Dashboard.open_modal` re-clicks rather than waiting once, because only
+one of those two recovers.
+
 One console line is a red herring: `pageerror: Cannot read properties of undefined
 (reading 'parent_style')` fires on **every** run, passing or failing. It is
 [bokeh#15274](https://github.com/bokeh/bokeh/issues/15274) — our plot grid is a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,10 @@ markers = [
 ]
 filterwarnings = [
   "error",
+  # A browser test whose modal only opened on a retry still passes, but must
+  # say so: the rate of these is the field measurement of #1185. Reported in
+  # the warnings summary instead of failing the run (drive_dashboard.py).
+  "default:modal opened only on attempt:UserWarning",
 ]
 pythonpath = "tests"
 

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -170,17 +170,15 @@ class Dashboard:
         """
         for attempt in range(retries):
             try:
-                locator = (
-                    self.page.locator(target).first
-                    if isinstance(target, str)
-                    else target
-                )
-                locator.click(timeout=4000)
+                self._locate(target).click(timeout=4000)
                 return
             except PlaywrightTimeoutError:
                 if attempt == retries - 1:
                     raise
                 self.page.wait_for_timeout(1000)
+
+    def _locate(self, target: str | Locator) -> Locator:
+        return self.page.locator(target).first if isinstance(target, str) else target
 
     def open_modal(self, trigger: str | Locator, *, retries: int = 3):
         """Click a trigger and wait for its modal (``[role=dialog]``) to show.
@@ -188,23 +186,35 @@ class Dashboard:
         A click can land and still open nothing, without raising: it is
         delivered for a Bokeh model the server has already discarded, or the
         session's event loop is blocked long enough that the round-trip has
-        not been processed yet (#1174, #1185). So each attempt re-clicks
-        rather than spending the whole budget inside one wait -- a single long
-        wait rides out a stalled loop but never recovers a dropped click.
+        not been processed yet (#1174, #1185). Waiting longer recovers the
+        second; only another click recovers the first. So the budget is spent
+        across several waits, re-clicking between them.
+
+        A trigger the click consumes cannot be re-clicked, though -- a
+        layer-picker entry dismisses the menu it lives in -- and there the
+        click did land, so waiting is the only recovery. Hence the re-click is
+        conditional on the trigger still being there.
 
         Returns the dialog locator. Dismiss with ``page.keyboard.press("Escape")``
         (a ModalEscapeCloser widget makes Escape work from initial focus) or by
         clicking ``.pnx-dialog-close``.
         """
         dialog = self.page.locator("[role=dialog]").first
+        self.click(trigger, retries=retries)
         for attempt in range(retries):
-            self.click(trigger, retries=retries)
             try:
                 dialog.wait_for(state="visible", timeout=MODAL_ATTEMPT_MS)
                 return dialog
             except PlaywrightTimeoutError:
                 if attempt == retries - 1:
                     raise
+                try:
+                    if self._locate(trigger).is_visible():
+                        self._locate(trigger).click(timeout=4000)
+                except PlaywrightTimeoutError:
+                    # A re-click that cannot land is not the failure worth
+                    # reporting; let the next wait raise on the missing dialog.
+                    pass
 
     def screenshot(self, path: str | Path, *, full_page: bool = True) -> None:
         self.page.screenshot(path=str(path), full_page=full_page)

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -64,6 +64,7 @@ from urllib.error import URLError
 
 from playwright.sync_api import (
     Browser,
+    Locator,
     Page,
     sync_playwright,
 )
@@ -82,6 +83,10 @@ SETTLE_MS = 5000
 # Override the Chromium binary when the installed playwright package does not
 # match the browsers available on disk (e.g. a preprovisioned container).
 _CHROMIUM_ENV = "PLAYWRIGHT_CHROMIUM_EXECUTABLE"
+# Per-attempt wait for a modal to appear after its trigger is clicked. The total
+# budget is this times the retry count; see Dashboard.open_modal for why it is
+# spent across several clicks rather than in one wait.
+MODAL_ATTEMPT_MS = 8000
 # Console lines kept per session. A dashboard session logs steadily, so the tail
 # is what matters and the cap keeps a long run from growing without bound.
 CONSOLE_LIMIT = 200
@@ -154,32 +159,52 @@ class Dashboard:
         self.page.get_by_text(name, exact=True).first.click()
         self.page.wait_for_timeout(SETTLE_MS)
 
-    def click(self, selector: str, *, retries: int = 3) -> None:
+    def click(self, target: str | Locator, *, retries: int = 3) -> None:
         """Click a stable ``lt-*`` selector, retrying if a rebuild detaches it.
 
         Staging/commit/stop rebuilds the affected workflow row, so a click can
         race the rebuild and hit a detached element. Re-locate and retry.
+
+        ``target`` may also be a ready-made locator, for a trigger that carries
+        no ``lt-*`` hook of its own (a layer-picker menu entry, say).
         """
         for attempt in range(retries):
             try:
-                self.page.locator(selector).first.click(timeout=4000)
+                locator = (
+                    self.page.locator(target).first
+                    if isinstance(target, str)
+                    else target
+                )
+                locator.click(timeout=4000)
                 return
             except PlaywrightTimeoutError:
                 if attempt == retries - 1:
                     raise
                 self.page.wait_for_timeout(1000)
 
-    def open_modal(self, trigger_selector: str, *, retries: int = 3):
+    def open_modal(self, trigger: str | Locator, *, retries: int = 3):
         """Click a trigger and wait for its modal (``[role=dialog]``) to show.
+
+        A click can land and still open nothing, without raising: it is
+        delivered for a Bokeh model the server has already discarded, or the
+        session's event loop is blocked long enough that the round-trip has
+        not been processed yet (#1174, #1185). So each attempt re-clicks
+        rather than spending the whole budget inside one wait -- a single long
+        wait rides out a stalled loop but never recovers a dropped click.
 
         Returns the dialog locator. Dismiss with ``page.keyboard.press("Escape")``
         (a ModalEscapeCloser widget makes Escape work from initial focus) or by
         clicking ``.pnx-dialog-close``.
         """
-        self.click(trigger_selector, retries=retries)
         dialog = self.page.locator("[role=dialog]").first
-        dialog.wait_for(state="visible", timeout=10000)
-        return dialog
+        for attempt in range(retries):
+            self.click(trigger, retries=retries)
+            try:
+                dialog.wait_for(state="visible", timeout=MODAL_ATTEMPT_MS)
+                return dialog
+            except PlaywrightTimeoutError:
+                if attempt == retries - 1:
+                    raise
 
     def screenshot(self, path: str | Path, *, full_page: bool = True) -> None:
         self.page.screenshot(path=str(path), full_page=full_page)

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -55,6 +55,7 @@ import sys
 import tempfile
 import time
 import urllib.request
+import warnings
 from collections import deque
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -87,6 +88,13 @@ _CHROMIUM_ENV = "PLAYWRIGHT_CHROMIUM_EXECUTABLE"
 # budget is this times the retry count; see Dashboard.open_modal for why it is
 # spent across several clicks rather than in one wait.
 MODAL_ATTEMPT_MS = 8000
+# Opening prefix of the warning a recovered modal emits. Retries that hid
+# themselves would make the browser job look healthy and take away the only
+# field measurement of how often the dashboard stalls (#1185), so a recovery is
+# reported even though the test passes. pytest swallows stdout from a passing
+# test, hence a warning: pyproject downgrades this one message from the
+# blanket ``error`` filter so it lands in the run's warnings summary.
+RECOVERY_PREFIX = "modal opened only on attempt"
 # Console lines kept per session. A dashboard session logs steadily, so the tail
 # is what matters and the cap keeps a long run from growing without bound.
 CONSOLE_LIMIT = 200
@@ -195,26 +203,47 @@ class Dashboard:
         click did land, so waiting is the only recovery. Hence the re-click is
         conditional on the trigger still being there.
 
+        Every recovery warns (see :data:`RECOVERY_PREFIX`), naming which of the
+        two it was, so absorbing these does not also hide how often they happen.
+
         Returns the dialog locator. Dismiss with ``page.keyboard.press("Escape")``
         (a ModalEscapeCloser widget makes Escape work from initial focus) or by
         clicking ``.pnx-dialog-close``.
         """
         dialog = self.page.locator("[role=dialog]").first
         self.click(trigger, retries=retries)
+        reclicks = 0
         for attempt in range(retries):
             try:
                 dialog.wait_for(state="visible", timeout=MODAL_ATTEMPT_MS)
-                return dialog
             except PlaywrightTimeoutError:
                 if attempt == retries - 1:
                     raise
-                try:
-                    if self._locate(trigger).is_visible():
-                        self._locate(trigger).click(timeout=4000)
-                except PlaywrightTimeoutError:
-                    # A re-click that cannot land is not the failure worth
-                    # reporting; let the next wait raise on the missing dialog.
-                    pass
+                reclicks += self._reclick_if_present(trigger)
+            else:
+                if attempt:
+                    how = f"{reclicks} re-click(s)" if reclicks else "waiting alone"
+                    warnings.warn(
+                        f"{RECOVERY_PREFIX} {attempt + 1} of {retries} via {how}"
+                        f" ({trigger!r}): the session was slow to act on the"
+                        f" click (#1185) or dropped it (#1174)",
+                        stacklevel=2,
+                    )
+                return dialog
+
+    def _reclick_if_present(self, trigger: str | Locator) -> bool:
+        """Re-issue a click whose effect never arrived. True if one was sent.
+
+        A failed re-click is not the failure worth reporting -- the caller's
+        next wait raises on the missing dialog, which says more.
+        """
+        try:
+            if not self._locate(trigger).is_visible():
+                return False
+            self._locate(trigger).click(timeout=4000)
+        except PlaywrightTimeoutError:
+            return False
+        return True
 
     def screenshot(self, path: str | Path, *, full_page: bool = True) -> None:
         self.page.screenshot(path=str(path), full_page=full_page)

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -276,8 +276,7 @@ def test_multi_layer_cell_gear_picks_the_layer_to_configure():
         # first: the source selector is pre-filled with the chosen layer's
         # source. (The dialog's own inner_text is empty -- Panel renders each
         # widget into its own shadow root -- so assert on the chip itself.)
-        entries[1].click()
-        page.locator("[role=dialog]").first.wait_for(state="visible", timeout=10000)
+        dash.open_modal(entries[1])
         chip = page.locator(".choices__list--multiple .choices__item").first
         chip.wait_for(state="visible", timeout=10000)
         assert chip.inner_text().startswith("monitor2")


### PR DESCRIPTION
A click can land and still open nothing, without raising — so `open_modal` spending its entire budget inside a single `wait_for` could only ever recover one of the two ways that happens.

The diagnostics from #1173 show both, and the server log tail tells them apart. Static assets are served off the same IOLoop as everything else, so their timings measure how long that loop was blocked; in the failing runs two of the modal own stylesheets took 4778 ms to serve from localhost. That is a queued round-trip, and waiting longer does fix it. The other signature — sub-millisecond serves and no post-click server activity at all — is a dropped click, and no amount of waiting helps.

So each attempt now re-clicks, giving a larger total budget than before *and* covering the dropped case. `click`/`open_modal` also accept a ready-made locator, which lets the layer-picker menu entry (no `lt-*` hook of its own, previously waiting on the dialog inline) go through the same path.

This is a harness workaround and labelled as one in the docstring. The stalls it papers over are #1185; the full diagnosis is in #1174.

## Test plan

- [x] The three flaky modal tests pass locally
- [ ] Browser job green across a few CI runs (it has been failing ~44% of the time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
