### PR TITLE
Reap the dead-server child if it outlives its wait

### DIFF
--- a/tests/dashboard/drive_dashboard_test.py
+++ b/tests/dashboard/drive_dashboard_test.py
@@ -53,7 +53,13 @@ def test_wait_until_ready_reports_a_dead_server_instead_of_waiting_it_out(tmp_pa
             stdout=logf,
             stderr=subprocess.STDOUT,
         )
-    proc.wait(timeout=10)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        # A child left unreaped surfaces as a ResourceWarning in whatever test
+        # is running when its Popen is collected, never in this one.
+        drive_dashboard._terminate(proc)
+        raise
 
     started = time.monotonic()
     with pytest.raises(RuntimeError, match="exited with code 3") as exc_info:


### PR DESCRIPTION
The one `wait` in the browser-test helpers that could still leave a child unreaped. A child that is never waited on raises a `ResourceWarning` when its `Popen` is collected, and `filterwarnings = ["error"]` turns that into a failure of whichever test happens to be running by then -- never the one that leaked.

That misattribution is what #1186 was: the session-churn test failing for a dashboard the launcher had killed without reaping. The launcher was fixed in cea4aea34; this wait was the remainder. It is unlikely to fire -- the child prints one line and exits -- but the cost of it firing is another flake investigation pointed at the wrong test.

## Test plan

- [x] `pytest -m browser tests/dashboard/drive_dashboard_test.py` passes
