### PR TITLE
Make WorkflowSpec.params required, defaulting to NoParams

### DIFF
--- a/src/ess/livedata/config/instrument.py
+++ b/src/ess/livedata/config/instrument.py
@@ -25,6 +25,7 @@ from .workflow_spec import (
     DETECTORS,
     REDUCTION,
     AuxSources,
+    NoParams,
     WorkflowGroup,
     WorkflowId,
     WorkflowSpec,
@@ -600,7 +601,7 @@ class Instrument:
         title: str,
         description: str = '',
         source_names: Sequence[str] | None = None,
-        params: type[Any] | None = None,
+        params: type[pydantic.BaseModel] = NoParams,
         aux_sources: AuxSources | None = None,
         outputs: type[Any],
         device_outputs: dict[str, str] | None = None,
@@ -635,8 +636,9 @@ class Instrument:
             Optional list of source names that the workflow can handle. This is used to
             create a workflow specification.
         params:
-            Optional Pydantic model class defining workflow parameters. Must be
-            explicit (not inferred from factory).
+            Pydantic model class defining workflow parameters. Must be explicit
+            (not inferred from factory). Defaults to :class:`NoParams` for
+            workflows that take no configuration.
         aux_sources:
             Optional declarative auxiliary source definitions. If provided,
             this will be used for validation and UI generation. The auxiliary source
@@ -764,11 +766,8 @@ class Instrument:
         )
 
         for reg in list(self.workflow_factory.registrations()):
-            params = reg.spec.params
-            if (
-                reg.factory is None
-                and params is not None
-                and issubclass(params, MonitorDataParamsBase)
+            if reg.factory is None and issubclass(
+                reg.spec.params, MonitorDataParamsBase
             ):
                 self.workflow_factory.attach_factory(reg.spec.get_id())(
                     create_monitor_workflow_factory

--- a/src/ess/livedata/config/instruments/dummy/specs.py
+++ b/src/ess/livedata/config/instruments/dummy/specs.py
@@ -77,7 +77,6 @@ area_panel_view_handle = instrument.register_spec(
     title='Area Panel',
     description='Area detector image view',
     source_names=['area_panel'],
-    params=None,
     outputs=DetectorViewOutputs,
 )
 
@@ -89,5 +88,4 @@ total_counts_handle = instrument.register_spec(
     description='Dummy workflow that simply computes the total counts.',
     source_names=['panel_0'],
     outputs=TotalCountsOutputs,
-    params=None,
 )

--- a/src/ess/livedata/config/instruments/tbl/specs.py
+++ b/src/ess/livedata/config/instruments/tbl/specs.py
@@ -103,6 +103,5 @@ orca_view_handle = instrument.register_spec(
     title='Orca Detector',
     description='512x512 image downsampled from full resolution',
     source_names=['orca_detector'],
-    params=None,
     outputs=DetectorViewOutputs,
 )

--- a/src/ess/livedata/config/workflow_spec.py
+++ b/src/ess/livedata/config/workflow_spec.py
@@ -391,6 +391,19 @@ class DataKey(BaseModel, frozen=True):
     )
 
 
+class NoParams(BaseModel):
+    """
+    Params model for workflows that take no configuration.
+
+    Workflows always have a params model, so consumers never branch on its
+    absence; "takes no parameters" is expressed as a model with no fields.
+    Extra fields are rejected so that sending params to such a workflow is an
+    error rather than silently ignored.
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+
 class WorkflowSpec(BaseModel):
     """
     Model for workflow specification.
@@ -444,7 +457,13 @@ class WorkflowSpec(BaseModel):
             "backend rejects reset commands."
         ),
     )
