### PR TITLE
Cut CI test time: parallelize pytest and cache pip installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '${{ needs.formatting.outputs.min_python }}'
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - name: Run integration tests
@@ -138,6 +140,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '${{ needs.formatting.outputs.min_python }}'
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - name: Install chromium system libraries
@@ -193,6 +197,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install ".[${{ matrix.instrument }}]"
       - name: Smoke-check backend services
@@ -217,6 +223,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version-file: '.github/workflows/python-version-ci'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install ".[dashboard]"
       - name: Smoke-check dashboard for each instrument

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install .
       - run: python tests/package_test.py
@@ -69,6 +71,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r ${{ inputs.pip-recipe }}
       - run: tox -e ${{ inputs.tox-env }}

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -18,8 +18,10 @@ logger = logging.getLogger(__name__)
 #: Time allowed for the broker to answer a metadata request before diagnostics
 #: give up. Diagnostics run on the failure path, where the broker being gone is
 #: one of the hypotheses, so the probe must not add a per-topic stall to every
-#: timeout.
-_BROKER_PROBE_TIMEOUT = 3.0
+#: timeout. A live local broker answers metadata requests in milliseconds; the
+#: helper unit tests exercise the timeout path without a broker and pay the
+#: full probe on every expected failure, so keep it short.
+_BROKER_PROBE_TIMEOUT = 0.5
 
 
 class WaitTimeout(Exception):

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps = -r requirements/test.txt
 setenv =
   JUPYTER_PLATFORM_DIRS = 1
 # Override pyproject.toml addopts: include slow tests, still skip browser tests
-commands = pytest -m "not integration and not browser" {posargs}
+commands = pytest -m "not integration and not browser" -n auto {posargs}
 
 [testenv:integration]
 description = Run integration tests (requires Kafka to be running)
@@ -34,7 +34,7 @@ setenv =
   PIP_INDEX_URL = https://pypi.anaconda.org/scipp-nightly-wheels/simple
   PIP_EXTRA_INDEX_URL = https://pypi.org/simple
 # Override pyproject.toml addopts: include slow tests, still skip browser tests
-commands = pytest -m "not integration and not browser" {posargs}
+commands = pytest -m "not integration and not browser" -n auto {posargs}
 
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.
@@ -42,7 +42,7 @@ deps =
   -r requirements/basetest.txt
   esslivedata
 # Override pyproject.toml addopts: include slow tests, still skip browser tests
-commands = pytest -m "not integration and not browser" {posargs}
+commands = pytest -m "not integration and not browser" -n auto {posargs}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
The main test job runs ~4650 tests serially (~6 min) even though pytest-xdist is already a pinned test dependency; this adds `-n auto` to the pytest tox envs (py312, nightly, unpinned). The full suite passes with `-n auto` locally in 60 s; on the 4-core runners this should land around 2 min. The integration env stays serial (shared Kafka topics), and the browser env is untouched (parallelizing it is a separate PR, pending a flakiness look).

Two smaller items in the same spirit:

- The `helpers_test.py` expected-timeout tests each paid the full 3 s broker probe in `dump_diagnostics` (no broker exists in the unit-test env). A live broker answers metadata requests in milliseconds, so the probe is now 0.5 s: 5 × 3.3 s → 5 × 0.8 s.
- `setup-python` never cached pip downloads, so every job re-downloaded all wheels. Now cached, keyed on the requirements lockfiles (or `pyproject.toml` where the job installs the package directly).

## Test plan

- [x] Full `pytest -m "not integration and not browser" -n auto` passes locally (4667 passed, 60 s).
- [x] `tests/integration/helpers_test.py` passes, negative-path tests down from 3.3 s to 0.8 s each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
