### PR TITLE
Build per-layer cell toolbars lazily instead of hidden

### DIFF
--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -202,8 +202,8 @@ class CellWidget:
     """
     Per-session widget for a single plot cell.
 
-    Builds a Panel ``Column`` with a titlebar, a (toggleable) column of
-    per-layer toolbars, and a content area showing the composed plot or a
+    Builds a Panel ``Column`` with a titlebar, a column of per-layer toolbars
+    built on first reveal, and a content area showing the composed plot or a
     status placeholder. Owns the cell's autoscale controller and the panes
     updated in place by the poll loop (titlebar freshness pill, per-layer
     time-range labels).
@@ -369,13 +369,16 @@ class CellWidget:
         self._freeze_pill_for_status(layer_states)
 
         # Per-layer toolbars, wrapped in a column the titlebar toggle can hide.
-        layer_toolbars = self._build_layer_toolbars(layer_states)
+        # Populated only once revealed: a hidden Panel component still creates
+        # every one of its Bokeh models, and the toolbars are a quarter of a
+        # cell's model count while most cells are never expanded.
         layers_column = pn.Column(
-            *layer_toolbars,
             sizing_mode='stretch_width',
             margin=0,
             visible=self._toolbars_shown,
         )
+        if self._toolbars_shown:
+            layers_column[:] = self._build_layer_toolbars(layer_states)
         titlebar = self._build_titlebar(layers_column)
 
         # Create content area (placeholder or plot)
@@ -450,6 +453,8 @@ class CellWidget:
 
         def on_toggle_toolbars(visible: bool) -> None:
             self._toolbars_shown = visible
+            if visible and not layers_column.objects:
+                layers_column[:] = self._build_layer_toolbars(self._layer_states())
             layers_column.visible = visible
 
         geometry = cell.geometry
@@ -514,6 +519,10 @@ class CellWidget:
 
             time_pane = create_layer_time_pane()
             self._layer_time_panes[layer_id] = time_pane
+            # Seed from the layer's current bounds: toolbars revealed between
+            # frames would otherwise read blank until the next data flush.
+            if state.plotter is not None:
+                self.update_layer_time(layer_id, state.plotter.time_bounds)
 
             rows.append(
                 create_layer_info_row(

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -40,6 +40,7 @@ from ess.livedata.dashboard.widgets.styles import StatusPill
 from ess.livedata.dashboard.widgets.workflow_status_widget import (
     WorkflowStatusListWidget,
 )
+from tests.helpers.panel_ui import click_tool
 
 hv.extension('bokeh')
 
@@ -321,9 +322,12 @@ class TestFreshnessIndicator:
         _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
 
         # First poll adds the tab and builds the cell; activate then poll again
-        # so the freshness pane fills for the now-active grid.
+        # so the freshness pane fills for the now-active grid. The per-layer
+        # time panes exist only once their toolbars are revealed.
         plot_grid_tabs._poll_for_plot_updates()
         plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+        for cell_widget in plot_grid_tabs._cells.values():
+            click_tool(cell_widget.view, 'lt-tool-layer-details')
         plot_grid_tabs._poll_for_plot_updates()
 
         panes = [cw.freshness_pane for cw in plot_grid_tabs._cells.values()]
@@ -361,9 +365,12 @@ class TestFreshnessIndicator:
         )
 
         # First poll adds the tab and builds the cell; activate then poll again
-        # so the per-layer time panes fill for the now-active grid.
+        # so the per-layer time panes fill for the now-active grid. The panes
+        # exist only once their toolbars are revealed.
         plot_grid_tabs._poll_for_plot_updates()
         plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+        for cell_widget in plot_grid_tabs._cells.values():
+            click_tool(cell_widget.view, 'lt-tool-layer-details')
         plot_grid_tabs._poll_for_plot_updates()
 
         (cell_widget,) = plot_grid_tabs._cells.values()
@@ -375,10 +382,13 @@ class TestFreshnessIndicator:
     def test_rebuilt_cell_refills_its_time_panes_on_the_same_poll(
         self, plot_orchestrator, plot_data_service, plot_grid_tabs
     ):
-        """A rebuild mints blank panes, so the poll that rebuilds must refill them.
+        """A rebuilt cell must show its age and time range straight away.
 
-        Otherwise the cell shows no age and no time range until the next frame
-        or the stall tick, however good the data behind it is.
+        A rebuild mints blank panes, so the poll that rebuilds refills them (a
+        revealed cell's panes are additionally seeded from current bounds as
+        they are built). Without either, the cell shows no age and no time
+        range until the next frame or the stall tick, however good the data
+        behind it is.
         """
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
         layer_id = _inject_layer(
@@ -389,6 +399,8 @@ class TestFreshnessIndicator:
         )
         plot_grid_tabs._poll_for_plot_updates()
         plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+        for cell_widget in plot_grid_tabs._cells.values():
+            click_tool(cell_widget.view, 'lt-tool-layer-details')
         plot_grid_tabs._poll_for_plot_updates()
 
         # A new plotter bumps the layer version, so the next poll rebuilds the

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -17,6 +17,7 @@ from ess.livedata.dashboard.widgets.plot_grid_tabs import PlotGridTabs
 from ess.livedata.dashboard.widgets.workflow_status_widget import (
     WorkflowStatusListWidget,
 )
