### PR TITLE
Skip HoloViews' range computation where the dashboard owns the axes

### DIFF
--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -940,8 +940,12 @@ class Plotter:
 
         False lets :meth:`_frame_opts` hand HoloViews ``apply_ranges=False``,
         which skips computing bounds, deriving extents and writing the Bokeh
-        ranges on every frame -- a third of a 1D layer's repaint. It is safe in
-        two cases, and this property is the single place that decides:
+        ranges on every frame -- a third of a 1D layer's repaint. That work is
+        per element, so it is not a fixed cost per layer: it grows both with the
+        elements a layer draws (a multi-source selection overlays one per
+        source) and with the number of layers sharing the cell's figure, whose
+        range updates are fused (see ``widgets/cell.py``). It is safe in two
+        cases, and this property is the single place that decides:
 
         - the cell's :class:`~.cell_autoscale.CellAutoscaleController` writes
           both numeric axes itself on every render, i.e. ``AUTOSCALE_AXES``

--- a/src/ess/livedata/dashboard/plots.py
+++ b/src/ess/livedata/dashboard/plots.py
@@ -463,6 +463,12 @@ def format_time_info(bounds: TimeBounds) -> str:
     return f'{format_time_ns_local(bounds.min_end)} (Lag: {lag_s:.1f}s)'
 
 
+def _is_element_opt(opt: hv.Options) -> bool:
+    """Whether ``opt`` targets an Element rather than a container."""
+    element = getattr(hv, opt.key.split('.')[0], None)
+    return isinstance(element, type) and issubclass(element, hv.Element)
+
+
 class Plotter:
     """
     Base class for plots that support autoscaling.
@@ -473,6 +479,14 @@ class Plotter:
 
     AUTOSCALE_AXES: ClassVar[frozenset[Axis]] = frozenset()
     """Per-axis autoscale capability. Override per subclass."""
+
+    IS_ANNOTATION: ClassVar[bool] = False
+    """Whether this layer is drawn in another layer's coordinate space.
+
+    ROI overlays are annotations: they are composed on top of the layer that
+    determines the figure's bounds, so they never need bounds of their own. See
+    :attr:`applies_ranges`.
+    """
 
     _autoscale_axes_override: frozenset[Axis] | None = None
 
@@ -742,7 +756,7 @@ class Plotter:
         # Computed outside the try so a render failure still stamps the bounds
         # of the data that was received.
         self._time_bounds = _compute_time_bounds(data)
-        self._set_cached_state(result.opts(*self.style_opts()))
+        self._set_cached_state(result.opts(*self._frame_opts()))
 
     def _build_result(
         self,
@@ -918,6 +932,50 @@ class Plotter:
         return [
             hv.opts.Overlay(shared_axes=True, title=''),
             hv.opts.Layout(shared_axes=False),
+        ]
+
+    @property
+    def applies_ranges(self) -> bool:
+        """Whether HoloViews must compute this layer's axis bounds from its data.
+
+        False lets :meth:`_frame_opts` hand HoloViews ``apply_ranges=False``,
+        which skips computing bounds, deriving extents and writing the Bokeh
+        ranges on every frame -- a third of a 1D layer's repaint. It is safe in
+        two cases, and this property is the single place that decides:
+
+        - the cell's :class:`~.cell_autoscale.CellAutoscaleController` writes
+          both numeric axes itself on every render, i.e. ``AUTOSCALE_AXES``
+          covers x and y (see :attr:`autoscale_axes` for the per-instance
+          narrowing) *and* the layer renders into one figure whose handles the
+          controller can reach -- a layout-mode plotter draws one figure per
+          element, which is also what makes it non-overlayable, and
+          ``RangeHandles`` writes through a single figure's ``x_range`` /
+          ``y_range``, so nothing would set the bounds;
+        - the layer is an annotation drawn in another layer's coordinate space
+          and so never determines the bounds (:attr:`IS_ANNOTATION`), which is
+          what HoloViews does for its own annotation plotters.
+
+        A plotter owning a figure whose axes nobody writes -- ``BarsPlotter``,
+        ``TablePlotter``, ``SlicerPlotter`` (which autoscales only the color
+        axis) -- keeps HoloViews' computation, so the default is the safe one:
+        a new plotter misses the saving rather than rendering on empty bounds.
+        """
+        writes_both_axes = {'x', 'y'} <= self.autoscale_axes and self.is_overlayable
+        return not (self.IS_ANNOTATION or writes_both_axes)
+
+    def _frame_opts(self) -> list[hv.Options]:
+        """:meth:`style_opts`, plus the range opt-out where it applies.
+
+        The opt-out goes on the leaf element opts only. Ranges are a property of
+        the elements, so opting the container out measures the same as not doing
+        it, and ``LayoutPlot`` has no ``apply_ranges`` parameter at all -- adding
+        it there raises.
+        """
+        opts = self.style_opts()
+        if self.applies_ranges:
+            return opts
+        return [
+            opt(apply_ranges=False) if _is_element_opt(opt) else opt for opt in opts
         ]
 
     def plot(

--- a/src/ess/livedata/dashboard/roi_readback_plots.py
+++ b/src/ess/livedata/dashboard/roi_readback_plots.py
@@ -8,7 +8,7 @@ workflow outputs, with per-shape colors based on ROI index.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 import holoviews as hv
 import pydantic
@@ -70,6 +70,8 @@ class RectanglesReadbackPlotter(Plotter):
     Takes ROI readback DataArrays with roi_index coordinate and renders
     rectangles with per-shape colors based on the ROI index.
     """
