### PR TITLE
Speed up the browser tests: poll instead of sleep, run two xdist workers

### DIFF
--- a/tests/helpers/browser.py
+++ b/tests/helpers/browser.py
@@ -46,7 +46,10 @@ DATA_FINGERPRINT_JS = """() => {
     for (let i = 0; i < Math.min(column.length, 64); i++) {
       const v = column[i];
       if (typeof v === 'number' && Number.isFinite(v)) checksum += v;
-      else if (v && typeof v.length === 'number') sample(v);
+      // Strings also have a numeric length, but 'x'[0] === 'x', so recursing
+      // into one never terminates. A string column contributes via `length`.
+      else if (v && typeof v !== 'string' && typeof v.length === 'number')
+        sample(v);
     }
   };
   for (const doc of (window.Bokeh && Bokeh.documents) || []) {
@@ -85,11 +88,19 @@ def fingerprint(dash: Dashboard) -> dict:
 
 
 def assert_updating(dash: Dashboard, label: str) -> None:
-    """Assert the session's rendered data changes within the update window."""
+    """Assert the session's rendered data changes within the update window.
+
+    Polls rather than sleeping out the window: the fake backend emits at 1 Hz,
+    so a healthy session passes in about a second instead of always paying the
+    full window.
+    """
     before = fingerprint(dash)
-    dash.page.wait_for_timeout(UPDATE_WINDOW_MS)
-    after = fingerprint(dash)
-    assert after != before, f"{label} stopped receiving data updates: {before}"
+    wait_until(
+        dash,
+        lambda: fingerprint(dash) != before,
+        label=f"a data update ({label} stopped receiving data updates: {before})",
+        timeout_ms=UPDATE_WINDOW_MS,
+    )
 
 
 def wait_until(

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ setenv =
 # System libraries for chromium are not installed here; on CI a workflow step
 # runs `playwright install-deps chromium` (needs sudo) before invoking tox.
 commands_pre = playwright install chromium
-commands = pytest -m browser {posargs} tests/dashboard/
+commands = pytest -m browser -n 2 {posargs} tests/dashboard/
 
 [testenv:nightly]
 deps = -r requirements/nightly.txt


### PR DESCRIPTION
Browser-test-helper changes plus parallelization, no test semantics weakened:

`assert_updating` slept out the full 6 s update window on every call before comparing fingerprints. It now polls the fingerprint until it changes (same 6 s deadline), so a healthy session — the fake backend emits at 1 Hz — passes in about a second. Across the 15 call sites this takes the serial suite from 8:01 to 6:44 locally.

The data-fingerprint sampler recursed into any value with a numeric `.length`. Strings have one, and `'x'[0] === 'x'`, so a single string column in any rendered ColumnDataSource recursed until `RangeError: Maximum call stack size exceeded`. Serial runs never happened to fingerprint while a string column was present; under shifted timing (parallel runs) it fails deterministically. String columns now contribute via the length count only.

The tox browser env now runs with `pytest -n 2`: each test launches its own dashboard on a dynamically allocated port, so the suite parallelizes, and two workers on the 4-core runners should roughly halve the job. Whether parallel load raises the #1185 stall-flake rate can only be measured by running it here; if it does, dropping the `-n 2` is a one-line revert. Locally, combined with the #1195 fixes, `-n 4` passes 16/16 in 3:31.

## Test plan

- [x] Full browser suite passes serially (16/16, 6:44).
- [x] Full browser suite passes with `-n 4` when combined with the #1195 fixes (16/16, 3:31).
- [ ] Watch the browser job here and on the next few main runs for stall flakes ("modal opened only on attempt" warnings, update-window failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
