### PR TITLE
fix: Warm the colormap machinery at startup instead of first render to avoid multi-second delay of first image plots

### DIFF
--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -10,6 +10,7 @@ from urllib.request import urlopen
 import holoviews as hv
 import panel as pn
 from holoviews.plotting.bokeh.plot import LayoutPlot
+from holoviews.plotting.util import process_cmap
 from panel.io.resources import CDN_DIST
 from panel.theme.material import Material
 
@@ -51,6 +52,13 @@ ANNOUNCEMENTS_URL = (
 
 pn.extension('holoviews', 'modal', notifications=True, template='material')
 hv.extension('bokeh')
+
+# The first colormap resolution walks every provider, and colorcet's import
+# registers hundreds of colormaps with matplotlib, each miss paying difflib
+# suggestion generation -- ~2.5 s of CPU. Lazily that lands on a session's
+# IOLoop during its first plot render, blocking every request for seconds
+# (#1185). Resolve one cmap now to pay it here, at process startup.
+process_cmap('viridis')
 
 # Remove Bokeh logo from Layout toolbars by patching LayoutPlot.initialize_plot
 

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -57,7 +57,7 @@ hv.extension('bokeh')
 # registers hundreds of colormaps with matplotlib, each miss paying difflib
 # suggestion generation -- ~2.5 s of CPU. Lazily that lands on a session's
 # IOLoop during its first plot render, blocking every request for seconds
-# (#1185). Resolve one cmap now to pay it here, at process startup.
+# (holoviz/holoviews#6981). Resolve one cmap now to pay it here, at process startup.
 process_cmap('viridis')
 
 # Remove Bokeh logo from Layout toolbars by patching LayoutPlot.initialize_plot


### PR DESCRIPTION
## Overview

This issue was found when investigating flaky CI jobs, but it turns out it solves a long-standing issue: image plots not showing up for a "long" time (seconds) when they are first created. The difference is very clearly noticeable with the real dashboard:
- start detector workflow, wait (to make sure jobs are started and data is received by dashboard).
- switch to tab with detector plots and observe how long it takes them to show up

With manual timing is see:
- Before: ~4.5 seconds
- After: ~1.5 seconds

## Details

Partial fix for #1185, targeting the dominant stall: the cold start of the colormap machinery.

The first colormap resolution in a dashboard process walks every holoviews provider (`process_cmap` -> `_list_cmaps("colorcet")`); colorcet's import then registers hundreds of colormaps with matplotlib, and each registration check misses the registry and pays difflib "did you mean" suggestion generation -- ~2.5 s of CPU in total. Left lazy, that lands on a session's IOLoop during its first plot render, blocking every request behind it. Measured with the #1185 fetch probe around the first Detectors render on an idle 24-core machine: max asset stall 4.7-4.8 s -- the same 4778 ms the CI failure logs show, so this was the cold start all along, not runner load. `process_cmap('viridis')` at module init pays it once at process startup instead.

After the warmup the probe reads median 4 ms, p90 ~130 ms, max 1.1-1.3 s; the residual peak is genuine bokeh model creation for the grid cells on first render (follow-up material, tracked in #1185 along with the measured steady-state pass composition).

## Test plan

- [x] Stall probe before/after (numbers above, two runs each).
- [x] `null_transport_startup_test` passes (exercises the module init path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