+
+    IS_ANNOTATION: ClassVar[bool] = True
 
     def __init__(self, params: RectanglesReadbackParams) -> None:
         super().__init__()
@@ -179,6 +181,8 @@ class PolygonsReadbackPlotter(Plotter):
     Takes ROI readback DataArrays with roi_index coordinate and renders
     polygons with per-shape colors based on the ROI index.
     """
+
+    IS_ANNOTATION: ClassVar[bool] = True
 
     def __init__(self, params: PolygonsReadbackParams) -> None:
         super().__init__()

--- a/src/ess/livedata/dashboard/widgets/cell.py
+++ b/src/ess/livedata/dashboard/widgets/cell.py
@@ -710,6 +710,12 @@ class CellWidget:
             # produces a single DynamicMap whose outputs are plain Overlays;
             # opts applied afterwards land on the OverlayPlot and persist.
             result = hv.Overlay(plots).collate()
+            # Sharing one figure also fuses the layers' update cost: a send on
+            # any one layer re-runs the OverlayPlot's range machinery over every
+            # subplot, so a layer's repaint grows with the number of layers in
+            # its cell. Only the data push stays proportional to the sender.
+            # `Plotter.applies_ranges` is what keeps that off the layers whose
+            # axes the cell writes itself.
 
         # Skip the cell-level hooks for a non-overlayable layer: a Layout's
         # sub-figures each carry their own SaveTool, and a Table's DataTable

--- a/tests/dashboard/plot_range_ownership_test.py
+++ b/tests/dashboard/plot_range_ownership_test.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Range-ownership invariant: every figure ends up with bounds around its data.
+
+``Plotter.applies_ranges`` lets a plotter hand HoloViews ``apply_ranges=False``,
+which stops it computing bounds from the data on every frame -- a third of a 1D
+layer's repaint. That is only sound where something else sets the bounds: the
+cell's :class:`CellAutoscaleController`, or the layer being an annotation drawn
+in another layer's coordinate space.
+
+The failure mode is silent and does not look like a crash: the figure renders on
+Bokeh's default unit range, so a detector image becomes a flat rectangle between
+0 and 1. It is invisible to tests that only check that elements and figures
+exist. These tests therefore render each plotter through the real
+``compute -> hook -> bokeh`` path and assert the resulting axis ranges actually
+span the data -- which is what a viewer sees.
+"""
+
+from __future__ import annotations
+
+import holoviews as hv
+import numpy as np
+import pytest
+import scipp as sc
+from bokeh.models import Plot
+from holoviews.plotting.bokeh import BokehRenderer
+
+from ess.livedata.config.workflow_spec import DataKey, WorkflowId
+from ess.livedata.dashboard import plots
+from ess.livedata.dashboard.cell_autoscale import build_controller_from_layers
+from ess.livedata.dashboard.plot_params import (
+    CombineMode,
+    LayoutParams,
+    PlotParams1d,
+    PlotParams2d,
+    PlotParams3d,
+)
+from ess.livedata.dashboard.slicer_plotter import SlicerPlotter
+
+hv.extension('bokeh')
+
+X_COORDS = [10.0, 20.0, 30.0]
+Y_VALUES = [1.0, 2.0, 3.0]
+
+
+def _keys(n: int) -> list[DataKey]:
+    wf = WorkflowId(instrument='test', name='wf', version=1)
+    return [
+        DataKey(workflow_id=wf, source_name=f's{i}', output_name='out')
+        for i in range(n)
+    ]
+
+
+def _data_1d(n: int) -> dict:
+    da = sc.DataArray(
+        sc.array(dims=['x'], values=Y_VALUES),
+        coords={'x': sc.array(dims=['x'], values=X_COORDS)},
+    )
+    return dict.fromkeys(_keys(n), da)
+
+
+def _data_2d(n: int) -> dict:
+    da = sc.DataArray(
+        sc.array(dims=['y', 'x'], values=np.arange(12.0).reshape(3, 4)),
+        coords={
+            'x': sc.arange('x', 4, dtype='float64'),
+            'y': sc.arange('y', 3, dtype='float64'),
+        },
+    )
+    return dict.fromkeys(_keys(n), da)
+
+
+def _data_3d() -> dict:
+    da = sc.DataArray(
+        sc.array(dims=['z', 'y', 'x'], values=np.arange(24.0).reshape(2, 3, 4)),
+        coords={
+            'x': sc.arange('x', 4, dtype='float64'),
+            'y': sc.arange('y', 3, dtype='float64'),
+            'z': sc.arange('z', 2, dtype='float64'),
+        },
+    )
+    return dict.fromkeys(_keys(1), da)
+
+
+def _rendered_figures(plotter, data: dict) -> list[Plot]:
+    """Render through the cell's path, including its autoscale hook.
+
+    A non-overlayable layer gets no cell-level hooks -- a Layout's sub-figures
+    and a Table have no single figure for them to act on, so ``_compose_plot``
+    returns early (``widgets/cell.py``). Mirroring that here is the point: it is
+    exactly the case where nothing would write the bounds.
+    """
+    plotter.compute({'primary': data})
+    state = plotter.get_cached_state()
+    assert not isinstance(state, hv.Text), f'plotter did not plot the data: {state}'
+    obj = plotter.create_presenter().present(hv.streams.Pipe(data=state))
+    if plotter.is_overlayable:
+        obj = obj.opts(hooks=[build_controller_from_layers([plotter]).make_hook()])
+    bokeh_state = BokehRenderer.instance().get_plot(obj).state
+    return [m for m in bokeh_state.references() if isinstance(m, Plot)]
+
+
+def _spans(axis_range, lo: float, hi: float) -> bool:
+    start, end = axis_range.start, axis_range.end
+    return start is not None and end is not None and start <= lo and end >= hi
+
+
+@pytest.mark.parametrize('combine', [CombineMode.overlay, CombineMode.layout])
+@pytest.mark.parametrize('n_sources', [1, 2])
+def test_line_figures_span_their_data(combine, n_sources):
+    params = PlotParams1d(layout=LayoutParams(combine_mode=combine))
+    figures = _rendered_figures(
+        plots.LinePlotter.from_params(params), _data_1d(n_sources)
+    )
+
+    assert len(figures) == (n_sources if combine == CombineMode.layout else 1)
+    for fig in figures:
+        assert _spans(fig.x_range, X_COORDS[0], X_COORDS[-1])
+        assert _spans(fig.y_range, Y_VALUES[0], Y_VALUES[-1])
+
+
+@pytest.mark.parametrize('combine', [CombineMode.overlay, CombineMode.layout])
+@pytest.mark.parametrize('n_sources', [1, 2])
+def test_image_figures_span_their_data(combine, n_sources):
+    """Layout mode is the case that regressed.
+
+    ``RangeHandles`` writes through a single figure's ``x_range`` / ``y_range``,
+    which a layout-mode plotter does not have -- it draws one figure per source.
+    Opting such a plotter out of HoloViews' range computation leaves nobody to
+    set the bounds, and every sub-figure collapses onto the unit range.
+    """
+    params = PlotParams2d(layout=LayoutParams(combine_mode=combine))
+    figures = _rendered_figures(
+        plots.ImagePlotter.from_params(params), _data_2d(n_sources)
+    )
+
+    assert len(figures) == (n_sources if combine == CombineMode.layout else 1)
+    for fig in figures:
+        assert _spans(fig.x_range, 0.0, 3.0)
+        assert _spans(fig.y_range, 0.0, 2.0)
+
+
+def test_slicer_figure_spans_its_data():
+    """The slicer autoscales only the color axis, so HoloViews keeps x and y."""
+    figures = _rendered_figures(SlicerPlotter.from_params(PlotParams3d()), _data_3d())
+
+    assert len(figures) == 1
+    assert _spans(figures[0].x_range, 0.0, 3.0)
+    assert _spans(figures[0].y_range, 0.0, 2.0)