+from tests.helpers.panel_ui import click_tool
 
 hv.extension('bokeh')
 
@@ -1195,6 +1196,67 @@ def _add_static_cell(plot_orchestrator, grid_id, geometry, *, positions='10, 20'
     cell_id = plot_orchestrator.add_cell(grid_id, geometry)
     plot_orchestrator.add_layer(cell_id, config)
     return cell_id
+
+
+class TestLayerToolbars:
+    """Per-layer toolbars are built when first revealed, not when hidden.
+
+    A hidden Panel component still creates every one of its Bokeh models, and
+    the toolbars start collapsed, so building them eagerly charges every
+    session for detail most cells never show (#1198).
+    """
+
+    @staticmethod
+    def _geometry():
+        from ess.livedata.dashboard.plot_orchestrator import CellGeometry
+
+        return CellGeometry(row=0, col=0, row_span=1, col_span=1)
+
+    def _cell_widget(self, plot_orchestrator, plot_grid_tabs):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+        return next(iter(plot_grid_tabs._cells.values()))
+
+    def test_collapsed_cell_builds_no_layer_toolbars(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        cell_widget = self._cell_widget(plot_orchestrator, plot_grid_tabs)
+
+        assert cell_widget.layer_time_panes == {}
+
+    def test_revealing_builds_them(self, plot_orchestrator, plot_grid_tabs):
+        cell_widget = self._cell_widget(plot_orchestrator, plot_grid_tabs)
+        click_tool(cell_widget.view, 'lt-tool-layer-details')
+
+        assert cell_widget.toolbars_shown
+        assert len(cell_widget.layer_time_panes) == 1
+
+    def test_hiding_and_revealing_again_keeps_one_set(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        cell_widget = self._cell_widget(plot_orchestrator, plot_grid_tabs)
+        click_tool(cell_widget.view, 'lt-tool-layer-details')
+        panes = dict(cell_widget.layer_time_panes)
+        click_tool(cell_widget.view, 'lt-tool-layer-details')
+        click_tool(cell_widget.view, 'lt-tool-layer-details')
+
+        assert cell_widget.layer_time_panes == panes
+
+    def test_rebuild_preserves_revealed_toolbars(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        cell_widget = self._cell_widget(plot_orchestrator, plot_grid_tabs)
+        cell_id = next(iter(plot_grid_tabs._cells))
+        click_tool(cell_widget.view, 'lt-tool-layer-details')
+
+        plot_orchestrator.set_cell_title(cell_id, 'renamed')
+        _tick(plot_grid_tabs)
+
+        rebuilt = plot_grid_tabs._cells[cell_id]
+        assert rebuilt is not cell_widget
+        assert rebuilt.toolbars_shown
+        assert len(rebuilt.layer_time_panes) == 1
 
 
 class TestCellReconcile:

--- a/tests/helpers/panel_ui.py
+++ b/tests/helpers/panel_ui.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Driving Panel widget trees from unit tests via the ``lt-*`` automation hooks.
+
+The same stable CSS classes browser automation targets (see
+``.claude/rules/dashboard-widgets.md``) address a button in-process, so a test
+clicks what a user clicks instead of indexing into a layout that a refactor
+will renumber.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def find_by_css_class(widget: Any, css_class: str) -> Any | None:
+    """Depth-first search of a Panel widget tree for a component's hook class."""
+    if css_class in (getattr(widget, 'css_classes', None) or []):
+        return widget
+    for child in getattr(widget, 'objects', []):
+        found = find_by_css_class(child, css_class)
+        if found is not None:
+            return found
+    return None
+
+
+def click_tool(widget: Any, css_class: str) -> None:
+    """Click the tool button carrying ``css_class`` somewhere under ``widget``."""
+    button = find_by_css_class(widget, css_class)
+    if button is None:
+        raise AssertionError(f"No widget with css class {css_class!r}")
+    button.clicks += 1


### PR DESCRIPTION
The per-layer toolbars in a plot cell start collapsed, but they were built up front and hidden with `visible=False`. A hidden Panel component still creates every one of its Bokeh models (our own rule in `.claude/rules/dashboard-widgets.md` says as much), so every session paid for detail most cells never show — and the poll loop then wrote time readouts into those invisible panes on every frame.

They are now built when the toggle first reveals them. Each layer's time pane is seeded from the layer's current bounds as it is built, so a toolbar revealed between frames does not read blank until the next data flush.

Measured on the dummy fixture (#1198 harness, differencing settled 6- and 12-cell censuses): **98 -> 75 models per cell**, and freeze-exit — bokeh's model-graph recompute, O(models), on every pass — **49 -> 40 ms** on a 12-cell grid. Model count also drives the first-render block and the client's instantiation cost, which is the larger half.

Tests reach the toggle through its committed `lt-tool-layer-details` hook rather than by indexing the layout; the new `tests/helpers/panel_ui.py` does that lookup for any `lt-*` button.

## Test plan

- [x] `pytest tests/dashboard` passes (new coverage: collapsed cell builds no toolbars, revealing builds them once, a rebuild preserves the revealed state)
- [x] Manual: expand a cell's layer details in a running dashboard, confirm the rows appear with their time range already filled in, collapse and expand again