-    params: type[BaseModel] | None = Field(description="Model for workflow param.")
+    params: type[BaseModel] = Field(
+        default=NoParams,
+        description=(
+            "Model for workflow params. Defaults to :class:`NoParams` for "
+            "workflows that take no configuration."
+        ),
+    )
     outputs: type[WorkflowOutputsBase] = Field(
         default=DefaultOutputs,
         description=(

--- a/src/ess/livedata/dashboard/configuration_adapter.py
+++ b/src/ess/livedata/dashboard/configuration_adapter.py
@@ -115,9 +115,7 @@ class ConfigurationAdapter[Model](ABC):
             if k in inputs and v in inputs[k].choices
         }
 
-    def set_aux_sources(
-        self, aux_source_names: dict[str, str] | None
-    ) -> type[Model] | None:
+    def set_aux_sources(self, aux_source_names: dict[str, str] | None) -> type[Model]:
         """Set auxiliary sources and return the parameter model class.
 
         Parameters
@@ -128,13 +126,14 @@ class ConfigurationAdapter[Model](ABC):
         Returns
         -------
         :
-            Pydantic model class for parameters, or None if no parameters.
+            Pydantic model class for parameters. A model with no fields means
+            the workflow or plotter takes no parameters.
         """
         self._cached_aux_sources = aux_source_names
         return self.model_class()
 
     @abstractmethod
-    def model_class(self) -> type[Model] | None:
+    def model_class(self) -> type[Model]:
         """
         Pydantic model class for parameters.
 
@@ -213,13 +212,8 @@ class ConfigurationAdapter[Model](ABC):
         if self._config_state is None:
             return {}
 
-        # Check compatibility with current model
-        model_class = self.model_class()
-        if model_class is None:
-            # No model defined, return params as-is
-            return self._config_state.params
-
         # Check if stored params have ANY overlap with current model fields
+        model_class = self.model_class()
         # If no field names match, the config is from an incompatible version
         stored_keys = set(self._config_state.params.keys())
         model_fields = set(model_class.model_fields.keys())

--- a/src/ess/livedata/dashboard/job_orchestrator.py
+++ b/src/ess/livedata/dashboard/job_orchestrator.py
@@ -294,19 +294,17 @@ class JobOrchestrator:
                 )
             else:
                 # Use defaults from spec, converting to dicts
-                params = {}
-                if spec.params is not None:
-                    try:
-                        params = spec.params().model_dump(mode='json')
-                    except pydantic.ValidationError:
-                        # Params model has required fields without defaults
-                        # These workflows don't use JobOrchestrator staging
-                        self._workflows[workflow_id] = WorkflowState()
-                        logger.debug(
-                            'Initialized workflow %s (params cannot be instantiated)',
-                            workflow_id,
-                        )
-                        continue
+                try:
+                    params = spec.params().model_dump(mode='json')
+                except pydantic.ValidationError:
+                    # Params model has required fields without defaults
+                    # These workflows don't use JobOrchestrator staging
+                    self._workflows[workflow_id] = WorkflowState()
+                    logger.debug(
+                        'Initialized workflow %s (params cannot be instantiated)',
+                        workflow_id,
+                    )
+                    continue
 
                 aux_source_names = {}
                 if spec.aux_sources is not None:

--- a/src/ess/livedata/dashboard/plot_configuration_adapter.py
+++ b/src/ess/livedata/dashboard/plot_configuration_adapter.py
@@ -97,7 +97,7 @@ class PlotConfigurationAdapter(ConfigurationAdapter):
         """Description for the configuration panel."""
         return self._plot_spec.description
 
-    def model_class(self) -> type[pydantic.BaseModel] | None:
+    def model_class(self) -> type[pydantic.BaseModel]:
         """Get the pydantic model class for plotter parameters.
 
         When a ``params_factory`` and output template dims are both available,

--- a/src/ess/livedata/dashboard/widgets/configuration_widget.py
+++ b/src/ess/livedata/dashboard/widgets/configuration_widget.py
@@ -174,7 +174,7 @@ class ConfigurationWidget:
         except Exception as e:
             return ErrorWidget(str(e))
 
-        if model_class is None or not model_class.model_fields:
+        if not model_class.model_fields:
             return NoParamsWidget()
         return ModelWidget(
             model_class=model_class,

--- a/src/ess/livedata/dashboard/workflow_configuration_adapter.py
+++ b/src/ess/livedata/dashboard/workflow_configuration_adapter.py
@@ -57,7 +57,7 @@ class WorkflowConfigurationAdapter(ConfigurationAdapter[pydantic.BaseModel]):
         """Map each param field name to the titles of the outputs it shapes."""
         return self._spec.get_param_output_titles()
 
-    def model_class(self) -> type[pydantic.BaseModel] | None:
+    def model_class(self) -> type[pydantic.BaseModel]:
         """Get workflow parameters model class."""
         return self._spec.params
 

--- a/src/ess/livedata/workflows/workflow_factory.py
+++ b/src/ess/livedata/workflows/workflow_factory.py
@@ -11,6 +11,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from ess.livedata.config.stream import ChainPatchBinding, ContextBinding
 from ess.livedata.config.workflow_spec import (
+    NoParams,
     WorkflowConfig,
     WorkflowId,
     WorkflowSpec,
@@ -253,19 +254,19 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
             type_hints = typing.get_type_hints(factory, globalns=factory.__globals__)
             inferred_params = type_hints.get('params', None)
 
-            if spec.params is not None and inferred_params is not None:
-                # Spec params may be a subclass of the factory's declared type
-                # (e.g. dynamic subclasses produced by ``make_detector_view_params``).
-                if not issubclass(spec.params, inferred_params):
-                    raise TypeError(f"Params type mismatch for {workflow_id}")
-            elif spec.params is None and inferred_params is not None:
-                raise TypeError(
-                    f"Factory has params but spec has none for {workflow_id}"
-                )
-            elif spec.params is not None and inferred_params is None:
+            if spec.params is NoParams:
+                if inferred_params is not None:
+                    raise TypeError(
+                        f"Factory has params but spec has none for {workflow_id}"
+                    )
+            elif inferred_params is None:
                 raise TypeError(
                     f"Spec has params but factory has none for {workflow_id}"
                 )
+            # Spec params may be a subclass of the factory's declared type
+            # (e.g. dynamic subclasses produced by ``make_detector_view_params``).
+            elif not issubclass(spec.params, inferred_params):
+                raise TypeError(f"Params type mismatch for {workflow_id}")
 
             self._registrations[workflow_id] = dataclasses.replace(
                 self._registrations[workflow_id], factory=factory
@@ -352,15 +353,9 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
 
         reg = self._registrations[workflow_id]
         workflow_spec = reg.spec
-        if (model_cls := workflow_spec.params) is None:
-            if config.params:
-                raise ValueError(
-                    f"Workflow '{workflow_id}' does not require parameters, "
-                    f"but received: {config.params}"
-                )
-            workflow_params = None
-        else:
-            workflow_params = model_cls.model_validate(config.params)
+        # NoParams forbids extra fields, so params sent to a workflow that takes
+        # none are rejected here rather than silently dropped.
+        workflow_params = workflow_spec.params.model_validate(config.params)
 
         # Validate aux_sources configuration
         if workflow_spec.aux_sources is None:
@@ -394,7 +389,7 @@ class WorkflowFactory(Mapping[WorkflowId, WorkflowSpec]):
         kwargs = {}
         if 'source_name' in sig.parameters:
             kwargs['source_name'] = source_name
-        if workflow_params and 'params' in sig.parameters:
+        if 'params' in sig.parameters:
             kwargs['params'] = workflow_params
         if 'aux_source_names' in sig.parameters:
             kwargs['aux_source_names'] = aux_source_names or {}

--- a/tests/config/device_contract_test.py
+++ b/tests/config/device_contract_test.py
@@ -115,7 +115,6 @@ def _spec(*, source_names: list[str], device_outputs: dict[str, str]) -> Workflo
         version=1,
         title='WF',
         description='',
-        params=None,
         outputs=_ScalarOutputs,
         device_outputs=device_outputs,
         source_names=source_names,

--- a/tests/config/instrument_test.py
+++ b/tests/config/instrument_test.py
@@ -17,6 +17,7 @@ from ess.livedata.config.workflow_spec import (
     MONITORS,
     REDUCTION,
     JobId,
+    NoParams,
     WorkflowId,
     WorkflowOutputsBase,
 )
@@ -764,7 +765,7 @@ class TestInstrumentRegisterSpec:
         assert spec.group is REDUCTION  # default
         assert spec.description == ""  # default
         assert spec.source_names == []  # default
-        assert spec.params is None  # default
+        assert spec.params is NoParams  # default
         assert spec.aux_sources is None  # default
         assert spec.outputs is SimpleTestOutputs
 

--- a/tests/config/registered_workflow_specs_test.py
+++ b/tests/config/registered_workflow_specs_test.py
@@ -46,22 +46,21 @@ def _collect_workflow_specs():
 
 @pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflow_specs())
 def test_workflow_spec_params_validation(instrument_name: str, workflow_id: WorkflowId):
-    """Test that spec.params is None or a valid Pydantic BaseModel class.
+    """Test that spec.params is a valid Pydantic BaseModel class.
 
-    Since params are now explicitly registered (not inferred from factory),
-    this validates they're properly set in the spec.
+    Since params are explicitly registered (not inferred from factory), this
+    validates they're properly set in the spec.
     """
     instrument = instrument_registry[instrument_name]
     spec = instrument.workflow_factory[workflow_id]
 
-    if spec.params is not None:
-        assert issubclass(spec.params, pydantic.BaseModel), (
-            f"spec.params for {workflow_id} should be a Pydantic BaseModel subclass, "
-            f"got {spec.params}"
-        )
-        # Verify we can instantiate with defaults
-        instance = spec.params()
-        assert isinstance(instance, pydantic.BaseModel)
+    assert issubclass(spec.params, pydantic.BaseModel), (
+        f"spec.params for {workflow_id} should be a Pydantic BaseModel subclass, "
+        f"got {spec.params}"
+    )
+    # Verify we can instantiate with defaults
+    instance = spec.params()
+    assert isinstance(instance, pydantic.BaseModel)
 
 
 @pytest.mark.parametrize(("instrument_name", "workflow_id"), _collect_workflow_specs())
@@ -127,9 +126,6 @@ def test_workflow_params_serialization_roundtrip(
     """
     instrument = instrument_registry[instrument_name]
     spec = instrument.workflow_factory[workflow_id]
-
-    if spec.params is None:
-        pytest.skip("Workflow has no parameters")
 
     # Create instance with defaults
     original = spec.params()
@@ -210,13 +206,10 @@ def test_workflow_config_widget_adapter_compatibility(
     # First set aux sources (get defaults if available, otherwise None)
     aux_dict = adapter.aux_sources.get_defaults() if adapter.aux_sources else None
     model_class = adapter.set_aux_sources(aux_dict)
-    if spec.params is not None:
-        assert model_class == spec.params
-        # Verify we can instantiate with defaults
-        instance = model_class()
-        assert isinstance(instance, pydantic.BaseModel)
-    else:
-        assert model_class is None
+    assert model_class == spec.params
+    # Verify we can instantiate with defaults
+    instance = model_class()
+    assert isinstance(instance, pydantic.BaseModel)
 
 
 def _collect_workflow_outputs():

--- a/tests/config/workflow_spec_test.py
+++ b/tests/config/workflow_spec_test.py
@@ -14,6 +14,7 @@ from ess.livedata.config.workflow_spec import (
     AuxSources,
     CumulativeOutput,
     JobId,
+    NoParams,
     OutputView,
     SeriesOutput,
     Temporality,
@@ -100,7 +101,6 @@ class TestWorkflowSpecAuxSources:
             version=1,
             title="Test Workflow",
             description="A test workflow",
-            params=None,
             outputs=SimpleTestOutputs,
             group=REDUCTION,
         )
@@ -125,7 +125,6 @@ class TestWorkflowSpecAuxSources:
             version=1,
             title="Test Workflow",
             description="A test workflow",
-            params=None,
             aux_sources=aux,
             outputs=SimpleTestOutputs,
             group=REDUCTION,
@@ -156,7 +155,6 @@ class TestWorkflowSpecOutputs:
             version=1,
             title="Test Workflow",
             description="A test workflow",
-            params=None,
             outputs=TestOutputs,
             group=REDUCTION,
         )
@@ -183,7 +181,6 @@ class TestWorkflowSpecOutputs:
             version=1,
             title="Test Workflow",
             description="A test workflow",
-            params=None,
             outputs=TestOutputs,
             group=REDUCTION,
         )
@@ -213,7 +210,6 @@ class TestWorkflowSpecOutputs:
             version=1,
             title="Test Workflow",
             description="A test workflow",
-            params=None,
             outputs=TestOutputs,
             group=REDUCTION,
         )
@@ -235,7 +231,6 @@ class TestWorkflowSpecOutputs:
             version=1,
             title="Test Workflow",
             description="A test workflow",
-            params=None,
             outputs=TestOutputs,
             group=REDUCTION,
         )
