### PR TITLE
Recompute the model graph only on passes that changed it

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -36,7 +36,7 @@ def refresh(self):
 
 **Key principles**:
 - Widgets detect changes via version counters on shared state, not via push callbacks
-- All widget updates run inside `SessionUpdater._batched_update()` for efficient recomputation
+- All widget updates run inside `batched_update()` for efficient recomputation
 - Widget event handlers should only call methods on shared components, never rebuild directly
 
 ## Icons

--- a/src/ess/livedata/dashboard/batched_update.py
+++ b/src/ess/livedata/dashboard/batched_update.py
@@ -33,6 +33,9 @@ def batched_update() -> Iterator[None]:
     Nesting is a no-op: an inner batch is already covered by the outer one.
     """
     doc = pn.state.curdoc
+    # The freeze is the inner context so that it recomputes before the hold
+    # dispatches: a model added during the pass must be attached to the document
+    # by the time the queued events are serialized.
     with pn.io.hold(), _frozen_models(doc):
         yield
 

--- a/src/ess/livedata/dashboard/batched_update.py
+++ b/src/ess/livedata/dashboard/batched_update.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Batching of the Bokeh document mutations a single IOLoop pass makes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import panel as pn
+
+if TYPE_CHECKING:
+    from bokeh.document import Document
+
+
+@contextmanager
+def batched_update() -> Iterator[None]:
+    """Batch the document events and model-graph recomputes of one pass.
+
+    ``pn.io.hold()`` batches document change events so they are dispatched to
+    the browser in one WebSocket flush, avoiding staggered rendering.
+
+    The freeze batches Bokeh's model-graph recomputation. Without it, each
+    operation that mutates the model graph (pipe.send, layout child changes)
+    triggers a full BFS traversal of every model in the document via
+    ``_pop_freeze`` -> ``recompute`` -> ``collect_models``, at O(models) cost.
+    Holding the freeze counter above zero for the whole pass makes the inner
+    freeze/unfreeze cycles (Panel's per-model ``freeze_doc``, HoloViews'
+    ``hold_render``) no-ops, collapsing N recomputes into 1 -- or into none, see
+    :func:`_frozen_models`.
+
+    Nesting is a no-op: an inner batch is already covered by the outer one.
+    """
+    doc = pn.state.curdoc
+    with pn.io.hold(), _frozen_models(doc):
+        yield
+
+
+@contextmanager
+def _frozen_models(doc: Document | None) -> Iterator[None]:
+    """Freeze the document's model graph, recomputing it only if it changed.
+
+    ``doc.models.freeze()`` recomputes when it exits whether or not anything
+    changed. A pass that mutates nothing -- the unconditional full pass, or any
+    pass whose handlers find no work -- then pays an O(models) walk for nothing:
+    tens of milliseconds on a document holding a plot grid, once a second or
+    more, on the IOLoop every session on the server shares.
+
+    So instead of Bokeh's ``freeze``, hold the freeze counter up ourselves and
+    recompute at the end only if the pass could have changed which models are
+    reachable from the roots. That is the case exactly when Bokeh called
+    ``DocumentModelManager.invalidate`` -- its own signal that a property change
+    touched model references, intercepted here because while frozen it does
+    nothing -- or when the roots themselves changed, which Bokeh signals by
+    freezing around the change rather than by invalidating.
+
+    Data-only changes (``ColumnDataSource`` patches and streams) invalidate
+    nothing by design, so a pass that merely pushes new data into existing
+    glyphs now recomputes nothing either.
+    """
+    if doc is None:
+        yield
+        return
+    models = doc.models
+    if 'invalidate' in models.__dict__:
+        # An enclosing batch already installed the hook below and holds the
+        # freeze; re-installing here would unhook it again on exit.
+        yield
+        return
+    invalidated = False
+
+    def invalidate() -> None:
+        nonlocal invalidated
+        invalidated = True
+
+    roots = doc.roots
+    models.invalidate = invalidate  # type: ignore[method-assign]
+    models._push_freeze()
+    try:
+        yield
+    finally:
+        del models.invalidate
+        # Pop by hand: ``_pop_freeze`` would recompute unconditionally. Unlike
+        # Bokeh's ``freeze`` this also runs on the exception path, so a raising
+        # handler cannot leave the document frozen for good.
+        models._freeze_count -= 1
+        if models._freeze_count == 0 and (invalidated or doc.roots != roots):
+            models.recompute()

--- a/src/ess/livedata/dashboard/range_hook.py
+++ b/src/ess/livedata/dashboard/range_hook.py
@@ -45,9 +45,9 @@ def _ordered_write(
     first; otherwise write the low first. This guards renders that run outside
     a document hold, where each set dispatches its own PATCH-DOC and a stale
     intermediate could momentarily invert the range. Per-tick autoscale writes
-    do run under ``session_updater._batched_update`` (``pn.io.hold`` +
-    ``doc.models.freeze``), which collapses both sets into one frame, so the
-    ordering is belt-and-suspenders there rather than load-bearing.
+    do run under ``batched_update`` (``pn.io.hold`` + a model-graph freeze),
+    which collapses both sets into one frame, so the ordering is
+    belt-and-suspenders there rather than load-bearing.
 
     On a datetime axis the float targets are epoch *nanoseconds* by contract
     (see ``plots._finite_min_max``); they are cast back to ``np.datetime64[ns]``

--- a/src/ess/livedata/dashboard/session_updater.py
+++ b/src/ess/livedata/dashboard/session_updater.py
@@ -12,14 +12,14 @@ in the correct session context.
 from __future__ import annotations
 
 import time
-from collections.abc import Callable, Iterable, Iterator
-from contextlib import contextmanager, nullcontext
+from collections.abc import Callable, Iterable
 from functools import partial
 from typing import TYPE_CHECKING
 
 import panel as pn
 import structlog
 
+from .batched_update import batched_update
 from .notification_queue import NotificationEvent, NotificationQueue
 from .notifications import show_notification
 from .session_registry import SessionId, SessionRegistry
@@ -341,7 +341,7 @@ class SessionUpdater:
         if not notifications and not handlers:
             return
 
-        with self._batched_update():
+        with batched_update():
             self._show_notifications(notifications)
             for handler in handlers:
                 try:
@@ -365,26 +365,6 @@ class SessionUpdater:
                 "Error in has_work predicate for session %s", self._session_id
             )
             return True
-
-    @contextmanager
-    def _batched_update(self) -> Iterator[None]:
-        """Batch UI updates using hold + freeze.
-
-        ``pn.io.hold()`` batches document change events so they are dispatched
-        to the browser in one WebSocket flush, avoiding staggered rendering.
-
-        ``doc.models.freeze()`` batches Bokeh model-graph recomputation.
-        Without it, each operation that mutates the model graph (pipe.send,
-        layout child changes) triggers a full BFS traversal of every model in
-        the document via ``_pop_freeze`` → ``recompute`` → ``collect_models``,
-        at O(M) cost. The outer freeze keeps the counter above zero so that
-        inner freeze/unfreeze cycles (e.g. HoloViews ``hold_render``) are
-        no-ops, collapsing N recomputes into 1.
-        """
-        doc = pn.state.curdoc
-        freeze = doc.models.freeze() if doc is not None else nullcontext()
-        with pn.io.hold(), freeze:
-            yield
 
     def _poll_notifications(self) -> list[NotificationEvent]:
         """Poll NotificationQueue for new events."""

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Mapping, Sequence
-from contextlib import nullcontext
 
 import panel as pn
 import structlog
 
 from ess.livedata.config.workflow_spec import WorkflowId, WorkflowSpec
 
+from ..batched_update import batched_update
 from ..notifications import show_error
 from ..plot_data_service import PlotDataService
 from ..plot_orchestrator import (
@@ -118,16 +118,14 @@ class _BatchedTabs(pn.Tabs):
     ``_apply_update`` calls) that independently serializes PATCH-DOC
     messages and recomputes the Bokeh model graph for each step.
 
-    Wrapping the cascade in ``pn.io.hold()`` + ``doc.models.freeze()``
-    collapses N dispatches/recomputes into 1 each.
+    Wrapping the cascade in :func:`batched_update` collapses N
+    dispatches/recomputes into 1 each.
 
     See https://github.com/holoviz/panel/issues/8461.
     """
 
     def _update_active(self, *events) -> None:
