### PR TITLE
Gate hidden-grid cell rebuilds on surviving the reveal

### DIFF
--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -481,6 +481,25 @@ class PlotGridTabs:
                     # Grid was re-enabled or is new — create fresh tab
                     self._add_grid_tab(grid_id, grid_config)
 
+    def _add_plot(
+        self, grid_id: GridId, geometry: CellGeometry, plot_config: PlotConfig
+    ) -> None:
+        """Commit a configured plot to the orchestrator, surfacing races."""
+        try:
+            cell_id = self._orchestrator.add_cell(grid_id, geometry)
+            self._orchestrator.add_layer(cell_id, plot_config)
+        except KeyError:
+            # The grid vanished while the modal was open (removed or
+            # replaced by another session).
+            show_error('Cannot add plot: the grid was removed.')
+        except ValueError:
+            # The position is occupied in topology but rendered as an empty
+            # cell: another session placed a plot while the modal was open,
+            # or this grid's widgets were not built yet (hidden grids defer
+            # cell builds, so occupancy lags topology until the reveal pass
+            # inserts the widgets).
+            show_error('Cannot add plot: that position is already occupied.')
+
     def _on_plot_requested(self, grid_id: GridId, geometry: CellGeometry) -> None:
         """
         Handle plot request from PlotGrid.
@@ -495,18 +514,9 @@ class PlotGridTabs:
         geometry
             Cell geometry of the selected region.
         """
-
-        def on_success(plot_config: PlotConfig) -> None:
-            """Handle successful plot configuration."""
-            try:
-                cell_id = self._orchestrator.add_cell(grid_id, geometry)
-                self._orchestrator.add_layer(cell_id, plot_config)
-            except KeyError:
-                # The grid vanished while the modal was open (removed or
-                # replaced by another session).
-                show_error('Cannot add plot: the grid was removed.')
-
-        self._show_config_modal(on_success=on_success)
+        self._show_config_modal(
+            on_success=lambda cfg: self._add_plot(grid_id, geometry, cfg)
+        )
 
     def _on_reconfigure_layer(self, layer_id: LayerId) -> None:
         """
@@ -735,10 +745,15 @@ class PlotGridTabs:
         A hidden grid therefore does no display work at all between switches --
         not even on the periodic full pass. Its layers are deactivated
         (``activate_layer(..., False)``), so unless another session is viewing
-        them they do not even compute, though their buffers keep filling; this
-        pass only keeps their structure reconciled. What the user sees on
-        returning to the tab is the latest state, computed on the switch, not a
-        five-second-old rendering.
+        them they do not even compute, though their buffers keep filling. Its
+        cell widgets are rebuilt only while another session holds a viewer
+        token on them: then the plotters have computed state and the build is
+        a real plot pre-warming this session's tab switch. With no viewers the
+        build would be a placeholder that the reveal's 0->1 activation bumps
+        and discards, so it is skipped; the stale signature/version records
+        make the reveal pass build the cell once (#1216). What the user sees
+        on returning to the tab is the latest state, computed on the switch,
+        not a five-second-old rendering.
         """
         # Snapshot before reading any layer state, and record it only once the
         # pass completes (below). The ingestion thread bumps this counter while
@@ -797,10 +812,10 @@ class PlotGridTabs:
                 # title). Plotter swaps keep the layer ids and are handled by
                 # the per-layer version path below.
                 signature = self._cell_signature(cell)
-                if cell_id not in self._cells or signature != self._cell_signatures.get(
-                    cell_id
-                ):
-                    cells_to_rebuild[cell_id] = (cell, plot_grid, grid_id)
+                rebuild = (
+                    cell_id not in self._cells
+                    or signature != self._cell_signatures.get(cell_id)
+                )
 
                 for layer in cell.layers:
                     layer_id = layer.layer_id
@@ -824,11 +839,11 @@ class PlotGridTabs:
                         )
                         self._session_layers[layer_id] = session_layer
                         # New layer → rebuild cell
-                        cells_to_rebuild[cell_id] = (cell, plot_grid, grid_id)
+                        rebuild = True
                     else:
                         # Check for version changes (plotter changes increment version)
                         if state.version != session_layer.last_seen_version:
-                            cells_to_rebuild[cell_id] = (cell, plot_grid, grid_id)
+                            rebuild = True
                             versions_to_apply[layer_id] = state.version
 
                     # Drive the layer compute gate: on 0→1 the orchestrator
@@ -857,6 +872,25 @@ class PlotGridTabs:
                     # no-op anyway unless the presenter has a pending update.
                     if is_active and flush_due:
                         session_layer.update_pipe()