@@ -260,7 +255,6 @@ class TestWorkflowSpecOutputs:
             version=1,
             title="Test Workflow",
             description="A test workflow",
-            params=None,
             outputs=TestOutputs,
             group=REDUCTION,
         )
@@ -310,7 +304,7 @@ class _CouplingOutputs(WorkflowOutputsBase):
     total_in_range: sc.DataArray = Field(title='Total in range')
 
 
-def _coupling_spec(params: type[BaseModel] | None = _CouplingParams) -> WorkflowSpec:
+def _coupling_spec(params: type[BaseModel] = _CouplingParams) -> WorkflowSpec:
     return WorkflowSpec(
         instrument="test",
         name="test_workflow",
@@ -346,7 +340,9 @@ class TestParamOutputCoupling:
         assert _coupling_spec().get_output_param_titles('nonexistent') == []
 
     def test_get_output_param_titles_empty_without_params(self) -> None:
-        assert _coupling_spec(params=None).get_output_param_titles('histogram') == []
+        assert (
+            _coupling_spec(params=NoParams).get_output_param_titles('histogram') == []
+        )
 
     def test_get_output_param_titles_skips_absent_params(self) -> None:
         # An output may be shared with a params variant lacking some fields;
@@ -452,7 +448,6 @@ class TestWorkflowConfigFromParams:
         config = WorkflowConfig.from_params(
             workflow_id=sample_workflow_id,
             job_id=job_id,
-            params=None,
             aux_source_names=None,
         )
 
@@ -470,7 +465,6 @@ class TestWorkflowConfigFromParams:
         config = WorkflowConfig.from_params(
             workflow_id=sample_workflow_id,
             job_id=custom_job_id,
-            params=None,
         )
 
         assert config.job_id == custom_job_id
@@ -781,7 +775,6 @@ class TestFindTimeseriesOutputs:
             version=1,
             title='Test',
             description='Test',
-            params=None,
             outputs=TimeseriesOutputs,
             source_names=['source1', 'source2'],
             group=TIMESERIES,
@@ -810,7 +803,6 @@ class TestFindTimeseriesOutputs:
             version=1,
             title='Test',
             description='Test',
-            params=None,
             outputs=NonTimeseriesOutputs,
             source_names=['source1'],
             group=REDUCTION,
@@ -836,7 +828,6 @@ class TestFindTimeseriesOutputs:
             version=1,
             title='Test',
             description='Test',
-            params=None,
             outputs=NoTimeCoordOutputs,
             source_names=['source1'],
             group=REDUCTION,
@@ -860,7 +851,6 @@ class TestFindTimeseriesOutputs:
             version=1,
             title='Test',
             description='Test',
-            params=None,
             outputs=NoFactoryOutputs,
             source_names=['source1'],
             group=REDUCTION,
@@ -903,7 +893,6 @@ class TestFindTimeseriesOutputs:
             version=1,
             title='TS 1',
             description='Test',
-            params=None,
             outputs=TimeseriesOutputs,
             source_names=['src1'],
             group=TIMESERIES,
@@ -914,7 +903,6 @@ class TestFindTimeseriesOutputs:
             version=1,
             title='Det 1',
             description='Test',
-            params=None,
             outputs=NonTimeseriesOutputs,
             source_names=['src2'],
             group=REDUCTION,
@@ -944,7 +932,6 @@ class TestOutputViews:
             title='T',
             description='D',
             outputs=Outputs,
-            params=None,
             group=REDUCTION,
         )
         views = spec.get_output_views()
