### PR TITLE
Remove unreachable empty-BaseModel fallbacks for plotter params

### DIFF
--- a/src/ess/livedata/dashboard/plot_orchestrator.py
+++ b/src/ess/livedata/dashboard/plot_orchestrator.py
@@ -1400,9 +1400,6 @@ class PlotOrchestrator:
             self._logger.warning('Skipping cell with unknown plotter %s', plot_name)
             return None
 
-        if spec.params is None:
-            return pydantic.BaseModel()
-
         try:
             return spec.params(**params)
         except Exception:

--- a/src/ess/livedata/dashboard/plotting_controller.py
+++ b/src/ess/livedata/dashboard/plotting_controller.py
@@ -208,12 +208,11 @@ class PlottingController:
             DataService.unregister_subscriber() to stop receiving updates
             (e.g., when workflow restarts).
         """
+        spec = plotter_registry.get_spec(plot_name)
         # Validate params if dict, pass through if already a model
         if isinstance(params, dict):
-            spec = plotter_registry.get_spec(plot_name)
-            params = spec.params(**params) if spec.params else pydantic.BaseModel()
+            params = spec.params(**params)
 
-        spec = plotter_registry.get_spec(plot_name)
         window = params.time_window if isinstance(params, TimeWindowMixin) else None
 
         # Flatten keys for extractor creation

--- a/src/ess/livedata/dashboard/widgets/cell_properties_modal.py
+++ b/src/ess/livedata/dashboard/widgets/cell_properties_modal.py
@@ -191,7 +191,7 @@ class CellPropertiesModal:
         self, base_config: PlotConfig, view_name: str, plotter_name: str
     ) -> None:
         spec = self._plotting_controller.get_spec(plotter_name)
-        params = spec.params() if spec.params else None
+        params = spec.params()
         overlay_config = PlotConfig(
             data_sources={
                 PRIMARY: DataSourceConfig(


### PR DESCRIPTION
`pydantic.BaseModel()` was instantiated as an empty params model in two places in the dashboard. Pydantic v2 raises `PydanticUserError` ("Pydantic models should inherit from BaseModel, BaseModel cannot be instantiated directly") on that, so both would have blown up — but neither is reachable: `PlotterSpec.params` is a required, non-optional `type[BaseModel]` field. Pydantic rejects `None` at construction, and `register_plotter` always derives the value from the factory's `params` type hint, so the `spec.params is None` / `if spec.params` guards standing in front of those calls can never be taken.

Rather than replace the fallback with an empty model subclass, this removes the dead guards: the field's type already says params is always present. A third site in `cell_properties_modal.py` had the same `if spec.params else None` check — dead for the same reason, harmless but misleading about the contract — and goes too. Removing the guard in `PlottingController` also exposed a duplicate `get_spec` call it was hiding.

For contrast, `WorkflowSpec.params` *is* genuinely `type[BaseModel] | None`, and 13 of 56 registered workflows rely on it (`timeseries_data` on every instrument, plus three detector/counts workflows). Those sites are untouched; whether that optionality earns its keep is a separate question. The distinction that matters here is that `PlotterSpec` enforces presence structurally rather than by convention, so these branches are unreachable by construction and not merely unused today. A plotter that genuinely takes no parameters is already expressible as an empty model — `spec.params(**{})` works — so the `None` branch was never an escape hatch anyone needed.

## Test plan

No behaviour change — the removed code was unreachable, so no test can distinguish before from after. Existing suite passes (4600 passed, 54 skipped, 8 xfailed).
