### PR TITLE
Keep the plotter choice when stepping back into the plotter step

### DIFF
--- a/src/ess/livedata/dashboard/widgets/plot_config_modal.py
+++ b/src/ess/livedata/dashboard/widgets/plot_config_modal.py
@@ -704,6 +704,7 @@ class PlotterSelectionStep(WizardStep[OutputSelection | None, PlotterSelection])
         self._initial_config = initial_config
         self._instrument_config = instrument_config
         self._output_selection: OutputSelection | None = None
+        self._rendered_output: OutputSelection | None = None
         self._selected_plot_name: str | None = None
         self._radio_group: pn.widgets.RadioButtonGroup | None = None
         self._content_container = pn.Column(sizing_mode='stretch_width')
@@ -776,10 +777,18 @@ class PlotterSelectionStep(WizardStep[OutputSelection | None, PlotterSelection])
                 workflow_id=self._initial_config.workflow_id,
                 view_name=self._initial_config.view_name,
             )
-        self._update_plotter_selection()
+        # Rebuilding discards the user's plotter and axis choices, so rebuild only
+        # when the output they were derived from changed. Same guard as the
+        # configuration step, which recreates its panel only on a changed selection.
+        if (
+            self._output_selection is None
+            or self._output_selection != self._rendered_output
+        ):
+            self._update_plotter_selection()
 
     def _update_plotter_selection(self) -> None:
         """Update plotter selection based on workflow and output selection."""
+        self._rendered_output = self._output_selection
         self._content_container.clear()
 
         if self._output_selection is None:

--- a/tests/dashboard/widgets/plot_config_modal_test.py
+++ b/tests/dashboard/widgets/plot_config_modal_test.py
@@ -788,19 +788,16 @@ class TestNavigation:
         assert wizard.radio('Workflow').value == IMAGE_ID
         assert wizard.radio('Output').value == 'image'
 
-    def test_back_resets_the_plotter_choice_but_not_the_output_choice(
+    def test_back_keeps_the_plotter_choice_and_the_output_choice(
         self, open_wizard
     ) -> None:
-        # Entering the plotter step rebuilds its radio group and preselects the
-        # first offered plotter, so stepping back and forth drops a non-default
-        # choice; the workflow/output step keeps its widgets and its selection.
         wizard = open_wizard()
         wizard.click('Next')
         wizard.radio('Plotter Type').value = 'overlay_1d'
         wizard.click('Next')
 
         wizard.click('Back')
-        assert wizard.radio('Plotter Type').value == 'image'
+        assert wizard.radio('Plotter Type').value == 'overlay_1d'
         wizard.click('Back')
         assert wizard.radio('Workflow').value == IMAGE_ID
 
@@ -810,6 +807,7 @@ class TestNavigation:
         wizard = open_wizard()
         wizard.click('Next')
         assert 'image' in wizard.radio('Plotter Type').options.values()
+        wizard.radio('Plotter Type').value = 'overlay_1d'
 
         wizard.click('Back')
         wizard.radio('Group').value = MONITORS.name
@@ -819,6 +817,8 @@ class TestNavigation:
         offered = set(wizard.radio('Plotter Type').options.values())
         assert 'image' not in offered
         assert 'lines' in offered
+        # A choice made for the previous output does not outlive that output.
+        assert wizard.radio('Plotter Type').value != 'overlay_1d'
 
     def test_cancelling_yields_no_config(self, open_wizard) -> None:
         wizard = open_wizard()


### PR DESCRIPTION
Follow-up to the behaviour #1184 pinned rather than changed: stepping **Back** into the plotter step reset a non-default plotter to the first offered one, because the step rebuilt its radio group on every entry. For correlation histograms the same rebuild also cleared the axis-source selectors, so an axis pair chosen before visiting the configuration step was silently lost too.

The step now rebuilds only when the output its plotters were derived from actually changed — the guard the configuration step already applies to its parameter panel, so the three wizard steps finally agree on what surviving a Back means. A plotter picked for one output still does not outlive switching to another output.

Stacked on #1184 (`plot-config-modal-tests`), whose test suite pins the old behaviour; that test is updated here rather than left to fail after a merge. Review/merge #1184 first.

## Test plan

- Unit tests in `plot_config_modal_test.py` cover both directions: Back keeps the choice, changing the output drops it. The updated test fails on the parent branch and passes here.
- Full dashboard suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