@@ -975,7 +962,6 @@ class TestOutputViews:
             title='T',
             description='D',
             outputs=Outputs,
-            params=None,
             group=REDUCTION,
         )
         views = spec.get_output_views()
@@ -993,7 +979,6 @@ class TestOutputViews:
             title='T',
             description='D',
             outputs=Outputs,
-            params=None,
             group=REDUCTION,
         )
         assert spec.get_output_view('nonexistent') is None
@@ -1027,7 +1012,6 @@ class TestOutputViews:
             title='T',
             description='D',
             outputs=Outputs,
-            params=None,
             group=REDUCTION,
         )
         template = spec.get_output_template('histogram')
@@ -1053,7 +1037,6 @@ class TestOutputViews:
                 title='T',
                 description='D',
                 outputs=Outputs,
-                params=None,
                 group=REDUCTION,
             )
 
@@ -1075,7 +1058,6 @@ class TestOutputViews:
             title='T',
             description='D',
             outputs=Outputs,
-            params=None,
             group=REDUCTION,
         )
         assert [v.title for v in spec.get_output_views()] == ['A', 'B']
@@ -1091,7 +1073,6 @@ class TestUnambiguousWindowing:
             version=1,
             title='T',
             description='D',
-            params=None,
             outputs=outputs,
             group=REDUCTION,
         )

