### PR TITLE
Keep cells alive through transient render errors

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -11,6 +11,12 @@ from typing import Any, ClassVar
 
 import holoviews as hv
 import numpy as np
+
+# holoviews imports pandas lazily during rendering (e.g. the masked-type check
+# in its isfinite). If that first import races another thread's pandas import,
+# the render fails on a partially initialized module (#1192). Import eagerly,
+# before any render thread exists.
+import pandas  # noqa: F401
 import scipp as sc
 from bokeh.models import TeeHead
 from holoviews.core.util import range_pad
@@ -722,9 +728,7 @@ class Plotter:
             result = self._build_result(data, resolver, **kwargs)
         except Exception as e:
             self._range_targets = {}
-            result = hv.Text(0.5, 0.5, f"Error: {e}").opts(
-                text_align='center', text_baseline='middle', responsive=True
-            )
+            result = self._error_placeholder(f"Error: {e}")
 
         # Time bounds drive the cell titlebar's freshness indicator; they are
         # kept off the plot title to avoid minting an OptionTree entry per tick.
@@ -784,6 +788,27 @@ class Plotter:
                 )
             ]
 
+        return self._combine(plots)
+
+    def _error_placeholder(self, message: str) -> hv.Element:
+        """Stand-in frame for a failed render.
+
+        Must share the container type of the plotter's data frames: the
+        session's DynamicMap holds one type per plotter, and a mismatched
+        frame wedges it permanently (#1193). Plotters whose
+        :meth:`_build_result` emits a different frame type override this to
+        match.
+        """
+        return self._combine(
+            [
+                hv.Text(0.5, 0.5, message).opts(
+                    text_align='center', text_baseline='middle', responsive=True
+                )
+            ]
+        )
+
+    def _combine(self, plots: list[hv.Element]) -> hv.Overlay | hv.Layout:
+        """Combine elements into the container type every frame must share."""
         if self.layout_params.combine_mode == 'overlay':
             return hv.Overlay(plots)
         # Always a Layout in layout mode, even for a single dataset, so that

--- a/src/ess/livedata/dashboard/table_plotter.py
+++ b/src/ess/livedata/dashboard/table_plotter.py
@@ -110,6 +110,12 @@ class TablePlotter(Plotter):
             precision=params.format.precision,
         )
 
+    def _error_placeholder(self, message: str) -> hv.Element:
+        """Bare Text, matching this plotter's uncombined no-data placeholder."""
+        return hv.Text(0.5, 0.5, message).opts(
+            text_align='center', text_baseline='middle', **self._sizing_opts
+        )
+
     def _build_result(
         self,
         data: dict[DataKey, sc.DataArray],

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1568,6 +1568,40 @@ class TestPlotterOverlayMode:
         assert 'No data' in str(text_element.data)
 
 
+class TestRenderErrorPlaceholder:
+    """A failed render must not change the container type of the frame.
+
+    The session's DynamicMap holds one container type per plotter; a bare
+    error placeholder next to Overlay/Layout frames wedges it permanently and
+    the cell never updates again (#1193).
+    """
+
+    @pytest.fixture
+    def poison_data(self):
+        """Data a LinePlotter cannot render: a Curve needs 1-D input."""
+        return sc.DataArray(sc.array(dims=['x', 'y'], values=[[1.0], [2.0]]))
+
+    @pytest.mark.parametrize(
+        ('combine_mode', 'container'),
+        [('overlay', hv.Overlay), ('layout', hv.Layout)],
+    )
+    def test_error_placeholder_uses_same_container_as_data(
+        self, data_key, poison_data, combine_mode, container
+    ):
+        from ess.livedata.dashboard.plot_params import LayoutParams
+
+        params = PlotParams1d(layout=LayoutParams(combine_mode=combine_mode))
+        plotter = plots.LinePlotter.from_params(params)
+
+        plotter.compute({'primary': {data_key: poison_data}})
+        result = plotter.get_cached_state()
+
+        assert isinstance(result, container)
+        text_element = next(iter(result))
+        assert isinstance(text_element, hv.Text)
+        assert 'Error' in str(text_element.data)
+
+
 class TestOverlayUnitConsistency:
     """Layers sharing one figure must share one unit per axis.
 

--- a/tests/dashboard/plots_test.py
+++ b/tests/dashboard/plots_test.py
@@ -1601,6 +1601,37 @@ class TestRenderErrorPlaceholder:
         assert isinstance(text_element, hv.Text)
         assert 'Error' in str(text_element.data)
 
+    def test_rendered_plot_survives_error_frame_and_recovers(
+        self, data_key, poison_data
+    ):
+        """A rendered session shows the error, then data again.
+
+        The wedge lives in the rendered plot's frame pull (``get_plot_frame``
+        caches each frame into the DynamicMap): with a bare-Text placeholder
+        the error frame raised there, and the cell never updated again.
+        """
+        good = {
+            data_key: sc.DataArray(
+                sc.array(dims=['x'], values=[1.0, 2.0]),
+                coords={'x': sc.array(dims=['x'], values=[0.0, 1.0])},
+            )
+        }
+        plotter = plots.LinePlotter.from_params(PlotParams1d())
+        plotter.compute({'primary': good})
+        pipe = hv.streams.Pipe(data=plotter.get_cached_state())
+        dmap = plotter.create_presenter().present(pipe)
+        plot = render_to_bokeh(dmap)
+
+        plotter.compute({'primary': {data_key: poison_data}})
+        pipe.send(plotter.get_cached_state())
+        (error_frame,) = plot.current_frame
+        assert isinstance(error_frame, hv.Text)
+
+        plotter.compute({'primary': good})
+        pipe.send(plotter.get_cached_state())
+        (recovered_frame,) = plot.current_frame
+        assert isinstance(recovered_frame, hv.Curve)
+
 
 class TestOverlayUnitConsistency:
     """Layers sharing one figure must share one unit per axis.


### PR DESCRIPTION
Fixes #1192 and fixes #1193, the chain behind the "plot stopped receiving data updates" browser-test flake (which reproduces serially on an idle machine, so it is not a CI-load artifact).

holoviews imports pandas lazily during rendering (`masked_types` reached via `isfinite` in range computation). If that first pandas import of the process races another thread's import, the render fails on a partially initialized module. plots.py now imports pandas eagerly, before any render thread exists (#1192).

When a render fails, `Plotter.compute` cached a bare `hv.Text` error placeholder next to the `Overlay`/`Layout` frames the cell's DynamicMap normally holds; holoviews refuses mixed types, so every later frame raised and the cell was dead for the session's lifetime. The placeholder now goes through the same combine step as data frames, via an overridable `_error_placeholder`. `TablePlotter` overrides it to keep its existing bare-Text convention (its frames are `hv.Table`, the latent case noted in #1193).

## Test plan

- [x] New regression tests: the error placeholder shares the container type of data frames (overlay and layout modes), and a rendered plot shows the error frame and then recovers to data — exercising the `get_plot_frame` path where the wedge lived. All flip on the old code.
- [x] Full unit suite passes (4669 passed).
- [ ] Browser suite flake rate: observe `test_clicking_out_an_empty_region_creates_a_live_plot` over the next runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