### PR DESCRIPTION
Part of #1198. HoloViews recomputes each layer's axis bounds from the data on every frame, in every session — deriving extents, scanning the dimensions and writing the Bokeh ranges. For most of our layers that result is then discarded: `CellAutoscaleController` writes both numeric axes itself on every render, and ROI readback overlays are drawn in the image's coordinate space and never determine bounds at all.

Those plotters now carry HoloViews' documented `apply_ranges=False`, which skips the computation. It rides in the opts `compute()` already applies to the finished frame, so it costs no extra option application (the lesson of #1206), and being a static plot option it triggers no param update after the first render.

## Measured

6-cell grid (12 layers) at 1 Hz, one session, fake backend, four alternating runs per side, pooled over the settled data passes:

| | ms per layer per frame | range over runs |
|---|---|---|
| `main` | 8.33 | 7.58 – 8.96 |
| this branch | **6.69** | 6.55 – 6.84 |

−20 %, with no overlap between the two sides. Isolated, the saving is 1.30 ms per 1D layer and 0.44 ms per 2D layer; the grid figure is higher than that mix predicts because the ROI annotation layers benefit too.

### It scales per element, not per layer

HoloViews' range work runs per element — `_compute_group_range` per element, `get_extents` per subplot, `dimension_range` per dimension — so a layer holding several elements saves several times over. That is the common case, not a corner one: a `LinePlotter` with a multi-source selection overlays every source into a single layer, and `Overlay1DPlotter` draws one curve per ROI spectrum.

