### PR TITLE
tests: Wait once for a modal instead of re-clicking its trigger

### DIFF
--- a/.claude/rules/dashboard-widgets.md
+++ b/.claude/rules/dashboard-widgets.md
@@ -129,8 +129,7 @@ assets are served off the same IOLoop as everything else, so their `tornado.acce
 timings measure how long that loop was blocked: a `GET /static/...` taking seconds
 means the click's round-trip was queued behind the session's periodic pass, not lost
 (#1185). Sub-millisecond serves with no post-click activity at all point at a dropped
-click instead. `Dashboard.open_modal` re-clicks rather than waiting once, because only
-one of those two recovers.
+click instead.
 
 One console line is a red herring: `pageerror: Cannot read properties of undefined
 (reading 'parent_style')` fires on **every** run, passing or failing. It is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,10 +119,6 @@ markers = [
 ]
 filterwarnings = [
   "error",
-  # A browser test whose modal only opened on a retry still passes, but must
-  # say so: the rate of these is the field measurement of #1185. Reported in
-  # the warnings summary instead of failing the run (drive_dashboard.py).
-  "default:modal opened only on attempt:UserWarning",
 ]
 pythonpath = "tests"
 

--- a/scripts/drive_dashboard.py
+++ b/scripts/drive_dashboard.py
@@ -55,7 +55,6 @@ import sys
 import tempfile
 import time
 import urllib.request
-import warnings
 from collections import deque
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -84,17 +83,10 @@ SETTLE_MS = 5000
 # Override the Chromium binary when the installed playwright package does not
 # match the browsers available on disk (e.g. a preprovisioned container).
 _CHROMIUM_ENV = "PLAYWRIGHT_CHROMIUM_EXECUTABLE"
-# Per-attempt wait for a modal to appear after its trigger is clicked. The total
-# budget is this times the retry count; see Dashboard.open_modal for why it is
-# spent across several clicks rather than in one wait.
-MODAL_ATTEMPT_MS = 8000
-# Opening prefix of the warning a recovered modal emits. Retries that hid
-# themselves would make the browser job look healthy and take away the only
-# field measurement of how often the dashboard stalls (#1185), so a recovery is
-# reported even though the test passes. pytest swallows stdout from a passing
-# test, hence a warning: pyproject downgrades this one message from the
-# blanket ``error`` filter so it lands in the run's warnings summary.
-RECOVERY_PREFIX = "modal opened only on attempt"
+# Wait for a modal to appear after its trigger is clicked. Generous against a
+# loaded runner: the click's round-trip queues behind the session's periodic
+# pass, and the worst open measured under full CPU saturation is ~2 s.
+MODAL_WAIT_MS = 10000
 # Console lines kept per session. A dashboard session logs steadily, so the tail
 # is what matters and the cap keeps a long run from growing without bound.
 CONSOLE_LIMIT = 200
@@ -188,23 +180,8 @@ class Dashboard:
     def _locate(self, target: str | Locator) -> Locator:
         return self.page.locator(target).first if isinstance(target, str) else target
 
-    def open_modal(self, trigger: str | Locator, *, retries: int = 3):
+    def open_modal(self, trigger: str | Locator, *, retries: int = 3) -> Locator:
         """Click a trigger and wait for its modal (``[role=dialog]``) to show.
-
-        A click can land and still open nothing, without raising: it is
-        delivered for a Bokeh model the server has already discarded, or the
-        session's event loop is blocked long enough that the round-trip has
-        not been processed yet (#1174, #1185). Waiting longer recovers the
-        second; only another click recovers the first. So the budget is spent
-        across several waits, re-clicking between them.
-
-        A trigger the click consumes cannot be re-clicked, though -- a
-        layer-picker entry dismisses the menu it lives in -- and there the
-        click did land, so waiting is the only recovery. Hence the re-click is
-        conditional on the trigger still being there.
-
-        Every recovery warns (see :data:`RECOVERY_PREFIX`), naming which of the
-        two it was, so absorbing these does not also hide how often they happen.
 
         Returns the dialog locator. Dismiss with ``page.keyboard.press("Escape")``
         (a ModalEscapeCloser widget makes Escape work from initial focus) or by
@@ -212,38 +189,8 @@ class Dashboard:
         """
         dialog = self.page.locator("[role=dialog]").first
         self.click(trigger, retries=retries)
-        reclicks = 0
-        for attempt in range(retries):
-            try:
-                dialog.wait_for(state="visible", timeout=MODAL_ATTEMPT_MS)
-            except PlaywrightTimeoutError:
-                if attempt == retries - 1:
-                    raise
-                reclicks += self._reclick_if_present(trigger)
-            else:
-                if attempt:
-                    how = f"{reclicks} re-click(s)" if reclicks else "waiting alone"
-                    warnings.warn(
-                        f"{RECOVERY_PREFIX} {attempt + 1} of {retries} via {how}"
-                        f" ({trigger!r}): the session was slow to act on the"
-                        f" click (#1185) or dropped it (#1174)",
-                        stacklevel=2,
-                    )
-                return dialog
-
-    def _reclick_if_present(self, trigger: str | Locator) -> bool:
-        """Re-issue a click whose effect never arrived. True if one was sent.
-
-        A failed re-click is not the failure worth reporting -- the caller's
-        next wait raises on the missing dialog, which says more.
-        """
-        try:
-            if not self._locate(trigger).is_visible():
-                return False
-            self._locate(trigger).click(timeout=4000)
-        except PlaywrightTimeoutError:
-            return False
-        return True
+        dialog.wait_for(state="visible", timeout=MODAL_WAIT_MS)
+        return dialog
 
     def screenshot(self, path: str | Path, *, full_page: bool = True) -> None:
         self.page.screenshot(path=str(path), full_page=full_page)


### PR DESCRIPTION
## Overview

Removes the `open_modal` re-click added as an explicit harness workaround for #1174, now that #1197 removed the stall it was covering. `open_modal` goes back to one click and one wait.

## Why now

The multi-second block a click could queue behind was the cold start of the colormap machinery, which #1197 moved to process startup. Across the browser jobs before that landed, 13 of 21 emitted a modal-recovery warning and 9 of 21 failed a modal test; across the 10 jobs after it, none did (Fisher one-sided: p=0.0017 and p=0.021). `browser-test-speedups` merged near the same boundary, but four baseline runs already contained it and still flaked, so it is not the explanation.

Headroom is now about 4x: driving `main` with the retry bypassed, 63 tests across 7 rounds passed with 30 modal opens, worst 2.3 s under full CPU saturation, against a 10 s wait.

The retry also could not answer the question it was built for. Every recovery it logged was "attempt 2 via 1 re-click", but the re-click fires before the second wait, so the warning cannot separate the re-click from the extra waiting. And absorbing the symptom into a warnings-summary line costs the loud failure that the remaining event-loop work (#1185, #1198) wants as its detector.

`Dashboard.click` keeps its retry-on-detach: a row rebuild genuinely detaches the element and Playwright raises, which is a different mechanism.

Caveat worth stating: 10 clean jobs bound the residual per-run flake rate at about 26% (95% upper), so this is "not observed", not "proven impossible". A recurrence now shows up as a red browser job.

## Test plan

- [x] `tox -e browser` equivalent (`pytest -m browser -n 2`) after the strip: 9 passed.
- [x] Seven further rounds on `main` with the retry path bypassed (3 unloaded at `-n 12`, 4 at `-n 2` with all 24 cores saturated): 63 passed, no modal open above 2.3 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
