### PR TITLE
Render plots on the 2D canvas instead of WebGL

### DIFF
--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -54,6 +54,19 @@ ANNOUNCEMENTS_URL = (
 pn.extension('holoviews', 'modal', notifications=True, template='material')
 hv.extension('bokeh')
 
+# HoloViews defaults its Bokeh renderer to `webgl=True`, which sets
+# `output_backend='webgl'` on every figure. That gives each plot a second, WebGL
+# canvas: Bokeh then resizes, scissors and clears it before every paint
+# (`prepare_webgl`) and blits it over the 2D canvas afterwards (`blit_webgl` ->
+# a full-canvas `drawImage`), per plot, per frame. WebGL only accelerates marker
+# and line glyphs at glyph counts we never reach -- our views are histogrammed
+# images and short curves, and images have no WebGL path at all -- so the round
+# trip is pure overhead. Dropping it cuts the browser's main-thread time on a
+# 12-cell grid by ~3x in steady state and roughly halves the block on a tab
+# switch. Individual figures can still opt in via
+# `backend_opts={'plot.output_backend': 'webgl'}`.
+hv.renderer('bokeh').webgl = False
+
 # HoloViews registers `apply_nodata` as a data-mode compositor for Image, Raster,
 # QuadMesh and ImageStack, implementing the `nodata` plot option: an integer
 # sentinel value is rewritten to NaN, which draws transparent. It cannot fire here

--- a/src/ess/livedata/dashboard/reduction.py
+++ b/src/ess/livedata/dashboard/reduction.py
@@ -58,13 +58,18 @@ hv.extension('bokeh')
 # `output_backend='webgl'` on every figure. That gives each plot a second, WebGL
 # canvas: Bokeh then resizes, scissors and clears it before every paint
 # (`prepare_webgl`) and blits it over the 2D canvas afterwards (`blit_webgl` ->
-# a full-canvas `drawImage`), per plot, per frame. WebGL only accelerates marker
-# and line glyphs at glyph counts we never reach -- our views are histogrammed
-# images and short curves, and images have no WebGL path at all -- so the round
-# trip is pure overhead. Dropping it cuts the browser's main-thread time on a
-# 12-cell grid by ~3x in steady state and roughly halves the block on a tab
-# switch. Individual figures can still opt in via
-# `backend_opts={'plot.output_backend': 'webgl'}`.
+# a full-canvas `drawImage`), per plot, per renderer, per frame. Because that
+# canvas is shared by the whole page, resizing it to each plot's frame
+# reallocates its drawing buffer whenever neighbouring cells differ in size,
+# which ours do. The cost is therefore fixed per figure, whatever it draws,
+# while the saving scales with content -- and our content stays below where the
+# GL path starts to pay: curves are a few hundred points against a break-even
+# near 30k, and detector images are mostly 320^2 or smaller. Bokeh does have a
+# WebGL path for images, it simply does not earn the round trip at these sizes.
+# Dropping it cuts the browser's main-thread time on a 12-cell grid by ~3x in
+# steady state and roughly halves the block on a tab switch. Individual figures
+# can still opt in via `backend_opts={'plot.output_backend': 'webgl'}`; see
+# #1218 for where that might be worth doing.
 hv.renderer('bokeh').webgl = False
 
 # HoloViews registers `apply_nodata` as a data-mode compositor for Image, Raster,


### PR DESCRIPTION
HoloViews defaults its Bokeh renderer to `webgl=True` (`holoviews/plotting/bokeh/renderer.py`), so every figure we create gets `output_backend='webgl'`. Bokeh then keeps one WebGL canvas shared by the whole page: before each plot's primary repaint it resizes that canvas to the plot's frame, scissors and clears it (`prepare_webgl`), and after every WebGL-backed renderer it blits the result into that plot's 2D canvas (`blit_webgl`, a full-canvas `drawImage`). The cost is therefore **per plot and per renderer, not per glyph**: a 12-cell grid with two layers per cell pays 12 canvas resizes and 24 blits on every update, whatever it is drawing. Our views never draw enough to earn that back — curves are a few hundred points, timeseries are capped near 3.9 k by downsampling, and WebGL only starts to pay for a line somewhere above 30 k points. Rendering on the 2D canvas removes the round trip.

Resizing the shared canvas is disproportionately expensive when neighbouring cells differ in size, because assigning a different width or height reallocates its drawing buffer. Our grids do mix cell sizes: the Detectors grid alone combines row-spanning cells, a column-spanning cell, and differing aspect settings. Reported upstream as bokeh/bokeh#15320.

Note this is not a case of WebGL being unavailable for what we draw. Bokeh has WebGL implementations for `line`, `multi_line`, `step`, markers, `quad` and `image` alike, and our detector images do currently render through the GL path. The round trip simply costs more, at grid scale, than that path saves.

Found while profiling the browser side of the plot-grid block in #1203 (see [this comment](https://github.com/scipp/esslivedata/issues/1203#issuecomment-5206378872) for the full traces). It is a client-side cost paid continuously, by every session, not only at a tab switch.

## Measured

Chromium via Playwright on macOS, `ANGLE (Intel, ANGLE Metal Renderer: Intel(R) Iris(TM) Plus Graphics 645)`. Median main-thread time per repaint, canvas versus webgl, after an equal warm-up of both backends. Rather than a single speedup figure, the numbers below separate what WebGL *costs* per plot from what it *gains* per plot, so the trade can be evaluated for any particular view.

What WebGL costs, independent of content. Measured on 12-cell grids of two-point lines, so none of it is glyph work, and quoted as a range over four runs:

| cost, per repaint | |
|---|---|
| clear and blit, per WebGL renderer | **0.3 - 0.5 ms** |
| shared-canvas reallocation, per plot whose size differs from the previously painted one | **+3.2 - 4.1 ms** |

Both scale with canvas area; these are for cells of roughly 400x300. The two costs add: the reallocation term comes out at 3.2 - 4.0 ms per plot when measured on grids of two-point lines, and independently at 3.8 ms per plot when measured on grids carrying real content.

What WebGL gains, per plot per data update. These are noisier than the costs above, so the range across runs is given:

| content | gain |
|---|---|
| curve up to 10 k points | none (webgl loses 0.1 - 0.3 ms) |
| curve, 30 k points | +0.3 - 0.6 ms |
| curve, 100 k points | +2.6 - 4.7 ms |
| image up to 256x256 | none (webgl loses up to 0.7 ms) |
| image, 512x512 to 1448x1448 | 0 - 7 ms |
| image, 2048x2048 | +13 - 71 ms |

Image gains vary considerably between runs, which is why they are given as ranges over four runs; the costs above were stable to within 25% across the same four.

Put together, for the shape of grid this dashboard actually builds -- 12 cells, two layers each, cells of differing sizes because of row and column spans:

| 12-cell grid, realistic content, mixed sizes | canvas | webgl | overhead |
|---|---|---|---|
| data update | 81.95 ms | 134.30 ms | +52.35 ms |
| repaint | 23.80 ms | 78.50 ms | +54.70 ms |

That is 24 blits plus 12 reallocations, against images small enough to gain nothing from the GL path. With uniform cell sizes the same grid costs only 9 ms more in WebGL rather than 55, which is the measure of what the reallocation alone is worth.

The opposite case exists and is worth knowing: a single 1280x1280 image gains about 5 ms and pays one blit, so WebGL wins for an NMX panel viewed on its own. That is what `backend_opts` is for.

Two results worth keeping in view, because they look like contradictions and are not: a single large image is faster in WebGL on a GPU, and 16 short curves are slower than one curve holding twice as many points. Both follow from the cost being per renderer, not per glyph.

Server-side timings are unchanged, as expected: `output_backend` is a figure property that only affects rendering in the browser.

Individual figures can still opt in with `backend_opts={'plot.output_backend': 'webgl'}` if a view ever plots a single large image or enough points to want it. Note `roi_request_plots.py` already forces `'canvas'` on one layer to dodge a Bokeh WebGL bug with dashed lines; that override is now redundant but left in place, since it documents the bug and keeps the layer correct if the global default ever changes back.

### On benchmarking this in a container

An earlier round of these measurements was taken in headless Chromium inside a devcontainer, and reported gains of roughly 3.5x. Those numbers were an artefact: the container has no GPU, so Chromium falls back to ANGLE's SwiftShader software rasterizer and every WebGL glyph is rasterized on the CPU. A 3600-point line costs tens of milliseconds per paint there against about 2 ms on the 2D canvas. The same 12-cell realistic grid measures around **10x** without a GPU and **1.09x** with one.

The software fallback also hides the reallocation cost rather than showing it: with glyph rasterization saturating the pipeline, adding mixed cell sizes to that grid changes nothing measurable, while on a GPU it is the dominant term. A GPU-less benchmark is not merely pessimistic about WebGL, it misattributes where the cost is.

Any comparison of rendering backends therefore has to run on real graphics hardware. `WEBGL_debug_renderer_info` reporting SwiftShader means the result is measuring the software fallback, not the backend.

## Test plan

Automated coverage cannot see this: it is a rendering-backend property, so unit tests and the Playwright suite pass identically either way. It needs eyes on a real browser.

Run a dashboard with a grid big enough to feel the difference:

```sh
# a 12-cell grid, from the committed fixture
TMP=$(mktemp -d) && mkdir -p "$TMP/cfg"
cp -r tests/dashboard/ui_config_fixtures/dummy "$TMP/cfg/dummy"
python -m ess.livedata.dashboard.reduction --instrument dummy --transport fake \
    --auto-start --port 5011 --config-dir "$TMP/cfg" --no-fetch-announcements
```

Open <http://localhost:5011>, go to the **Detectors** tab. To compare against `main`, run a second server from a `main` checkout on another port and put the two windows side by side. To get past the fixture's 3 cells, edit `"$TMP/cfg/dummy/plot_configs.yaml"` to repeat the `Detectors` grid's cells over more rows/columns before launching (`.scratch/1203/grid_stall.py:expand_grid` does exactly this if you prefer to script it).

What to check:

- [ ] Detector images (2D), monitor curves (1D) and ROI overlays all render, with the same colours, colourbars, axes and fonts as `main`.
- [ ] ROI editing still works: draw a box on a detector image, drag and resize it, and confirm the dashed edit outline and the readback overlay both draw correctly. This is the one place WebGL was already being disabled per-figure for a rendering bug, so it is the most likely place to notice a difference.
- [ ] Pan, zoom, box-zoom, reset and hover behave normally on both image and line plots.
- [ ] Legends, log colour axes and the autoscale toolbar buttons look and behave as before.
- [ ] Watch a busy grid for a minute: no visual artefacts, no tearing, no missing repaints — the failure mode to look for is a plot that stops updating or draws stale content, not a slow one.
- [ ] With DevTools open on the Performance tab, record a few seconds on the Detectors tab: `prepare_webgl` and `blit_webgl` should be gone entirely, and total scripting time should be visibly lower than on `main`.

Worth a look on more than one machine if convenient: the trade-off depends on the GPU, and a machine where WebGL was genuinely helping would show up as *slower* rendering here. The numbers above come from an Intel integrated GPU on macOS.