--- a/tests/core/orchestrating_processor_test.py
+++ b/tests/core/orchestrating_processor_test.py
@@ -310,7 +310,6 @@ class TestEmptyBatchContextReplay:
             version=1,
             title='Replay probe',
             source_names=[CHOPPER_CASCADE_SOURCE],
-            params=None,
             outputs=_ReplayOutputs,
         )
         handle.attach_factory()(lambda: FakeProcessor())

--- a/tests/dashboard/fake_backend_test.py
+++ b/tests/dashboard/fake_backend_test.py
@@ -108,7 +108,6 @@ def _spec(outputs: type[WorkflowOutputsBase], name: str) -> WorkflowSpec:
         version=1,
         title=name,
         description='',
-        params=None,
         outputs=outputs,
         group=REDUCTION,
         source_names=['source1'],

--- a/tests/dashboard/job_orchestrator_test.py
+++ b/tests/dashboard/job_orchestrator_test.py
@@ -116,7 +116,6 @@ def workflow_no_params() -> WorkflowSpec:
         title="Workflow Without Params",
         description="Test workflow without params",
         source_names=["det_1", "det_2"],
-        params=None,
         outputs=SimpleTestOutputs,
         group=REDUCTION,
     )

--- a/tests/dashboard/plotting_controller_test.py
+++ b/tests/dashboard/plotting_controller_test.py
@@ -77,7 +77,6 @@ class TestGetAvailablePlottersFromSpec:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -110,7 +109,6 @@ class TestGetAvailablePlottersFromSpec:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -135,7 +133,6 @@ class TestGetAvailablePlottersFromSpec:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -170,7 +167,6 @@ class TestGetAvailableOverlays:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -201,7 +197,6 @@ class TestGetAvailableOverlays:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -242,7 +237,6 @@ class TestGetAvailableOverlays:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -287,7 +281,6 @@ class TestGetAvailableOverlays:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -344,7 +337,6 @@ class TestGetAvailableOverlays:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -389,7 +381,6 @@ class TestGetAvailableOverlays:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -429,7 +420,6 @@ class TestGetAvailableOverlays:
             title='Test',
             description='Test',
             outputs=TestOutputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -514,7 +504,6 @@ class TestHiddenWindowFields:
             title='T',
             description='D',
             outputs=outputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -634,7 +623,6 @@ class TestSinceStartAvailable:
             title='T',
             description='D',
             outputs=outputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -834,7 +822,6 @@ class TestWorkflowSpecFieldFor:
             title='T',
             description='D',
             outputs=Outputs,