+
+                # A hidden grid's cell is rebuilt only when the build will
+                # survive its reveal: with a viewer token held by another
+                # session the plotters have computed state and the build is a
+                # real plot pre-warming this session's tab switch. With no
+                # viewers it would be a placeholder that the reveal's 0→1
+                # activation bumps and discards (#1216). Skipping leaves the
+                # signature/version records stale, so the reveal pass (or a
+                # viewer appearing) triggers the rebuild again. Checked after
+                # the activate_layer calls above so this session's own
+                # released tokens do not count.
+                if rebuild and (
+                    is_active
+                    or any(
+                        self._plot_data_service.has_viewers(layer.layer_id)
+                        for layer in cell.layers
+                    )
+                ):
+                    cells_to_rebuild[cell_id] = (cell, plot_grid, grid_id)
 
         # Clean up orphaned session layers (removed from orchestrator). Per-cell
         # widget state (freshness/time panes, autoscale) is swept on cell rebuild
@@ -888,19 +922,12 @@ class PlotGridTabs:
                 plot_grid.remove_widget_at(cell_widget.geometry)
             cell_widget.dispose()
 
-        # Rebuild affected cells.
-        # Defer insertion to allow Bokeh to process any pending model updates
-        # from pipe.send() calls above. Without deferral, widget removal can
-        # race with DynamicMap updates, causing KeyError when Panel tries to
-        # access removed models. The guard skips the insert if the cell was
-        # removed before the deferred callback runs.
+        # Rebuild affected cells. Built and inserted synchronously: the pass
+        # holds the document lock, so a pn.state.execute here would run inline
+        # anyway rather than defer.
         for cell_id, (cell, plot_grid, grid_id) in cells_to_rebuild.items():
             view = self._build_cell(cell_id, cell).view
-            pn.state.execute(
-                lambda g=cell.geometry, w=view, pg=plot_grid, cid=cell_id: (
-                    pg.insert_widget_at(g, w) if cid in self._cells else None
-                )
-            )
+            plot_grid.insert_widget_at(cell.geometry, view)
             # Record signature/grid and bump versions only after a successful
             # rebuild — if _build_cell raised, the stale records make the next
             # poll retry.

--- a/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_layout_test.py
@@ -258,8 +258,10 @@ class TestPollHandlesLayoutPlotters:
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
         layer_id = _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
 
-        # First poll adds the grid tab and builds the cell/session layer.
+        # First poll adds the grid tab; revealing it builds the cell/session
+        # layer (the switch runs the pass synchronously in tests).
         plot_grid_tabs._poll_for_plot_updates()
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
 
         session_layer = plot_grid_tabs._session_layers.get(layer_id)
         assert session_layer is not None
@@ -277,6 +279,7 @@ class TestPollHandlesLayoutPlotters:
         layer_id = _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
 
         plot_grid_tabs._poll_for_plot_updates()
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         version_after_first_poll = plot_grid_tabs._session_layers[
             layer_id
         ].last_seen_version
@@ -449,10 +452,18 @@ class TestFreshnessIndicator:
         grid_id = plot_orchestrator.add_grid(title='Test', nrows=2, ncols=2)
         # Leave a non-plot static tab active so the grid is hidden.
         plot_grid_tabs.tabs.active = 0
-        _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
+        layer_id = _inject_layer(plot_orchestrator, plot_data_service, grid_id, plotter)
+
+        # Another session's viewer token makes the hidden cell build (#1216).
+        class _OtherSessionViewer:
+            pass
+
+        token = _OtherSessionViewer()
+        plot_data_service.set_active(layer_id, token, True)
 
         plot_grid_tabs._poll_for_plot_updates()
 
+        assert plot_grid_tabs._cells
         for cell_widget in plot_grid_tabs._cells.values():
             assert cell_widget.freshness_pane.object in ('', None)
 

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -1171,18 +1171,14 @@ class TestDisabledGridTabs:
         assert plot_grid_tabs.tabs._names[static:] == ['B']
 
 
-def _add_static_cell(plot_orchestrator, grid_id, geometry, *, positions='10, 20'):
-    """Add a cell with a single static (no-workflow) vlines layer.
-
-    Static overlays compute from params alone, so they let cell-reconcile tests
-    run without workflow data.
-    """
+def _static_plot_config(positions='10, 20'):
+    """A static (no-workflow) vlines plot config, computed from params alone."""
     from ess.livedata.config.workflow_spec import WorkflowId
     from ess.livedata.dashboard.data_roles import PRIMARY
     from ess.livedata.dashboard.plot_orchestrator import DataSourceConfig, PlotConfig
     from ess.livedata.dashboard.static_plots import LinesCoordinates, VLinesParams
 
