### PR TITLE
Fix narrow layer-picker menu on multi-layer cell gear

### DIFF
--- a/src/ess/livedata/dashboard/widgets/plot_widgets.py
+++ b/src/ess/livedata/dashboard/widgets/plot_widgets.py
@@ -99,7 +99,7 @@ def create_overlay_add_button(
     stylesheets = create_tool_button_stylesheet(button_color, hover_color)
     stylesheets.append(
         """
-        .bk-menu {
+        .bk-Menu {
             min-width: 200px !important;
             right: 0 !important;
             left: auto !important;
@@ -342,7 +342,7 @@ def _create_configure_button_or_menu(
     stylesheets = create_tool_button_stylesheet(button_color, hover_color)
     stylesheets.append(
         """
-        .bk-menu {
+        .bk-Menu {
             min-width: 200px !important;
             right: 0 !important;
             left: auto !important;

--- a/tests/dashboard/browser_ui_test.py
+++ b/tests/dashboard/browser_ui_test.py
@@ -326,6 +326,14 @@ def test_multi_layer_cell_gear_picks_the_layer_to_configure():
         for entry in entries:
             wait_until(dash, entry.is_visible, label="layer menu entry")
 
+        # The dropdown's min-width rule targets the popup's actual DOM class
+        # (Bokeh's Dropdown menu is `bk-Menu`, not the lowercase `bk-menu` a
+        # stale selector would suggest); a mismatch silently drops the rule
+        # and wraps every entry across multiple lines.
+        menu_box = page.locator(".bk-Menu").bounding_box()
+        assert menu_box is not None
+        assert menu_box["width"] >= 200
+
         # Choosing one opens the config modal for that layer, not the cell's
         # first: the source selector is pre-filled with the chosen layer's
         # source. (The dialog's own inner_text is empty -- Panel renders each


### PR DESCRIPTION
## Summary
- The multi-layer cell gear's layer-picker dropdown wraps every entry across multiple lines instead of rendering on one line.
- Root cause: the `min-width: 200px` rule targeted `.bk-menu`, but Bokeh's `Dropdown` popup carries the class `bk-Menu`. The case mismatch silently dropped the rule, so the popup fell back to its intrinsic (very narrow) width.
- Fixed both occurrences (the layer-picker gear and the overlay `+` menu, which shares the same stylesheet pattern) and added a bounding-box width assertion to the existing browser test so a regression fails loudly.

## Test plan
- [x] `test_multi_layer_cell_gear_picks_the_layer_to_configure` (browser) passes with the fix and fails against the old selector (verified locally).
- [x] Manually open a multi-layer cell's gear menu and confirm entries render on one line.