Curves in one layer, one `pipe.send`, median of three runs per point:

| curves | baseline | with opt-out | saved | % |
|---|---|---|---|---|
| 1 | 5.49 | 4.80 | 0.69 | 12.6 |
| 2 | 7.79 | 6.34 | 1.45 | 18.6 |
| 4 | 11.92 | 9.40 | 2.52 | 21.1 |
| 8 | 21.39 | 16.04 | 5.35 | 25.0 |
| 16 | 41.08 | 30.88 | 10.20 | 24.8 |

Flat at ~0.65 ms per curve across the range, so a layer with N curves saves about what N single-curve layers would. The percentage improves with element count because the fixed per-layer overhead — the send, the DynamicMap hop, the freeze exit — amortises while the range saving keeps growing.

### And with the layers sharing a cell

Elements per layer is only half of it. A cell collates its layers into a single `OverlayPlot` (`_compose_plot`), so a send on *one* layer re-runs the overlay's range machinery across every subplot in the cell — 4 `get_extents` calls per layer in the cell, per send. `_update_glyphs` stays at 1, so only the sending layer's data is pushed; it is specifically the range work that fans out.

Sending on one layer of an N-layer cell, medians of three processes:

| layers in the cell | baseline | with opt-out | saved | `get_extents` per send |
|---|---|---|---|---|
| 1 | 4.58 | 4.15 | 0.43 | 1 |
| 2 | 6.90 | 5.59 | 1.31 | 8 |
| 3 | 8.42 | 6.83 | 1.59 | 12 |
| 4 | 10.13 | 8.43 | 1.70 | 16 |

This is what reconciles the isolated numbers with the grid. The fixture's six-layer cycle is one 1-layer cell, one 3-layer cell (image plus two ROI overlays) and one 2-layer cell, which predicts `(1×0.43 + 3×1.59 + 2×1.31) / 6` = 1.30 ms per layer against the 1.64 measured; the remainder is plausibly the real data these cells carry (log color scale, hover, 64-bin histograms) versus the bench's synthetic curves.

The general shape: a layer's repaint cost is not local to that layer, so the saving scales with elements per layer *and* with the number of layers sharing the cell.

Taking ranges apart also showed that the largest single component was option lookups (0.87 ms over 34 calls per frame for a 2-curve overlay) rather than range arithmetic. `apply_ranges=False` removes about half of the total; the rest is addressable upstream by memoizing lookups for the duration of one render, tracked in #1215.

## Why the opt-out is per plotter

It defaults to off, so a plotter whose axes nobody writes — `BarsPlotter`, `TablePlotter`, the slicer (which autoscales only the color axis) — keeps HoloViews' computation. That direction fails safe: a new plotter misses the saving instead of silently rendering on Bokeh's unit range. A global switch with carve-outs would fail the other way, and for a bar chart of 0D scalars a default 0..1 range is wrong rather than a don't-care.

The condition also requires `is_overlayable`, which is not incidental: a layout-mode plotter draws one figure per source, while `RangeHandles` writes through a single figure's `x_range`/`y_range`. The cell already skips its hooks for such layers for the same reason. Without that guard, detector images in layout mode collapse onto 0..1 — a silent, viewer-visible failure that no existing test caught, since the elements and figures all still exist. The new test renders through the real `compute -> hook -> bokeh` path and asserts the axis ranges actually span the data, and it fails on all four layout parametrisations if the guard is removed.

## Test plan

- [x] `pytest tests/dashboard` — 2090 passed, 4 xfailed
- [x] New range-ownership tests fail on every layout parametrisation when the `is_overlayable` guard is removed
- [x] Detectors and Diagnostics grids render identically to `main` (checked here against the dummy fixture with the fake backend: axes, colorbars, datetime axis, table and slicer all unchanged — worth a second look on real data)
- [x] Pan/zoom with an autoscale toggle off still preserves the manual range