-        doc = pn.state.curdoc
-        freeze = doc.models.freeze() if doc is not None else nullcontext()
-        with pn.io.hold(), freeze:
+        with batched_update():
             super()._update_active(*events)
 
 

--- a/tests/dashboard/batched_update_test.py
+++ b/tests/dashboard/batched_update_test.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 import pytest
 from bokeh.document import Document
 from bokeh.models import Column, Div
+from bokeh.plotting import figure
 from panel.io.state import set_curdoc
 
 from ess.livedata.dashboard.batched_update import batched_update
@@ -35,10 +36,17 @@ def doc() -> Document:
 
 
 @pytest.fixture
-def recomputes(doc: Document) -> Callable[[], int]:
+def recomputes(doc: Document) -> Iterator[Callable[[], int]]:
     counter = RecomputeCounter(doc)
     yield lambda: counter.count
     counter.restore()
+
+
+def assert_graph_is_consistent(doc: Document) -> None:
+    """Assert every model reachable from the roots is attached, and no other."""
+    reachable = {model for root in doc.roots for model in root.references()}
+    assert set(doc.models) == reachable
+    assert all(model.document is doc for model in reachable)
 
 
 def test_pass_that_mutates_nothing_does_not_recompute(
@@ -89,6 +97,57 @@ def test_root_added_during_pass_is_attached(doc: Document) -> None:
     with set_curdoc(doc), batched_update():
         doc.add_root(root)
     assert doc.models.get_by_id(root.children[0].id) is not None
+
+
+def test_data_only_pass_does_not_recompute(
+    doc: Document, recomputes: Callable[[], int]
+) -> None:
+    """Plot updates reach the browser as data patches, which must stay free.
+
+    Bokeh routes ``ColumnDataSource`` patches and streams through hinted events
+    that deliberately skip invalidation. Recomputing on them would put an
+    O(models) walk on every tick of every plot; skipping is only correct because
+    data columns cannot hold model references.
+    """
+    plot = figure()
+    plot.line([1, 2, 3], [1, 4, 9])
+    doc.roots[0].children = [*doc.roots[0].children, plot]
+    source = plot.renderers[0].data_source
+    baseline = recomputes()
+
+    with set_curdoc(doc), batched_update():
+        source.stream({'x': [4], 'y': [16]})
+        source.patch({'y': [(0, 2)]})
+
+    assert recomputes() == baseline
+    assert_graph_is_consistent(doc)
+
+
+def test_inner_bokeh_freeze_does_not_recompute_mid_pass(
+    doc: Document, recomputes: Callable[[], int]
+) -> None:
+    """Panel's ``freeze_doc`` and HoloViews' ``hold_render`` freeze per update.
+
+    Their ``_pop_freeze`` must find the counter still raised, or the batch
+    collapses into one recompute per widget update.
+    """
+    with set_curdoc(doc), batched_update():
+        for i in range(3):
+            with doc.models.freeze():
+                doc.roots[0].children = [*doc.roots[0].children, Div(text=str(i))]
+            assert recomputes() == 0
+
+    assert recomputes() == 1
+    assert_graph_is_consistent(doc)
+
+
+def test_root_added_by_nested_pass_is_attached(doc: Document) -> None:
+    """The outer batch snapshots the roots, so it must see the inner's change."""
+    root = Column(children=[Div(text="from the inner pass")])
+    with set_curdoc(doc), batched_update():
+        with batched_update():
+            doc.add_root(root)
+    assert_graph_is_consistent(doc)
 
 
 def test_nested_pass_recomputes_once_for_both(

--- a/tests/dashboard/batched_update_test.py
+++ b/tests/dashboard/batched_update_test.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from collections.abc import Callable
+
+import pytest
+from bokeh.document import Document
+from bokeh.models import Column, Div
+from panel.io.state import set_curdoc
+
+from ess.livedata.dashboard.batched_update import batched_update
+
+
+class RecomputeCounter:
+    """Counts the document's model-graph recomputes without suppressing them."""
+
+    def __init__(self, doc: Document) -> None:
+        self._models = doc.models
+        self._inner = doc.models.recompute
+        self.count = 0
+        doc.models.recompute = self._recompute  # type: ignore[method-assign]
+
+    def _recompute(self) -> None:
+        self.count += 1
+        self._inner()
+
+    def restore(self) -> None:
+        del self._models.recompute
+
+
+@pytest.fixture
+def doc() -> Document:
+    document = Document()
+    document.add_root(Column(children=[Div(text="root")]))
+    return document
+
+
+@pytest.fixture
+def recomputes(doc: Document) -> Callable[[], int]:
+    counter = RecomputeCounter(doc)
+    yield lambda: counter.count
+    counter.restore()
+
+
+def test_pass_that_mutates_nothing_does_not_recompute(
+    doc: Document, recomputes: Callable[[], int]
+) -> None:
+    with set_curdoc(doc), batched_update():
+        pass
+    assert recomputes() == 0
+
+
+def test_pass_that_only_reads_the_graph_does_not_recompute(
+    doc: Document, recomputes: Callable[[], int]
+) -> None:
+    with set_curdoc(doc), batched_update():
+        assert len(doc.models) == 2
+        assert doc.roots[0].children[0].text == "root"
+    assert recomputes() == 0
+
+
+def test_added_model_is_attached_to_the_document(doc: Document) -> None:
+    added = Div(text="added")
+    with set_curdoc(doc), batched_update():
+        doc.roots[0].children = [*doc.roots[0].children, added]
+    assert doc.models.get_by_id(added.id) is added
+    assert added.document is doc
+
+
+def test_removed_model_is_detached_from_the_document(doc: Document) -> None:
+    removed = doc.roots[0].children[0]
+    with set_curdoc(doc), batched_update():
+        doc.roots[0].children = []
+    assert doc.models.get_by_id(removed.id) is None
+    assert removed.document is None
+
+
+def test_many_mutations_recompute_once(
+    doc: Document, recomputes: Callable[[], int]
+) -> None:
+    with set_curdoc(doc), batched_update():
+        for i in range(5):
+            doc.roots[0].children = [*doc.roots[0].children, Div(text=str(i))]
+    assert recomputes() == 1
+    assert len(doc.models) == 7
+
+
+def test_root_added_during_pass_is_attached(doc: Document) -> None:
+    root = Column(children=[Div(text="second root")])
+    with set_curdoc(doc), batched_update():
+        doc.add_root(root)
+    assert doc.models.get_by_id(root.children[0].id) is not None
+
+
+def test_nested_pass_recomputes_once_for_both(
+    doc: Document, recomputes: Callable[[], int]
+) -> None:
+    inner_added = Div(text="inner")
+    outer_added = Div(text="outer")
+    with set_curdoc(doc), batched_update():
+        doc.roots[0].children = [*doc.roots[0].children, outer_added]
+        with batched_update():
+            doc.roots[0].children = [*doc.roots[0].children, inner_added]
+    assert recomputes() == 1
+    assert doc.models.get_by_id(inner_added.id) is inner_added
+    assert doc.models.get_by_id(outer_added.id) is outer_added
+
+
+def test_raising_pass_leaves_the_document_usable(doc: Document) -> None:
+    with pytest.raises(RuntimeError):  # noqa: PT012
+        with set_curdoc(doc), batched_update():
+            doc.roots[0].children = [*doc.roots[0].children, Div(text="added")]
+            raise RuntimeError("handler blew up")
+
+    # A document left frozen would swallow this mutation until the next freeze.
+    added = Div(text="after")
+    doc.roots[0].children = [*doc.roots[0].children, added]
+    assert doc.models.get_by_id(added.id) is added
+
+
+def test_works_without_a_current_document() -> None:
+    with batched_update():
+        pass


### PR DESCRIPTION
Closes #1202.

`doc.models.freeze()` recomputes the document's model graph when it exits, whether or not anything changed, at O(models). Every `SessionUpdater` pass and every tab switch paid that on the IOLoop all sessions share.

The freeze counter is now held up directly for the pass, and the recompute at the end runs only if the pass could have changed which models are reachable from the roots: Bokeh called `DocumentModelManager.invalidate` — its own signal that a property change touched model references, interceptable here because while frozen it does nothing — or the roots themselves changed, which Bokeh signals by freezing around the change rather than by invalidating. Batching is otherwise unchanged: the counter is up for the whole pass, so inner freeze/unfreeze cycles (Panel's `freeze_doc`, HoloViews' `hold_render`) stay no-ops and a mutating pass still recomputes exactly once. Unlike Bokeh's `freeze`, the pop also runs on the exception path, so a raising handler can no longer leave the document frozen for good.

The idiom was duplicated in `_BatchedTabs`, so it moved into one `batched_update()` both call.

## Measured

Fake backend, dummy fixture, synthetic N-cell grid at 1 Hz, one session; this branch against `main` in the same harness, timing each pass and the recompute it skipped.

| grid | models | full pass (5 s cadence) | steady-state data pass |
|---|---|---|---|
| 6 cells | 473 | 33 ms → 0.2 ms | −17 ms of ~150 ms |
| 24 cells | 1753 | 128–213 ms → 0.7 ms | −141 ms of ~1.1 s |

The steady-state data passes benefit too, which #1202 did not anticipate: plot updates reach the browser as `ColumnDataSource` patches and streams, which Bokeh deliberately does not invalidate on, so a pass that only pushes new data into existing glyphs recomputes nothing at all.

That the *whole* steady state is such passes was not obvious, so it was measured rather than assumed: instrumented to record the outcome of every pass, a session sitting on the dummy fixture's Detectors grid for 90 s ran **106 passes and skipped the recompute in all 106**, including the 5 s full passes. The other per-tick cell updates do not put that back: the freshness pill and the text readouts write strings into panes that already exist, and a string cannot hold a model reference. So the saving is a recompute per pass at the tick cadence (~1.2/s there), not one per 5 s — about 3–6 % of a core per session at 6 cells, 15–30 % at 24 cells, growing with document size.

## Risk

Correctness now rests on Bokeh's invalidation being complete. `invalidate` has a single call site, `Model.trigger`, which skips it only for hinted events — `ColumnsStreamed` and `ColumnsPatched`, whose payload is column data and cannot carry model references — and which otherwise counts references by recursing through lists, tuples, dicts, dataclasses and non-Model `HasProps`. Reachability therefore cannot change without either that signal or a roots change, by induction over passes: a subtree becomes reachable only through a property set on an already-reachable model, and reachable implies attached implies `trigger` invalidates.

A hole in that would break any unfrozen Bokeh app too, since unfrozen Bokeh recomputes on exactly the same signal — but the exposure differs in degree, and this is where the change actually costs something. Unfrozen, an orphaned model heals at the next invalidating change anywhere in the document, which in a live app is near-constant. Here every mutation is inside a batch, and a steady state made entirely of data passes invalidates nothing at all, so an orphan can persist for as long as the session only pushes data. Until now the unconditional recompute papered over such a hole once per pass, and it no longer does. The failure mode would be a model that is added but never attached to the document.

The residual risk is therefore less a hole in Bokeh today than a future Bokeh changing the contract. The unit tests are written to pin the mechanism rather than the outcome, so that shift fails the suite instead of the dashboard.

## Test plan

- New unit tests drive a real `Document`: added/removed models attach and detach, many mutations recompute once, a pass that mutates nothing recomputes zero times, a data-only pass (stream + patch) recomputes zero times and leaves the graph consistent, an inner Bokeh `freeze()` does not recompute mid-pass, nested batches including a root added by the inner one, and a raising pass leaves the document usable.
- Full suite green; all 16 `-m browser` tests pass (they render plots, drive modals, and cover multi-session).
- The browser suite was also run with a temporary check that, on every skipped recompute, recomputed the reachable set and compared it against `doc.models`: 212 skips, no mismatch. Probing 14 mutation styles directly against Bokeh (in-place `children` mutation, glyphs and tabs added after attach, `data_source` swap, `CustomJS.args`, `js_on_change`, `tags`, `stylesheets`, deep detached subtrees) found no invalidation hole either.
