### PR TITLE
Unregister HoloViews' no-op nodata compositor

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -633,6 +633,12 @@ class Plotter:
         calculation should properly adjust the color limits. Since zeros can never
         be included we want to adjust to the lowest positive value.
 
+        Masking values for display belongs here rather than in HoloViews. Its
+        `nodata` plot option is inert -- ``reduction`` unregisters the compositor
+        implementing it, and that registry is global, so it cannot be turned back
+        on for a single plot. A frame masked here is computed once and shared by
+        every session, instead of being re-derived per session on every render.
+
         Parameters
         ----------
         data:

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -9,8 +9,9 @@ from urllib.request import urlopen
 
 import holoviews as hv
 import panel as pn
+from holoviews.core.options import Compositor
 from holoviews.plotting.bokeh.plot import LayoutPlot
-from holoviews.plotting.util import process_cmap
+from holoviews.plotting.util import apply_nodata, process_cmap
 from panel.io.resources import CDN_DIST
 from panel.theme.material import Material
 
@@ -52,6 +53,24 @@ ANNOUNCEMENTS_URL = (
 
 pn.extension('holoviews', 'modal', notifications=True, template='material')
 hv.extension('bokeh')
+
+# HoloViews registers `apply_nodata` as a data-mode compositor for Image, Raster,
+# QuadMesh and ImageStack, implementing the `nodata` plot option: an integer
+# sentinel value is rewritten to NaN, which draws transparent. It cannot fire here
+# -- no plotter offers the option, and the 2D path converts to float64, which the
+# operation passes through -- but the machinery around it runs on every frame of
+# every 2D layer regardless, wrapping the element in overlays, matching patterns
+# and cloning the result back in, ~1.4 ms per layer per update.
+#
+# `Compositor.definitions` is global and matched per element type, so there is no
+# re-enabling this for one plot: masking values for display is ours to do in
+# `Plotter.compute` (see `Plotter._prepare_2d_image_data`), where it costs one
+# pass per frame rather than one per frame *per session*.
+Compositor.definitions = [
+    definition
+    for definition in Compositor.definitions
+    if definition.operation is not apply_nodata
+]
 
 # Resolving a colormap imports colorcet, which registers hundreds of colormaps with
 # matplotlib. Left lazy, that lands on a session's IOLoop during its first plot render

--- a/tests/dashboard/nodata_compositor_test.py
+++ b/tests/dashboard/nodata_compositor_test.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""The dashboard renders 2D data without HoloViews' ``apply_nodata`` compositor.
+
+HoloViews runs that compositor over every ``Image``/``Raster``/``QuadMesh``/
+``ImageStack`` frame. The operation rewrites an integer sentinel value to NaN and
+returns its input for anything else, but the compositor machinery around it --
+overlay wrapping, pattern matching, cloning the result back in -- runs per frame
+regardless and costs ~1.4 ms per 2D layer per update, so ``reduction``
+unregisters it.
+
+Removing it is sound because the operation could never fire here: no plotter
+offers the ``nodata`` option, and the 2D path converts to float64 before
+plotting, which ``apply_nodata`` passes through untouched. Zero-transparency is
+ours to do, in scipp (``_prepare_2d_image_data``). These tests pin that the
+compositor is gone and that 2D data still arrives in Bokeh as float, unchanged.
+"""
+
+from __future__ import annotations
+
+import holoviews as hv
+import numpy as np
+import pytest
+import scipp as sc
+from bokeh.models import ColumnDataSource, Plot
+from holoviews.core.options import Compositor
+from holoviews.plotting.bokeh import BokehRenderer
+from holoviews.plotting.util import apply_nodata
+
+# Imported for its side effect: unregistering the compositor.
+import ess.livedata.dashboard.reduction  # noqa: F401
+from ess.livedata.config.workflow_spec import DataKey, WorkflowId
+from ess.livedata.dashboard import plots
+from ess.livedata.dashboard.plot_params import PlotParams2d
+
+_VALUES = np.arange(1.0, 13.0)
+
+
+def test_apply_nodata_compositor_is_unregistered() -> None:
+    assert not [d for d in Compositor.definitions if d.operation is apply_nodata]
+
+
+def _data_2d(*, bin_edges: bool) -> dict:
+    nx, ny = (5, 4) if bin_edges else (4, 3)
+    return {
+        DataKey(
+            workflow_id=WorkflowId(instrument='test', name='wf', version=1),
+            source_name='s0',
+            output_name='out',
+        ): sc.DataArray(
+            sc.array(dims=['y', 'x'], values=_VALUES.reshape(3, 4)),
+            coords={'x': sc.arange('x', float(nx)), 'y': sc.arange('y', float(ny))},
+        )
+    }
+
+
+@pytest.mark.parametrize('bin_edges', [False, True], ids=['image', 'quadmesh'])
+def test_2d_data_reaches_bokeh_unchanged(bin_edges: bool) -> None:
+    """The 2D element types the compositor used to match still render."""
+    plotter = plots.ImagePlotter.from_params(PlotParams2d())
+    plotter.compute({'primary': _data_2d(bin_edges=bin_edges)})
+    state = plotter.get_cached_state()
+    assert not isinstance(state, hv.Text), f'plotter did not plot the data: {state}'
+
+    presenter = plotter.create_presenter()
+    rendered = presenter.present(hv.streams.Pipe(data=state))
+    models = BokehRenderer.instance().get_plot(rendered).state.references()
+    assert [model for model in models if isinstance(model, Plot)]
+
+    columns = [
+        np.asarray(column).ravel()
+        for model in models
+        if isinstance(model, ColumnDataSource)
+        for column in model.data.values()
+    ]
+    # Float, so `apply_nodata` would have passed the values through even if a
+    # plotter did set `nodata`.
+    assert any(
+        column.dtype == np.float64 and np.array_equal(np.sort(column), _VALUES)
+        for column in columns
+        if column.size == _VALUES.size
+    ), 'the plotted values did not reach any ColumnDataSource'


### PR DESCRIPTION
HoloViews applies its `apply_nodata` compositor to every `Image`/`Raster`/`QuadMesh`/`ImageStack` frame. It implements the `nodata` plot option: an integer sentinel value is rewritten to NaN so it draws transparent, which matters for geo rasters and datashader aggregations. It cannot fire here — no plotter offers the option, and our 2D path converts to float64 before plotting, which the operation passes through untouched.

The machinery around the operation runs regardless, and it runs *per frame per session*: the rule is applied to the session's DynamicMap, so every pushed frame is wrapped in overlays, pattern-matched, passed through the no-op and cloned back in, behind an extra DynamicMap callback hop. That is pure overhead on the per-layer repaint path that #1198 identified as the dashboard's capacity ceiling.

Measured with a 6-cell grid (12 layers) at 1 Hz, seven alternating runs per side, pooled over the settled full passes: median 10.8 -> 8.8 ms per layer per frame. One run of each side overlapped, so the honest read is 1.5-2 ms. The saving is per session, so it scales with session count — a single-session harness understates it. Both sides of that A/B predate #1206, which cut a different phase of the same pass, so the absolute per-layer figures are lower on current `main`; the delta measured here is unaffected.

`Compositor.definitions` is a global registry matched by element type, so this is all-or-nothing: `.opts(nodata=...)` is now inert in the dashboard. That is the right trade, and the reasoning is recorded next to both the removal and `Plotter._prepare_2d_image_data`, because we are likely to want display masking later (e.g. drawing masked detector regions differently). Masking belongs in `Plotter.compute`, in scipp: a frame masked there is computed once and shared by every session, rather than re-derived per session on every render — the same argument as #1206. Only the `apply_nodata` definitions are removed; the compositors that are load-bearing for element types we never create (`Distribution`, `Bivariate`, `Sankey`, `HexTiles`, `ImageStack` -> RGB) stay registered.

## Test plan

- Unit tests cover that the compositor is unregistered and that 2D data still reaches Bokeh unchanged as float64, on both the `Image` and `QuadMesh` paths.
- [x] 2D detector plots render as before in a live dashboard (colormap, color limits, autoscale).