-            params=None,
             group=REDUCTION,
         )
 
@@ -866,7 +853,6 @@ class TestWorkflowSpecFieldFor:
             title='T',
             description='D',
             outputs=BareOutputs,
-            params=None,
             group=REDUCTION,
         )
         # The auto-generated view maps `result` via since_start. Asking for

--- a/tests/dashboard/save_filename_test.py
+++ b/tests/dashboard/save_filename_test.py
@@ -48,7 +48,6 @@ _WORKFLOW_REGISTRY = {
         version=1,
         title='Test Workflow',
         description='test',
-        params=None,
         outputs=_TestOutputs,
         group=REDUCTION,
     )

--- a/tests/dashboard/widgets/plot_config_modal_test.py
+++ b/tests/dashboard/widgets/plot_config_modal_test.py
@@ -254,7 +254,6 @@ def _make_workflow_spec(
         title=title,
         description=f"{title} description",
         source_names=source_names or [],
-        params=None,
         outputs=outputs,
         group=group,
     )

--- a/tests/dashboard/widgets/plot_widgets_test.py
+++ b/tests/dashboard/widgets/plot_widgets_test.py
@@ -151,7 +151,6 @@ class TestGetPlotCellDisplayInfo:
             title='Beam monitor data',
             description='D',
             outputs=CumulativeOutputs,
