### PR TITLE
Derive PlotGrid occupancy from topology, not inserted widgets

### DIFF
--- a/src/ess/livedata/dashboard/widgets/plot_grid.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -208,6 +208,11 @@ class PlotGrid:
     plot_request_callback:
         Callback invoked when a region is selected with the cell geometry.
         This callback will be called asynchronously and should not return a value.
+    occupied_geometries:
+        Returns the cell geometries topology currently holds for this grid.
+        Topology is the authority on occupancy: this session's widgets can lag
+        it (another session may have added a cell between polls), so occupancy
+        must not be derived from inserted widgets (#1219).
     """
 
     def __init__(
@@ -215,10 +220,12 @@ class PlotGrid:
         nrows: int,
         ncols: int,
         plot_request_callback: Callable[[CellGeometry], None],
+        occupied_geometries: Callable[[], Iterable[CellGeometry]],
     ) -> None:
         self._nrows = nrows
         self._ncols = ncols
         self._plot_request_callback = plot_request_callback
+        self._occupied_geometries = occupied_geometries
 
         # State tracking
         self._occupied_cells: dict[CellGeometry, pn.Column] = {}
@@ -290,6 +297,12 @@ class PlotGrid:
 
     def _on_cell_click(self, row: int, col: int) -> None:
         """Handle cell click for region selection."""
+        if self._is_cell_occupied(row, col):
+            # An empty-cell button can sit over an occupied position while
+            # this session's widgets lag topology (another session added a
+            # cell between polls). Ignore the click rather than offer a
+            # region that cannot be filled.
+            return
         if self._first_click is None:
             # First click - start selection
             self._first_click = (row, col)
@@ -310,6 +323,12 @@ class PlotGrid:
             # Clear selection highlight
             self._clear_selection()
 
+            # The disabled styling of invalid cells normally prevents this
+            # click, but topology can change between the styling pass and the
+            # click landing.
+            if not self._is_region_available(row_start, col_start, row_end, col_end):
+                return
+
             # Request plot from callback, passing cell geometry
             geometry = CellGeometry(
                 row=row_start, col=col_start, row_span=row_span, col_span=col_span
@@ -317,24 +336,20 @@ class PlotGrid:
             self._plot_request_callback(geometry)
 
     def _is_cell_occupied(self, row: int, col: int) -> bool:
-        """Check if a specific cell is occupied by a plot."""
-        for geometry in self._occupied_cells:
-            if (
-                geometry.row <= row < geometry.row + geometry.row_span
-                and geometry.col <= col < geometry.col + geometry.col_span
-            ):
-                return True
-        return False
+        """Check if topology holds a cell covering this grid slot."""
+        return not self._is_region_available(row, col, row, col)
 
     def _is_region_available(
         self, row_start: int, col_start: int, row_end: int, col_end: int
     ) -> bool:
-        """Check if an entire region is available for plot insertion."""
-        for row in range(row_start, row_end + 1):
-            for col in range(col_start, col_end + 1):
-                if self._is_cell_occupied(row, col):
-                    return False
-        return True
+        """Check if topology holds no cell overlapping the region."""
+        region = CellGeometry(
+            row=row_start,
+            col=col_start,
+            row_span=row_end - row_start + 1,
+            col_span=col_end - col_start + 1,
+        )
+        return not any(g.overlaps(region) for g in self._occupied_geometries())
 
     def _refresh_all_cells(self) -> None:
         """Refresh all empty cells based on current selection state."""

--- a/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
+++ b/src/ess/livedata/dashboard/widgets/plot_grid_tabs.py
@@ -327,11 +327,18 @@ class PlotGridTabs:
         def grid_callback(geometry: CellGeometry) -> None:
             self._on_plot_requested(grid_id, geometry)
 
+        def occupied_geometries() -> tuple[CellGeometry, ...]:
+            config = self._orchestrator.peek_grid(grid_id)
+            if config is None:
+                return ()
+            return tuple(cell.geometry for cell in config.cells.values())
+
         # Create PlotGrid widget with grid-specific callback
         plot_grid = PlotGrid(
             nrows=grid_config.nrows,
             ncols=grid_config.ncols,
             plot_request_callback=grid_callback,
+            occupied_geometries=occupied_geometries,
         )
 
         # Store widget reference

--- a/tests/dashboard/widgets/plot_config_modal_test.py
+++ b/tests/dashboard/widgets/plot_config_modal_test.py
@@ -879,7 +879,12 @@ class TestClickToPlace:
     def grid(self) -> tuple[PlotGrid, list[CellGeometry]]:
         requested: list[CellGeometry] = []
         return (
-            PlotGrid(nrows=3, ncols=3, plot_request_callback=requested.append),
+            PlotGrid(
+                nrows=3,
+                ncols=3,
+                plot_request_callback=requested.append,
+                occupied_geometries=lambda: [],
+            ),
             requested,
         )
 
@@ -912,6 +917,7 @@ class TestClickToPlace:
             plot_request_callback=lambda geometry: placed.append(
                 (geometry, open_wizard())
             ),
+            occupied_geometries=lambda: [],
         )
 
         _click_cell(plot_grid, 1, 0)
@@ -937,6 +943,7 @@ class TestClickToPlace:
             plot_request_callback=lambda geometry: placed.append(
                 (geometry, open_wizard())
             ),
+            occupied_geometries=lambda: [],
         )
 
         _click_cell(plot_grid, 0, 0)

--- a/tests/dashboard/widgets/plot_grid_tabs_test.py
+++ b/tests/dashboard/widgets/plot_grid_tabs_test.py
@@ -1362,6 +1362,24 @@ class TestCellReconcile:
 
         assert plot_grid_tabs._current_modal is None
 
+    def test_empty_cell_click_racing_cross_session_add_opens_no_modal(
+        self, plot_orchestrator, plot_grid_tabs
+    ):
+        """A cell added by another session occupies topology before this
+        session's poll inserts its widget; the still-rendered empty cell must
+        swallow the two-click gesture instead of opening the wizard on a
+        region that cannot be filled (#1219)."""
+        grid_id = plot_orchestrator.add_grid(title='G', nrows=2, ncols=2)
+        _tick(plot_grid_tabs)
+        _add_static_cell(plot_orchestrator, grid_id, self._geometry())
+
+        plot_grid = plot_grid_tabs._grid_widgets[grid_id]
+        button = plot_grid.panel[0, 0][0]
+        button.param.trigger('clicks')
+        button.param.trigger('clicks')
+
+        assert plot_grid_tabs._current_modal is None
+
     # Opening a Modal outside a served document warns; irrelevant here, since
     # what is under test is the poll gate the open/close toggles.
     @pytest.mark.filterwarnings('ignore:To use the Modal:UserWarning')

--- a/tests/dashboard/widgets/plot_grid_test.py
+++ b/tests/dashboard/widgets/plot_grid_test.py
@@ -5,7 +5,28 @@ import numpy as np
 import panel as pn
 import pytest
 
+from ess.livedata.dashboard.plot_orchestrator import CellGeometry
 from ess.livedata.dashboard.widgets.plot_grid import PlotGrid
+
+
+def make_grid(
+    nrows: int,
+    ncols: int,
+    callback: 'FakeCallback',
+    topology: list[CellGeometry],
+) -> PlotGrid:
+    """PlotGrid consulting ``topology`` for occupancy, as PlotGridTabs wires it.
+
+    ``topology`` stands in for the orchestrator's grid config, the authority
+    on which positions are occupied; ``insert_plot_from_callback`` appends to
+    it before inserting, mirroring add_cell-then-insert in production.
+    """
+    return PlotGrid(
+        nrows=nrows,
+        ncols=ncols,
+        plot_request_callback=callback,
+        occupied_geometries=lambda: topology,
+    )
 
 
 class FakeCallback:
@@ -138,13 +159,17 @@ def count_occupied_cells(grid: PlotGrid) -> int:
 
 
 def insert_plot_from_callback(
-    grid: PlotGrid, callback: FakeCallback, plot: hv.DynamicMap
+    grid: PlotGrid,
+    callback: FakeCallback,
+    plot: hv.DynamicMap,
+    topology: list[CellGeometry],
 ) -> None:
     """
     Insert a plot at the region captured by the callback.
 
-    This mimics the workflow used by PlotGridTabs: reading the region
-    from the callback arguments and calling insert_widget_at with a plot widget.
+    This mimics the workflow used by PlotGridTabs: the region enters topology
+    (``add_cell``) and the widget is inserted at it. The close button removes
+    both again, like a topology removal followed by the widget sweep.
 
     Parameters
     ----------
@@ -154,6 +179,8 @@ def insert_plot_from_callback(
         The FakeCallback that captured the region arguments.
     plot:
         The HoloViews DynamicMap to insert.
+    topology:
+        The occupancy list the grid consults (see ``make_grid``).
     """
     # Get region from last callback invocation
     try:
@@ -174,6 +201,7 @@ def insert_plot_from_callback(
     )
 
     def on_close() -> None:
+        topology.remove(geometry)
         grid.remove_widget_at(geometry)
 
     close_button = create_tool_button(
@@ -190,20 +218,21 @@ def insert_plot_from_callback(
         styles={'position': 'relative'},
     )
 
-    # Insert widget at the position
+    # Region enters topology first, then the widget is inserted at it.
+    topology.append(geometry)
     grid.insert_widget_at(geometry, widget)
 
 
 class TestPlotGridInitialization:
     def test_grid_has_panel_property(self, mock_callback: FakeCallback) -> None:
-        grid = PlotGrid(nrows=2, ncols=2, plot_request_callback=mock_callback)
+        grid = make_grid(2, 2, mock_callback, [])
         assert grid.panel is not None
         assert isinstance(grid.panel, pn.GridSpec)
 
     def test_grid_starts_with_empty_clickable_cells(
         self, mock_callback: FakeCallback
     ) -> None:
-        grid = PlotGrid(nrows=2, ncols=2, plot_request_callback=mock_callback)
+        grid = make_grid(2, 2, mock_callback, [])
 
         # All cells should have clickable buttons
         for row in range(2):
@@ -219,7 +248,7 @@ class TestPlotGridInitialization:
     ) -> None:
         # Committed automation contract: the click-to-place gesture is addressed
         # by grid position, and only ever lands on a cell that is still empty.
-        grid = PlotGrid(nrows=2, ncols=2, plot_request_callback=mock_callback)
+        grid = make_grid(2, 2, mock_callback, [])
 
         for row in range(2):
             for col in range(2):
@@ -233,7 +262,8 @@ class TestCellSelection:
     def test_single_cell_selection_triggers_callback(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=3, ncols=3, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(3, 3, mock_callback, topology)
 
         # First click should not trigger callback
         simulate_click(grid, 1, 1)
@@ -244,7 +274,7 @@ class TestCellSelection:
         mock_callback.assert_called_once()
 
         # Complete the deferred insertion
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # Cell should now contain a plot
         assert is_cell_occupied(grid, 1, 1)
@@ -252,7 +282,8 @@ class TestCellSelection:
     def test_rectangular_region_selection(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=4, ncols=4, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(4, 4, mock_callback, topology)
 
         # Click two corners of a region
         simulate_click(grid, 0, 0)
@@ -261,7 +292,7 @@ class TestCellSelection:
         mock_callback.assert_called_once()
 
         # Complete the deferred insertion
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # All cells in the 2x3 region should be occupied
         assert is_cell_occupied(grid, 0, 0)
@@ -278,13 +309,14 @@ class TestCellSelection:
     def test_selection_works_regardless_of_click_order(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=4, ncols=4, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(4, 4, mock_callback, topology)
 
         # Click bottom-right first, then top-left
         simulate_click(grid, 2, 2)
         simulate_click(grid, 1, 1)
 
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # Should still create a 2x2 region
         assert is_cell_occupied(grid, 1, 1)
@@ -295,7 +327,7 @@ class TestCellSelection:
     def test_first_click_changes_cell_appearance(
         self, mock_callback: FakeCallback
     ) -> None:
-        grid = PlotGrid(nrows=3, ncols=3, plot_request_callback=mock_callback)
+        grid = make_grid(3, 3, mock_callback, [])
 
         # Get initial button state
         button_before = get_cell_button(grid, 0, 0)
@@ -317,17 +349,18 @@ class TestPlotInsertion:
     def test_multiple_plots_can_be_inserted(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=3, ncols=3, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(3, 3, mock_callback, topology)
 
         # Insert first plot
         simulate_click(grid, 0, 0)
         simulate_click(grid, 0, 0)
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # Insert second plot
         simulate_click(grid, 2, 2)
         simulate_click(grid, 2, 2)
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # Both cells should be occupied
         assert is_cell_occupied(grid, 0, 0)
@@ -336,11 +369,12 @@ class TestPlotInsertion:
     def test_inserted_plot_has_close_button(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=3, ncols=3, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(3, 3, mock_callback, topology)
 
         simulate_click(grid, 1, 1)
         simulate_click(grid, 1, 1)
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # Should be able to find a close button
         close_button = find_close_button(grid, 1, 1)
@@ -351,12 +385,13 @@ class TestPlotRemoval:
     def test_clicking_close_button_removes_plot(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=3, ncols=3, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(3, 3, mock_callback, topology)
 
         # Insert plot
         simulate_click(grid, 0, 0)
         simulate_click(grid, 1, 1)
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # Verify plot is there
         assert is_cell_occupied(grid, 0, 0)
@@ -375,12 +410,13 @@ class TestPlotRemoval:
     def test_removed_cells_become_selectable_again(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=3, ncols=3, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(3, 3, mock_callback, topology)
 
         # Insert and remove plot
         simulate_click(grid, 1, 1)
         simulate_click(grid, 1, 1)
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         close_button = find_close_button(grid, 1, 1)
         assert close_button is not None
@@ -394,7 +430,7 @@ class TestPlotRemoval:
 
         assert mock_callback.call_count == 1
 
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
         assert is_cell_occupied(grid, 1, 1)
 
 
@@ -402,12 +438,13 @@ class TestOverlapPrevention:
     def test_cannot_select_overlapping_region(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=4, ncols=4, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(4, 4, mock_callback, topology)
 
         # Insert plot at (1, 1) to (2, 2)
         simulate_click(grid, 1, 1)
         simulate_click(grid, 2, 2)
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # Start new selection at (0, 0)
         simulate_click(grid, 0, 0)
@@ -420,12 +457,13 @@ class TestOverlapPrevention:
     def test_non_overlapping_regions_can_be_selected(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=4, ncols=4, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(4, 4, mock_callback, topology)
 
         # Insert plot at (1, 1) to (2, 2)
         simulate_click(grid, 1, 1)
         simulate_click(grid, 2, 2)
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         mock_callback.reset()
 
@@ -434,19 +472,57 @@ class TestOverlapPrevention:
         simulate_click(grid, 0, 0)
         mock_callback.assert_called_once()
 
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
         assert is_cell_occupied(grid, 0, 0)
+
+
+class TestTopologyOccupancy:
+    """Occupancy comes from topology, not inserted widgets (#1219).
+
+    A position occupied in topology can still render an empty-cell button in
+    this session (another session added the cell between polls). Such
+    positions must not accept clicks nor count as available.
+    """
+
+    def test_click_on_stale_empty_cell_is_ignored(
+        self, mock_callback: FakeCallback
+    ) -> None:
+        topology: list[CellGeometry] = []
+        grid = make_grid(2, 2, mock_callback, topology)
+        topology.append(CellGeometry(row=0, col=0, row_span=1, col_span=1))
+
+        # The button still renders (no widget was inserted), but clicks on it
+        # must neither start a selection nor request a plot.
+        simulate_click(grid, 0, 0)
+        simulate_click(grid, 0, 0)
+
+        mock_callback.assert_not_called()
+
+    def test_region_turning_occupied_mid_selection_is_not_requested(
+        self, mock_callback: FakeCallback
+    ) -> None:
+        topology: list[CellGeometry] = []
+        grid = make_grid(3, 3, mock_callback, topology)
+
+        simulate_click(grid, 0, 0)
+        # Another session takes (1, 1) while the selection is in progress; the
+        # styling pass already ran, so the second-click button is still live.
+        topology.append(CellGeometry(row=1, col=1, row_span=1, col_span=1))
+        simulate_click(grid, 2, 2)
+
+        mock_callback.assert_not_called()
 
 
 class TestErrorHandling:
     def test_insert_without_callback_shows_no_error(
         self, mock_callback: FakeCallback, mock_plot: hv.DynamicMap
     ) -> None:
-        grid = PlotGrid(nrows=3, ncols=3, plot_request_callback=mock_callback)
+        topology: list[CellGeometry] = []
+        grid = make_grid(3, 3, mock_callback, topology)
 
         # Try to insert without making a selection (callback wasn't invoked)
         # This should handle gracefully (no crash)
-        insert_plot_from_callback(grid, mock_callback, mock_plot)
+        insert_plot_from_callback(grid, mock_callback, mock_plot, topology)
 
         # No cells should be occupied
         assert not is_cell_occupied(grid, 0, 0)
@@ -454,7 +530,7 @@ class TestErrorHandling:
 
     def test_callback_error_prevents_plot_insertion(self) -> None:
         error_callback = FakeCallback(side_effect=ValueError('Test error'))
-        grid = PlotGrid(nrows=3, ncols=3, plot_request_callback=error_callback)
+        grid = make_grid(3, 3, error_callback, [])
 
         simulate_click(grid, 0, 0)
 


### PR DESCRIPTION
Second half of #1219 (kept separate from #1220 so each reviews standalone; together they complete the issue — no auto-close keyword here so it stays open until both land).

## What

`PlotGrid` decided which cells are free from `_occupied_cells`, a dict populated only when this session inserts a widget. Topology is the actual authority on occupancy, and the two disagree whenever another session adds a cell between this session's polls (and, once #1220 lands, whenever a hidden grid's builds are deferred): the grid renders a clickable empty cell over an occupied position, and completing the wizard there hits `add_cell`'s overlap `ValueError`.

Occupancy for the selection gesture now comes from a callable returning the grid's topology geometries (`PlotGridTabs` wires it to `peek_grid`). Clicks on positions topology holds are ignored, and the second click re-validates the region before opening the wizard — the disabled styling is computed at first-click time and can go stale mid-selection for the same cross-session reason.

`_occupied_cells` remains as widget-insertion bookkeeping (insert/remove); it no longer feeds selection decisions.

The `ValueError` handler for the remaining simultaneous-wizard race (two sessions completing the wizard on the same region — no occupancy check can prevent that one) is part of #1220.

## Test plan

Unit tests cover the two disagreement windows: a click on a stale empty cell over an occupied position is swallowed, and a region that turns occupied mid-selection is not requested. An integration test drives the cross-session race through `PlotGridTabs` (cell added by "another session" before this session's poll; the two-click gesture opens no wizard). Existing `PlotGrid` tests now wire occupancy through an explicit topology list, mirroring the production add-cell-then-insert ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