-    config = PlotConfig(
+    return PlotConfig(
         data_sources={
             PRIMARY: DataSourceConfig(
                 workflow_id=WorkflowId(instrument='test', name='wf', version=1),
@@ -1193,8 +1189,16 @@ def _add_static_cell(plot_orchestrator, grid_id, geometry, *, positions='10, 20'
         plot_name='vlines',
         params=VLinesParams(geometry=LinesCoordinates(positions=positions)),
     )
+
+
+def _add_static_cell(plot_orchestrator, grid_id, geometry, *, positions='10, 20'):
+    """Add a cell with a single static (no-workflow) vlines layer.
+
+    Static overlays compute from params alone, so they let cell-reconcile tests
+    run without workflow data.
+    """
     cell_id = plot_orchestrator.add_cell(grid_id, geometry)
-    plot_orchestrator.add_layer(cell_id, config)
+    plot_orchestrator.add_layer(cell_id, _static_plot_config(positions))
     return cell_id
 
 
@@ -1216,6 +1220,9 @@ class TestLayerToolbars:
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         _add_static_cell(plot_orchestrator, grid_id, self._geometry())
         _tick(plot_grid_tabs)
+        # Reveal the grid so its cell is built (the switch runs the pass
+        # synchronously in tests).
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         return next(iter(plot_grid_tabs._cells.values()))
 
     def test_collapsed_cell_builds_no_layer_toolbars(
@@ -1270,8 +1277,12 @@ class TestCellReconcile:
 
         return CellGeometry(row=0, col=0, row_span=1, col_span=1)
 
-    def test_new_cell_built_on_poll(self, plot_orchestrator, plot_grid_tabs):
+    def test_new_cell_on_active_grid_built_on_poll(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        _tick(plot_grid_tabs)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
 
         assert cell_id not in plot_grid_tabs._cells
@@ -1284,6 +1295,7 @@ class TestCellReconcile:
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
         _tick(plot_grid_tabs)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         assert cell_id in plot_grid_tabs._cells
         layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
 
@@ -1299,6 +1311,7 @@ class TestCellReconcile:
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
         _tick(plot_grid_tabs)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         widget_before = plot_grid_tabs._cells[cell_id]
 
         plot_orchestrator.set_cell_title(cell_id, 'Renamed')
@@ -1316,6 +1329,7 @@ class TestCellReconcile:
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
         _tick(plot_grid_tabs)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         widget = plot_grid_tabs._cells[cell_id]
 
         plot_orchestrator.set_grid_enabled(grid_id, enabled=False)
@@ -1337,6 +1351,7 @@ class TestCellReconcile:
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
         _tick(plot_grid_tabs)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
 
         events: list = []
         plot_grid_tabs.tabs.param.watch(events.append, 'objects')
@@ -1361,6 +1376,20 @@ class TestCellReconcile:
         plot_grid_tabs._on_reconfigure_layer(LayerId(uuid4()))
 
         assert plot_grid_tabs._current_modal is None
+
+    def test_add_plot_on_occupied_position_shows_error_not_raise(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """Completing the wizard for a position topology already holds must
+        show an error, not raise: another session filled the cell while the
+        modal was open, or the grid's widgets were not built yet and topology
+        rendered as clickable empty cells (#1216)."""
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+
+        plot_grid_tabs._add_plot(grid_id, self._geometry(), _static_plot_config())
+
+        assert len(plot_orchestrator.peek_grid(grid_id).cells) == 1
 
     # Opening a Modal outside a served document warns; irrelevant here, since
     # what is under test is the poll gate the open/close toggles.
@@ -1393,6 +1422,7 @@ class TestCellReconcile:
         grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
         cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
         _tick(plot_grid_tabs)
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
         widget_before = plot_grid_tabs._cells[cell_id]
         layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
 
@@ -1420,6 +1450,102 @@ class TestCellReconcile:
 
         # Reconfigure mints a fresh LayerId -> signature changed -> rebuilt.
         assert plot_grid_tabs._cells[cell_id] is not widget_before
+
+
+class TestHiddenGridRebuildGate:
+    """Hidden grids build cell widgets only when the build survives the reveal.
+
+    With no viewer in any session the build would be a placeholder that the
+    reveal's 0->1 activation bumps and discards, so it is skipped; another
+    session's viewer token makes it a real plot that pre-warms this session's
+    tab switch (#1216).
+    """
+
+    @staticmethod
+    def _geometry():
+        from ess.livedata.dashboard.plot_orchestrator import CellGeometry
+
+        return CellGeometry(row=0, col=0, row_span=1, col_span=1)
+
+    def test_unviewed_hidden_cell_is_not_built(self, plot_orchestrator, plot_grid_tabs):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+
+        _tick(plot_grid_tabs)
+
+        assert cell_id not in plot_grid_tabs._cells
+
+    def test_reveal_builds_the_deferred_cell(self, plot_orchestrator, plot_grid_tabs):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+
+        # The switch runs the pass synchronously in tests (no document).
+        plot_grid_tabs.tabs.active = plot_grid_tabs._static_tabs_count
+
+        assert cell_id in plot_grid_tabs._cells
+
+    def test_cell_viewed_by_another_session_is_built_while_hidden(
+        self, plot_orchestrator, plot_grid_tabs, plot_data_service
+    ):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+
+        class _OtherSessionViewer:
+            pass
+
+        token = _OtherSessionViewer()
+        plot_data_service.set_active(layer_id, token, True)
+        _tick(plot_grid_tabs)
+
+        assert cell_id in plot_grid_tabs._cells
+
+    def test_bump_while_hidden_defers_rebuild_to_reveal(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        _tick(plot_grid_tabs)
+        static = plot_grid_tabs._static_tabs_count
+        plot_grid_tabs.tabs.active = static
+        widget = plot_grid_tabs._cells[cell_id]
+        plot_grid_tabs.tabs.active = 0
+
+        plot_orchestrator.set_cell_title(cell_id, 'Renamed')
+        _tick(plot_grid_tabs)
+        assert plot_grid_tabs._cells[cell_id] is widget
+
+        plot_grid_tabs.tabs.active = static
+        assert plot_grid_tabs._cells[cell_id] is not widget
+
+    def test_plotter_swap_while_hidden_defers_rebuild_to_reveal(
+        self,
+        plot_orchestrator,
+        plot_grid_tabs,
+        plot_data_service,
+        plotting_controller,
+    ):
+        from ess.livedata.dashboard.static_plots import LinesCoordinates, VLinesParams
+
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        cell_id = _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+        layer_id = plot_orchestrator.get_cell(cell_id).layers[0].layer_id
+        _tick(plot_grid_tabs)
+        static = plot_grid_tabs._static_tabs_count
+        plot_grid_tabs.tabs.active = static
+        widget = plot_grid_tabs._cells[cell_id]
+        plot_grid_tabs.tabs.active = 0
+
+        plotter = plotting_controller.create_plotter(
+            'vlines', params=VLinesParams(geometry=LinesCoordinates(positions='30'))
+        )
+        plot_data_service.job_started(layer_id, plotter)
+        _tick(plot_grid_tabs)
+        assert plot_grid_tabs._cells[cell_id] is widget
+
+        plot_grid_tabs.tabs.active = static
+        assert plot_grid_tabs._cells[cell_id] is not widget
 
 
 class TestWakeGateContract:


### PR DESCRIPTION
Fixes #1216. Partially addresses #1219 (the `ValueError` handler; topology-driven occupancy is left for a follow-up).

## What

Every session's poll pass rebuilt the cell widgets of every enabled grid in the shared topology, visible or not — at page load and again on every layer version bump (job restarts, plotter swaps, errors). For a grid with no viewer in any session such a build is a placeholder: frame flushes skip layers without viewer tokens, so the reveal's 0→1 activation bumps the layer version and rebuilds the cell anyway, discarding the hidden build. The cost is per session and serialized on the shared IOLoop, so N parked sessions pay it N times back-to-back on every bump.

The poll pass now skips a hidden cell's rebuild unless another session holds a viewer token on one of its layers — the one case where the build is a real plot that survives the reveal and pre-warms the tab switch. Skipped rebuilds leave the session's signature/version records stale, so the reveal pass builds the cell once; N bumps while hidden coalesce into that single build.

Consequences handled along the way:

- A revealed grid's widgets can now lag topology for one pass, so completing the plot wizard on a stale empty cell can hit an occupied position. `add_cell`'s `ValueError` was uncaught in that handler (already reachable via the cross-session wizard race, #1219); it now shows an error notification.
- The `pn.state.execute` wrapper around cell insertion described a deferral that never happens (the pass holds the document lock, so it ran inline); the insert is now direct and the dead removed-cell guard is gone.

## Test plan

Automated tests cover the gate (hidden cell not built, reveal builds it, viewer token preserves the pre-warm build, bumps while hidden defer to the reveal) and the occupied-position error path.

Manual checks:

- [ ] Reveal of a grid whose cells were deferred shows no objectionable empty-cell flash before the widgets appear
- [ ] Two-browser session: with session A viewing a grid, session B parked elsewhere still gets pre-warmed cells and a fast tab switch to that grid
- [ ] Re-measure the idle-session poll cost from #1216 (no `CellWidget` construction while parked on Workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