-            params=None,
             source_names=['src1'],
             group=REDUCTION,
         )
@@ -196,7 +195,6 @@ class TestGetPlotCellDisplayInfo:
             title='Beam monitor data',
             description='D',
             outputs=CurrentOutputs,
-            params=None,
             source_names=['src1'],
             group=REDUCTION,
         )
@@ -241,7 +239,6 @@ class TestPlotterTitleInDisplayInfo:
             title='Detector counts',
             description='D',
             outputs=self._ImageOutputs,
-            params=None,
             source_names=['src1'],
             group=REDUCTION,
         )
@@ -361,7 +358,6 @@ class TestDeriveCellTitle:
             title='Detector XY Projection',
             description='D',
             outputs=_XYOutputs,
-            params=None,
             source_names=['Front Right'],
             group=REDUCTION,
         )

--- a/tests/workflows/workflow_factory_test.py
+++ b/tests/workflows/workflow_factory_test.py
@@ -12,6 +12,7 @@ from ess.livedata.config.workflow_spec import (
     AuxInput,
     AuxSources,
     JobId,
+    NoParams,
     WorkflowConfig,
     WorkflowId,
     WorkflowSpec,
@@ -51,7 +52,6 @@ def workflow_spec(workflow_id):
         version=workflow_id.version,
         title="Pretty name",
         description="Test description",
-        params=None,
         group=REDUCTION,
     )
 
@@ -66,7 +66,6 @@ def workflow_spec_with_sources(workflow_id):
         title="test-workflow",
         description="Test",
         source_names=["source1", "source2"],
-        params=None,
         group=REDUCTION,
     )
 
@@ -183,7 +182,6 @@ class TestWorkflowFactory:
             title="test-workflow",
             description="Test",
             source_names=["source1"],
-            params=None,
             group=REDUCTION,
         )
 
@@ -264,6 +262,28 @@ class TestWorkflowFactory:
         with pytest.raises(ValidationError):
             factory.create(source_name="any-source", config=config)
 
+    def test_params_for_workflow_taking_none_are_rejected(
+        self, workflow_id, workflow_spec
+    ):
+        """A workflow with no params must reject params rather than drop them."""
+        factory = WorkflowFactory()
+        assert workflow_spec.params is NoParams
+
+        handle = factory.register_spec(workflow_spec)
+
+        @handle.attach_factory()
+        def factory_func():
+            return make_dummy_workflow()
+
+        config = WorkflowConfig(
+            identifier=workflow_id,
+            job_id=JobId(source_name="any-source", job_number=uuid.uuid4()),
+            params={"unexpected": 1},
+        )
+
+        with pytest.raises(ValidationError):
+            factory.create(source_name="any-source", config=config)
+
     def test_unknown_workflow_id_raises_key_error(self):
         factory = WorkflowFactory()
         non_existent_id = WorkflowId(
@@ -294,7 +314,6 @@ class TestWorkflowFactory:
             title=workflow_spec_with_sources.title,
             description=workflow_spec_with_sources.description,
             source_names=["allowed-source"],
-            params=None,
             group=REDUCTION,
         )
 
@@ -330,7 +349,6 @@ class TestWorkflowFactory:
             version=workflow_id1.version,
             title="workflow1",
             description="Test 1",
-            params=None,
             group=REDUCTION,
         )
         spec2 = WorkflowSpec(
@@ -339,7 +357,6 @@ class TestWorkflowFactory:
             version=workflow_id2.version,
             title="workflow2",
             description="Test 2",
-            params=None,
             group=REDUCTION,
         )
 
@@ -393,7 +410,6 @@ class TestWorkflowFactory:
             version=workflow_id1.version,
             title="V1",
             description="Test 1",
