### PR TITLE
Style computed frames instead of the session's DynamicMap

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -339,15 +339,16 @@ class DefaultPresenter(PresenterBase):
     def present(self, pipe: hv.streams.Pipe) -> hv.DynamicMap:
         """Create a DynamicMap that passes through pre-computed elements.
 
-        Static styling is applied once on the DynamicMap (see
-        :meth:`Plotter.style_opts`) rather than per element on every tick.
+        The elements arrive already styled from :meth:`Plotter.compute`. Styling
+        must not be applied here: ``DynamicMap.opts`` is not a one-off, it wraps
+        the map in a ``Dynamic`` operation that re-applies the options to every
+        frame, in every session, on the shared IOLoop.
         """
 
         def passthrough(data):
             return data
 
-        dmap = hv.DynamicMap(passthrough, streams=[pipe], cache_size=1)
-        return dmap.opts(*self._plotter.style_opts())
+        return hv.DynamicMap(passthrough, streams=[pipe], cache_size=1)
 
 
 class StaticPresenter(PresenterBase):
@@ -735,7 +736,7 @@ class Plotter:
         # Computed outside the try so a render failure still stamps the bounds
         # of the data that was received.
         self._time_bounds = _compute_time_bounds(data)
-        self._set_cached_state(result)
+        self._set_cached_state(result.opts(*self.style_opts()))
 
     def _build_result(
         self,
@@ -896,12 +897,14 @@ class Plotter:
         return iter(self._range_targets.items())
 
     def style_opts(self) -> list[hv.Options]:
-        """Static HoloViews opts applied once on the presenter's DynamicMap.
+        """Static HoloViews opts, declared once and applied to each computed frame.
 
-        Hoisting styling here keeps ``compute()`` a pure data->element transform:
-        the per-tick build emits bare elements and styling is declared once at
-        render time, rather than minting an entry in the process-global option
-        store for every element on every tick. Subclasses extend this with opts
+        Declaring them here keeps the per-tick build free of styling decisions:
+        :meth:`compute` applies this list to the finished frame in a single call,
+        so options are never re-assembled per element. Applying them once per
+        frame on the shared compute path also keeps them off the per-session
+        render path, where HoloViews would re-apply them per frame per session
+        (see :meth:`DefaultPresenter.present`). Subclasses extend this with opts
         for their leaf element types; the base provides the container-level opts.
         """
         # title='' stops Bokeh promoting a single overlaid element's label to the

--- a/tests/dashboard/plot_sizing_invariant_test.py
+++ b/tests/dashboard/plot_sizing_invariant_test.py
@@ -164,3 +164,36 @@ def test_slicer_figure_adopts_the_panes_sizing_mode(aspect):
 
     assert len(figures) == 1
     assert figures[0].sizing_mode == pane_sizing_mode(aspect)
+
+
+@pytest.mark.parametrize(
+    ('plotter_cls', 'params_cls', 'make_data'),
+    [
+        (plots.LinePlotter, PlotParams1d, _data_1d),
+        (plots.ImagePlotter, PlotParams2d, _data_2d),
+    ],
+    ids=['line', 'image'],
+)
+@pytest.mark.parametrize('combine', [CombineMode.overlay, CombineMode.layout])
+def test_computed_frames_are_styled_before_they_reach_a_session(
+    plotter_cls, params_cls, make_data, combine
+):
+    """Styling must ride on the frame, not on the session's DynamicMap.
+
+    ``DynamicMap.opts`` is not a one-off: it wraps the map in a ``Dynamic``
+    operation that re-applies the options to every frame, in every session, on
+    the shared IOLoop. Rendering the cached frame on its own therefore has to
+    show the finished styling.
+    """
+    aspect = PlotAspect(
+        aspect_type=PlotAspectType.square, stretch_mode=StretchMode.width
+    )
+    params = params_cls(layout=LayoutParams(combine_mode=combine), plot_aspect=aspect)
+    plotter = plotter_cls.from_params(params)
+    plotter.compute({'primary': make_data(2)})
+
+    figures = _figures(plotter.get_cached_state())
+
+    assert figures
+    for fig in figures:
+        assert fig.sizing_mode == pane_sizing_mode(aspect)


### PR DESCRIPTION
## Motivation

`DefaultPresenter` applied the plotter's style opts to each session's DynamicMap. That reads as a one-off, but `Opts._dynamicmap_opts` does not set options on a DynamicMap -- it wraps the map in a `Dynamic` operation that re-applies them to **every frame**, minting a custom option id each time. The styling therefore ran per layer, per session, per frame, on the shared IOLoop, which is the resource a plot grid runs out of first (#1198).

This is the mechanism #958 was reaching for and did not get: that PR moved the styling decision out of the per-tick build (correct, and kept here), but attached the result somewhere that re-does the work per frame -- and moved it from the shared compute path onto each session's render path in the process.

## Approach

Apply the opts to the finished frame in `compute()`. The frame is computed once for all sessions and off the render path, so one typed `.opts()` call per frame now serves every session, and the session's DynamicMap goes back to being a bare passthrough.

This is the alternative to the merge-the-two-wrappers proposal in #1199: both end at one per-frame wrapper, but this route leaves the cell's hooks exactly where they are and so needs none of the hook-lifecycle machinery that proposal required (cell-scoped hooks vs layer-scoped DynamicMap). The remaining wrapper is the cell's `.opts(hooks=...)`, which cannot be hoisted -- hooks are session state.

## Measurements

Fake-backend 6-cell render harness, 12 layers at 1 Hz, single session, three alternating runs per side, pooled over the settled full passes: **11.7 / 12.4 / 11.7 ms -> 9.5 / 9.8 / 10.6 ms** of IOLoop time per layer per frame. The saving is per session, so it scales with the number of open sessions.

## Rendering equivalence

A bokeh-level model signature (every model in the rendered document, all non-default properties) over 51 plotter configurations -- both plotters, both combine modes, one and two sources, four aspect types, log and linear colour scales, error bars, and the slicer -- is identical before and after.

The new test in `plot_sizing_invariant_test.py` pins the invariant that styling rides on the frame rather than on the DynamicMap; it fails on every parametrisation without the change.

## Test plan

- [x] `tests/dashboard` (2066 passed, 4 xfailed)
- [x] Manual: open a grid with 1D, 2D, overlay and layout cells and confirm styling, sizing and colorbars are unchanged.

Closes #1199.