-            params=None,
             group=REDUCTION,
         )
         spec2 = WorkflowSpec(
@@ -402,7 +418,6 @@ class TestWorkflowFactory:
             version=workflow_id2.version,
             title="V2",
             description="Test 2",
-            params=None,
             group=REDUCTION,
         )
 
@@ -450,7 +465,6 @@ class TestWorkflowFactory:
             version=workflow_id.version,
             title="",
             description="Test",
-            params=None,
             group=REDUCTION,
         )
 
@@ -486,7 +500,6 @@ class TestWorkflowFactory:
             title="test-workflow",
             description="Test",
             source_names=sources,
-            params=None,
             group=REDUCTION,
         )
 
@@ -546,7 +559,6 @@ class TestWorkflowFactory:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,
             aux_sources=my_aux_sources,
             group=REDUCTION,
         )
@@ -579,7 +591,6 @@ class TestWorkflowFactory:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,
             group=REDUCTION,
         )
 
@@ -610,7 +621,6 @@ class TestWorkflowFactory:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,
             group=REDUCTION,
         )
 
@@ -646,7 +656,6 @@ class TestWorkflowFactory:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,
             aux_sources=my_aux_sources,
             group=REDUCTION,
         )
@@ -681,7 +690,6 @@ class TestTwoPhaseRegistration:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,
             group=REDUCTION,
         )
 
@@ -704,7 +712,6 @@ class TestTwoPhaseRegistration:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,
             group=REDUCTION,
         )
 
@@ -727,7 +734,6 @@ class TestTwoPhaseRegistration:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,
             group=REDUCTION,
         )
 
@@ -750,7 +756,6 @@ class TestTwoPhaseRegistration:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,
             group=REDUCTION,
         )
 
@@ -874,7 +879,6 @@ class TestTwoPhaseRegistration:
             version=workflow_id.version,
             title="test-workflow",
             description="Test",
-            params=None,  # Spec has no params
             group=REDUCTION,
         )
 
@@ -972,7 +976,6 @@ class TestContextKeyInjection:
             version=workflow_id.version,
             title='test-workflow',
             description='Test',
-            params=None,
             group=REDUCTION,
         )
         factory.register_spec(spec).attach_factory()(factory_func)
@@ -1025,7 +1028,6 @@ class TestSpecHandleAddContextBinding:
             title='test-workflow',
             description='Test',
             source_names=source_names,
-            params=None,
             group=REDUCTION,
         )
         handle = factory.register_spec(spec)


### PR DESCRIPTION
`WorkflowSpec.params` was `type[BaseModel] | None`, which forced every consumer to branch on absence: the spec↔factory validator, workflow instantiation, dashboard job staging, monitor factory attachment, and the whole configuration-adapter chain down to the widget that renders the form. Workflows taking no configuration now use `NoParams`, an empty model, which is also the field default — so their registrations simply omit `params`.

The optionality turned out not to be load-bearing anywhere. The clearest evidence: `configuration_widget` already read `if model_class is None or not model_class.model_fields`, collapsing "no model" and "model with no fields" into the same `NoParamsWidget`. Dropping `| None` at the source removes it through the adapter chain, so `model_class()` and `set_aux_sources()` stop returning `Optional` too.

This is not dead-code removal — 13 of 56 registered workflows take no params (`timeseries_data` on every instrument, plus three detector/counts workflows), so the case for the change is schema clarity, not disuse.

Two things worth a reviewer's attention:

- **Extra-params rejection changed mechanism.** Sending params to a workflow that takes none was previously a hand-rolled `ValueError`; it is now `extra='forbid'` on `NoParams`, so it raises `ValidationError`. Without `extra='forbid'` pydantic would silently ignore the extra fields, which would be a quiet regression. That path had no test at all — this PR adds one, verified to fail if `extra='forbid'` is removed.
- **Factories are untouched.** They already opt into `params` by declaring it in their signature (`if 'params' in sig.parameters`), so param-less factories do not grow an unused argument.

Skipped tests drop from 54 to 41: the params serialization-roundtrip test previously skipped the 13 param-less workflows and now exercises them.

## Test plan

Full suite including slow and browser tests passes: 4697 passed, 67 skipped, 8 xfailed.
